### PR TITLE
fix(graph-api): log query parameter shape, never parameter values

### DIFF
--- a/robosystems/graph_api/core/ladybug/engine.py
+++ b/robosystems/graph_api/core/ladybug/engine.py
@@ -18,6 +18,26 @@ from robosystems.graph_api.interfaces import GraphEngineInterface, GraphOperatio
 from robosystems.logger import log_app_error, log_db_query, logger
 
 
+def describe_param_shape(params: dict[str, Any] | None) -> dict[str, str]:
+  """Describe bound query parameters without their values.
+
+  Cypher parameter values are customer data by construction — entity names,
+  email addresses, account identifiers, amounts — so there is no safe subset to
+  allowlist and no value belongs in a log line. Deliberately *not* built on
+  ``SENSITIVE_QUERY_PARAMS``: that set is sixteen credential names matched
+  against URL query strings, correctly scoped to what it does, and growing it
+  into a PII list would produce something that looks like protection and is
+  not.
+
+  What actually diagnoses a failed query is which parameters were bound and
+  what types they carried — a missing key, an unexpected ``None``, a string
+  where a number was expected. That is what this returns.
+  """
+  if not params:
+    return {}
+  return {key: type(value).__name__ for key, value in params.items()}
+
+
 class ConnectionError(Exception):
   """Raised when database connection fails."""
 
@@ -154,7 +174,7 @@ class Engine(GraphEngineInterface):
         error_category="database",
         metadata={
           "query": cypher[:200],
-          "params": params,
+          "param_shape": describe_param_shape(params),
           "duration_ms": duration_ms,
           "database": str(self.database_path),
         },

--- a/tests/graph_api/core/ladybug/test_engine_logging.py
+++ b/tests/graph_api/core/ladybug/test_engine_logging.py
@@ -1,0 +1,64 @@
+"""Query parameter values must never reach a log line.
+
+The Operations Security Policy states that logs shall not contain sensitive
+data or payloads. Cypher parameter values are customer data by construction —
+entity names, email addresses, amounts — so the failed-query log records the
+shape of the bound parameters and never their values.
+"""
+
+from robosystems.graph_api.core.ladybug.engine import describe_param_shape
+
+
+class TestDescribeParamShape:
+  def test_returns_keys_and_types_never_values(self):
+    """The whole point: a caller reading the log learns which parameters were
+    bound and what they were, without learning who the customer is."""
+    shape = describe_param_shape(
+      {
+        "entity_name": "Northwind Traders LLC",
+        "email": "cfo@northwind.example",
+        "amount": 148250.75,
+        "period_count": 12,
+        "is_closed": True,
+      }
+    )
+
+    assert shape == {
+      "entity_name": "str",
+      "email": "str",
+      "amount": "float",
+      "period_count": "int",
+      "is_closed": "bool",
+    }
+
+    # No value, in any form, survives into the output.
+    rendered = str(shape)
+    for value in ("Northwind", "northwind.example", "148250", "cfo@"):
+      assert value not in rendered
+
+  def test_none_and_empty_are_empty_shapes(self):
+    """An unparameterized query logs an empty shape rather than a null that a
+    reader has to interpret."""
+    assert describe_param_shape(None) == {}
+    assert describe_param_shape({}) == {}
+
+  def test_none_valued_parameter_is_reported_as_such(self):
+    """A parameter bound to None is one of the failures this diagnostic exists
+    to catch, so it must be distinguishable from an absent key."""
+    shape = describe_param_shape({"cik": None, "year": 2026})
+    assert shape == {"cik": "NoneType", "year": "int"}
+
+  def test_nested_structures_do_not_leak_their_contents(self):
+    """A dict or list parameter is described by its container type only —
+    recursing would reintroduce exactly the values this exists to keep out."""
+    shape = describe_param_shape(
+      {
+        "rows": [{"email": "leak@example.com"}],
+        "filters": {"tax_id": "12-3456789"},
+      }
+    )
+
+    assert shape == {"rows": "list", "filters": "dict"}
+    rendered = str(shape)
+    assert "leak@example.com" not in rendered
+    assert "12-3456789" not in rendered


### PR DESCRIPTION
## Summary

Every failed Cypher query logged the complete, unredacted parameter dict. Cypher parameters carry customer data by construction — entity names, email addresses, account identifiers, amounts — so an ordinary error path was writing customer content into an operational log.

The Operations Security Policy states that **logs shall not contain sensitive data or payloads**. This was a breach of a stated control, not a hardening opportunity, which is why it is a `fix` rather than a `chore`.

## Why it slipped past otherwise solid redaction

The platform's redaction infrastructure is good: a sensitive-parameter filter on URL query strings, a uvicorn access-log filter (which matters because MCP accepts `?token=`), OTel span redaction sharing the same list, no request or response body logging, and no plaintext credentials anywhere.

The gap is that the JSON formatter passes `extra={"metadata": ...}` through **verbatim**. Anything logging structured metadata bypasses every one of those controls. This was the instance that carried customer data.

## Changes

`robosystems/graph_api/core/ladybug/engine.py`
- New module-level `describe_param_shape(params)` returning `{key: type_name}`.
- The failed-query log now emits `param_shape` instead of `params`.

What survives is what actually diagnoses a failure: which parameters were bound and what types they carried — a missing key, an unexpected `None`, a string where a number was expected. What is dropped is everything that cannot appear in a log. Nested containers are described by container type only; recursing would reintroduce the values.

**Deliberately not built on `SENSITIVE_QUERY_PARAMS`.** That set is sixteen credential names matched against URL query strings, correctly scoped to what it does. Extending it into a PII list would produce something that looks like protection and is not — and there is no safe subset of Cypher parameter values to allowlist in the first place, because the values *are* the customer's data.

## Scope

This was the only logging site emitting the parameter dict. The two other `"params": params` occurrences are payloads, not log lines: a JSON-RPC progress notification (`routers/graphs/mcp/remote.py:374`) and a worker task envelope (`worker/client.py:87`). Neither reaches a logger.

## Residual, stated rather than hidden

The query text is still logged, truncated to 200 characters. A caller that inlines literals rather than parameterizing can put customer values there. Removing it would remove the diagnostic entirely, and the statement kernel already pushes callers toward parameterized queries, so this is left deliberately.

Blast radius before the fix was contained but real: these records land in the 30-day `graph-api` log group, not the 400-day audit bucket, so nothing entered long-term retention.

## Testing

- New `tests/graph_api/core/ladybug/test_engine_logging.py`, four cases: keys and types are returned while no value survives in any form; `None` and `{}` produce empty shapes; a `None`-valued parameter stays distinguishable from an absent key (it is one of the failures the diagnostic exists to catch); nested dicts and lists do not leak their contents.
- The assertions check the *rendered* output for value fragments rather than only comparing dicts, so a future change that stringifies differently still fails.
- `uv run pytest tests/graph_api/core/ladybug/test_engine_logging.py` — 4 passed.
- `just test-code` — clean.

## Deploy Notes

No configuration, no migration. Changes only what a log line contains on the error path.