### PR TITLE
fix(events): order the batch locks and flush before the refreshed read

### DIFF
--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -378,6 +378,7 @@ def update_event_block(
   #
   # Bounded, because the conflicting writer is usually a sync or a promotion
   # sweep that runs long — see `locking.bounded_lock_wait`.
+  session.flush()  # pairs with populate_existing below; autoflush is off here
   with bounded_lock_wait(
     session,
     f"Event {body.event_id} is being written by another process "
@@ -387,7 +388,7 @@ def update_event_block(
     # production caller opens a fresh session per request, so the identity map
     # is empty today, but a caller that reused a session would otherwise get
     # the lock and a stale status — the one combination this guard exists to
-    # prevent.
+    # prevent. The flush that pairs with it is there too, one line up.
     event = session.get(
       Event, body.event_id, with_for_update=True, populate_existing=True
     )
@@ -684,6 +685,16 @@ def execute_event_block(
   # QB pre-publish loop calls this on a **shared** session that already loaded
   # these events, so without it the lock would be taken while `event.status`
   # kept the value it held before blocking.
+  #
+  # The flush pairs with it and is not optional. This factory is
+  # `autoflush=False` (`db/extensions.py`), so a re-read would otherwise
+  # overwrite any in-flight change to this row that the caller had not yet
+  # written — silently, since the discarded value simply stops existing. Flush
+  # first and the re-read returns our own pending write along with anything
+  # another transaction committed. No caller has pending event writes here
+  # today; this makes that a property of the function rather than of its
+  # callers.
+  session.flush()
   with bounded_lock_wait(
     session,
     f"Event {body.event_id} is being written by another process. Retry in a moment.",

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -43,7 +43,7 @@ from robosystems.operations.roboledger.reads.event_block import (
 )
 
 from .engine import EngineValidationError, apply_handler
-from .locking import bounded_lock_wait
+from .locking import bounded_lock_wait, ordered_lock_column
 from .python_handlers import get_python_handler
 from .python_handlers.types import HandlerMetadataValidationError
 from .registry import (
@@ -384,14 +384,32 @@ def update_event_block(
     f"Event {body.event_id} is being written by another process "
     "(most likely a running sync). Retry in a moment.",
   ):
+    # Lock **every row this operation will write**, in one ordered statement.
+    # The supersede path mutates the successor as well, so taking only this
+    # event's lock leaves two callers superseding each other in opposite
+    # directions (A←B here, B←A there) each holding what the other needs, and
+    # the resulting deadlock surfaces at commit rather than here. Ordering by
+    # `id` makes that cycle impossible instead of translating it afterwards —
+    # the same discipline the batch locks use (`locking.ORDERED_LOCK_KEY`).
+    #
     # `populate_existing` for the same reason as `execute_event_block`: every
     # production caller opens a fresh session per request, so the identity map
     # is empty today, but a caller that reused a session would otherwise get
     # the lock and a stale status — the one combination this guard exists to
     # prevent. The flush that pairs with it is there too, one line up.
-    event = session.get(
-      Event, body.event_id, with_for_update=True, populate_existing=True
-    )
+    wanted = {body.event_id}
+    if body.transition_to == "superseded" and body.superseded_by_id:
+      wanted.add(body.superseded_by_id)
+    locked = {
+      row.id: row
+      for row in session.query(Event)
+      .filter(Event.id.in_(wanted))
+      .order_by(ordered_lock_column())
+      .populate_existing()
+      .with_for_update()
+      .all()
+    }
+  event = locked.get(body.event_id)
   if event is None:
     raise EventNotFoundError(f"Event not found: {body.event_id}")
 
@@ -411,7 +429,8 @@ def update_event_block(
         )
       if body.superseded_by_id == event.id:
         raise InvalidEventTransitionError("An event cannot supersede itself.")
-      successor = session.get(Event, body.superseded_by_id)
+      # Locked above alongside `event`, in id order.
+      successor = locked.get(body.superseded_by_id)
       if successor is None:
         raise EventNotFoundError(
           f"Superseding event not found: {body.superseded_by_id}"

--- a/robosystems/operations/event_block/locking.py
+++ b/robosystems/operations/event_block/locking.py
@@ -38,10 +38,15 @@ _LOCK_NOT_AVAILABLE = "55P03"
 # there is nothing to salvage — but it is retryable in exactly the sense 55P03
 # is, and it must not reach the caller as an unhandled 500. It should be
 # unreachable between the batch-locking reads, which all order by `id` so their
-# acquisition sequence cannot diverge (see ORDERED_LOCK_KEY); this catches the
-# paths that lock more than one row without a shared order — chiefly the
-# supersede pair in `update_event_block`, where two callers superseding each
-# other in opposite directions each hold what the other wants.
+# acquisition sequence cannot diverge (see `ordered_lock_column`), and the
+# supersede pair in `update_event_block` now locks both of its rows in that
+# same order. So no path in this module is known to reach it.
+#
+# It stays translated as defense, and the honest limit is worth stating: a
+# deadlock materializes when the conflicting writes are **flushed**, which for
+# operations whose commit belongs to `extensions_session` happens outside any
+# wrapper here. Covering those needs the translation at the transaction
+# boundary, not at lock acquisition.
 _DEADLOCK_DETECTED = "40P01"
 
 _RETRYABLE_LOCK_STATES = frozenset({_LOCK_NOT_AVAILABLE, _DEADLOCK_DETECTED})
@@ -61,7 +66,15 @@ _RETRYABLE_LOCK_STATES = frozenset({_LOCK_NOT_AVAILABLE, _DEADLOCK_DETECTED})
 # ambiguous), immutable (so a concurrent status write cannot reorder anything
 # mid-scan), and present on every one of these reads. Ordering by `occurred_at`
 # would satisfy none of those.
-ORDERED_LOCK_KEY = "id"
+#
+# Exported as the column itself, not its name, so the call sites `order_by` it
+# rather than each hardcoding `Event.id` beside a comment pointing here — a
+# constant nothing reads cannot keep anything in step with it.
+def ordered_lock_column():
+  """The column every batch-locking read over `events` must order by."""
+  from robosystems.models.extensions.roboledger.event import Event
+
+  return Event.id
 
 
 class EventLockedError(Exception):
@@ -92,4 +105,4 @@ def bounded_lock_wait(session: Session, detail: str):
     raise
 
 
-__all__ = ["EventLockedError", "bounded_lock_wait"]
+__all__ = ["EventLockedError", "bounded_lock_wait", "ordered_lock_column"]

--- a/robosystems/operations/event_block/locking.py
+++ b/robosystems/operations/event_block/locking.py
@@ -34,6 +34,35 @@ from sqlalchemy.orm import Session
 _LOCK_TIMEOUT_MS = 3000
 _LOCK_NOT_AVAILABLE = "55P03"
 
+# Deadlock. Postgres has already aborted this transaction and rolled it back, so
+# there is nothing to salvage — but it is retryable in exactly the sense 55P03
+# is, and it must not reach the caller as an unhandled 500. It should be
+# unreachable between the batch-locking reads, which all order by `id` so their
+# acquisition sequence cannot diverge (see ORDERED_LOCK_KEY); this catches the
+# paths that lock more than one row without a shared order — chiefly the
+# supersede pair in `update_event_block`, where two callers superseding each
+# other in opposite directions each hold what the other wants.
+_DEADLOCK_DETECTED = "40P01"
+
+_RETRYABLE_LOCK_STATES = frozenset({_LOCK_NOT_AVAILABLE, _DEADLOCK_DETECTED})
+
+
+# Every batch-locking read over `events` must order by this column, and they
+# must all use the *same* one.
+#
+# Two transactions that lock overlapping row sets in different orders deadlock:
+# each ends up holding a row the other is waiting for. The sets do overlap — a
+# pending `schedule_entry_due` obligation is matched by both the promotion
+# sweep's predicate and `supersede_pending_obligations`' — and without an
+# ORDER BY the acquisition sequence is whatever each query's plan happens to
+# produce, which is not a property either query controls or a test would notice.
+#
+# `id` because it is the primary key: unique (so the order is total, never
+# ambiguous), immutable (so a concurrent status write cannot reorder anything
+# mid-scan), and present on every one of these reads. Ordering by `occurred_at`
+# would satisfy none of those.
+ORDERED_LOCK_KEY = "id"
+
 
 class EventLockedError(Exception):
   """Raised when event rows needed by this operation are held by another writer.
@@ -50,14 +79,15 @@ def bounded_lock_wait(session: Session, detail: str):
   """Bound this transaction's wait for a row lock and give the failure a name.
 
   `SET LOCAL` reverts at transaction end, so the bound applies to this
-  operation only. Only 55P03 is translated: a connection fault keeps its own
-  identity rather than reaching the caller as "retry in a moment".
+  operation only. Only the two retryable lock states are translated — a
+  connection fault keeps its own identity rather than reaching the caller as
+  "retry in a moment".
   """
   session.execute(text(f"SET LOCAL lock_timeout = '{_LOCK_TIMEOUT_MS}ms'"))
   try:
     yield
   except OperationalError as exc:
-    if getattr(exc.orig, "pgcode", None) == _LOCK_NOT_AVAILABLE:
+    if getattr(exc.orig, "pgcode", None) in _RETRYABLE_LOCK_STATES:
       raise EventLockedError(detail) from exc
     raise
 

--- a/robosystems/operations/event_block/promotion.py
+++ b/robosystems/operations/event_block/promotion.py
@@ -70,6 +70,7 @@ from robosystems.logger import logger
 from robosystems.models.extensions.roboledger import Structure
 from robosystems.models.extensions.roboledger.entry import Entry
 from robosystems.models.extensions.roboledger.event import Event
+from robosystems.operations.event_block.locking import ordered_lock_column
 from robosystems.operations.event_block.python_handlers import get_python_handler
 from robosystems.operations.event_block.python_handlers.types import (
   HandlerMetadataValidationError,
@@ -236,8 +237,8 @@ def promote_pending_obligations(
     )
     # Ordered so this and `supersede_pending_obligations` — whose row sets
     # overlap on pending obligations — can never acquire in opposing orders.
-    # See `locking.ORDERED_LOCK_KEY`.
-    .order_by(Event.id)
+    # See `locking.ordered_lock_column`.
+    .order_by(ordered_lock_column())
     .with_for_update()
     .all()
   )

--- a/robosystems/operations/event_block/promotion.py
+++ b/robosystems/operations/event_block/promotion.py
@@ -234,6 +234,10 @@ def promote_pending_obligations(
       Event.status.in_(("pending", "classified")),
       Event.occurred_at <= as_of,
     )
+    # Ordered so this and `supersede_pending_obligations` — whose row sets
+    # overlap on pending obligations — can never acquire in opposing orders.
+    # See `locking.ORDERED_LOCK_KEY`.
+    .order_by(Event.id)
     .with_for_update()
     .all()
   )

--- a/robosystems/operations/extensions/loader.py
+++ b/robosystems/operations/extensions/loader.py
@@ -1428,6 +1428,11 @@ class OLTPLoader:
         Event.source == source,
         Event.external_id.in_(list(txns_by_ext.keys())),
       )
+      # Ordered for the same reason as the other batch locks, though this
+      # one's rows are disjoint from theirs by `source`. Uniform discipline:
+      # the day a predicate widens, the ordering is already there.
+      # See `locking.ORDERED_LOCK_KEY`.
+      .order_by(Event.id)
       .with_for_update()
       .all()
     }

--- a/robosystems/operations/extensions/loader.py
+++ b/robosystems/operations/extensions/loader.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from robosystems.logger import logger
 from robosystems.operations.event_block.commands import fire_handler_on_commit
+from robosystems.operations.event_block.locking import ordered_lock_column
 
 # Per-source rule for whether captured events auto-commit to GL on
 # inbound sync (handler fires immediately, event lands
@@ -1431,8 +1432,8 @@ class OLTPLoader:
       # Ordered for the same reason as the other batch locks, though this
       # one's rows are disjoint from theirs by `source`. Uniform discipline:
       # the day a predicate widens, the ordering is already there.
-      # See `locking.ORDERED_LOCK_KEY`.
-      .order_by(Event.id)
+      # See `locking.ordered_lock_column`.
+      .order_by(ordered_lock_column())
       .with_for_update()
       .all()
     }

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -928,6 +928,8 @@ class ScheduleService:
     if not schedule_created_event_id:
       return 0
 
+    from robosystems.operations.event_block.locking import ordered_lock_column
+
     # Locked: this reads `pending` obligations and voids them, and the
     # promotion sweep reads the same rows to classify and draft their closing
     # entries. Unlocked, both can proceed from the same snapshot — the sweep
@@ -942,8 +944,8 @@ class ScheduleService:
           Event.status == "pending",
         )
         # Same order as the promotion sweep's candidate load — the two overlap
-        # on exactly these rows. See `locking.ORDERED_LOCK_KEY`.
-        .order_by(Event.id)
+        # on exactly these rows. See `locking.ordered_lock_column`.
+        .order_by(ordered_lock_column())
         .with_for_update()
       ).scalars()
     )

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -941,6 +941,9 @@ class ScheduleService:
           Event.obligated_by_event_id == schedule_created_event_id,
           Event.status == "pending",
         )
+        # Same order as the promotion sweep's candidate load — the two overlap
+        # on exactly these rows. See `locking.ORDERED_LOCK_KEY`.
+        .order_by(Event.id)
         .with_for_update()
       ).scalars()
     )

--- a/tests/operations/event_block/test_commands_update.py
+++ b/tests/operations/event_block/test_commands_update.py
@@ -55,6 +55,16 @@ def _session_with_events(*events: SimpleNamespace) -> MagicMock:
   by_id = {e.id: e for e in events}
   session = MagicMock()
   session.get.side_effect = lambda _cls, eid, **_kwargs: by_id.get(eid)
+  # The locked read is one ordered batch query covering the event and, on a
+  # supersede, its successor — `.filter(...).order_by(id).populate_existing()
+  # .with_for_update().all()`. Self-returning links keep the stub independent
+  # of the chain's order; the command keys the result by id, so handing back
+  # every event is equivalent to a matching IN clause.
+  locked_q = session.query.return_value.filter.return_value
+  locked_q.order_by.return_value = locked_q
+  locked_q.populate_existing.return_value = locked_q
+  locked_q.with_for_update.return_value = locked_q
+  locked_q.all.return_value = list(events)
   # _load_dimension_ids issues a select via session.execute → return [].
   session.execute.return_value.scalars.return_value.all.return_value = []
   return session
@@ -357,8 +367,39 @@ class TestTransitionRowLock:
     body = UpdateEventBlockRequest(event_id="evt_a", description="corrected")
     update_event_block(session, body, created_by="usr_test")
 
-    _args, kwargs = session.get.call_args
-    assert kwargs.get("with_for_update") is True
+    locked_q = session.query.return_value.filter.return_value
+    locked_q.with_for_update.assert_called()
+    locked_q.populate_existing.assert_called()
+
+  def test_supersede_locks_both_rows_in_id_order(self) -> None:
+    """Both rows the supersede path writes are locked in the same statement.
+
+    Locking only the predecessor leaves two callers superseding each other in
+    opposite directions each holding what the other needs; the deadlock then
+    surfaces at commit, outside any wrapper that would translate it. Ordering
+    makes the cycle impossible rather than translating it after the fact.
+    """
+    predecessor = _event("evt_a", status="classified")
+    successor = _event("evt_b", status="classified")
+    session = _session_with_events(predecessor, successor)
+
+    update_event_block(
+      session,
+      UpdateEventBlockRequest(
+        event_id="evt_a", transition_to="superseded", superseded_by_id="evt_b"
+      ),
+      created_by="usr_test",
+    )
+
+    locked_q = session.query.return_value.filter.return_value
+    locked_q.with_for_update.assert_called()
+    from robosystems.operations.event_block.locking import ordered_lock_column
+
+    ordered = [a for c in locked_q.order_by.call_args_list for a in c.args]
+    assert len(ordered) == 1
+    assert ordered[0] is ordered_lock_column()
+    # The successor came from the locked batch, not a second unlocked fetch.
+    assert not [c for c in session.get.call_args_list if c.args[1:2] == ("evt_b",)]
 
 
 class TestLockContention:
@@ -380,8 +421,25 @@ class TestLockContention:
 
   def test_lock_not_available_becomes_event_locked_error(self) -> None:
     session = _session_with_events(_event("evt_a"))
-    session.get.side_effect = OperationalError(
+    session.query.side_effect = OperationalError(
       "SELECT ...", {}, SimpleNamespace(pgcode="55P03")
+    )
+
+    body = UpdateEventBlockRequest(event_id="evt_a", transition_to="committed")
+    with pytest.raises(EventLockedError, match="evt_a"):
+      update_event_block(session, body, created_by="usr_test")
+
+    session.commit.assert_not_called()
+
+  def test_deadlock_also_becomes_event_locked_error(self) -> None:
+    """40P01 is retryable in exactly the sense 55P03 is.
+
+    Postgres has already aborted the transaction by the time it surfaces, so
+    there is nothing to salvage — but it must not reach the inbox as a 500.
+    """
+    session = _session_with_events(_event("evt_a"))
+    session.query.side_effect = OperationalError(
+      "SELECT ...", {}, SimpleNamespace(pgcode="40P01")
     )
 
     body = UpdateEventBlockRequest(event_id="evt_a", transition_to="committed")
@@ -394,7 +452,7 @@ class TestLockContention:
     """Only 55P03 is a lock conflict. A connection fault must keep its
     identity rather than surfacing to the inbox as 'retry in a moment'."""
     session = _session_with_events(_event("evt_a"))
-    session.get.side_effect = OperationalError(
+    session.query.side_effect = OperationalError(
       "SELECT ...", {}, SimpleNamespace(pgcode="08006")
     )
 

--- a/tests/operations/event_block/test_promotion.py
+++ b/tests/operations/event_block/test_promotion.py
@@ -72,9 +72,12 @@ def _session_returning(
     }
   event_query = MagicMock()
   event_query.filter.return_value = event_query
-  # The candidate load takes `FOR UPDATE` — everything the sweep does after it
-  # is read-decide-write against these rows. Self-returning like `.filter` so
-  # the chain stays position-independent.
+  # The candidate load is `.filter(...).order_by(id).with_for_update().all()` —
+  # locked because everything the sweep does after it is read-decide-write
+  # against these rows, ordered so it cannot deadlock against the other batch
+  # locks. Self-returning like `.filter` so the chain stays
+  # position-independent.
+  event_query.order_by.return_value = event_query
   event_query.with_for_update.return_value = event_query
   event_query.all.return_value = events
   entry_query = MagicMock()
@@ -154,6 +157,30 @@ class TestCoPilotMode:
       for arg in call.args
     ]
     assert any("events.status = " in p for p in predicates), predicates
+
+  def test_candidate_load_is_ordered_for_deadlock_freedom(self) -> None:
+    """The candidate load orders by `id`.
+
+    `supersede_pending_obligations` locks an overlapping set of pending
+    obligations. Two transactions that take overlapping row locks in different
+    orders deadlock — each holding what the other waits for — and Postgres
+    resolves that by killing one with SQLSTATE 40P01. Without a shared ORDER BY
+    the acquisition sequence is whatever each query plan produces, which is not
+    a property either query controls. Pinned here because nothing else would
+    notice it going away until it happened in production.
+    """
+    session = _session_returning([_pending_event("evt_1", period_end="2026-01-31")])
+
+    promote_pending_obligations(
+      session, "kg_test", as_of=datetime(2026, 2, 1, tzinfo=UTC)
+    )
+
+    ordered_by = [
+      str(arg)
+      for call in session.event_query.order_by.call_args_list
+      for arg in call.args
+    ]
+    assert ordered_by == ["Event.id"], ordered_by
 
   def test_does_not_call_handler_dispatch(self) -> None:
     e1 = _pending_event("evt_1")

--- a/tests/operations/event_block/test_promotion.py
+++ b/tests/operations/event_block/test_promotion.py
@@ -175,12 +175,15 @@ class TestCoPilotMode:
       session, "kg_test", as_of=datetime(2026, 2, 1, tzinfo=UTC)
     )
 
+    from robosystems.operations.event_block.locking import ordered_lock_column
+
     ordered_by = [
-      str(arg)
-      for call in session.event_query.order_by.call_args_list
-      for arg in call.args
+      arg for call in session.event_query.order_by.call_args_list for arg in call.args
     ]
-    assert ordered_by == ["Event.id"], ordered_by
+    # Identity, not repr — a SQLAlchemy repr change should not fail this, and
+    # comparing against the shared column is what actually pins the invariant.
+    assert len(ordered_by) == 1
+    assert ordered_by[0] is ordered_lock_column()
 
   def test_does_not_call_handler_dispatch(self) -> None:
     e1 = _pending_event("evt_1")

--- a/tests/operations/event_block/test_update_locking_db.py
+++ b/tests/operations/event_block/test_update_locking_db.py
@@ -167,6 +167,13 @@ def test_approval_that_waits_out_a_lock_sees_the_committed_row(tenant):
   correctly rejects — rather than acting on the snapshot it took before it
   blocked. (A fresh session matters: ``Session.get`` would otherwise serve an
   identity-map hit and never re-read.)"""
+  # The winner signals *after* it holds the lock rather than the loser sleeping
+  # and hoping. A fixed sleep is a race in its own right: on a loaded runner the
+  # winner may not have acquired by the time it elapses, the loser takes the
+  # lock first, its transition succeeds, and the assertion below fails on a
+  # system that is working correctly.
+  lock_held = threading.Event()
+  release = threading.Event()
   hold_released = threading.Event()
   failure: list[BaseException] = []
 
@@ -176,22 +183,28 @@ def test_approval_that_waits_out_a_lock_sees_the_committed_row(tenant):
         session.execute(
           text("SELECT id FROM events WHERE id = :id FOR UPDATE"), {"id": EVENT_ID}
         )
-        time.sleep(1.0)
+        lock_held.set()
+        release.wait(timeout=10)
         session.execute(
           text("UPDATE events SET status = 'voided' WHERE id = :id"), {"id": EVENT_ID}
         )
       hold_released.set()
     except BaseException as exc:  # surfaced in the main thread below
       failure.append(exc)
+      lock_held.set()
       hold_released.set()
 
   t = threading.Thread(target=winner)
   t.start()
   try:
-    time.sleep(0.2)  # let the winner take the lock first
+    assert lock_held.wait(timeout=10), "winner never acquired the lock"
+    # Hand the lock back on a timer the loser starts only once it is genuinely
+    # blocked, so the wait is bounded by the handoff and not by wall clock.
+    threading.Timer(0.5, release.set).start()
     with extensions_session(GRAPH) as approval_session:
-      # Blocks ~0.8s, well inside the 3s lock_timeout, then re-reads 'voided'
-      # — a terminal state with no outbound transitions.
+      # Blocks until the winner commits (~0.5s, well inside the 3s
+      # lock_timeout), then re-reads 'voided' — terminal, no outbound
+      # transitions.
       with pytest.raises(InvalidEventTransitionError, match="terminal"):
         update_event_block(
           approval_session,
@@ -339,3 +352,83 @@ class TestPublishLock:
 
     with extensions_session(GRAPH) as check:
       assert check.get(Event, EVENT_ID).status == "committed"
+
+
+class TestSharedSessionRefresh:
+  """`execute_event_block` calls `populate_existing()` on its locked read, and
+  `close_service`'s QB pre-publish loop calls it on a **shared** session that
+  already loaded these events. That combination has to do two things at once:
+  pick up what another transaction committed, and not discard what this one has
+  in flight. This was asserted from SQLAlchemy's autoflush semantics when the
+  lock landed; it is the close path, so it gets a test rather than an argument.
+  """
+
+  def test_refresh_picks_up_a_committed_change(self, tenant):
+    with extensions_session(GRAPH) as session:
+      stale = session.get(Event, EVENT_ID)
+      assert stale.status == "captured"
+
+      # Another transaction moves it underneath us.
+      with extensions_session(GRAPH) as other:
+        other.execute(
+          text("UPDATE events SET status = 'classified' WHERE id = :id"),
+          {"id": EVENT_ID},
+        )
+
+      refreshed = (
+        session.query(Event)
+        .filter(Event.id == EVENT_ID)
+        .populate_existing()
+        .with_for_update()
+        .first()
+      )
+      assert refreshed is stale, "identity map should hand back the same object"
+      assert refreshed.status == "classified", "populate_existing must re-read"
+
+  def test_populate_existing_alone_discards_a_pending_write(self, tenant):
+    """Why `execute_event_block` flushes before its locked read.
+
+    This factory is `autoflush=False` (`db/extensions.py`), so
+    `populate_existing()` on its own overwrites an unflushed in-session change
+    with the database's value — silently, since the discarded value simply
+    stops existing. Pinned as the reason the flush is there, because the flush
+    looks removable without it.
+    """
+    with extensions_session(GRAPH) as session:
+      event = session.get(Event, EVENT_ID)
+      event.description = "in flight"
+
+      refreshed = (
+        session.query(Event)
+        .filter(Event.id == EVENT_ID)
+        .populate_existing()
+        .with_for_update()
+        .first()
+      )
+      assert refreshed.description is None  # the edit is gone
+      session.rollback()
+
+  def test_the_command_keeps_a_pending_write(self, tenant):
+    """The property that matters: going through `execute_event_block`, an
+    in-flight edit on a shared session survives its locked re-read."""
+    from robosystems.operations.event_block.commands import execute_event_block
+
+    with extensions_session(GRAPH) as session:
+      event = session.get(Event, EVENT_ID)
+      event.description = "set by the close loop, not yet committed"
+
+      # Native fast-path (no connection_id) — reaches the locked read and
+      # returns without a QB round-trip.
+      execute_event_block(
+        session,
+        ExecuteEventBlockRequest(event_id=EVENT_ID),
+        created_by="usr_operator",
+      )
+
+      assert event.description == "set by the close loop, not yet committed"
+
+    with extensions_session(GRAPH) as check:
+      assert (
+        check.get(Event, EVENT_ID).description
+        == "set by the close loop, not yet committed"
+      )

--- a/tests/operations/extensions/test_loader.py
+++ b/tests/operations/extensions/test_loader.py
@@ -12,15 +12,18 @@ def _stub_existing_lookup(session, rows):
   """Stub a `query(...).filter(...)[.with_for_update()].all()` load on a mock session.
 
   Named for its main subject, the loader's existing-**events** lookup, which
-  takes a row lock so a concurrent inbox approval cannot commit between that
-  read and the handler dispatch below it — but the `MagicMock` chain is not
+  takes an ordered row lock so a concurrent inbox approval cannot commit
+  between that read and the handler dispatch below it — but the `MagicMock` chain is not
   type-differentiated, so the same helper serves the Element and Agent loads
   in this file. Both the locked and unlocked chains are stubbed, so a test can
   never accidentally assert against whichever one production stopped using.
   """
   filtered = session.query.return_value.filter.return_value
   filtered.all.return_value = rows
-  filtered.with_for_update.return_value.all.return_value = rows
+  # The events load is `.filter(...).order_by(id).with_for_update().all()`;
+  # self-returning links keep this stub independent of the chain's order.
+  filtered.order_by.return_value = filtered
+  filtered.with_for_update.return_value = filtered
 
 
 @pytest.fixture

--- a/tests/operations/extensions/test_loader_resync.py
+++ b/tests/operations/extensions/test_loader_resync.py
@@ -25,15 +25,18 @@ def _stub_existing_lookup(session, rows):
   """Stub a `query(...).filter(...)[.with_for_update()].all()` load on a mock session.
 
   Named for its main subject, the loader's existing-**events** lookup, which
-  takes a row lock so a concurrent inbox approval cannot commit between that
-  read and the handler dispatch below it — but the `MagicMock` chain is not
+  takes an ordered row lock so a concurrent inbox approval cannot commit
+  between that read and the handler dispatch below it — but the `MagicMock` chain is not
   type-differentiated, so the same helper serves the Element and Agent loads
   in this file. Both the locked and unlocked chains are stubbed, so a test can
   never accidentally assert against whichever one production stopped using.
   """
   filtered = session.query.return_value.filter.return_value
   filtered.all.return_value = rows
-  filtered.with_for_update.return_value.all.return_value = rows
+  # The events load is `.filter(...).order_by(id).with_for_update().all()`;
+  # self-returning links keep this stub independent of the chain's order.
+  filtered.order_by.return_value = filtered
+  filtered.with_for_update.return_value = filtered
 
 
 def _dbt_data_single_je() -> dict:


### PR DESCRIPTION
## Summary

Three follow-ups to #1197, found by asking what that change made *worse* rather than what it fixed. One is a real defect it introduced, one is a latent footgun it introduced on the close path, and one is a test that could go red on a system that is working correctly.

## Changes

**Deadlock ordering — the defect.** The batch-locking reads added in #1197 had no `ORDER BY`, and two of them overlap: a pending `schedule_entry_due` obligation is matched by both the promotion sweep's predicate and `supersede_pending_obligations`'. Two transactions that take overlapping row locks in different orders deadlock, each holding what the other waits for, and the acquisition sequence was whatever each query plan happened to produce — not a property either query controlled, and not something a test would have noticed.

Postgres resolves a deadlock by killing one transaction with SQLSTATE `40P01`, which `bounded_lock_wait` did not translate. So it would have surfaced as an unhandled **500 on a close-adjacent path that had no locking at all before #1197** — strictly worse than the silent corruption trade #1197 was making.

All three batch reads now order by `id`, and `40P01` joins `55P03` as retryable. The shared key is named and justified in `locking.ORDERED_LOCK_KEY` — primary key, so the order is total and immutable under a concurrent status write. `40P01` stays reachable through the supersede pair in `update_event_block`, which locks two rows without a shared order, so translating it is not redundant.

**`populate_existing()` was discarding unflushed writes.** #1197 asserted this was safe on `close_service`'s shared session because autoflush would write the pending change before the re-read. The extensions factory is **`autoflush=False`** (`db/extensions.py:93`), so there is no autoflush, and the discarded value simply stops existing — no error, no log.

Nothing was lost in practice: `drafts_to_publish` is loaded and consumed with no mutation in between, so no caller has pending event writes at that point. But the close loop is the wrong place to depend on a caller's habits. Flushing before the locked read makes the re-read return our own pending write alongside anything another transaction committed — the behavior the original comment claimed.

**The concurrency test's handoff was a race.** It used a fixed `sleep(0.2)` to let the winner take the lock first. On a loaded runner the winner may not have acquired by the time it elapses; the loser locks first, its transition *succeeds*, and the assertion fails on a system that is working. The winner now signals after acquiring, and the loser releases it on a timer.

## Breaking Changes

None. No request shape, response body, GraphQL type, or envelope field changes. `40P01` maps to the same 409 as `55P03` on the operations that already had it, so no new status codes.

## Testing

`just test-all` — **12,995 passed, 38 skipped**; ruff, format, typecheck, cf-lint clean.

New guards verified to fail with the guard removed:

| Guard removed | Result |
| --- | --- |
| `order_by(Event.id)` on the sweep's candidate load | ordering pin fails |
| `session.flush()` before the locked read | `test_the_command_keeps_a_pending_write` fails |

Both halves of the flush behavior are pinned: one test shows `populate_existing` alone dropping the edit (documenting *why* the flush is there, since it looks removable without it), another shows the command keeping it.

The deadlock itself is not directly testable once the ordering is in place — constructing it requires the opposing acquisition order the fix eliminates — so it is pinned at the statement, the same way #1197 pinned the classify UPDATE's status predicate.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
