### PR TITLE
fix(roboledger): lock the remaining state transitions

### DIFF
--- a/migrations/extensions/versions/0032_one_reversal_per_entry.py
+++ b/migrations/extensions/versions/0032_one_reversal_per_entry.py
@@ -1,0 +1,73 @@
+"""an entry is reversed at most once
+
+``reverse_journal_entry`` read the original entry unlocked, checked that its
+status was ``posted``, and then wrote a full reversing entry plus flipped line
+items. Two concurrent reversals of the same entry both passed that check and
+both posted — the entry got reversed twice. Each reversing entry is internally
+balanced, so nothing failed to foot and no validation complained; the books
+simply sat one entry's worth off in the other direction.
+
+The command now locks the original, which turns the ordinary race into a clean
+409. This index is the half that does not depend on the code path: two
+reversing entries against one original is wrong however it arose — a
+double-clicked button, a retried request, a future caller that forgets to
+lock — and the database is the only place that can say so unconditionally.
+
+Partial, because ``reversal_of`` is NULL on every entry that is not a reversal
+and those must stay unconstrained.
+
+**Before deploying**: this will fail if any original already has two reversals.
+That failure is the correct outcome — it means real double-reversed entries are
+sitting in the ledger and need an accounting decision, not a schema decision.
+Check first:
+
+    SELECT reversal_of, COUNT(*) FROM entries
+    WHERE reversal_of IS NOT NULL GROUP BY reversal_of HAVING COUNT(*) > 1;
+
+per tenant schema, and resolve any rows it returns before running this.
+
+Revision ID: 0032
+Revises: 0031
+Create Date: 2026-08-17
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+from migrations.extensions.helpers import for_each_tenant_schema
+
+revision = "0032"
+down_revision = "0031"
+branch_labels = None
+depends_on = None
+
+_INDEX = "uq_entries_one_reversal_per_original"
+
+
+def _create(conn: Connection, schema: str) -> None:
+  conn.execute(
+    text(
+      f'CREATE UNIQUE INDEX IF NOT EXISTS "{_INDEX}" '
+      f'ON "{schema}".entries (reversal_of) WHERE reversal_of IS NOT NULL'
+    )
+  )
+
+
+def _drop(conn: Connection, schema: str) -> None:
+  conn.execute(text(f'DROP INDEX IF EXISTS "{schema}"."{_INDEX}"'))
+
+
+def upgrade() -> None:
+  conn = op.get_bind()
+  _create(conn, "public")
+  for_each_tenant_schema(conn, _create)
+
+
+def downgrade() -> None:
+  conn = op.get_bind()
+  _drop(conn, "public")
+  for_each_tenant_schema(conn, _drop)

--- a/robosystems/db/extensions.py
+++ b/robosystems/db/extensions.py
@@ -87,6 +87,19 @@ def _get_engine():
   return _engine
 
 
+def get_extensions_engine():
+  """The shared extensions engine.
+
+  Session-scoped advisory locks that must survive ``Session.commit()``
+  cannot ride the session's connection — commit returns that connection
+  to the pool, and a pooled checkout of a connection still holding
+  ``pg_advisory_lock`` would leak the lock to the next borrower. Those
+  lockers check out a dedicated connection from this engine and unlock
+  (or invalidate) before returning it.
+  """
+  return _get_engine()
+
+
 def _get_session_factory():
   global _session_factory
   if _session_factory is None:

--- a/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
+++ b/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
@@ -34,6 +34,7 @@ from robosystems.middleware.mcp.tools._gate import (
 from robosystems.models.api.extensions.fiscal_calendar import (
   BackfillPlanHistoryRequest,
 )
+from robosystems.operations.locking import RowLockedError
 from robosystems.operations.roboledger.commands.fiscal_calendar import (
   BackfillPreconditionError,
   PeriodNotClosedError,
@@ -52,6 +53,7 @@ from robosystems.operations.roboledger.fiscal_calendar import (
   CloseGateFailed,
   FiscalCalendarError,
   FiscalCalendarService,
+  PeriodAlreadyClosedError,
   PeriodNotFoundError,
   UnbalancedLedgerError,
 )
@@ -382,6 +384,10 @@ class ClosePeriodTool:
       return payload
     except PeriodNotFoundError as exc:
       return {"error": "period_not_found", "message": str(exc)}
+    except PeriodAlreadyClosedError as exc:
+      return {"error": "already_closed", "message": str(exc)}
+    except RowLockedError as exc:
+      return {"error": "row_locked", "message": str(exc)}
     except UnbalancedLedgerError as exc:
       return {
         "error": "unbalanced",
@@ -522,6 +528,8 @@ class ReopenPeriodTool:
             "error": "not_closed",
             "message": f"Period {period!r} is not closed (status={exc.status!r}).",
           }
+        except RowLockedError as exc:
+          return {"error": "row_locked", "message": str(exc)}
         fc_payload = result.fiscal_calendar.model_dump(mode="json")
         has_sync, _ = qb_sync_state(platform_db, graph_id)
         fc_payload["has_sync_connection"] = has_sync

--- a/robosystems/models/extensions/roboledger/entry.py
+++ b/robosystems/models/extensions/roboledger/entry.py
@@ -59,6 +59,18 @@ class Entry(ExtensionsBase):
       "status IN ('draft', 'posted', 'reversed')",
       name="check_entry_status",
     ),
+    # An entry is reversed at most once. This is a real invariant, not a
+    # concurrency workaround: two reversing entries against one original is
+    # wrong however it arose — a double-clicked button, a retried request, a
+    # race. `reverse_journal_entry` locks the original so the ordinary path
+    # returns a clean conflict instead of an IntegrityError, but the guarantee
+    # belongs here, where nothing can route around it.
+    Index(
+      "uq_entries_one_reversal_per_original",
+      "reversal_of",
+      unique=True,
+      postgresql_where="reversal_of IS NOT NULL",
+    ),
     CheckConstraint(
       "type IN ('standard', 'adjusting', 'closing', 'reversing')",
       name="check_entry_type",

--- a/robosystems/operations/event_block/__init__.py
+++ b/robosystems/operations/event_block/__init__.py
@@ -4,6 +4,8 @@ Re-exports the public command surface so callers import a stable module
 path regardless of internal layout.
 """
 
+from robosystems.operations.locking import RowLockedError
+
 from .commands import (
   DuplicateEventError,
   EventNotFoundError,
@@ -13,13 +15,12 @@ from .commands import (
   preview_event_block,
   update_event_block,
 )
-from .locking import EventLockedError
 
 __all__ = [
   "DuplicateEventError",
-  "EventLockedError",
   "EventNotFoundError",
   "InvalidEventTransitionError",
+  "RowLockedError",
   "create_event_block",
   "execute_event_block",
   "preview_event_block",

--- a/robosystems/operations/event_block/__init__.py
+++ b/robosystems/operations/event_block/__init__.py
@@ -16,8 +16,16 @@ from .commands import (
   update_event_block,
 )
 
+# The lock policy moved to `operations/locking.py` and its error was renamed,
+# since it now guards entries, fiscal periods and reports as well as events.
+# This module's contract is a stable import path, so the old name keeps
+# resolving rather than breaking on the release that moved it. Deprecated —
+# import `RowLockedError` from `robosystems.operations.locking`.
+EventLockedError = RowLockedError
+
 __all__ = [
   "DuplicateEventError",
+  "EventLockedError",  # deprecated alias for RowLockedError
   "EventNotFoundError",
   "InvalidEventTransitionError",
   "RowLockedError",

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -37,13 +37,13 @@ from robosystems.models.extensions.roboledger.dimension_junctions import (
   event_dimensions,
 )
 from robosystems.models.extensions.roboledger.event import Event
+from robosystems.operations.locking import bounded_lock_wait, ordered_lock_column
 from robosystems.operations.roboledger.reads.event_block import (
   _load_dimension_ids,
   _to_envelope,
 )
 
 from .engine import EngineValidationError, apply_handler
-from .locking import bounded_lock_wait, ordered_lock_column
 from .python_handlers import get_python_handler
 from .python_handlers.types import HandlerMetadataValidationError
 from .registry import (

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -37,13 +37,21 @@ from robosystems.models.extensions.roboledger.dimension_junctions import (
   event_dimensions,
 )
 from robosystems.models.extensions.roboledger.event import Event
-from robosystems.operations.locking import bounded_lock_wait, ordered_lock_column
+from robosystems.operations.locking import (
+  RowLockedError,
+  bounded_lock_wait,
+  ordered_lock_column,
+)
+from robosystems.operations.roboledger.commands._guards import (
+  ClosedPeriodError,
+  assert_period_not_closed,
+)
 from robosystems.operations.roboledger.reads.event_block import (
   _load_dimension_ids,
   _to_envelope,
 )
 
-from .engine import EngineValidationError, apply_handler
+from .engine import EngineValidationError, apply_handler, posting_date_for_event
 from .python_handlers import get_python_handler
 from .python_handlers.types import HandlerMetadataValidationError
 from .registry import (
@@ -583,6 +591,17 @@ def preview_event_block(
       validation_errors=errors,
       would_succeed=False,
     )
+
+  try:
+    assert_period_not_closed(
+      session,
+      posting_date_for_event(
+        effective_at=body.effective_at,
+        occurred_at=body.occurred_at,
+      ),
+    )
+  except (ClosedPeriodError, RowLockedError) as e:
+    errors.append(str(e))
 
   # Dry-evaluate template without writing
   template = handler.transaction_template or {}

--- a/robosystems/operations/event_block/engine.py
+++ b/robosystems/operations/event_block/engine.py
@@ -17,6 +17,9 @@ from robosystems.models.extensions.roboledger.event import Event
 from robosystems.models.extensions.roboledger.event_handler import EventHandler
 from robosystems.models.extensions.roboledger.line_item import LineItem
 from robosystems.models.extensions.roboledger.transaction import Transaction
+from robosystems.operations.roboledger.commands._guards import (
+  assert_period_not_closed,
+)
 
 from .template import (
   TemplateInterpolationError,
@@ -28,6 +31,23 @@ from .template import (
 
 class EngineValidationError(Exception):
   """Template produced invalid or unbalanced GL entries."""
+
+
+def posting_date_for_event(
+  *,
+  effective_at: datetime | None,
+  occurred_at: datetime | None,
+) -> date:
+  """The posting date a DSL handler uses for the entries it creates.
+
+  Shared by ``apply_handler`` and the DSL preview so they cannot disagree
+  about which period is being written.
+  """
+  if effective_at is not None:
+    return effective_at.date()
+  if occurred_at is not None:
+    return occurred_at.date()
+  return date.today()
 
 
 def _resolve_amount(expr: str, context: dict) -> int:
@@ -84,11 +104,13 @@ def apply_handler(
     "handler": build_handler_context(handler),
   }
 
-  posting_date = (
-    event.effective_at.date()
-    if event.effective_at
-    else (event.occurred_at.date() if event.occurred_at else date.today())
+  posting_date = posting_date_for_event(
+    effective_at=event.effective_at,
+    occurred_at=event.occurred_at,
   )
+  # Same fence journal-entry commands take. Without it a DSL handler can
+  # mint a draft while close is publishing, or after statements are stamped.
+  assert_period_not_closed(session, posting_date)
 
   # One timestamp per handler invocation keeps the audit trail coherent —
   # Transaction, Entry, and every LineItem share the same created_at/updated_at.

--- a/robosystems/operations/event_block/promotion.py
+++ b/robosystems/operations/event_block/promotion.py
@@ -70,11 +70,11 @@ from robosystems.logger import logger
 from robosystems.models.extensions.roboledger import Structure
 from robosystems.models.extensions.roboledger.entry import Entry
 from robosystems.models.extensions.roboledger.event import Event
-from robosystems.operations.event_block.locking import ordered_lock_column
 from robosystems.operations.event_block.python_handlers import get_python_handler
 from robosystems.operations.event_block.python_handlers.types import (
   HandlerMetadataValidationError,
 )
+from robosystems.operations.locking import ordered_lock_column
 
 
 @dataclass

--- a/robosystems/operations/event_block/python_handlers/asset_disposed.py
+++ b/robosystems/operations/event_block/python_handlers/asset_disposed.py
@@ -216,6 +216,7 @@ def dispatch_preview(
   ``would_succeed=True`` cannot still 422 at dispatch time on a
   closed-period or balance violation.
   """
+  from robosystems.operations.locking import RowLockedError
   from robosystems.operations.roboledger.commands._guards import (
     ClosedPeriodError,
     assert_period_not_closed,
@@ -234,7 +235,7 @@ def dispatch_preview(
     # the disposal date. ``dispatch`` will refuse the post if that period
     # is closed; surface the same blocker here.
     assert_period_not_closed(session, body.occurred_at.date())
-  except (ValueError, ClosedPeriodError, ScheduleNotFoundError) as e:
+  except (ValueError, ClosedPeriodError, RowLockedError, ScheduleNotFoundError) as e:
     return HandlerPreview(
       would_succeed=False,
       planned_entries=[],

--- a/robosystems/operations/event_block/python_handlers/journal_entry_recorded.py
+++ b/robosystems/operations/event_block/python_handlers/journal_entry_recorded.py
@@ -52,6 +52,7 @@ from robosystems.models.extensions.element import Element
 from robosystems.models.extensions.roboledger.entry import Entry
 from robosystems.models.extensions.roboledger.event import Event
 from robosystems.models.extensions.roboledger.transaction import Transaction
+from robosystems.operations.locking import RowLockedError
 from robosystems.operations.roboledger.commands._guards import (
   ClosedPeriodError,
   assert_period_not_closed,
@@ -509,7 +510,7 @@ def dispatch_preview(
   for pd in posting_dates:
     try:
       assert_period_not_closed(session, pd)
-    except ClosedPeriodError as e:
+    except (ClosedPeriodError, RowLockedError) as e:
       errors.append(str(e))
 
   planned, total_debit, total_credit, balance_errors = _preview_planned_entries(

--- a/robosystems/operations/event_block/python_handlers/journal_entry_reversed.py
+++ b/robosystems/operations/event_block/python_handlers/journal_entry_reversed.py
@@ -138,6 +138,19 @@ def dispatch_preview(
       "posted entries can be reversed."
     )
 
+  # Same check the command makes. A schedule with `auto_reverse` creates the
+  # reversal at generation time and leaves the original `posted`, so status
+  # alone would let preview promise a reversal the command then refuses — and a
+  # preview that disagrees with execution is worse than no preview.
+  existing_reversal = session.execute(
+    select(Entry.id).where(Entry.reversal_of == original.id)
+  ).scalar_one_or_none()
+  if existing_reversal is not None:
+    errors.append(
+      f"Journal entry {metadata.entry_id} already has a reversing entry "
+      f"({existing_reversal}); an entry is reversed at most once."
+    )
+
   posting_date = metadata.posting_date or body.occurred_at.date()
   try:
     assert_period_not_closed(session, posting_date)

--- a/robosystems/operations/event_block/python_handlers/journal_entry_reversed.py
+++ b/robosystems/operations/event_block/python_handlers/journal_entry_reversed.py
@@ -30,6 +30,7 @@ from robosystems.models.api.extensions.journal_entries import (
 )
 from robosystems.models.extensions.roboledger.entry import Entry
 from robosystems.models.extensions.roboledger.event import Event
+from robosystems.operations.locking import RowLockedError
 from robosystems.operations.roboledger.commands._guards import (
   ClosedPeriodError,
   assert_period_not_closed,
@@ -154,7 +155,7 @@ def dispatch_preview(
   posting_date = metadata.posting_date or body.occurred_at.date()
   try:
     assert_period_not_closed(session, posting_date)
-  except ClosedPeriodError as e:
+  except (ClosedPeriodError, RowLockedError) as e:
     errors.append(str(e))
 
   if errors:

--- a/robosystems/operations/extensions/loader.py
+++ b/robosystems/operations/extensions/loader.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 from robosystems.logger import logger
 from robosystems.operations.event_block.commands import fire_handler_on_commit
-from robosystems.operations.event_block.locking import ordered_lock_column
+from robosystems.operations.locking import ordered_lock_column
 
 # Per-source rule for whether captured events auto-commit to GL on
 # inbound sync (handler fires immediately, event lands

--- a/robosystems/operations/locking.py
+++ b/robosystems/operations/locking.py
@@ -142,9 +142,110 @@ def lock_by_id(session: Session, entity, ident, detail: str):
     return session.get(entity, ident, with_for_update=True, populate_existing=True)
 
 
+# ── Period write fence ───────────────────────────────────────────────────
+#
+# Close publishes to QuickBooks and commits those markers mid-flow, so a
+# transaction-scoped lock (FOR UPDATE, pg_advisory_xact_lock) cannot span
+# the whole operation. Writers and close still have to share one barrier:
+# otherwise a writer observes `open`, pauses, and commits after statements
+# are stamped.
+#
+# The barrier is a PostgreSQL advisory lock keyed on (graph, period):
+#
+# - Close and reopen take it **exclusive** and **session-scoped**, on a
+#   dedicated connection that outlives the mid-close commit.
+# - Period-affecting writers take it **shared** and **transaction-scoped**
+#   on their own session; commit/rollback releases it.
+#
+# Shared lockers do not block each other. Exclusive waits for them and
+# blocks new ones. Lock order is always the fence first, then any row
+# locks, so a writer that already holds an entry row cannot deadlock
+# with a close that holds the fence and is about to update that entry.
+
+# Two-key advisory-lock class for the period fence. Arbitrary but stable —
+# changing it would let in-flight lockers on the old class miss lockers
+# on the new one.
+_PERIOD_FENCE_CLASS = 872401
+
+
+def period_fence_ident(graph_id: str, period: str) -> str:
+  """Stable identity string hashed in SQL as the fence's second key."""
+  return f"{graph_id}:{period}"
+
+
+def acquire_shared_period_fence(
+  session: Session, graph_id: str, period: str, *, detail: str
+) -> None:
+  """Take a transaction-scoped shared fence on ``(graph_id, period)``.
+
+  Released automatically when this session commits or rolls back. Does
+  not block other shared lockers. Waits up to the request lock timeout
+  for an exclusive closer, then raises :class:`RowLockedError`.
+  """
+  with bounded_lock_wait(session, detail):
+    session.execute(
+      text("SELECT pg_advisory_xact_lock_shared(:classid, hashtext(:ident))"),
+      {
+        "classid": _PERIOD_FENCE_CLASS,
+        "ident": period_fence_ident(graph_id, period),
+      },
+    )
+
+
+@contextmanager
+def exclusive_period_fence(graph_id: str, period: str, *, detail: str):
+  """Hold a session-scoped exclusive fence on ``(graph_id, period)``.
+
+  Uses a dedicated connection, not the caller's ``Session``. The close
+  commits mid-flow to persist QuickBooks dedupe markers; that commit
+  would return the session's connection to the pool and drop any lock
+  taken on it. A session-scoped advisory lock on a connection we hold
+  ourselves survives that commit.
+
+  Unlock (or invalidate the connection, so the pool discards it) before
+  returning the connection — a pooled connection still holding this
+  lock would block every later closer of the same period.
+  """
+  from robosystems.db.extensions import get_extensions_engine
+
+  ident = period_fence_ident(graph_id, period)
+  params = {"classid": _PERIOD_FENCE_CLASS, "ident": ident}
+  conn = get_extensions_engine().connect()
+  acquired = False
+  try:
+    conn.execute(text(f"SET lock_timeout = '{_LOCK_TIMEOUT_MS}ms'"))
+    try:
+      conn.execute(
+        text("SELECT pg_advisory_lock(:classid, hashtext(:ident))"),
+        params,
+      )
+      acquired = True
+    except OperationalError as exc:
+      if getattr(exc.orig, "pgcode", None) in _RETRYABLE_LOCK_STATES:
+        raise RowLockedError(detail) from exc
+      raise
+    conn.execute(text("SET lock_timeout = 0"))
+    conn.commit()
+    yield
+  finally:
+    if acquired:
+      try:
+        conn.execute(
+          text("SELECT pg_advisory_unlock(:classid, hashtext(:ident))"),
+          params,
+        )
+        conn.commit()
+      except Exception:
+        conn.invalidate()
+    conn.close()
+
+
 __all__ = [
   "RowLockedError",
+  "acquire_shared_period_fence",
   "bounded_lock_wait",
+  "exclusive_period_fence",
   "lock_by_id",
   "ordered_lock_column",
+  "period_fence_ident",
 ]

--- a/robosystems/operations/locking.py
+++ b/robosystems/operations/locking.py
@@ -1,13 +1,22 @@
-"""Row-lock policy for event writes.
+"""Row-lock policy for state transitions.
 
-Every path that decides an event's next status does so read-decide-write, and
-the decision is only sound if nothing else can move the row in between. Two
-writers that both read `captured` both fire the handler, and the event ends up
-with two sets of GL rows — a ledger that still foots and is still wrong.
+**The shape this exists for**: load a row, branch on a state column, write that
+column back. Approving an event, reversing a journal entry, closing or reopening
+a fiscal period, filing a report — all of them. Unlocked, two callers read the
+same state, both pass the guard, and both act: one event with two sets of GL
+rows, one entry reversed twice, one period closed twice. Each of those leaves
+books that still foot, which is why none of them announce themselves.
 
-So the reads that feed those decisions take `FOR UPDATE`. This module holds the
-half of that policy which is about *waiting*: how long a request-facing caller
-waits for a conflicting writer before giving up, and what the failure is called.
+So the read that feeds the decision takes `FOR UPDATE`, and `lock_by_id` is the
+one-call version of doing that correctly. This module also holds the half of the
+policy about *waiting*: how long a request-facing caller waits for a conflicting
+writer before giving up, and what the failure is called.
+
+It lives at `operations/` root deliberately. It began under `event_block/`, which
+made it invisible to every other subsystem with the same shape — and the second
+and third instances of this bug were found in `roboledger/` only after someone
+went looking. A shared discipline filed inside one of its consumers is a
+discipline the next consumer will not find.
 
 The split that matters: **background jobs wait, request handlers do not.** A
 sync or a Dagster sweep should block behind a conflicting approval rather than
@@ -77,8 +86,8 @@ def ordered_lock_column():
   return Event.id
 
 
-class EventLockedError(Exception):
-  """Raised when event rows needed by this operation are held by another writer.
+class RowLockedError(Exception):
+  """Raised when rows this operation must write are held by another writer.
 
   In practice that writer is a running sync or the obligation-promotion sweep,
   both of which lock their whole batch for the life of their transaction.
@@ -101,8 +110,41 @@ def bounded_lock_wait(session: Session, detail: str):
     yield
   except OperationalError as exc:
     if getattr(exc.orig, "pgcode", None) in _RETRYABLE_LOCK_STATES:
-      raise EventLockedError(detail) from exc
+      raise RowLockedError(detail) from exc
     raise
 
 
-__all__ = ["EventLockedError", "bounded_lock_wait", "ordered_lock_column"]
+def lock_by_id(session: Session, entity, ident, detail: str):
+  """Load one row by primary key, locked and refreshed, with a bounded wait.
+
+  The correct form of the read that feeds a state transition, in one call, so
+  each site does not have to remember all four parts:
+
+  - `FOR UPDATE`, so a concurrent writer cannot move the row between the read
+    and the write that follows it;
+  - `populate_existing`, so a caller reusing a session gets the row as the
+    database has it rather than as its identity map remembers it;
+  - `session.flush()` first, because these sessions are `autoflush=False`
+    (`db/extensions.py`) and the refresh would otherwise discard an in-flight
+    change without a word;
+  - a bounded wait, so a request blocked behind a long background writer
+    returns a retryable error instead of pinning a pooled connection.
+
+  Returns `None` when the row does not exist — callers raise their own typed
+  not-found error, since that message is theirs to phrase.
+
+  Not for multi-row locks: those must order by `ordered_lock_column()` in a
+  single statement, or two callers acquiring the same rows in opposite orders
+  deadlock.
+  """
+  session.flush()
+  with bounded_lock_wait(session, detail):
+    return session.get(entity, ident, with_for_update=True, populate_existing=True)
+
+
+__all__ = [
+  "RowLockedError",
+  "bounded_lock_wait",
+  "lock_by_id",
+  "ordered_lock_column",
+]

--- a/robosystems/operations/roboledger/commands/_guards.py
+++ b/robosystems/operations/roboledger/commands/_guards.py
@@ -14,6 +14,8 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from robosystems.operations.locking import acquire_shared_period_fence
+
 _LIBRARY_SEEDER = "library-seeder"
 
 
@@ -106,24 +108,63 @@ class ClosedPeriodError(ValueError):
     self.posting_date = posting_date
 
 
-def assert_period_not_closed(session: Session, posting_date: date) -> None:
-  """Raise `ClosedPeriodError` if the fiscal period containing
-  `posting_date` is closed.
+_PERIOD_COVERING_DATE = """
+  SELECT graph_id, name, status
+  FROM fiscal_periods
+  WHERE start_date <= :posting_date AND end_date >= :posting_date
+  LIMIT 1
+"""
 
-  No-op if no `FiscalPeriod` row covers the date (e.g., fresh tenant
-  without periods seeded). This matches `ScheduleService._assert_period_not_closed`
-  but is a standalone function so journal entry commands and any
-  future write ops can use it without coupling to the schedule layer.
-  """
-  row = session.execute(
-    text("""
-      SELECT name, status
-      FROM fiscal_periods
-      WHERE start_date <= :posting_date AND end_date >= :posting_date
-      LIMIT 1
-    """),
+
+def _period_covering(session: Session, posting_date: date):
+  return session.execute(
+    text(_PERIOD_COVERING_DATE),
     {"posting_date": posting_date},
   ).fetchone()
 
-  if row is not None and row.status == "closed":
-    raise ClosedPeriodError(row.name, posting_date)
+
+def assert_period_not_closed(session: Session, *posting_dates: date) -> None:
+  """Raise `ClosedPeriodError` if any fiscal period covering the given
+  dates is closed.
+
+  Takes the shared period fence on each distinct period (sorted, so two
+  writers that touch overlapping months cannot deadlock) and re-reads
+  status under that fence. Close holds the exclusive side of the same
+  fence across its QuickBooks publish and the database close, so a
+  writer cannot observe `open` and then commit after the close has
+  finished.
+
+  No-op if no `FiscalPeriod` row covers a date (e.g., fresh tenant
+  without periods seeded). The shared fence is transaction-scoped and
+  released when the caller's session commits or rolls back.
+  """
+  dates = [d for d in posting_dates if d is not None]
+  if not dates:
+    return
+
+  found: list[tuple[tuple[str, str], date]] = []
+  seen: set[tuple[str, str]] = set()
+  for posting_date in dates:
+    row = _period_covering(session, posting_date)
+    if row is None:
+      continue
+    key = (row.graph_id, row.name)
+    if key in seen:
+      continue
+    seen.add(key)
+    found.append((key, posting_date))
+
+  found.sort(key=lambda item: item[0])
+  for (graph_id, name), posting_date in found:
+    acquire_shared_period_fence(
+      session,
+      graph_id,
+      name,
+      detail=(
+        f"Period {name} is being closed or reopened by another process. "
+        "Retry in a moment."
+      ),
+    )
+    row = _period_covering(session, posting_date)
+    if row is not None and row.status == "closed":
+      raise ClosedPeriodError(row.name, posting_date)

--- a/robosystems/operations/roboledger/commands/fiscal_calendar.py
+++ b/robosystems/operations/roboledger/commands/fiscal_calendar.py
@@ -264,10 +264,14 @@ def reopen_period(
   doesn't exist, `PeriodNotClosedError` if it's not actually closed,
   or service-level `FiscalCalendarError` for calendar issues.
   """
-  # Locked, and against the same row `close_period` locks — a reopen
-  # interleaved with a close leaves a period marked closed whose statements
-  # were retracted, which is the one state the close/reopen pair must never
-  # produce.
+  # Locked: this decides from `fp.status` and then writes it, so two concurrent
+  # reopens cannot both retract the same month's statements.
+  #
+  # It does **not** serialize against `close_period`, which cannot take a
+  # transaction-scoped lock at all (its QB pre-publish commits mid-close — see
+  # that function's comment). A reopen interleaved with a close can still leave
+  # a period marked closed whose statements were retracted; closing that needs
+  # the session-scoped lock the close is waiting on.
   session.flush()
   with bounded_lock_wait(
     session,

--- a/robosystems/operations/roboledger/commands/fiscal_calendar.py
+++ b/robosystems/operations/roboledger/commands/fiscal_calendar.py
@@ -23,6 +23,7 @@ from robosystems.models.api.extensions.fiscal_calendar import (
 )
 from robosystems.models.extensions.roboledger.entry import Entry
 from robosystems.models.extensions.roboledger.fiscal_period import FiscalPeriod
+from robosystems.operations.locking import bounded_lock_wait
 from robosystems.operations.roboledger.fiscal_calendar import (
   CloseGateFailed,
   FiscalCalendarError,
@@ -263,11 +264,23 @@ def reopen_period(
   doesn't exist, `PeriodNotClosedError` if it's not actually closed,
   or service-level `FiscalCalendarError` for calendar issues.
   """
-  fp = (
-    session.query(FiscalPeriod)
-    .filter(FiscalPeriod.graph_id == graph_id, FiscalPeriod.name == period)
-    .one_or_none()
-  )
+  # Locked, and against the same row `close_period` locks — a reopen
+  # interleaved with a close leaves a period marked closed whose statements
+  # were retracted, which is the one state the close/reopen pair must never
+  # produce.
+  session.flush()
+  with bounded_lock_wait(
+    session,
+    f"Period {period} is being closed or reopened by another process. "
+    "Retry in a moment.",
+  ):
+    fp = (
+      session.query(FiscalPeriod)
+      .filter(FiscalPeriod.graph_id == graph_id, FiscalPeriod.name == period)
+      .populate_existing()
+      .with_for_update()
+      .one_or_none()
+    )
   if fp is None:
     raise PeriodNotFoundInLedgerError(period)
   if fp.status != "closed":

--- a/robosystems/operations/roboledger/commands/fiscal_calendar.py
+++ b/robosystems/operations/roboledger/commands/fiscal_calendar.py
@@ -23,11 +23,16 @@ from robosystems.models.api.extensions.fiscal_calendar import (
 )
 from robosystems.models.extensions.roboledger.entry import Entry
 from robosystems.models.extensions.roboledger.fiscal_period import FiscalPeriod
-from robosystems.operations.locking import bounded_lock_wait
+from robosystems.operations.locking import (
+  RowLockedError,
+  bounded_lock_wait,
+  exclusive_period_fence,
+)
 from robosystems.operations.roboledger.fiscal_calendar import (
   CloseGateFailed,
   FiscalCalendarError,
   FiscalCalendarService,
+  PeriodAlreadyClosedError,
   PeriodCloseService,
   PeriodNotFoundError,
   UnbalancedLedgerError,
@@ -196,23 +201,36 @@ def close_period(
   human-driven ones.
 
   Raises `CloseGateFailed`, `PeriodNotFoundError`,
+  `PeriodAlreadyClosedError`, `RowLockedError`,
   `UnbalancedLedgerError`, `FiscalCalendarError` — caller translates
   to appropriate HTTP status codes.
   """
   has_sync, last_sync_at = qb_sync_state(platform_db, graph_id)
-  result = close_service.close(
-    session,
+  # Exclusive fence spans the QB publish commit *and* this commit. A
+  # lock taken only inside `close()` would be released before the
+  # caller's commit, and a writer could sneak a draft into the month
+  # whose statements we just stamped.
+  with exclusive_period_fence(
     graph_id,
     period,
-    actor_id=actor_id,
-    actor_type=actor_type,
-    has_sync_connection=has_sync,
-    last_sync_at=last_sync_at,
-    allow_stale_sync=allow_stale_sync,
-    allow_stranded_obligations=allow_stranded_obligations,
-    note=note,
-  )
-  session.commit()
+    detail=(
+      f"Period {period} is being closed or reopened by another process. "
+      "Retry in a moment."
+    ),
+  ):
+    result = close_service.close(
+      session,
+      graph_id,
+      period,
+      actor_id=actor_id,
+      actor_type=actor_type,
+      has_sync_connection=has_sync,
+      last_sync_at=last_sync_at,
+      allow_stale_sync=allow_stale_sync,
+      allow_stranded_obligations=allow_stranded_obligations,
+      note=note,
+    )
+    session.commit()
 
   # The close's writes (entries posted, statement sets stamped) change
   # graph-materialized state, so the blue/green pipeline must rebuild —
@@ -264,68 +282,76 @@ def reopen_period(
   doesn't exist, `PeriodNotClosedError` if it's not actually closed,
   or service-level `FiscalCalendarError` for calendar issues.
   """
-  # Locked: this decides from `fp.status` and then writes it, so two concurrent
-  # reopens cannot both retract the same month's statements.
-  #
-  # It does **not** serialize against `close_period`, which cannot take a
-  # transaction-scoped lock at all (its QB pre-publish commits mid-close — see
-  # that function's comment). A reopen interleaved with a close can still leave
-  # a period marked closed whose statements were retracted; closing that needs
-  # the session-scoped lock the close is waiting on.
-  session.flush()
-  with bounded_lock_wait(
-    session,
-    f"Period {period} is being closed or reopened by another process. "
-    "Retry in a moment.",
-  ):
-    fp = (
-      session.query(FiscalPeriod)
-      .filter(FiscalPeriod.graph_id == graph_id, FiscalPeriod.name == period)
-      .populate_existing()
-      .with_for_update()
-      .one_or_none()
-    )
-  if fp is None:
-    raise PeriodNotFoundInLedgerError(period)
-  if fp.status != "closed":
-    raise PeriodNotClosedError(period, fp.status)
-
-  fp.status = "closing"
-  fp.closed_at = None
-  fp.closed_by = None
-  session.flush()
-
-  calendar = service.retreat_closed_through(
-    session,
+  # Exclusive fence first — the same one `close_period` holds across its
+  # mid-flow QuickBooks commit — then the FiscalPeriod row lock. Two
+  # concurrent reopens cannot both retract the same month's statements,
+  # and a reopen cannot interleave with a close (that used to leave a
+  # period marked closed whose statements had been retracted).
+  with exclusive_period_fence(
     graph_id,
     period,
-    reason=reason,
-    actor_id=actor_id,
-    actor_type=actor_type,
-    note=note,
-  )
-  # Re-stamp schedule facts the retreated boundary has re-opened: the reopened
-  # window's facts were tagged 'historical' at generation and must return to
-  # 'in_scope' so the roll-forward carry-in and the re-close see the movement.
-  # Function-level import — commands.schedules ↔ information_block.schedule form
-  # a module-load cycle that a top-level import here would trip.
-  from robosystems.operations.roboledger.commands.schedules import (
-    reinstate_reopened_schedule_scopes,
-  )
+    detail=(
+      f"Period {period} is being closed or reopened by another process. "
+      "Retry in a moment."
+    ),
+  ):
+    session.flush()
+    with bounded_lock_wait(
+      session,
+      f"Period {period} is being closed or reopened by another process. "
+      "Retry in a moment.",
+    ):
+      fp = (
+        session.query(FiscalPeriod)
+        .filter(FiscalPeriod.graph_id == graph_id, FiscalPeriod.name == period)
+        .populate_existing()
+        .with_for_update()
+        .one_or_none()
+      )
+    if fp is None:
+      raise PeriodNotFoundInLedgerError(period)
+    if fp.status != "closed":
+      raise PeriodNotClosedError(period, fp.status)
 
-  reinstate_reopened_schedule_scopes(session)
+    fp.status = "closing"
+    fp.closed_at = None
+    fp.closed_by = None
+    session.flush()
 
-  # Retract the reopened month's canonical statement sets. Function-level
-  # import — statement_sets pulls in information-block machinery this
-  # module otherwise never loads (same posture as the schedules import
-  # above).
-  from robosystems.operations.roboledger.reports.statement_sets import (
-    retract_canonical_statement_sets,
-  )
+    calendar = service.retreat_closed_through(
+      session,
+      graph_id,
+      period,
+      reason=reason,
+      actor_id=actor_id,
+      actor_type=actor_type,
+      note=note,
+    )
+    # Re-stamp schedule facts the retreated boundary has re-opened: the
+    # reopened window's facts were tagged 'historical' at generation and
+    # must return to 'in_scope' so the roll-forward carry-in and the
+    # re-close see the movement. Function-level import — commands.schedules
+    # ↔ information_block.schedule form a module-load cycle that a
+    # top-level import here would trip.
+    from robosystems.operations.roboledger.commands.schedules import (
+      reinstate_reopened_schedule_scopes,
+    )
 
-  ps, pe = period_date_range(period)
-  retracted = retract_canonical_statement_sets(session, period_start=ps, period_end=pe)
-  session.commit()
+    reinstate_reopened_schedule_scopes(session)
+
+    # Retract the reopened month's canonical statement sets.
+    # Function-level import — statement_sets pulls in information-block
+    # machinery this module otherwise never loads (same posture as the
+    # schedules import above).
+    from robosystems.operations.roboledger.reports.statement_sets import (
+      retract_canonical_statement_sets,
+    )
+
+    ps, pe = period_date_range(period)
+    retracted = retract_canonical_statement_sets(
+      session, period_start=ps, period_end=pe
+    )
+    session.commit()
 
   # The reopen retracts the month's canonical statement sets — graph
   # state changed; mirror close_period's marker.
@@ -499,12 +525,14 @@ def backfill_plan_history(
       )
     except (
       CloseGateFailed,
+      PeriodAlreadyClosedError,
       PeriodNotFoundError,
       UnbalancedLedgerError,
       WritebackFailed,
       StatementStampError,
       PeriodNotClosedError,
       FiscalCalendarError,
+      RowLockedError,
     ) as exc:
       session.rollback()
       processed.append(

--- a/robosystems/operations/roboledger/commands/journal_entries.py
+++ b/robosystems/operations/roboledger/commands/journal_entries.py
@@ -83,6 +83,27 @@ class JournalEntryNotDraftError(ValueError):
     self.status = status
 
 
+class JournalEntryAlreadyReversedError(ValueError):
+  """Raised when the entry already has a reversing entry against it.
+
+  Reachable without any race: a schedule with ``auto_reverse`` creates the
+  reversal at generation time and leaves the original's status untouched, so
+  the ``status == 'posted'`` check below passes on an entry that is already
+  reversed. Before `uq_entries_one_reversal_per_original` that produced a
+  second reversal — the double-post this work exists to stop; after it, the
+  insert would fail on the index. Neither is an answer a caller can act on,
+  so the state gets named here instead.
+  """
+
+  def __init__(self, entry_id: str, reversing_entry_id: str) -> None:
+    super().__init__(
+      f"Journal entry {entry_id} already has a reversing entry "
+      f"({reversing_entry_id}); an entry is reversed at most once."
+    )
+    self.entry_id = entry_id
+    self.reversing_entry_id = reversing_entry_id
+
+
 class JournalEntryNotPostedError(ValueError):
   """Raised when trying to reverse a non-posted entry.
 
@@ -486,6 +507,16 @@ def reverse_journal_entry(
     raise JournalEntryNotFoundError(body.entry_id)
   if original.status != "posted":
     raise JournalEntryNotPostedError(original.id, original.status)
+
+  # Checked under the lock, so the answer cannot go stale between here and the
+  # insert. `uq_entries_one_reversal_per_original` still backs it — this turns
+  # the constraint from the thing that reports the problem into the thing that
+  # guarantees it.
+  existing_reversal = session.execute(
+    select(Entry.id).where(Entry.reversal_of == original.id)
+  ).scalar_one_or_none()
+  if existing_reversal is not None:
+    raise JournalEntryAlreadyReversedError(str(original.id), str(existing_reversal))
 
   original_lines = _load_line_items(session, original.id)
   if not original_lines:

--- a/robosystems/operations/roboledger/commands/journal_entries.py
+++ b/robosystems/operations/roboledger/commands/journal_entries.py
@@ -52,7 +52,7 @@ from robosystems.models.api.extensions.journal_entries import (
 from robosystems.models.extensions.roboledger.entry import Entry
 from robosystems.models.extensions.roboledger.line_item import LineItem
 from robosystems.models.extensions.roboledger.transaction import Transaction
-from robosystems.operations.locking import lock_by_id
+from robosystems.operations.locking import RowLockedError, lock_by_id
 from robosystems.operations.roboledger.commands._guards import (
   assert_period_not_closed,
 )
@@ -293,6 +293,22 @@ def _load_entry_or_404(session: Session, entry_id: str) -> Entry:
   return entry
 
 
+def _raise_if_posting_date_moved(entry: Entry, peeked_date) -> None:
+  """Refuse to take a period fence after the entry row is already locked.
+
+  Fence-then-row is the documented order. Re-fencing here because the
+  posting date moved under us would invert that — a close holding the
+  new period's exclusive fence and waiting to update this entry
+  deadlocks. The caller retries, peeks the current date, and acquires
+  in the right order.
+  """
+  if entry.posting_date != peeked_date:
+    raise RowLockedError(
+      f"Journal entry {entry.id} was moved to another period by another "
+      "process. Retry in a moment."
+    )
+
+
 # ── Create ───────────────────────────────────────────────────────────────
 
 
@@ -391,7 +407,8 @@ def update_journal_entry(
     `JournalEntryNotDraftError` (422) if the entry is posted or reversed.
     `ClosedPeriodError` (422) if the existing or new `posting_date`
       falls in a closed period.
-    `RowLockedError` (409) if another writer holds the entry.
+    `RowLockedError` (409) if another writer holds the entry, or if the
+      posting date moved under us (retry so locks are acquired in order).
     `UnbalancedJournalEntryError` (422) if replacement line items don't
       balance.
   """
@@ -416,8 +433,7 @@ def update_journal_entry(
   )
   if entry is None:
     raise JournalEntryNotFoundError(body.entry_id)
-  if entry.posting_date != peeked_date:
-    assert_period_not_closed(session, entry.posting_date)
+  _raise_if_posting_date_moved(entry, peeked_date)
   if entry.status != "draft":
     raise JournalEntryNotDraftError(entry.id, entry.status)
 
@@ -476,7 +492,8 @@ def delete_journal_entry(session: Session, body: DeleteJournalEntryRequest) -> d
     `JournalEntryNotDraftError` (422) if the entry is posted or reversed.
     `ClosedPeriodError` (422) if the entry's posting_date is in a closed
       period.
-    `RowLockedError` (409) if another writer holds the entry.
+    `RowLockedError` (409) if another writer holds the entry, or if the
+      posting date moved under us (retry so locks are acquired in order).
   """
   peek = _load_entry_or_404(session, body.entry_id)
   peeked_date = peek.posting_date
@@ -491,8 +508,7 @@ def delete_journal_entry(session: Session, body: DeleteJournalEntryRequest) -> d
   )
   if entry is None:
     raise JournalEntryNotFoundError(body.entry_id)
-  if entry.posting_date != peeked_date:
-    assert_period_not_closed(session, entry.posting_date)
+  _raise_if_posting_date_moved(entry, peeked_date)
   if entry.status != "draft":
     raise JournalEntryNotDraftError(entry.id, entry.status)
 

--- a/robosystems/operations/roboledger/commands/journal_entries.py
+++ b/robosystems/operations/roboledger/commands/journal_entries.py
@@ -389,20 +389,35 @@ def update_journal_entry(
   Raises:
     `JournalEntryNotFoundError` (404) if the entry does not exist.
     `JournalEntryNotDraftError` (422) if the entry is posted or reversed.
-    `ClosedPeriodError` (422) if the new `posting_date` falls in a closed
-      period.
+    `ClosedPeriodError` (422) if the existing or new `posting_date`
+      falls in a closed period.
+    `RowLockedError` (409) if another writer holds the entry.
     `UnbalancedJournalEntryError` (422) if replacement line items don't
       balance.
   """
-  entry = _load_entry_or_404(session, body.entry_id)
-  # Fence before the draft check. Close holds the exclusive side across
-  # its bulk draft→posted update; taking the shared side first means we
-  # either wait for that close (and then refuse the now-closed period)
-  # or hold it so the close cannot finish underneath this write.
-  dates = [entry.posting_date]
+  # Peek dates, fence, then lock and refresh. An unlocked load that we
+  # then trust for `status` can mutate a posted entry: another request
+  # posts it while we wait on the fence. Capture the peeked date as a
+  # value — after `lock_by_id` the peeked instance is the same identity
+  # and `populate_existing` would make `peek.posting_date` lie.
+  peek = _load_entry_or_404(session, body.entry_id)
+  peeked_date = peek.posting_date
+  dates = [peeked_date]
   if body.posting_date is not None:
     dates.append(body.posting_date)
   assert_period_not_closed(session, *dates)
+
+  entry = lock_by_id(
+    session,
+    Entry,
+    body.entry_id,
+    f"Journal entry {body.entry_id} is being written by another process. "
+    "Retry in a moment.",
+  )
+  if entry is None:
+    raise JournalEntryNotFoundError(body.entry_id)
+  if entry.posting_date != peeked_date:
+    assert_period_not_closed(session, entry.posting_date)
   if entry.status != "draft":
     raise JournalEntryNotDraftError(entry.id, entry.status)
 
@@ -459,11 +474,25 @@ def delete_journal_entry(session: Session, body: DeleteJournalEntryRequest) -> d
   Raises:
     `JournalEntryNotFoundError` (404) if the entry does not exist.
     `JournalEntryNotDraftError` (422) if the entry is posted or reversed.
+    `ClosedPeriodError` (422) if the entry's posting_date is in a closed
+      period.
+    `RowLockedError` (409) if another writer holds the entry.
   """
-  entry = _load_entry_or_404(session, body.entry_id)
-  # Same fence as create/update: deleting a draft in a period that is
-  # being closed would drop an entry the close is about to post.
-  assert_period_not_closed(session, entry.posting_date)
+  peek = _load_entry_or_404(session, body.entry_id)
+  peeked_date = peek.posting_date
+  assert_period_not_closed(session, peeked_date)
+
+  entry = lock_by_id(
+    session,
+    Entry,
+    body.entry_id,
+    f"Journal entry {body.entry_id} is being written by another process. "
+    "Retry in a moment.",
+  )
+  if entry is None:
+    raise JournalEntryNotFoundError(body.entry_id)
+  if entry.posting_date != peeked_date:
+    assert_period_not_closed(session, entry.posting_date)
   if entry.status != "draft":
     raise JournalEntryNotDraftError(entry.id, entry.status)
 

--- a/robosystems/operations/roboledger/commands/journal_entries.py
+++ b/robosystems/operations/roboledger/commands/journal_entries.py
@@ -26,9 +26,10 @@ Design notes:
   forever — the audit trail shows original + reversal side by side.
 
 - **Closed-period gate.** Enforced via `assert_period_not_closed()` from
-  `_guards.py`. Rejects writes whose `posting_date` falls in a closed
-  fiscal period. Applied to create, update (when posting_date changes),
-  and reverse (on the reversal's posting_date).
+  `_guards.py`. That guard takes the shared period fence, so a write
+  cannot land after close has finished. Applied to create, update
+  (existing date and any new date), delete, and reverse (original and
+  reversal dates).
 """
 
 from __future__ import annotations
@@ -394,13 +395,16 @@ def update_journal_entry(
       balance.
   """
   entry = _load_entry_or_404(session, body.entry_id)
+  # Fence before the draft check. Close holds the exclusive side across
+  # its bulk draft→posted update; taking the shared side first means we
+  # either wait for that close (and then refuse the now-closed period)
+  # or hold it so the close cannot finish underneath this write.
+  dates = [entry.posting_date]
+  if body.posting_date is not None:
+    dates.append(body.posting_date)
+  assert_period_not_closed(session, *dates)
   if entry.status != "draft":
     raise JournalEntryNotDraftError(entry.id, entry.status)
-
-  # If the caller is changing posting_date, check the new date
-  # isn't in a closed period.
-  if body.posting_date is not None:
-    assert_period_not_closed(session, body.posting_date)
 
   # Scalar field updates (only mutate what the caller explicitly set).
   updates = body.model_dump(exclude_unset=True)
@@ -457,6 +461,9 @@ def delete_journal_entry(session: Session, body: DeleteJournalEntryRequest) -> d
     `JournalEntryNotDraftError` (422) if the entry is posted or reversed.
   """
   entry = _load_entry_or_404(session, body.entry_id)
+  # Same fence as create/update: deleting a draft in a period that is
+  # being closed would drop an entry the close is about to post.
+  assert_period_not_closed(session, entry.posting_date)
   if entry.status != "draft":
     raise JournalEntryNotDraftError(entry.id, entry.status)
 
@@ -489,12 +496,21 @@ def reverse_journal_entry(
     `ClosedPeriodError` (422) if the reversal's posting_date falls in
       a closed period.
   """
+  # Period fence first, then the entry row. Close takes the exclusive
+  # fence and then bulk-updates entries; a reversal that locked the
+  # entry first and the fence second would deadlock with that order.
+  peek = session.get(Entry, body.entry_id)
+  if peek is None:
+    raise JournalEntryNotFoundError(body.entry_id)
+  posting_date = body.posting_date or datetime.now(UTC).date()
+  assert_period_not_closed(session, peek.posting_date, posting_date)
+
   # Locked, because everything below decides from `original.status`. Two
   # concurrent reversals of the same entry both read 'posted', both pass the
   # guard, and both write a full reversing entry — the entry gets reversed
   # twice. Each reversing entry is internally balanced, so the trial balance
   # stays happy while the books sit a full entry off in the other direction.
-  # `ck_entries_one_reversal_per_original` is the database's half of this;
+  # `uq_entries_one_reversal_per_original` is the database's half of this;
   # the lock is what turns a would-be IntegrityError into a clean 409.
   original = lock_by_id(
     session,
@@ -521,9 +537,6 @@ def reverse_journal_entry(
   original_lines = _load_line_items(session, original.id)
   if not original_lines:
     raise ValueError(f"Journal entry {original.id} has no line items to reverse")
-
-  posting_date = body.posting_date or datetime.now(UTC).date()
-  assert_period_not_closed(session, posting_date)
   memo = body.memo or f"Reversal of journal entry {original.id}"
   now = datetime.now(UTC)
 

--- a/robosystems/operations/roboledger/commands/journal_entries.py
+++ b/robosystems/operations/roboledger/commands/journal_entries.py
@@ -51,6 +51,7 @@ from robosystems.models.api.extensions.journal_entries import (
 from robosystems.models.extensions.roboledger.entry import Entry
 from robosystems.models.extensions.roboledger.line_item import LineItem
 from robosystems.models.extensions.roboledger.transaction import Transaction
+from robosystems.operations.locking import lock_by_id
 from robosystems.operations.roboledger.commands._guards import (
   assert_period_not_closed,
 )
@@ -467,7 +468,22 @@ def reverse_journal_entry(
     `ClosedPeriodError` (422) if the reversal's posting_date falls in
       a closed period.
   """
-  original = _load_entry_or_404(session, body.entry_id)
+  # Locked, because everything below decides from `original.status`. Two
+  # concurrent reversals of the same entry both read 'posted', both pass the
+  # guard, and both write a full reversing entry — the entry gets reversed
+  # twice. Each reversing entry is internally balanced, so the trial balance
+  # stays happy while the books sit a full entry off in the other direction.
+  # `ck_entries_one_reversal_per_original` is the database's half of this;
+  # the lock is what turns a would-be IntegrityError into a clean 409.
+  original = lock_by_id(
+    session,
+    Entry,
+    body.entry_id,
+    f"Journal entry {body.entry_id} is being written by another process. "
+    "Retry in a moment.",
+  )
+  if original is None:
+    raise JournalEntryNotFoundError(body.entry_id)
   if original.status != "posted":
     raise JournalEntryNotPostedError(original.id, original.status)
 

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -506,11 +506,11 @@ def regenerate_report(
       — restate instead of regenerating.
     ValueError: if period_end < period_start in the new body.
   """
-  # Locked: the two guards below decide from `filing_status` and
-  # `generation_status`, then write the first. Lower stakes than the ledger
-  # transitions — a concurrent double-file overwrites the audit stamp rather
-  # than duplicating anything — but "who filed this, and when" is exactly the
-  # field an auditor reads, so last-writer-wins is not good enough for it.
+  # Locked: the guard below decides from `filing_status` — filed and archived
+  # reports are immutable — and the regeneration then rewrites the report's
+  # facts. Unlocked, a file landing between that check and the rewrite gets a
+  # report stamped `filed` whose contents were replaced underneath it, which
+  # is the state the immutability check exists to prevent.
   from robosystems.operations.locking import lock_by_id
 
   report_def = lock_by_id(
@@ -665,13 +665,24 @@ def file_report(session: Session, report_id: str, filed_by: str) -> ReportRespon
   """
   from datetime import UTC, datetime
 
+  # Locked: the two guards below decide from `filing_status` and
+  # `generation_status`, then write the first. Lower stakes than the ledger
+  # transitions — a concurrent double-file overwrites the audit stamp rather
+  # than duplicating anything — but "who filed this, and when" is exactly the
+  # field an auditor reads, so last-writer-wins is not good enough for it.
+  from robosystems.operations.locking import lock_by_id
   from robosystems.operations.roboledger.reads.reports import (
     load_structures,
     report_to_response,
     resolve_entity_name,
   )
 
-  report_def = session.get(Report, report_id)
+  report_def = lock_by_id(
+    session,
+    Report,
+    report_id,
+    f"Report {report_id} is being written by another process. Retry in a moment.",
+  )
   if report_def is None:
     raise ReportNotFoundError(report_id)
 

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -506,7 +506,19 @@ def regenerate_report(
       — restate instead of regenerating.
     ValueError: if period_end < period_start in the new body.
   """
-  report_def = session.get(Report, report_id)
+  # Locked: the two guards below decide from `filing_status` and
+  # `generation_status`, then write the first. Lower stakes than the ledger
+  # transitions — a concurrent double-file overwrites the audit stamp rather
+  # than duplicating anything — but "who filed this, and when" is exactly the
+  # field an auditor reads, so last-writer-wins is not good enough for it.
+  from robosystems.operations.locking import lock_by_id
+
+  report_def = lock_by_id(
+    session,
+    Report,
+    report_id,
+    f"Report {report_id} is being written by another process. Retry in a moment.",
+  )
   if report_def is None:
     raise ReportNotFoundError(report_id)
   if report_def.created_by != acting_user_id:

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -721,13 +721,22 @@ def transition_filing_status(
   Other transitions (submit for review, withdraw, archive) are routed
   through here so the legal-transition graph stays in one place.
   """
+  # Locked with the rest of the report lifecycle. Unlocked, this reads a status,
+  # waits behind a concurrent file, and then writes its own over the top —
+  # leaving `filed_at` and `filed_by` populated on a report back in `draft`.
+  from robosystems.operations.locking import lock_by_id
   from robosystems.operations.roboledger.reads.reports import (
     load_structures,
     report_to_response,
     resolve_entity_name,
   )
 
-  report_def = session.get(Report, report_id)
+  report_def = lock_by_id(
+    session,
+    Report,
+    report_id,
+    f"Report {report_id} is being written by another process. Retry in a moment.",
+  )
   if report_def is None:
     raise ReportNotFoundError(report_id)
 
@@ -779,7 +788,17 @@ def delete_report(
   Revoke each recipient first. Shared *copies* are unaffected: the recipient's
   schema holds no share rows for a report they did not send.
   """
-  report_def = session.get(Report, report_id)
+  # Locked with the rest of the report lifecycle: the filed-report immutability
+  # guard below decides from `filing_status`, so unlocked a delete can pass it
+  # and then remove a report that was filed in between.
+  from robosystems.operations.locking import lock_by_id
+
+  report_def = lock_by_id(
+    session,
+    Report,
+    report_id,
+    f"Report {report_id} is being written by another process. Retry in a moment.",
+  )
   if report_def is None:
     return False
   if report_def.created_by != acting_user_id:

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -265,8 +265,8 @@ def promote_obligations(
   sweep is idempotent (re-running skips already-classified rows and
   reconciles to existing drafts).
   """
-  from robosystems.operations.event_block.locking import bounded_lock_wait
   from robosystems.operations.event_block.promotion import promote_pending_obligations
+  from robosystems.operations.locking import bounded_lock_wait
 
   # Request-facing, so the wait is bounded: the sweep locks its whole candidate
   # set, and the Dagster sensor runs the same function every few minutes. An
@@ -390,7 +390,7 @@ def update_schedule(
   # impossible: either the new template + new pending events both land,
   # or neither does.
   if template_changed:
-    from robosystems.operations.event_block.locking import (
+    from robosystems.operations.locking import (
       bounded_lock_wait as _bounded_lock_wait,
     )
 

--- a/robosystems/operations/roboledger/fiscal_calendar/__init__.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/__init__.py
@@ -6,6 +6,7 @@ closed, which is the next target, what's required to close the next one.
 
 from .close_service import (
   CloseGateFailed,
+  PeriodAlreadyClosedError,
   PeriodCloseError,
   PeriodCloseResult,
   PeriodCloseService,
@@ -33,6 +34,7 @@ __all__ = [
   "CloseableGateResult",
   "FiscalCalendarError",
   "FiscalCalendarService",
+  "PeriodAlreadyClosedError",
   "PeriodCloseError",
   "PeriodCloseResult",
   "PeriodCloseService",

--- a/robosystems/operations/roboledger/fiscal_calendar/close_service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_service.py
@@ -23,6 +23,7 @@ from robosystems.logger import logger
 from robosystems.models.extensions.roboledger.entry import Entry
 from robosystems.models.extensions.roboledger.fiscal_calendar import FiscalCalendar
 from robosystems.models.extensions.roboledger.fiscal_period import FiscalPeriod
+from robosystems.operations.locking import bounded_lock_wait
 
 from .periods import period_date_range
 from .service import (
@@ -69,6 +70,20 @@ class PeriodNotFoundError(PeriodCloseError):
 
   def __init__(self, period: str):
     super().__init__(f"Fiscal period {period!r} not found.")
+    self.period = period
+
+
+class PeriodAlreadyClosedError(PeriodCloseError):
+  """Raised when the period is already closed at the post-publish revalidation.
+
+  The exclusive period fence is supposed to stop a second closer before
+  this, but the database close still re-locks the FiscalPeriod row after
+  the QuickBooks commit and refuses `status='closed'`. Without that
+  check a closer that skipped the fence would stamp again.
+  """
+
+  def __init__(self, period: str):
+    super().__init__(f"Fiscal period {period!r} is already closed.")
     self.period = period
 
 
@@ -250,37 +265,34 @@ class PeriodCloseService:
       session, graph_id, period_start, period_end, actor_id=actor_id
     )
 
-    # Find the FiscalPeriod row before mutating anything so we can detect
-    # the re-close path (status='closing' means a prior reopen).
+    # The exclusive period fence (taken by `close_period` / `reopen_period`
+    # around this call and their commit) is what serializes the whole
+    # operation, including the QB publish above. That fence is
+    # session-scoped on a dedicated connection because the publish
+    # **commits** — a FOR UPDATE taken before it would be released.
     #
-    # NOT locked, deliberately, and this is a known gap rather than an
-    # oversight. A row lock taken here would protect nothing: the QB
-    # pre-publish above **commits** (its durability boundary — the
-    # qb_external_id markers must survive a later failure), and a
-    # transaction-scoped lock cannot span a commit. Taking it earlier fails
-    # the same way, because that commit would release it.
-    #
-    # Two concurrent closes can therefore both pass the gate and both publish,
-    # and the loser then finds status='closed', which `is_reclose` does not
-    # reject — it proceeds as a normal close and stamps again. Closing that
-    # needs a lock whose lifetime is the session rather than the transaction
-    # (`pg_advisory_lock`, not `pg_advisory_xact_lock`) or a persisted
-    # close-intent row, which is a change to the close's concurrency model and
-    # belongs in its own change.
-    #
-    # The second half of that change, easy to miss: every period-affecting
-    # writer must take the same lock. `assert_period_not_closed`
-    # (`commands/_guards.py`) is a plain read, so a writer can observe `open`,
-    # pause, and commit after the close has finished — leaving a draft, or an
-    # edited posted entry, inside a period whose statements are already
-    # stamped. Locking the close alone would not fix that.
-    fp = (
-      session.query(FiscalPeriod)
-      .filter(FiscalPeriod.graph_id == graph_id, FiscalPeriod.name == period)
-      .one_or_none()
-    )
+    # The row lock here is the second half: it serializes the database
+    # close against anyone who skipped the fence, and it revalidates
+    # status so a loser cannot treat `closed` as a normal first-close
+    # and stamp again. Writers participate via the shared side of the
+    # same fence in `assert_period_not_closed`.
+    session.flush()
+    with bounded_lock_wait(
+      session,
+      f"Period {period} is being closed or reopened by another process. "
+      "Retry in a moment.",
+    ):
+      fp = (
+        session.query(FiscalPeriod)
+        .filter(FiscalPeriod.graph_id == graph_id, FiscalPeriod.name == period)
+        .populate_existing()
+        .with_for_update()
+        .one_or_none()
+      )
     if fp is None:
       raise PeriodNotFoundError(period)
+    if fp.status == "closed":
+      raise PeriodAlreadyClosedError(period)
     is_reclose = fp.status == "closing"
 
     # 3. Draft → posted. The pre-publish step already promoted every
@@ -738,6 +750,7 @@ class PeriodCloseService:
 
 __all__ = [
   "CloseGateFailed",
+  "PeriodAlreadyClosedError",
   "PeriodCloseError",
   "PeriodCloseResult",
   "PeriodCloseService",

--- a/robosystems/operations/roboledger/fiscal_calendar/close_service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_service.py
@@ -266,7 +266,14 @@ class PeriodCloseService:
     # needs a lock whose lifetime is the session rather than the transaction
     # (`pg_advisory_lock`, not `pg_advisory_xact_lock`) or a persisted
     # close-intent row, which is a change to the close's concurrency model and
-    # belongs in its own change. See `specs/ledger/event-write-isolation.md` §5.
+    # belongs in its own change.
+    #
+    # The second half of that change, easy to miss: every period-affecting
+    # writer must take the same lock. `assert_period_not_closed`
+    # (`commands/_guards.py`) is a plain read, so a writer can observe `open`,
+    # pause, and commit after the close has finished — leaving a draft, or an
+    # edited posted entry, inside a period whose statements are already
+    # stamped. Locking the close alone would not fix that.
     fp = (
       session.query(FiscalPeriod)
       .filter(FiscalPeriod.graph_id == graph_id, FiscalPeriod.name == period)
@@ -540,14 +547,25 @@ class PeriodCloseService:
     failed_events: list[dict] = []
     for entry, event in drafts_to_publish:
       try:
-        result = execute_event_block(
-          session,
-          ExecuteEventBlockRequest(
-            event_id=str(event.id),
-            connection_id=qb_connection_id,
-          ),
-          created_by=actor_id,
-        )
+        # Each publish gets its own SAVEPOINT. Without one, a *database* error
+        # here — `execute_event_block` bounds its lock wait, so a timeout
+        # surfaces as RowLockedError over an aborted transaction — poisons the
+        # whole transaction. The loop would carry on collecting failures, every
+        # later statement would fail on the aborted transaction, and the
+        # `session.commit()` below would take the qb_external_id markers for
+        # entries that DID reach QuickBooks down with it. QuickBooks would hold
+        # journal entries the ledger has no record of sending, and the retried
+        # close would publish them again once QB's RequestId window expired —
+        # the precise duplication this function's commit exists to prevent.
+        with session.begin_nested():
+          result = execute_event_block(
+            session,
+            ExecuteEventBlockRequest(
+              event_id=str(event.id),
+              connection_id=qb_connection_id,
+            ),
+            created_by=actor_id,
+          )
         if result.status == "pending":
           # QB rejected — collect for the batch error.
           failed_events.append(

--- a/robosystems/operations/roboledger/fiscal_calendar/close_service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_service.py
@@ -23,6 +23,7 @@ from robosystems.logger import logger
 from robosystems.models.extensions.roboledger.entry import Entry
 from robosystems.models.extensions.roboledger.fiscal_calendar import FiscalCalendar
 from robosystems.models.extensions.roboledger.fiscal_period import FiscalPeriod
+from robosystems.operations.locking import bounded_lock_wait
 
 from .periods import period_date_range
 from .service import (
@@ -252,11 +253,26 @@ class PeriodCloseService:
 
     # Find the FiscalPeriod row before mutating anything so we can detect
     # the re-close path (status='closing' means a prior reopen).
-    fp = (
-      session.query(FiscalPeriod)
-      .filter(FiscalPeriod.graph_id == graph_id, FiscalPeriod.name == period)
-      .one_or_none()
-    )
+    # Locked. Everything from here decides from `fp.status` — the re-close
+    # branch, the draft promotion, the QB pre-publish, the statement stamping —
+    # and then writes it. Two concurrent closes of the same period would each
+    # read it as closeable and each run the whole close, publishing to
+    # QuickBooks and stamping statements twice. Some of that is accidentally
+    # idempotent (QB's request_id dedup, replace-semantics on stamping); none
+    # of it is a guard.
+    session.flush()
+    with bounded_lock_wait(
+      session,
+      f"Period {period} is being closed or reopened by another process. "
+      "Retry in a moment.",
+    ):
+      fp = (
+        session.query(FiscalPeriod)
+        .filter(FiscalPeriod.graph_id == graph_id, FiscalPeriod.name == period)
+        .populate_existing()
+        .with_for_update()
+        .one_or_none()
+      )
     if fp is None:
       raise PeriodNotFoundError(period)
     is_reclose = fp.status == "closing"

--- a/robosystems/operations/roboledger/fiscal_calendar/close_service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_service.py
@@ -23,7 +23,6 @@ from robosystems.logger import logger
 from robosystems.models.extensions.roboledger.entry import Entry
 from robosystems.models.extensions.roboledger.fiscal_calendar import FiscalCalendar
 from robosystems.models.extensions.roboledger.fiscal_period import FiscalPeriod
-from robosystems.operations.locking import bounded_lock_wait
 
 from .periods import period_date_range
 from .service import (
@@ -253,26 +252,26 @@ class PeriodCloseService:
 
     # Find the FiscalPeriod row before mutating anything so we can detect
     # the re-close path (status='closing' means a prior reopen).
-    # Locked. Everything from here decides from `fp.status` — the re-close
-    # branch, the draft promotion, the QB pre-publish, the statement stamping —
-    # and then writes it. Two concurrent closes of the same period would each
-    # read it as closeable and each run the whole close, publishing to
-    # QuickBooks and stamping statements twice. Some of that is accidentally
-    # idempotent (QB's request_id dedup, replace-semantics on stamping); none
-    # of it is a guard.
-    session.flush()
-    with bounded_lock_wait(
-      session,
-      f"Period {period} is being closed or reopened by another process. "
-      "Retry in a moment.",
-    ):
-      fp = (
-        session.query(FiscalPeriod)
-        .filter(FiscalPeriod.graph_id == graph_id, FiscalPeriod.name == period)
-        .populate_existing()
-        .with_for_update()
-        .one_or_none()
-      )
+    #
+    # NOT locked, deliberately, and this is a known gap rather than an
+    # oversight. A row lock taken here would protect nothing: the QB
+    # pre-publish above **commits** (its durability boundary — the
+    # qb_external_id markers must survive a later failure), and a
+    # transaction-scoped lock cannot span a commit. Taking it earlier fails
+    # the same way, because that commit would release it.
+    #
+    # Two concurrent closes can therefore both pass the gate and both publish,
+    # and the loser then finds status='closed', which `is_reclose` does not
+    # reject — it proceeds as a normal close and stamps again. Closing that
+    # needs a lock whose lifetime is the session rather than the transaction
+    # (`pg_advisory_lock`, not `pg_advisory_xact_lock`) or a persisted
+    # close-intent row, which is a change to the close's concurrency model and
+    # belongs in its own change. See `specs/ledger/event-write-isolation.md` §5.
+    fp = (
+      session.query(FiscalPeriod)
+      .filter(FiscalPeriod.graph_id == graph_id, FiscalPeriod.name == period)
+      .one_or_none()
+    )
     if fp is None:
       raise PeriodNotFoundError(period)
     is_reclose = fp.status == "closing"

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -928,7 +928,7 @@ class ScheduleService:
     if not schedule_created_event_id:
       return 0
 
-    from robosystems.operations.event_block.locking import ordered_lock_column
+    from robosystems.operations.locking import ordered_lock_column
 
     # Locked: this reads `pending` obligations and voids them, and the
     # promotion sweep reads the same rows to classify and draft their closing

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -34,6 +34,9 @@ from robosystems.models.extensions.roboledger import (
 )
 from robosystems.models.extensions.rule import Rule
 from robosystems.models.extensions.trait import Trait
+from robosystems.operations.roboledger.commands._guards import (
+  assert_period_not_closed,
+)
 from robosystems.operations.roboledger.fact_set import create_fact_set
 from robosystems.utils.ulid import generate_prefixed_ulid
 
@@ -1154,6 +1157,17 @@ class ScheduleService:
     debit_element_id = template["debit_element_id"]
     credit_element_id = template["credit_element_id"]
 
+    # Same fence the journal writers take. A schedule draft created after
+    # close has selected its batch is either omitted from QB publish or
+    # swept into posted without review; both are wrong.
+    fence_dates = [posting_date]
+    if template.get("auto_reverse", False):
+      if period_end.month == 12:
+        fence_dates.append(date(period_end.year + 1, 1, 1))
+      else:
+        fence_dates.append(date(period_end.year, period_end.month + 1, 1))
+    assert_period_not_closed(session, *fence_dates)
+
     # ── Look up the existing entry (if any) for this structure + period ──
     existing_row = session.execute(
       text("""
@@ -1678,33 +1692,12 @@ class ScheduleService:
     }
 
   def _assert_period_not_closed(self, session: Session, posting_date: date) -> None:
-    """Raise ValueError if a FiscalPeriod containing `posting_date` is closed.
+    """Raise ClosedPeriodError if a FiscalPeriod containing `posting_date` is closed.
 
-    Used to prevent manual entries from being drafted into closed periods —
-    such drafts would be orphaned because close-period refuses to re-close a
-    closed month. If an adjustment is needed in a closed period, the user
-    must explicitly reopen the period first.
-
-    If no FiscalPeriod row covers the posting_date (e.g., demo or fresh
-    tenant without period rows seeded), this is a no-op: the caller's free
-    to create the entry and the period-state machine will handle it later.
+    Delegates to the shared guard so schedule-derived writes take the same
+    period fence as journal-entry commands and close.
     """
-    row = session.execute(
-      text("""
-        SELECT name, status
-        FROM fiscal_periods
-        WHERE start_date <= :posting_date AND end_date >= :posting_date
-        LIMIT 1
-      """),
-      {"posting_date": posting_date},
-    ).fetchone()
-
-    if row is not None and row.status == "closed":
-      raise ValueError(
-        f"Cannot draft manual entry in closed period {row.name!r} "
-        f"(posting_date={posting_date}). "
-        "Reopen the period first if the adjustment is needed there."
-      )
+    assert_period_not_closed(session, posting_date)
 
   def _delete_draft_entry(self, session: Session, entry_id: str) -> None:
     """Delete an entry and its line items (must be status='draft')."""

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -200,7 +200,6 @@ from robosystems.models.api.taxonomy_block import (
 from robosystems.models.core import User
 from robosystems.operations.event_block import (
   DuplicateEventError,
-  EventLockedError,
   EventNotFoundError,
   InvalidEventTransitionError,
 )
@@ -255,6 +254,7 @@ from robosystems.operations.information_block.metrics import (
 from robosystems.operations.information_block.rules.commands import (
   cmd_evaluate_rules,
 )
+from robosystems.operations.locking import RowLockedError
 from robosystems.operations.roboledger.commands._guards import (
   ClosedPeriodError,
   LibraryImmutableError,
@@ -1258,7 +1258,7 @@ update_information_block_op = _registrar.register(
       ScheduleNotFoundError: 404,
       # A schedule template change supersedes its pending obligations, which
       # the promotion sweep may be holding. Retryable.
-      EventLockedError: 409,
+      RowLockedError: 409,
     },
     mark_stale_reason="information_block_updated",
   )
@@ -1571,7 +1571,7 @@ update_event_block_op = _registrar.register(
       UnbalancedJournalEntryError: 422,
       # A running sync holds the event's row lock. Retryable, and the only
       # error here the caller should try again rather than fix.
-      EventLockedError: 409,
+      RowLockedError: 409,
     },
     mark_stale_reason="event_block_updated",
   )
@@ -1613,7 +1613,7 @@ execute_event_block_op = _registrar.register(
       QBAuthFailedError: 401,
       # Another writer holds the event's row lock. Retryable, and the publish
       # deliberately did not reach QuickBooks.
-      EventLockedError: 409,
+      RowLockedError: 409,
       ValueError: 422,
     },
     mark_stale_reason="event_published",
@@ -1769,7 +1769,7 @@ promote_obligations_op = _registrar.register(
     result_type=PromoteObligationsResponse,
     # The background sweep holds the candidate set's row locks. Retryable,
     # same as the approval path's conflict.
-    error_map={ValueError: 422, EventLockedError: 409},
+    error_map={ValueError: 422, RowLockedError: 409},
     mark_stale_reason="obligations_promoted",
   )
 )

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -431,6 +431,7 @@ from robosystems.operations.roboledger.fiscal_calendar import (
   CloseGateFailed,
   FiscalCalendarError,
   FiscalCalendarService,
+  PeriodAlreadyClosedError,
   PeriodNotFoundError,
   UnbalancedLedgerError,
   parse_period,
@@ -2001,6 +2002,10 @@ async def close_period_op(
       raise HTTPException(status_code=422, detail=detail)
     except PeriodNotFoundError as e:
       raise HTTPException(status_code=404, detail=str(e))
+    except PeriodAlreadyClosedError as e:
+      raise HTTPException(status_code=409, detail=str(e))
+    except RowLockedError as e:
+      raise HTTPException(status_code=409, detail=str(e))
     except UnbalancedLedgerError as e:
       raise HTTPException(
         status_code=422,
@@ -2396,6 +2401,8 @@ async def delete_report_op(
           raise HTTPException(status_code=409, detail=str(e))
         except ReportNotFiledError as e:
           raise HTTPException(status_code=422, detail=str(e))
+        except RowLockedError as e:
+          raise HTTPException(status_code=409, detail=str(e))
     except (ValueError, ProgrammingError):
       raise _ledger_404()
     if not deleted:
@@ -2667,6 +2674,8 @@ async def transition_filing_status_op(
           )
         except InvalidFilingTransitionError as e:
           raise HTTPException(status_code=422, detail=str(e))
+        except RowLockedError as e:
+          raise HTTPException(status_code=409, detail=str(e))
     except (ValueError, ProgrammingError):
       raise _ledger_404()
 

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -312,6 +312,7 @@ from robosystems.operations.roboledger.commands.fiscal_calendar import (
   set_close_target as cmd_set_close_target,
 )
 from robosystems.operations.roboledger.commands.journal_entries import (
+  JournalEntryAlreadyReversedError,
   JournalEntryNotDraftError,
   JournalEntryNotFoundError,
   JournalEntryNotPostedError,
@@ -1529,6 +1530,12 @@ create_event_block_op = _registrar.register(
       TemplateInterpolationError: 422,
       EngineValidationError: 422,
       HandlerMetadataValidationError: 422,
+      # Handlers reach locked rows — `journal_entry_reversed` locks the entry
+      # it reverses. Retryable, like every other lock conflict.
+      RowLockedError: 409,
+      # An entry is reversed at most once; a second attempt is a fixable
+      # request, not a retryable conflict.
+      JournalEntryAlreadyReversedError: 422,
       DisposalScheduleNotFoundError: 404,
       JournalEntryNotFoundError: 404,
       JournalEntryNotPostedError: 422,
@@ -2096,6 +2103,10 @@ async def reopen_period_op(
           note=body.note,
           service=_fiscal_svc,
         ).fiscal_calendar
+    except RowLockedError as e:
+      # A concurrent writer holds the rows this needs. Retryable, and the
+      # same 409 the registrar-driven operations return.
+      raise HTTPException(status_code=409, detail=str(e))
     except PeriodNotFoundInLedgerError:
       raise HTTPException(
         status_code=404, detail=f"Fiscal period {body.period!r} not found."
@@ -2290,6 +2301,10 @@ async def regenerate_report_op(
           return cmd_regenerate_report(
             session, graph_id, body.report_id, body, acting_user_id=str(user.id)
           )
+        except RowLockedError as e:
+          # A concurrent writer holds the rows this needs. Retryable, and the
+          # same 409 the registrar-driven operations return.
+          raise HTTPException(status_code=409, detail=str(e))
         except ReportNotFoundError:
           raise HTTPException(
             status_code=404, detail=f"Report '{body.report_id}' not found."

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -1725,6 +1725,7 @@ update_journal_entry_op = _registrar.register(
       JournalEntryNotFoundError: 404,
       JournalEntryNotDraftError: 422,
       ClosedPeriodError: 422,
+      RowLockedError: 409,
       UnbalancedJournalEntryError: 422,
       ValueError: 422,
     },
@@ -1747,6 +1748,8 @@ delete_journal_entry_op = _registrar.register(
     error_map={
       JournalEntryNotFoundError: 404,
       JournalEntryNotDraftError: 422,
+      ClosedPeriodError: 422,
+      RowLockedError: 409,
     },
     requires_created_by=False,
     mark_stale_reason="journal_entry_deleted",

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -1576,6 +1576,11 @@ update_event_block_op = _registrar.register(
       ElementResolutionError: 422,
       ClosedPeriodError: 422,
       UnbalancedJournalEntryError: 422,
+      # Approving a captured reversal fires the same handler create does, so
+      # this reaches the already-reversed guard too. Registered explicitly
+      # because it subclasses ValueError and would otherwise fall through to
+      # the generic handler and be reported as a 404.
+      JournalEntryAlreadyReversedError: 422,
       # A running sync holds the event's row lock. Retryable, and the only
       # error here the caller should try again rather than fix.
       RowLockedError: 409,
@@ -2179,6 +2184,9 @@ async def backfill_plan_history_op(
           service=_fiscal_svc,
           close_service=_close_svc,
         )
+    except RowLockedError as e:
+      # The internal reopen locks the period; another writer may hold it.
+      raise HTTPException(status_code=409, detail=str(e))
     except BackfillPreconditionError as e:
       raise HTTPException(
         status_code=422,
@@ -2596,6 +2604,10 @@ async def file_report_op(
       with extensions_session(graph_id) as session:
         try:
           return cmd_file_report(session, body.report_id, filed_by=str(user.id))
+        except RowLockedError as e:
+          # Another lifecycle write holds the report. Retryable, same 409 the
+          # registrar-driven operations return.
+          raise HTTPException(status_code=409, detail=str(e))
         except ReportNotFoundError:
           raise HTTPException(
             status_code=404, detail=f"Report '{body.report_id}' not found."

--- a/tests/middleware/mcp/tools/test_fiscal_calendar_tools.py
+++ b/tests/middleware/mcp/tools/test_fiscal_calendar_tools.py
@@ -350,6 +350,24 @@ class TestClosePeriodToolErrors:
     assert "1000" in result["message"]
     assert "900" in result["message"]
 
+  @pytest.mark.asyncio
+  async def test_already_closed_error(self):
+    from robosystems.operations.roboledger.fiscal_calendar import (
+      PeriodAlreadyClosedError,
+    )
+
+    result = await self._run_with_side_effect(PeriodAlreadyClosedError("2026-03"))
+    assert result["error"] == "already_closed"
+
+  @pytest.mark.asyncio
+  async def test_row_locked_error(self):
+    from robosystems.operations.locking import RowLockedError
+
+    result = await self._run_with_side_effect(
+      RowLockedError("Period 2026-03 is being closed")
+    )
+    assert result["error"] == "row_locked"
+
 
 class TestStatementStampErrorTranslation:
   @pytest.mark.asyncio

--- a/tests/operations/event_block/python_handlers/test_journal_entry_reversed.py
+++ b/tests/operations/event_block/python_handlers/test_journal_entry_reversed.py
@@ -113,6 +113,9 @@ class TestDispatchPreview:
       _line(element_id="elem_cash", debit=10000, credit=0, order=1),
       _line(element_id="elem_revenue", debit=0, credit=10000, order=2),
     ]
+    # Preview now makes the same already-reversed check the command does, so
+    # `execute` serves that lookup before the line-item read.
+    session.execute.return_value.scalar_one_or_none.return_value = None
     session.execute.return_value.scalars.return_value.all.return_value = line_items
 
     with patch(
@@ -187,3 +190,46 @@ def _line(element_id: str, debit: int, credit: int, order: int):
   li.credit_amount = credit
   li.line_order = order
   return li
+
+
+class TestPreviewAgreesWithExecution:
+  """Preview and the command must reach the same verdict.
+
+  A schedule with `auto_reverse` creates the reversal at generation time and
+  leaves the original `posted`, so a status-only preview promises a reversal
+  the command then refuses with `JournalEntryAlreadyReversedError`. A preview
+  that disagrees with execution is worse than no preview — an operator acts on
+  it.
+  """
+
+  def test_preview_refuses_an_already_reversed_entry(self) -> None:
+    from unittest.mock import MagicMock
+
+    from robosystems.models.api.event_block import CreateEventBlockRequest
+    from robosystems.operations.event_block.python_handlers.journal_entry_reversed import (
+      JournalEntryReversedMetadata,
+      dispatch_preview,
+    )
+
+    original = MagicMock()
+    original.id = "je_original"
+    original.status = "posted"  # untouched by the auto-reversal
+
+    session = MagicMock()
+    session.get.return_value = original
+    session.execute.return_value.scalar_one_or_none.return_value = "je_auto_rev"
+
+    body = CreateEventBlockRequest(
+      event_type="journal_entry_reversed",
+      event_category="adjustment",
+      event_class="economic",
+      occurred_at=datetime(2026, 2, 1, tzinfo=UTC),
+      source="manual",
+      metadata={},
+    )
+    metadata = JournalEntryReversedMetadata(entry_id="je_original")
+
+    preview = dispatch_preview(session, body, metadata)
+
+    assert preview.would_succeed is False
+    assert any("already has a reversing entry" in e for e in preview.validation_errors)

--- a/tests/operations/event_block/test_commands_python_handler.py
+++ b/tests/operations/event_block/test_commands_python_handler.py
@@ -351,6 +351,35 @@ class TestDslHandlerResolution:
     assert resp.would_succeed is True
     assert resp.matched_handler is not None
 
+  def test_dsl_preview_refuses_a_closed_period(self) -> None:
+    from robosystems.operations.roboledger.commands._guards import ClosedPeriodError
+
+    session = MagicMock()
+    session.get.return_value = MagicMock(agent_type="vendor")
+    body = _make_body(
+      event_type="invoice_issued",
+      event_category="purchase",
+      metadata={},
+      agent_id="agt_vendor",
+    )
+    with (
+      patch(
+        "robosystems.operations.event_block.commands.get_python_handler",
+        return_value=None,
+      ),
+      patch(
+        "robosystems.operations.event_block.commands.resolve_handler",
+        return_value=self._handler(),
+      ),
+      patch(
+        "robosystems.operations.event_block.commands.assert_period_not_closed",
+        side_effect=ClosedPeriodError("2026-03", body.occurred_at.date()),
+      ),
+    ):
+      resp = preview_event_block(session, body, created_by="usr_test")
+    assert resp.would_succeed is False
+    assert any("closed period" in e for e in resp.validation_errors)
+
 
 class TestCreateDualityFields:
   """Stream 1 of event-driven-ledger: create-side flow-through of REA fields."""

--- a/tests/operations/event_block/test_commands_update.py
+++ b/tests/operations/event_block/test_commands_update.py
@@ -16,7 +16,7 @@ from robosystems.operations.event_block.commands import (
   InvalidEventTransitionError,
   update_event_block,
 )
-from robosystems.operations.event_block.locking import EventLockedError
+from robosystems.operations.locking import RowLockedError
 
 
 def _event(event_id: str, status: str = "classified") -> SimpleNamespace:
@@ -393,7 +393,7 @@ class TestTransitionRowLock:
 
     locked_q = session.query.return_value.filter.return_value
     locked_q.with_for_update.assert_called()
-    from robosystems.operations.event_block.locking import ordered_lock_column
+    from robosystems.operations.locking import ordered_lock_column
 
     ordered = [a for c in locked_q.order_by.call_args_list for a in c.args]
     assert len(ordered) == 1
@@ -426,7 +426,7 @@ class TestLockContention:
     )
 
     body = UpdateEventBlockRequest(event_id="evt_a", transition_to="committed")
-    with pytest.raises(EventLockedError, match="evt_a"):
+    with pytest.raises(RowLockedError, match="evt_a"):
       update_event_block(session, body, created_by="usr_test")
 
     session.commit.assert_not_called()
@@ -443,7 +443,7 @@ class TestLockContention:
     )
 
     body = UpdateEventBlockRequest(event_id="evt_a", transition_to="committed")
-    with pytest.raises(EventLockedError, match="evt_a"):
+    with pytest.raises(RowLockedError, match="evt_a"):
       update_event_block(session, body, created_by="usr_test")
 
     session.commit.assert_not_called()

--- a/tests/operations/event_block/test_engine.py
+++ b/tests/operations/event_block/test_engine.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
-from unittest.mock import MagicMock
+from datetime import UTC, date, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from robosystems.models.extensions.roboledger.entry import (
   ENTRY_PROVENANCE_VALUES,
@@ -12,7 +14,11 @@ from robosystems.models.extensions.roboledger.entry import (
 from robosystems.models.extensions.roboledger.event import Event
 from robosystems.models.extensions.roboledger.event_handler import EventHandler
 from robosystems.models.extensions.roboledger.transaction import Transaction
-from robosystems.operations.event_block.engine import apply_handler
+from robosystems.operations.event_block.engine import (
+  apply_handler,
+  posting_date_for_event,
+)
+from robosystems.operations.roboledger.commands._guards import ClosedPeriodError
 
 
 def test_apply_handler_links_entry_and_transaction_to_originating_event() -> None:
@@ -67,3 +73,43 @@ def test_apply_handler_links_entry_and_transaction_to_originating_event() -> Non
   # so it never hit the constraint; assert the invariant explicitly instead.
   assert entry.provenance == "event_handler"
   assert entry.provenance in ENTRY_PROVENANCE_VALUES
+
+
+def test_posting_date_prefers_effective_at() -> None:
+  effective = datetime(2026, 1, 31, tzinfo=UTC)
+  occurred = datetime(2026, 2, 15, tzinfo=UTC)
+  assert posting_date_for_event(effective_at=effective, occurred_at=occurred) == date(
+    2026, 1, 31
+  )
+
+
+def test_apply_handler_refuses_a_closed_period() -> None:
+  session = MagicMock()
+  event = Event(
+    id="evt_invoice",
+    event_type="invoice_issued",
+    event_category="sales",
+    occurred_at=datetime(2026, 4, 1, tzinfo=UTC),
+    source="native",
+    amount=12500,
+    created_by="usr_test",
+  )
+  handler = EventHandler(
+    id="hdl_invoice",
+    name="Invoice Handler",
+    event_type="invoice_issued",
+    transaction_template={"transactions": []},
+    priority=10,
+    is_active=True,
+    origin="tenant",
+    created_by="usr_test",
+  )
+  with (
+    patch(
+      "robosystems.operations.event_block.engine.assert_period_not_closed",
+      side_effect=ClosedPeriodError("2026-04", date(2026, 4, 1)),
+    ),
+    pytest.raises(ClosedPeriodError),
+  ):
+    apply_handler(session, event, handler, created_by="usr_test")
+  session.add.assert_not_called()

--- a/tests/operations/event_block/test_promotion.py
+++ b/tests/operations/event_block/test_promotion.py
@@ -175,7 +175,7 @@ class TestCoPilotMode:
       session, "kg_test", as_of=datetime(2026, 2, 1, tzinfo=UTC)
     )
 
-    from robosystems.operations.event_block.locking import ordered_lock_column
+    from robosystems.operations.locking import ordered_lock_column
 
     ordered_by = [
       arg for call in session.event_query.order_by.call_args_list for arg in call.args

--- a/tests/operations/event_block/test_update_locking_db.py
+++ b/tests/operations/event_block/test_update_locking_db.py
@@ -41,8 +41,8 @@ from robosystems.operations.event_block.commands import (
   execute_event_block,
   update_event_block,
 )
-from robosystems.operations.event_block.locking import EventLockedError
 from robosystems.operations.event_block.promotion import promote_pending_obligations
+from robosystems.operations.locking import RowLockedError
 from robosystems.operations.roboledger.commands.schedules import promote_obligations
 
 pytestmark = pytest.mark.integration
@@ -145,7 +145,7 @@ def test_sync_batch_lock_blocks_an_approval(tenant):
     # must not proceed to fire the handler.
     started = time.monotonic()
     with extensions_session(GRAPH) as approval_session:
-      with pytest.raises(EventLockedError, match=EVENT_ID):
+      with pytest.raises(RowLockedError, match=EVENT_ID):
         update_event_block(
           approval_session,
           UpdateEventBlockRequest(event_id=EVENT_ID, transition_to="committed"),
@@ -297,7 +297,7 @@ class TestObligationSweepLock:
       assert result.stranded_event_ids == [self.OBLIGATION_ID]
 
       with extensions_session(GRAPH) as request_session:
-        with pytest.raises(EventLockedError, match="written by another process"):
+        with pytest.raises(RowLockedError, match="written by another process"):
           promote_obligations(
             request_session,
             PromoteObligationsRequest(dispatch_handlers=False),
@@ -342,7 +342,7 @@ class TestPublishLock:
         with patch(
           "robosystems.operations.event_block.qb_writeback.post_event_to_qb"
         ) as post:
-          with pytest.raises(EventLockedError, match=EVENT_ID):
+          with pytest.raises(RowLockedError, match=EVENT_ID):
             execute_event_block(
               publish_session,
               ExecuteEventBlockRequest(event_id=EVENT_ID),

--- a/tests/operations/roboledger/commands/test_fiscal_calendar.py
+++ b/tests/operations/roboledger/commands/test_fiscal_calendar.py
@@ -61,6 +61,18 @@ def _close_result(**overrides) -> PeriodCloseResult:
   return PeriodCloseResult(**defaults)
 
 
+def _stub_period_lock(session, fp):
+  """Stub the reopen/close period load, which is locked and refreshed.
+
+  `.filter(...).populate_existing().with_for_update().one_or_none()` — the
+  chain links self-return so the stub does not depend on their order.
+  """
+  q = session.query.return_value.filter.return_value
+  q.populate_existing.return_value = q
+  q.with_for_update.return_value = q
+  q.one_or_none.return_value = fp
+
+
 class TestClosePeriodResponseMapping:
   def _run(self, result: PeriodCloseResult):
     close_service = MagicMock()
@@ -133,7 +145,7 @@ class TestReopenRetractsCanonicalSets:
     session = MagicMock()
     fp = MagicMock()
     fp.status = fp_status
-    session.query.return_value.filter.return_value.one_or_none.return_value = fp
+    _stub_period_lock(session, fp)
 
     retract = MagicMock(return_value=list(retracted))
     with (
@@ -180,7 +192,7 @@ class TestReopenRetractsCanonicalSets:
 
   def test_period_not_found_raises(self):
     session = MagicMock()
-    session.query.return_value.filter.return_value.one_or_none.return_value = None
+    _stub_period_lock(session, None)
     with pytest.raises(PeriodNotFoundInLedgerError):
       reopen_period(
         session,
@@ -197,7 +209,7 @@ class TestReopenRetractsCanonicalSets:
     session = MagicMock()
     fp = MagicMock()
     fp.status = "open"
-    session.query.return_value.filter.return_value.one_or_none.return_value = fp
+    _stub_period_lock(session, fp)
     with pytest.raises(PeriodNotClosedError):
       reopen_period(
         session,

--- a/tests/operations/roboledger/commands/test_fiscal_calendar.py
+++ b/tests/operations/roboledger/commands/test_fiscal_calendar.py
@@ -39,6 +39,13 @@ GRAPH_ID = "kg01234567890abcdef"
 _MOD = "robosystems.operations.roboledger.commands.fiscal_calendar"
 
 
+@pytest.fixture(autouse=True)
+def _noop_exclusive_period_fence():
+  """Unit tests here mock the session; the exclusive fence talks to Postgres."""
+  with patch(f"{_MOD}.exclusive_period_fence") as fence:
+    yield fence
+
+
 def _fc_response() -> FiscalCalendarResponse:
   return FiscalCalendarResponse(graph_id=GRAPH_ID, fiscal_year_start_month=1)
 
@@ -139,6 +146,13 @@ class TestClosePeriodResponseMapping:
       self._run(_close_result())
     mark_stale.assert_called_once_with(GRAPH_ID, "period_closed")
 
+  def test_close_holds_the_exclusive_period_fence(self, _noop_exclusive_period_fence):
+    """The fence must wrap close() *and* the commit, or a writer can
+    land between them."""
+    self._run(_close_result())
+    _noop_exclusive_period_fence.assert_called_once()
+    assert _noop_exclusive_period_fence.call_args.args[:2] == (GRAPH_ID, "2026-01")
+
 
 class TestReopenRetractsCanonicalSets:
   def _run(self, fp_status="closed", retracted=("fs_a", "fs_b")):
@@ -173,12 +187,14 @@ class TestReopenRetractsCanonicalSets:
       )
     return result, retract, fp
 
-  def test_returns_result_with_retraction_count(self):
+  def test_returns_result_with_retraction_count(self, _noop_exclusive_period_fence):
     result, retract, fp = self._run()
     assert isinstance(result, ReopenPeriodResult)
     assert result.statement_sets_retracted == 2
     assert isinstance(result.fiscal_calendar, FiscalCalendarResponse)
     assert fp.status == "closing"
+    _noop_exclusive_period_fence.assert_called()
+    assert _noop_exclusive_period_fence.call_args.args[:2] == (GRAPH_ID, "2026-01")
 
   def test_retraction_keyed_by_month_window(self):
     _, retract, _ = self._run()

--- a/tests/operations/roboledger/commands/test_guards.py
+++ b/tests/operations/roboledger/commands/test_guards.py
@@ -1,0 +1,74 @@
+"""Unit tests for the closed-period write guard."""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.operations.roboledger.commands._guards import (
+  ClosedPeriodError,
+  assert_period_not_closed,
+)
+
+
+def _row(graph_id="kgabc", name="2026-01", status="open"):
+  row = MagicMock()
+  row.graph_id = graph_id
+  row.name = name
+  row.status = status
+  return row
+
+
+class TestAssertPeriodNotClosed:
+  def test_no_period_is_a_noop(self):
+    session = MagicMock()
+    session.execute.return_value.fetchone.return_value = None
+    assert_period_not_closed(session, date(2026, 1, 15))
+
+  def test_open_period_takes_the_shared_fence(self):
+    session = MagicMock()
+    session.execute.return_value.fetchone.return_value = _row()
+    with patch(
+      "robosystems.operations.roboledger.commands._guards.acquire_shared_period_fence"
+    ) as fence:
+      assert_period_not_closed(session, date(2026, 1, 15))
+    fence.assert_called_once()
+    assert fence.call_args.args[1] == "kgabc"
+    assert fence.call_args.args[2] == "2026-01"
+
+  def test_closed_period_raises_after_the_fence(self):
+    session = MagicMock()
+    session.execute.return_value.fetchone.return_value = _row(status="closed")
+    with (
+      patch(
+        "robosystems.operations.roboledger.commands._guards.acquire_shared_period_fence"
+      ) as fence,
+      pytest.raises(ClosedPeriodError) as exc,
+    ):
+      assert_period_not_closed(session, date(2026, 1, 15))
+    fence.assert_called_once()
+    assert exc.value.period_name == "2026-01"
+
+  def test_two_dates_lock_in_sorted_order(self):
+    session = MagicMock()
+    jan = _row(name="2026-01")
+    feb = _row(name="2026-02")
+    session.execute.return_value.fetchone.side_effect = [
+      feb,
+      jan,  # discovery (input order is Feb, Jan)
+      jan,
+      feb,  # re-read after each lock, sorted
+    ]
+    order: list[str] = []
+
+    def _fence(_session, _graph, period, *, detail):
+      order.append(period)
+
+    with patch(
+      "robosystems.operations.roboledger.commands._guards.acquire_shared_period_fence",
+      side_effect=_fence,
+    ):
+      assert_period_not_closed(session, date(2026, 2, 1), date(2026, 1, 15))
+    assert order == ["2026-01", "2026-02"]

--- a/tests/operations/roboledger/commands/test_journal_entries.py
+++ b/tests/operations/roboledger/commands/test_journal_entries.py
@@ -24,6 +24,7 @@ from robosystems.models.api.extensions.journal_entries import (
   ReverseJournalEntryRequest,
   UpdateJournalEntryRequest,
 )
+from robosystems.operations.locking import RowLockedError
 from robosystems.operations.roboledger.commands._guards import ClosedPeriodError
 from robosystems.operations.roboledger.commands.journal_entries import (
   JournalEntryNotDraftError,
@@ -562,8 +563,11 @@ class TestUpdateJournalEntry:
     assert kwargs.get("with_for_update") is True
     assert kwargs.get("populate_existing") is True
 
+  @patch(f"{MODULE}.assert_period_not_closed")
   @patch(f"{MODULE}._load_line_items", return_value=[])
-  def test_refences_if_the_locked_posting_date_moved(self, mock_load):
+  def test_moved_posting_date_is_retryable_not_refenced(self, mock_load, mock_guard):
+    """Re-fencing after the entry lock inverts fence→row and can deadlock
+    with a close that holds the new period. Retry peeks the current date."""
     peek = _mock_entry(status="draft")
     peek.posting_date = date(2026, 1, 15)
     locked = _mock_entry(status="draft")
@@ -571,13 +575,11 @@ class TestUpdateJournalEntry:
     session = MagicMock()
     session.execute.return_value.scalar_one_or_none.return_value = peek
     session.get.return_value = locked
-    with patch(f"{MODULE}.assert_period_not_closed") as mock_guard:
+    with pytest.raises(RowLockedError, match="moved to another period"):
       update_journal_entry(
         session, UpdateJournalEntryRequest(entry_id="entry_01", memo="x")
       )
-    assert mock_guard.call_count == 2
-    mock_guard.assert_any_call(session, date(2026, 1, 15))
-    mock_guard.assert_any_call(session, date(2026, 3, 1))
+    mock_guard.assert_called_once_with(session, date(2026, 1, 15))
 
 
 # ── delete_journal_entry ──────────────────────────────────────────────────
@@ -626,6 +628,19 @@ class TestDeleteJournalEntry:
     kwargs = session.get.call_args.kwargs
     assert kwargs.get("with_for_update") is True
     assert kwargs.get("populate_existing") is True
+
+  @patch(f"{MODULE}.assert_period_not_closed")
+  def test_moved_posting_date_is_retryable_not_refenced(self, mock_guard):
+    peek = _mock_entry(status="draft")
+    peek.posting_date = date(2026, 1, 15)
+    locked = _mock_entry(status="draft")
+    locked.posting_date = date(2026, 3, 1)
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.return_value = peek
+    session.get.return_value = locked
+    with pytest.raises(RowLockedError, match="moved to another period"):
+      delete_journal_entry(session, DeleteJournalEntryRequest(entry_id="entry_01"))
+    mock_guard.assert_called_once_with(session, date(2026, 1, 15))
 
 
 # ── reverse_journal_entry ─────────────────────────────────────────────────

--- a/tests/operations/roboledger/commands/test_journal_entries.py
+++ b/tests/operations/roboledger/commands/test_journal_entries.py
@@ -589,35 +589,38 @@ class TestReverseJournalEntry:
   def _body(self, entry_id: str = "entry_01"):
     return ReverseJournalEntryRequest(entry_id=entry_id, posting_date=_DATE)
 
-  def test_not_found_raises(self):
+  @staticmethod
+  def _session(original):
+    """Session whose locked load returns `original`.
+
+    The reversal loads the original through `lock_by_id` — `session.get` with
+    `with_for_update` and `populate_existing` — rather than a plain select,
+    because two concurrent reversals that both read 'posted' both post.
+    """
     session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.return_value = None
+    session.get.return_value = original
+    session.execute.return_value.scalar_one_or_none.return_value = original
+    return session
+
+  def test_not_found_raises(self):
+    session = self._session(None)
     with pytest.raises(JournalEntryNotFoundError):
       reverse_journal_entry(session, self._body(), "usr_1")
 
   def test_draft_entry_cannot_be_reversed(self):
-    session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.return_value = _mock_entry(
-      status="draft"
-    )
+    session = self._session(_mock_entry(status="draft"))
     with pytest.raises(JournalEntryNotPostedError) as exc_info:
       reverse_journal_entry(session, self._body(), "usr_1")
     assert exc_info.value.status == "draft"
 
   def test_reversed_entry_cannot_be_reversed_again(self):
-    session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.return_value = _mock_entry(
-      status="reversed"
-    )
+    session = self._session(_mock_entry(status="reversed"))
     with pytest.raises(JournalEntryNotPostedError):
       reverse_journal_entry(session, self._body(), "usr_1")
 
   @patch(f"{MODULE}._load_line_items", return_value=[])
   def test_entry_with_no_line_items_raises(self, mock_load):
-    session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.return_value = _mock_entry(
-      status="posted"
-    )
+    session = self._session(_mock_entry(status="posted"))
     with pytest.raises(ValueError, match="no line items"):
       reverse_journal_entry(session, self._body(), "usr_1")
 
@@ -629,11 +632,10 @@ class TestReverseJournalEntry:
     original = _mock_entry(status="posted")
     line = _mock_line("elem_a", debit=100, credit=0, order=1)
     line2 = _mock_line("elem_b", debit=0, credit=100, order=2)
-    session = MagicMock()
-    session.execute.side_effect = [
-      _scalar_exec(original),
-      _scalars_exec([line, line2]),
-    ]
+    session = self._session(original)
+    # The original now arrives via the locked load, so `execute` serves the
+    # bounded wait's `SET LOCAL lock_timeout` and then the line-item read.
+    session.execute.side_effect = [MagicMock(), _scalars_exec([line, line2])]
     with pytest.raises(ClosedPeriodError):
       reverse_journal_entry(session, self._body(), "usr_1")
 
@@ -650,8 +652,9 @@ class TestReverseJournalEntry:
 
     added_objects: list = []
     session = MagicMock()
+    session.get.return_value = original
     session.execute.side_effect = [
-      _scalar_exec(original),
+      MagicMock(),  # bounded wait's SET LOCAL lock_timeout
       _scalars_exec([line1, line2]),
       _scalars_exec([]),  # _load_line_items for reversing entry (response build)
     ]
@@ -689,8 +692,9 @@ class TestReverseJournalEntry:
 
     added_objects: list = []
     session = MagicMock()
+    session.get.return_value = original
     session.execute.side_effect = [
-      _scalar_exec(original),
+      MagicMock(),  # bounded wait's SET LOCAL lock_timeout
       _scalars_exec([line1, line2]),
       _scalars_exec([]),
     ]
@@ -729,8 +733,9 @@ class TestReverseJournalEntry:
 
     added_objects: list = []
     session = MagicMock()
+    session.get.return_value = original
     session.execute.side_effect = [
-      _scalar_exec(original),
+      MagicMock(),  # bounded wait's SET LOCAL lock_timeout
       _scalars_exec([line1, line2]),
       _scalars_exec([]),  # _load_line_items for reversing entry
     ]
@@ -755,8 +760,9 @@ class TestReverseJournalEntry:
     line2 = _mock_line("elem_b", debit=0, credit=200, order=2)
 
     session = MagicMock()
+    session.get.return_value = original
     session.execute.side_effect = [
-      _scalar_exec(original),
+      MagicMock(),  # bounded wait's SET LOCAL lock_timeout
       _scalars_exec([line1, line2]),
       _scalars_exec([]),  # _load_line_items for reversing entry
     ]

--- a/tests/operations/roboledger/commands/test_journal_entries.py
+++ b/tests/operations/roboledger/commands/test_journal_entries.py
@@ -80,6 +80,14 @@ def _mock_entry(
   return e
 
 
+def _session_for_entry(entry):
+  """Peek via execute, lock via session.get — the update/delete sequence."""
+  session = MagicMock()
+  session.execute.return_value.scalar_one_or_none.return_value = entry
+  session.get.return_value = entry
+  return session
+
+
 def _mock_line(element_id: str, debit: int, credit: int, order: int):
   li = MagicMock()
   li.id = f"li_{order:02d}"
@@ -454,34 +462,34 @@ class TestUpdateJournalEntry:
       update_journal_entry(session, UpdateJournalEntryRequest(entry_id="missing"))
     assert exc_info.value.entry_id == "missing"
 
+  @patch(f"{MODULE}.assert_period_not_closed")
   @patch(f"{MODULE}._load_line_items", return_value=[])
-  def test_posted_entry_raises(self, mock_load):
-    session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.return_value = _mock_entry(
-      status="posted"
-    )
+  def test_posted_entry_raises(self, mock_load, mock_guard):
+    entry = _mock_entry(status="posted")
     with pytest.raises(JournalEntryNotDraftError) as exc_info:
-      update_journal_entry(session, UpdateJournalEntryRequest(entry_id="entry_01"))
+      update_journal_entry(
+        _session_for_entry(entry), UpdateJournalEntryRequest(entry_id="entry_01")
+      )
     assert exc_info.value.status == "posted"
 
+  @patch(f"{MODULE}.assert_period_not_closed")
   @patch(f"{MODULE}._load_line_items", return_value=[])
-  def test_reversed_entry_raises(self, mock_load):
-    session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.return_value = _mock_entry(
-      status="reversed"
-    )
+  def test_reversed_entry_raises(self, mock_load, mock_guard):
+    entry = _mock_entry(status="reversed")
     with pytest.raises(JournalEntryNotDraftError) as exc_info:
-      update_journal_entry(session, UpdateJournalEntryRequest(entry_id="entry_01"))
+      update_journal_entry(
+        _session_for_entry(entry), UpdateJournalEntryRequest(entry_id="entry_01")
+      )
     assert exc_info.value.status == "reversed"
 
+  @patch(f"{MODULE}.assert_period_not_closed")
   @patch(f"{MODULE}._load_line_items", return_value=[])
-  def test_scalar_field_update(self, mock_load):
+  def test_scalar_field_update(self, mock_load, mock_guard):
     entry = _mock_entry(status="draft")
     entry.memo = "Old memo"
-    session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.return_value = entry
     update_journal_entry(
-      session, UpdateJournalEntryRequest(entry_id="entry_01", memo="New memo")
+      _session_for_entry(entry),
+      UpdateJournalEntryRequest(entry_id="entry_01", memo="New memo"),
     )
     assert entry.memo == "New memo"
 
@@ -489,30 +497,29 @@ class TestUpdateJournalEntry:
   @patch(f"{MODULE}._load_line_items", return_value=[])
   def test_posting_date_change_checks_period_gate(self, mock_load, mock_guard):
     entry = _mock_entry(status="draft")
-    session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.return_value = entry
+    session = _session_for_entry(entry)
     new_date = date(2026, 2, 1)
     update_journal_entry(
-      session, UpdateJournalEntryRequest(entry_id="entry_01", posting_date=new_date)
+      session,
+      UpdateJournalEntryRequest(entry_id="entry_01", posting_date=new_date),
     )
     mock_guard.assert_called_once_with(session, _DATE, new_date)
 
   @patch(f"{MODULE}._load_line_items", return_value=[])
   def test_memo_only_update_still_fences_the_existing_period(self, mock_load):
     entry = _mock_entry(status="draft")
-    session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.return_value = entry
+    session = _session_for_entry(entry)
     with patch(f"{MODULE}.assert_period_not_closed") as mock_guard:
       update_journal_entry(
         session, UpdateJournalEntryRequest(entry_id="entry_01", memo="Updated")
       )
-      mock_guard.assert_called_once_with(session, entry.posting_date)
+      mock_guard.assert_called_once_with(session, _DATE)
 
+  @patch(f"{MODULE}.assert_period_not_closed")
   @patch(f"{MODULE}._load_line_items", return_value=[])
-  def test_line_item_replacement_calls_delete(self, mock_load):
+  def test_line_item_replacement_calls_delete(self, mock_load, mock_guard):
     entry = _mock_entry(status="draft")
-    session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.return_value = entry
+    session = _session_for_entry(entry)
     body = UpdateJournalEntryRequest(
       entry_id="entry_01",
       line_items=[
@@ -525,12 +532,12 @@ class TestUpdateJournalEntry:
     session.query.assert_called()
     assert session.add.call_count == 2
 
+  @patch(f"{MODULE}.assert_period_not_closed")
   @patch(f"{MODULE}._load_line_items", return_value=[])
-  def test_unbalanced_replacement_raises_before_delete(self, mock_load):
+  def test_unbalanced_replacement_raises_before_delete(self, mock_load, mock_guard):
     """Validation must run before the delete so a bad batch cannot clobber existing lines."""
     entry = _mock_entry(status="draft")
-    session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.return_value = entry
+    session = _session_for_entry(entry)
     body = UpdateJournalEntryRequest(
       entry_id="entry_01",
       line_items=[
@@ -541,6 +548,36 @@ class TestUpdateJournalEntry:
     with pytest.raises(UnbalancedJournalEntryError):
       update_journal_entry(session, body)
     session.query.assert_not_called()
+
+  @patch(f"{MODULE}.assert_period_not_closed")
+  @patch(f"{MODULE}._load_line_items", return_value=[])
+  def test_locks_the_entry_after_the_period_fence(self, mock_load, mock_guard):
+    entry = _mock_entry(status="draft")
+    session = _session_for_entry(entry)
+    update_journal_entry(
+      session, UpdateJournalEntryRequest(entry_id="entry_01", memo="x")
+    )
+    session.get.assert_called()
+    kwargs = session.get.call_args.kwargs
+    assert kwargs.get("with_for_update") is True
+    assert kwargs.get("populate_existing") is True
+
+  @patch(f"{MODULE}._load_line_items", return_value=[])
+  def test_refences_if_the_locked_posting_date_moved(self, mock_load):
+    peek = _mock_entry(status="draft")
+    peek.posting_date = date(2026, 1, 15)
+    locked = _mock_entry(status="draft")
+    locked.posting_date = date(2026, 3, 1)
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.return_value = peek
+    session.get.return_value = locked
+    with patch(f"{MODULE}.assert_period_not_closed") as mock_guard:
+      update_journal_entry(
+        session, UpdateJournalEntryRequest(entry_id="entry_01", memo="x")
+      )
+    assert mock_guard.call_count == 2
+    mock_guard.assert_any_call(session, date(2026, 1, 15))
+    mock_guard.assert_any_call(session, date(2026, 3, 1))
 
 
 # ── delete_journal_entry ──────────────────────────────────────────────────
@@ -553,34 +590,42 @@ class TestDeleteJournalEntry:
     with pytest.raises(JournalEntryNotFoundError):
       delete_journal_entry(session, DeleteJournalEntryRequest(entry_id="missing"))
 
-  def test_posted_entry_cannot_be_deleted(self):
-    session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.return_value = _mock_entry(
-      status="posted"
-    )
+  @patch(f"{MODULE}.assert_period_not_closed")
+  def test_posted_entry_cannot_be_deleted(self, mock_guard):
+    entry = _mock_entry(status="posted")
     with pytest.raises(JournalEntryNotDraftError):
-      delete_journal_entry(session, DeleteJournalEntryRequest(entry_id="entry_01"))
+      delete_journal_entry(
+        _session_for_entry(entry), DeleteJournalEntryRequest(entry_id="entry_01")
+      )
 
-  def test_reversed_entry_cannot_be_deleted(self):
-    session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.return_value = _mock_entry(
-      status="reversed"
-    )
+  @patch(f"{MODULE}.assert_period_not_closed")
+  def test_reversed_entry_cannot_be_deleted(self, mock_guard):
+    entry = _mock_entry(status="reversed")
     with pytest.raises(JournalEntryNotDraftError):
-      delete_journal_entry(session, DeleteJournalEntryRequest(entry_id="entry_01"))
+      delete_journal_entry(
+        _session_for_entry(entry), DeleteJournalEntryRequest(entry_id="entry_01")
+      )
 
   def test_draft_entry_is_deleted(self):
     entry = _mock_entry(status="draft")
-    session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.return_value = entry
+    session = _session_for_entry(entry)
     with patch(f"{MODULE}.assert_period_not_closed") as mock_guard:
       result = delete_journal_entry(
         session, DeleteJournalEntryRequest(entry_id="entry_01")
       )
-    mock_guard.assert_called_once_with(session, entry.posting_date)
+    mock_guard.assert_called_once_with(session, _DATE)
     assert result == {"deleted": True}
     session.delete.assert_called_once_with(entry)
     session.flush.assert_called()
+
+  @patch(f"{MODULE}.assert_period_not_closed")
+  def test_locks_the_entry_after_the_period_fence(self, mock_guard):
+    entry = _mock_entry(status="draft")
+    session = _session_for_entry(entry)
+    delete_journal_entry(session, DeleteJournalEntryRequest(entry_id="entry_01"))
+    kwargs = session.get.call_args.kwargs
+    assert kwargs.get("with_for_update") is True
+    assert kwargs.get("populate_existing") is True
 
 
 # ── reverse_journal_entry ─────────────────────────────────────────────────

--- a/tests/operations/roboledger/commands/test_journal_entries.py
+++ b/tests/operations/roboledger/commands/test_journal_entries.py
@@ -495,19 +495,18 @@ class TestUpdateJournalEntry:
     update_journal_entry(
       session, UpdateJournalEntryRequest(entry_id="entry_01", posting_date=new_date)
     )
-    mock_guard.assert_called_once_with(session, new_date)
+    mock_guard.assert_called_once_with(session, _DATE, new_date)
 
   @patch(f"{MODULE}._load_line_items", return_value=[])
-  def test_no_posting_date_change_skips_period_gate(self, mock_load):
+  def test_memo_only_update_still_fences_the_existing_period(self, mock_load):
     entry = _mock_entry(status="draft")
     session = MagicMock()
     session.execute.return_value.scalar_one_or_none.return_value = entry
-    # Updating memo only — no posting_date in body
     with patch(f"{MODULE}.assert_period_not_closed") as mock_guard:
       update_journal_entry(
         session, UpdateJournalEntryRequest(entry_id="entry_01", memo="Updated")
       )
-      mock_guard.assert_not_called()
+      mock_guard.assert_called_once_with(session, entry.posting_date)
 
   @patch(f"{MODULE}._load_line_items", return_value=[])
   def test_line_item_replacement_calls_delete(self, mock_load):
@@ -574,9 +573,11 @@ class TestDeleteJournalEntry:
     entry = _mock_entry(status="draft")
     session = MagicMock()
     session.execute.return_value.scalar_one_or_none.return_value = entry
-    result = delete_journal_entry(
-      session, DeleteJournalEntryRequest(entry_id="entry_01")
-    )
+    with patch(f"{MODULE}.assert_period_not_closed") as mock_guard:
+      result = delete_journal_entry(
+        session, DeleteJournalEntryRequest(entry_id="entry_01")
+      )
+    mock_guard.assert_called_once_with(session, entry.posting_date)
     assert result == {"deleted": True}
     session.delete.assert_called_once_with(entry)
     session.flush.assert_called()

--- a/tests/operations/roboledger/commands/test_journal_entries.py
+++ b/tests/operations/roboledger/commands/test_journal_entries.py
@@ -599,7 +599,9 @@ class TestReverseJournalEntry:
     """
     session = MagicMock()
     session.get.return_value = original
-    session.execute.return_value.scalar_one_or_none.return_value = original
+    # The original arrives via the locked `session.get`; `execute` now serves
+    # the "does a reversal already exist" check, which these cases want empty.
+    session.execute.return_value.scalar_one_or_none.return_value = None
     return session
 
   def test_not_found_raises(self):
@@ -635,7 +637,11 @@ class TestReverseJournalEntry:
     session = self._session(original)
     # The original now arrives via the locked load, so `execute` serves the
     # bounded wait's `SET LOCAL lock_timeout` and then the line-item read.
-    session.execute.side_effect = [MagicMock(), _scalars_exec([line, line2])]
+    session.execute.side_effect = [
+      MagicMock(),  # bounded wait's SET LOCAL lock_timeout
+      _scalar_exec(None),  # no existing reversal
+      _scalars_exec([line, line2]),
+    ]
     with pytest.raises(ClosedPeriodError):
       reverse_journal_entry(session, self._body(), "usr_1")
 
@@ -655,6 +661,7 @@ class TestReverseJournalEntry:
     session.get.return_value = original
     session.execute.side_effect = [
       MagicMock(),  # bounded wait's SET LOCAL lock_timeout
+      _scalar_exec(None),  # no existing reversal
       _scalars_exec([line1, line2]),
       _scalars_exec([]),  # _load_line_items for reversing entry (response build)
     ]
@@ -695,6 +702,7 @@ class TestReverseJournalEntry:
     session.get.return_value = original
     session.execute.side_effect = [
       MagicMock(),  # bounded wait's SET LOCAL lock_timeout
+      _scalar_exec(None),  # no existing reversal
       _scalars_exec([line1, line2]),
       _scalars_exec([]),
     ]
@@ -736,6 +744,7 @@ class TestReverseJournalEntry:
     session.get.return_value = original
     session.execute.side_effect = [
       MagicMock(),  # bounded wait's SET LOCAL lock_timeout
+      _scalar_exec(None),  # no existing reversal
       _scalars_exec([line1, line2]),
       _scalars_exec([]),  # _load_line_items for reversing entry
     ]
@@ -763,6 +772,7 @@ class TestReverseJournalEntry:
     session.get.return_value = original
     session.execute.side_effect = [
       MagicMock(),  # bounded wait's SET LOCAL lock_timeout
+      _scalar_exec(None),  # no existing reversal
       _scalars_exec([line1, line2]),
       _scalars_exec([]),  # _load_line_items for reversing entry
     ]

--- a/tests/operations/roboledger/commands/test_reports_filing.py
+++ b/tests/operations/roboledger/commands/test_reports_filing.py
@@ -79,7 +79,10 @@ def test_file_report_transitions_draft_to_filed() -> None:
   assert result.filing_status == "filed"
   assert result.filed_by == "user_01"
   assert result.filed_at is not None
-  session.flush.assert_called_once()
+  # Two flushes: the locked read flushes first (these sessions are
+  # autoflush=False, so a refresh would otherwise drop an in-flight write),
+  # then the filing stamp itself.
+  assert session.flush.call_count == 2
 
 
 def test_file_report_transitions_under_review_to_filed() -> None:

--- a/tests/operations/roboledger/commands/test_state_transition_locks_db.py
+++ b/tests/operations/roboledger/commands/test_state_transition_locks_db.py
@@ -180,12 +180,8 @@ class TestReversalLock:
 
 
 class TestPeriodTransitionLock:
-  """Two concurrent reopens cannot both retract the same month's statements.
-
-  This does **not** cover reopen-vs-close: `close_period` cannot hold a
-  transaction-scoped lock, because its QB pre-publish commits mid-close. That
-  gap is recorded in the close's own comment and in the spec, not papered over
-  with a test that would imply otherwise.
+  """Reopen still row-locks the FiscalPeriod; close and writers share the
+  advisory period fence that survives the close's mid-flow commit.
   """
 
   @pytest.fixture(autouse=True)
@@ -238,6 +234,88 @@ class TestPeriodTransitionLock:
       )
       assert row.status == "closed"
       assert row.closed_at is not None
+
+
+class TestPeriodWriteFence:
+  """Close/reopen take an exclusive session-scoped fence; writers take
+  the shared transaction-scoped side. The two must block each other.
+  """
+
+  @pytest.fixture(autouse=True)
+  def open_period(self, tenant):
+    with extensions_session(GRAPH) as session:
+      session.execute(
+        text("DELETE FROM fiscal_periods WHERE graph_id = :g"), {"g": GRAPH}
+      )
+      session.add(
+        FiscalPeriod(
+          graph_id=GRAPH,
+          name=PERIOD,
+          start_date=date(2026, 1, 1),
+          end_date=date(2026, 1, 31),
+          period_type="monthly",
+          status="open",
+        )
+      )
+    yield
+
+  def test_exclusive_fence_blocks_a_second_closer(self, tenant):
+    from robosystems.operations.locking import exclusive_period_fence
+
+    with exclusive_period_fence(
+      GRAPH, PERIOD, detail=f"Period {PERIOD} is being closed"
+    ):
+      with pytest.raises(RowLockedError, match=PERIOD):
+        with exclusive_period_fence(
+          GRAPH, PERIOD, detail=f"Period {PERIOD} is being closed"
+        ):
+          pass
+
+  def test_exclusive_fence_blocks_a_writer(self, tenant):
+    from robosystems.operations.locking import exclusive_period_fence
+    from robosystems.operations.roboledger.commands._guards import (
+      assert_period_not_closed,
+    )
+
+    with exclusive_period_fence(
+      GRAPH, PERIOD, detail=f"Period {PERIOD} is being closed"
+    ):
+      with extensions_session(GRAPH) as writer:
+        with pytest.raises(RowLockedError, match=PERIOD):
+          assert_period_not_closed(writer, date(2026, 1, 15))
+
+  def test_shared_writer_fence_blocks_close(self, tenant):
+    from robosystems.operations.locking import exclusive_period_fence
+    from robosystems.operations.roboledger.commands._guards import (
+      assert_period_not_closed,
+    )
+
+    with extensions_session(GRAPH) as writer:
+      assert_period_not_closed(writer, date(2026, 1, 15))
+      with pytest.raises(RowLockedError, match=PERIOD):
+        with exclusive_period_fence(
+          GRAPH, PERIOD, detail=f"Period {PERIOD} is being closed"
+        ):
+          pass
+
+  def test_writer_sees_closed_after_status_flip(self, tenant):
+    from robosystems.operations.roboledger.commands._guards import (
+      ClosedPeriodError,
+      assert_period_not_closed,
+    )
+
+    with extensions_session(GRAPH) as session:
+      session.execute(
+        text(
+          "UPDATE fiscal_periods SET status = 'closed' "
+          "WHERE graph_id = :g AND name = :n"
+        ),
+        {"g": GRAPH, "n": PERIOD},
+      )
+
+    with extensions_session(GRAPH) as writer:
+      with pytest.raises(ClosedPeriodError):
+        assert_period_not_closed(writer, date(2026, 1, 15))
 
 
 class TestAlreadyReversed:
@@ -336,3 +414,29 @@ class TestFileReportLock:
       row = check.get(Report, self.REPORT_ID)
       assert row.filing_status == "draft"
       assert row.filed_at is None
+
+  def test_a_locked_report_cannot_change_filing_status(self, tenant):
+    from robosystems.operations.roboledger.commands.reports import (
+      transition_filing_status,
+    )
+
+    with extensions_session(GRAPH) as holder:
+      holder.execute(
+        text("SELECT id FROM reports WHERE id = :id FOR UPDATE"),
+        {"id": self.REPORT_ID},
+      )
+      with extensions_session(GRAPH) as other:
+        with pytest.raises(RowLockedError, match=self.REPORT_ID):
+          transition_filing_status(other, self.REPORT_ID, "under_review")
+
+  def test_a_locked_report_cannot_be_deleted(self, tenant):
+    from robosystems.operations.roboledger.commands.reports import delete_report
+
+    with extensions_session(GRAPH) as holder:
+      holder.execute(
+        text("SELECT id FROM reports WHERE id = :id FOR UPDATE"),
+        {"id": self.REPORT_ID},
+      )
+      with extensions_session(GRAPH) as other:
+        with pytest.raises(RowLockedError, match=self.REPORT_ID):
+          delete_report(other, self.REPORT_ID, "usr_seed")

--- a/tests/operations/roboledger/commands/test_state_transition_locks_db.py
+++ b/tests/operations/roboledger/commands/test_state_transition_locks_db.py
@@ -1,0 +1,235 @@
+"""DB-backed proof of the remaining roboledger state-transition locks.
+
+Three transitions had the shape `operations/locking.py` exists for — load a
+row, branch on a state column, write it back — with nothing held across the
+decision: reversing a journal entry, closing or reopening a fiscal period, and
+filing a report. Mock sessions can prove a keyword was passed; only a second
+real session proves a lock blocks.
+
+Runs against the real extensions database with a throwaway tenant schema, the
+same mechanism `create_tenant_schema` uses.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import IntegrityError, OperationalError
+
+import robosystems.models.extensions  # noqa: F401  (register models on the Base)
+from robosystems.config import env
+from robosystems.db.extensions import ExtensionsBase, extensions_session
+from robosystems.models.api.extensions.journal_entries import (
+  ReverseJournalEntryRequest,
+)
+from robosystems.models.extensions.roboledger.entry import Entry
+from robosystems.models.extensions.roboledger.fiscal_period import FiscalPeriod
+from robosystems.operations.locking import RowLockedError
+from robosystems.operations.roboledger.commands.journal_entries import (
+  reverse_journal_entry,
+)
+
+pytestmark = pytest.mark.integration
+
+GRAPH = "kgdddddddddddddddd04"
+ENTRY_ID = "je_lock_0001"
+PERIOD = "2026-01"
+
+
+def _tenant_tables():
+  return [t for t in ExtensionsBase.metadata.sorted_tables if t.schema is None]
+
+
+@pytest.fixture(scope="module")
+def tenant():
+  url = env.EXTENSIONS_DATABASE_URL
+  if not url:
+    pytest.skip("EXTENSIONS_DATABASE_URL not configured")
+  engine = create_engine(url)
+  try:
+    with engine.connect() as probe:
+      probe.execute(text("SELECT 1"))
+  except OperationalError as exc:
+    engine.dispose()
+    pytest.skip(f"extensions database unreachable: {exc.orig}")
+
+  try:
+    with engine.begin() as conn:
+      conn.execute(text(f"DROP SCHEMA IF EXISTS {GRAPH} CASCADE"))
+      conn.execute(text(f"CREATE SCHEMA {GRAPH}"))
+      ExtensionsBase.metadata.create_all(
+        bind=conn.execution_options(schema_translate_map={None: GRAPH}),
+        tables=_tenant_tables(),
+      )
+      # Migration 0032 creates this per tenant; metadata.create_all builds it
+      # from the model, so asserting it exists here also checks the two have
+      # not drifted apart.
+      present = conn.execute(
+        text(
+          "SELECT 1 FROM pg_indexes WHERE schemaname = :s "
+          "AND indexname = 'uq_entries_one_reversal_per_original'"
+        ),
+        {"s": GRAPH},
+      ).scalar()
+      assert present, "the one-reversal-per-entry index is missing from the model"
+    yield
+  finally:
+    with engine.begin() as conn:
+      conn.execute(text(f"DROP SCHEMA IF EXISTS {GRAPH} CASCADE"))
+    engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def posted_entry(tenant):
+  with extensions_session(GRAPH) as session:
+    session.execute(text("DELETE FROM line_items"))
+    session.execute(text("DELETE FROM entries"))
+    session.execute(
+      text("DELETE FROM fiscal_periods WHERE graph_id = :g"), {"g": GRAPH}
+    )
+    session.add(
+      Entry(
+        id=ENTRY_ID,
+        type="standard",
+        status="posted",
+        posting_date=date(2026, 1, 15),
+        memo="Original",
+        posted_at=datetime(2026, 1, 15, tzinfo=UTC),
+        created_by="usr_seed",
+      )
+    )
+  yield
+
+
+class TestReversalLock:
+  def test_a_locked_entry_cannot_be_reversed(self, tenant):
+    """The race that double-posts: two reversals both read 'posted'."""
+    with extensions_session(GRAPH) as holder:
+      holder.execute(
+        text("SELECT id FROM entries WHERE id = :id FOR UPDATE"), {"id": ENTRY_ID}
+      )
+      with extensions_session(GRAPH) as reverser:
+        with pytest.raises(RowLockedError, match=ENTRY_ID):
+          reverse_journal_entry(
+            reverser, ReverseJournalEntryRequest(entry_id=ENTRY_ID), "usr_op"
+          )
+
+    with extensions_session(GRAPH) as check:
+      assert check.get(Entry, ENTRY_ID).status == "posted"
+      assert (
+        check.execute(
+          text("SELECT COUNT(*) FROM entries WHERE reversal_of = :id"),
+          {"id": ENTRY_ID},
+        ).scalar()
+        == 0
+      )
+
+  def test_the_database_refuses_a_second_reversal(self, tenant):
+    """The lock makes the ordinary race a clean 409; this is the guarantee
+    that does not depend on anyone remembering to take it."""
+    with extensions_session(GRAPH) as session:
+      session.add(
+        Entry(
+          id="je_rev_a",
+          type="reversing",
+          status="posted",
+          posting_date=date(2026, 1, 16),
+          reversal_of=ENTRY_ID,
+          created_by="usr_op",
+        )
+      )
+
+    with pytest.raises(IntegrityError):
+      with extensions_session(GRAPH) as session:
+        session.add(
+          Entry(
+            id="je_rev_b",
+            type="reversing",
+            status="posted",
+            posting_date=date(2026, 1, 17),
+            reversal_of=ENTRY_ID,
+            created_by="usr_op",
+          )
+        )
+
+  def test_entries_that_are_not_reversals_are_unconstrained(self, tenant):
+    """`reversal_of IS NULL` on every ordinary entry — the index is partial
+    precisely so those stay unaffected."""
+    with extensions_session(GRAPH) as session:
+      for i in range(3):
+        session.add(
+          Entry(
+            id=f"je_plain_{i}",
+            type="standard",
+            status="posted",
+            posting_date=date(2026, 1, 20),
+            created_by="usr_op",
+          )
+        )
+
+    with extensions_session(GRAPH) as check:
+      assert (
+        check.execute(
+          text("SELECT COUNT(*) FROM entries WHERE reversal_of IS NULL")
+        ).scalar()
+        >= 3
+      )
+
+
+class TestPeriodTransitionLock:
+  """Close and reopen contend over the same `FiscalPeriod` row. Interleaved,
+  they can leave a period marked closed whose statements were retracted."""
+
+  @pytest.fixture(autouse=True)
+  def closed_period(self, tenant):
+    with extensions_session(GRAPH) as session:
+      session.add(
+        FiscalPeriod(
+          graph_id=GRAPH,
+          name=PERIOD,
+          start_date=date(2026, 1, 1),
+          end_date=date(2026, 1, 31),
+          period_type="monthly",
+          status="closed",
+          closed_at=datetime(2026, 2, 1, tzinfo=UTC),
+          closed_by="usr_seed",
+        )
+      )
+    yield
+
+  def test_a_locked_period_cannot_be_reopened(self, tenant):
+    from robosystems.operations.roboledger.commands.fiscal_calendar import (
+      reopen_period,
+    )
+
+    with extensions_session(GRAPH) as holder:
+      holder.execute(
+        text(
+          "SELECT name FROM fiscal_periods WHERE graph_id = :g AND name = :n FOR UPDATE"
+        ),
+        {"g": GRAPH, "n": PERIOD},
+      )
+      with extensions_session(GRAPH) as reopener:
+        with pytest.raises(RowLockedError, match=PERIOD):
+          reopen_period(
+            reopener,
+            MagicMock(),  # platform_db — unreached; the lock blocks first
+            GRAPH,
+            PERIOD,
+            actor_id="usr_op",
+            reason="correction",
+            note=None,
+            service=MagicMock(),
+          )
+
+    with extensions_session(GRAPH) as check:
+      row = (
+        check.query(FiscalPeriod)
+        .filter(FiscalPeriod.graph_id == GRAPH, FiscalPeriod.name == PERIOD)
+        .one()
+      )
+      assert row.status == "closed"
+      assert row.closed_at is not None

--- a/tests/operations/roboledger/commands/test_state_transition_locks_db.py
+++ b/tests/operations/roboledger/commands/test_state_transition_locks_db.py
@@ -23,13 +23,17 @@ import robosystems.models.extensions  # noqa: F401  (register models on the Base
 from robosystems.config import env
 from robosystems.db.extensions import ExtensionsBase, extensions_session
 from robosystems.models.api.extensions.journal_entries import (
+  DeleteJournalEntryRequest,
   ReverseJournalEntryRequest,
+  UpdateJournalEntryRequest,
 )
 from robosystems.models.extensions.roboledger.entry import Entry
 from robosystems.models.extensions.roboledger.fiscal_period import FiscalPeriod
 from robosystems.operations.locking import RowLockedError
 from robosystems.operations.roboledger.commands.journal_entries import (
+  delete_journal_entry,
   reverse_journal_entry,
+  update_journal_entry,
 )
 
 pytestmark = pytest.mark.integration
@@ -177,6 +181,50 @@ class TestReversalLock:
         ).scalar()
         >= 3
       )
+
+
+class TestDraftEntryLock:
+  """Update and delete must lock the entry after the period fence so a
+  concurrent post cannot leave them mutating a posted row."""
+
+  DRAFT_ID = "je_draft_0001"
+
+  @pytest.fixture(autouse=True)
+  def draft_entry(self, tenant):
+    with extensions_session(GRAPH) as session:
+      session.add(
+        Entry(
+          id=self.DRAFT_ID,
+          type="standard",
+          status="draft",
+          posting_date=date(2026, 1, 20),
+          memo="Draft",
+          created_by="usr_seed",
+        )
+      )
+    yield
+
+  def test_a_locked_entry_cannot_be_updated(self, tenant):
+    with extensions_session(GRAPH) as holder:
+      holder.execute(
+        text("SELECT id FROM entries WHERE id = :id FOR UPDATE"),
+        {"id": self.DRAFT_ID},
+      )
+      with extensions_session(GRAPH) as other:
+        with pytest.raises(RowLockedError, match=self.DRAFT_ID):
+          update_journal_entry(
+            other, UpdateJournalEntryRequest(entry_id=self.DRAFT_ID, memo="x")
+          )
+
+  def test_a_locked_entry_cannot_be_deleted(self, tenant):
+    with extensions_session(GRAPH) as holder:
+      holder.execute(
+        text("SELECT id FROM entries WHERE id = :id FOR UPDATE"),
+        {"id": self.DRAFT_ID},
+      )
+      with extensions_session(GRAPH) as other:
+        with pytest.raises(RowLockedError, match=self.DRAFT_ID):
+          delete_journal_entry(other, DeleteJournalEntryRequest(entry_id=self.DRAFT_ID))
 
 
 class TestPeriodTransitionLock:

--- a/tests/operations/roboledger/commands/test_state_transition_locks_db.py
+++ b/tests/operations/roboledger/commands/test_state_transition_locks_db.py
@@ -180,8 +180,13 @@ class TestReversalLock:
 
 
 class TestPeriodTransitionLock:
-  """Close and reopen contend over the same `FiscalPeriod` row. Interleaved,
-  they can leave a period marked closed whose statements were retracted."""
+  """Two concurrent reopens cannot both retract the same month's statements.
+
+  This does **not** cover reopen-vs-close: `close_period` cannot hold a
+  transaction-scoped lock, because its QB pre-publish commits mid-close. That
+  gap is recorded in the close's own comment and in the spec, not papered over
+  with a test that would imply otherwise.
+  """
 
   @pytest.fixture(autouse=True)
   def closed_period(self, tenant):
@@ -233,3 +238,101 @@ class TestPeriodTransitionLock:
       )
       assert row.status == "closed"
       assert row.closed_at is not None
+
+
+class TestAlreadyReversed:
+  """A schedule with `auto_reverse` creates the reversal at generation time and
+  leaves the original's status untouched, so `status == 'posted'` passes on an
+  entry that already has one. That is a reachable state with no race in it."""
+
+  def test_second_reversal_raises_a_domain_error(self, tenant):
+    from robosystems.operations.roboledger.commands.journal_entries import (
+      JournalEntryAlreadyReversedError,
+    )
+
+    with extensions_session(GRAPH) as session:
+      session.add(
+        Entry(
+          id="je_auto_rev",
+          type="reversing",
+          status="draft",
+          posting_date=date(2026, 2, 1),
+          reversal_of=ENTRY_ID,
+          provenance="schedule_derived",
+          created_by="usr_schedule",
+        )
+      )
+
+    with extensions_session(GRAPH) as session:
+      with pytest.raises(JournalEntryAlreadyReversedError) as exc:
+        reverse_journal_entry(
+          session, ReverseJournalEntryRequest(entry_id=ENTRY_ID), "usr_op"
+        )
+      assert exc.value.reversing_entry_id == "je_auto_rev"
+
+    # No second reversal, and the constraint never had to be the one to say so.
+    with extensions_session(GRAPH) as check:
+      assert (
+        check.execute(
+          text("SELECT COUNT(*) FROM entries WHERE reversal_of = :id"),
+          {"id": ENTRY_ID},
+        ).scalar()
+        == 1
+      )
+
+
+class TestFileReportLock:
+  """`filed_by` and `filed_at` are what an auditor reads; last-writer-wins is
+  not good enough for them."""
+
+  REPORT_ID = "rpt_lock_0001"
+
+  @pytest.fixture(autouse=True)
+  def draft_report(self, tenant):
+    from robosystems.models.extensions import Taxonomy
+    from robosystems.models.extensions.roboledger.report import Report
+
+    with extensions_session(GRAPH) as session:
+      session.execute(text("DELETE FROM reports"))
+      session.execute(text("DELETE FROM taxonomies"))
+      session.add(
+        Taxonomy(
+          id="tax_rpt_0001",
+          name="Reporting",
+          taxonomy_type="reporting_standard",
+          created_by="usr_seed",
+        )
+      )
+      session.flush()
+      session.add(
+        Report(
+          id=self.REPORT_ID,
+          taxonomy_id="tax_rpt_0001",
+          name="Q1",
+          period_start=date(2026, 1, 1),
+          period_end=date(2026, 3, 31),
+          filing_status="draft",
+          generation_status="complete",
+          created_by="usr_seed",
+        )
+      )
+    yield
+
+  def test_a_locked_report_cannot_be_filed(self, tenant):
+    from robosystems.operations.roboledger.commands.reports import file_report
+
+    with extensions_session(GRAPH) as holder:
+      holder.execute(
+        text("SELECT id FROM reports WHERE id = :id FOR UPDATE"),
+        {"id": self.REPORT_ID},
+      )
+      with extensions_session(GRAPH) as filer:
+        with pytest.raises(RowLockedError, match=self.REPORT_ID):
+          file_report(filer, self.REPORT_ID, "usr_op")
+
+    with extensions_session(GRAPH) as check:
+      from robosystems.models.extensions.roboledger.report import Report
+
+      row = check.get(Report, self.REPORT_ID)
+      assert row.filing_status == "draft"
+      assert row.filed_at is None

--- a/tests/operations/roboledger/fiscal_calendar/test_close_publish_durability.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_close_publish_durability.py
@@ -209,3 +209,31 @@ class TestPublishMarkerDurability:
     persisted = ext_session.get(Event, event.id)
     ext_session.refresh(persisted)
     assert persisted.metadata_.get("qb_external_id") == "qb_ok"
+
+  def test_lock_timeout_on_one_item_does_not_lose_prior_markers(self, ext_session):
+    """A RowLockedError aborts the transaction unless it is isolated in a
+    savepoint. The markers for entries that already reached QuickBooks
+    must still commit."""
+    from robosystems.operations.locking import RowLockedError
+
+    ok_entry, ok_event = _seed_draft(ext_session, "published first")
+    _locked_entry, locked_event = _seed_draft(ext_session, "lock timeout")
+    ext_session.commit()
+
+    def fake_execute(session, request, created_by):
+      if request.event_id == str(locked_event.id):
+        raise RowLockedError("event is being written")
+      _mark_published(session, request.event_id, "qb_ok")
+      return SimpleNamespace(status="fulfilled", qb_error=None)
+
+    with pytest.raises(WritebackFailed) as exc:
+      _publish(ext_session, fake_execute)
+    assert exc.value.failed_events[0]["event_id"] == str(locked_event.id)
+
+    ext_session.rollback()
+
+    persisted = ext_session.get(Event, ok_event.id)
+    ext_session.refresh(persisted)
+    assert persisted.metadata_.get("qb_external_id") == "qb_ok"
+    ext_session.refresh(ext_session.get(Event, locked_event.id))
+    assert not ext_session.get(Event, locked_event.id).metadata_.get("qb_external_id")

--- a/tests/operations/roboledger/fiscal_calendar/test_close_service.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_close_service.py
@@ -21,6 +21,7 @@ import pytest
 from robosystems.operations.roboledger.fiscal_calendar import (
   CloseGateFailed,
   FiscalCalendarService,
+  PeriodAlreadyClosedError,
   PeriodCloseService,
   PeriodNotFoundError,
   UnbalancedLedgerError,
@@ -100,9 +101,12 @@ def _mock_session_with_fp(fp, debit: int = 0, credit: int = 0, updated: int = 0)
   entry_query = MagicMock()
   entry_query.filter.return_value.update.return_value = updated
 
-  # FiscalPeriod.first() path
+  # FiscalPeriod path: filter → populate_existing → with_for_update → one_or_none
   fp_query = MagicMock()
-  fp_query.filter.return_value.one_or_none.return_value = fp
+  locked = fp_query.filter.return_value
+  locked.populate_existing.return_value = locked
+  locked.with_for_update.return_value = locked
+  locked.one_or_none.return_value = fp
 
   # Route session.query to the right mock based on model. Our service calls:
   # session.query(Entry).filter(...).update(...)
@@ -356,6 +360,27 @@ class TestPeriodNotFound:
       )
 
 
+class TestAlreadyClosedRevalidation:
+  def test_closed_status_after_publish_is_rejected(self):
+    """Post-publish row lock + revalidation: a loser must not stamp again."""
+    fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
+    svc = PeriodCloseService(fcs, statement_stamper=_noop_stamper)
+    session = _mock_session_with_fp(_fp(status="closed"))
+
+    with pytest.raises(PeriodAlreadyClosedError):
+      svc.close(
+        session,
+        GRAPH_ID,
+        "2026-01",
+        actor_id="usr_1",
+        has_sync_connection=False,
+        last_sync_at=None,
+      )
+
+    fcs.advance_closed_through.assert_not_called()
+    fcs.record_reclose.assert_not_called()
+
+
 # ────────────────────────────────────────────────────────────────────────────
 # Re-close routing
 # ────────────────────────────────────────────────────────────────────────────
@@ -502,7 +527,9 @@ class TestCloseAutoRunsRules:
     bs_exec.fetchone.return_value = bs_row
     schedules_exec = MagicMock()
     schedules_exec.scalars.return_value.all.return_value = schedule_ids
-    session.execute.side_effect = [bs_exec, schedules_exec]
+    # BS preflight, then SET LOCAL lock_timeout for the post-publish
+    # FiscalPeriod row lock, then the schedule-id query.
+    session.execute.side_effect = [bs_exec, MagicMock(), schedules_exec]
 
     eval_patcher = patch(
       "robosystems.operations.information_block.rules.engine."
@@ -576,7 +603,9 @@ class TestCloseAutoRunsRules:
     bs_exec.fetchone.return_value = bs_row
     schedules_exec = MagicMock()
     schedules_exec.scalars.return_value.all.return_value = ["struct_ok", "struct_bad"]
-    session.execute.side_effect = [bs_exec, schedules_exec]
+    # BS preflight, then SET LOCAL lock_timeout for the post-publish
+    # FiscalPeriod row lock, then the schedule-id query.
+    session.execute.side_effect = [bs_exec, MagicMock(), schedules_exec]
 
     from unittest.mock import patch
 
@@ -683,8 +712,8 @@ class TestCloseStampsStatementSets:
 
   def test_stamp_runs_after_post_and_before_schedule_rules(self):
     """At stamp time the FiscalPeriod is already closed (drafts posted)
-    and only the BS-preflight execute has run — the schedule-rule query
-    (the second session.execute) hasn't happened yet."""
+    and only the BS-preflight execute plus the post-publish lock_timeout
+    SET have run — the schedule-rule query hasn't happened yet."""
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
     fp = _fp(status="open")
     observed = {}
@@ -707,7 +736,7 @@ class TestCloseStampsStatementSets:
     )
 
     assert observed["fp_status"] == "closed"
-    assert observed["execute_calls"] == 1
+    assert observed["execute_calls"] == 2
 
   def test_stamper_receives_period_window_and_actor(self):
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))

--- a/tests/operations/roboledger/fiscal_calendar/test_close_service.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_close_service.py
@@ -91,7 +91,7 @@ def _mock_session_with_fp(fp, debit: int = 0, credit: int = 0, updated: int = 0)
   """Build a mocked session where:
 
   - Entry bulk-update returns `updated`
-  - FiscalPeriod locked load returns `fp`
+  - FiscalPeriod one_or_none() returns `fp`
   - BS equation SUM query returns (debit, credit)
   """
   session = MagicMock()
@@ -102,19 +102,11 @@ def _mock_session_with_fp(fp, debit: int = 0, credit: int = 0, updated: int = 0)
 
   # FiscalPeriod.first() path
   fp_query = MagicMock()
-  # The close loads the period locked and refreshed —
-  # `.filter(...).populate_existing().with_for_update().one_or_none()` — so
-  # two concurrent closes cannot each read it as closeable. Self-returning
-  # links keep this stub independent of the chain's order.
-  fp_filtered = fp_query.filter.return_value
-  fp_filtered.populate_existing.return_value = fp_filtered
-  fp_filtered.with_for_update.return_value = fp_filtered
-  fp_filtered.one_or_none.return_value = fp
+  fp_query.filter.return_value.one_or_none.return_value = fp
 
   # Route session.query to the right mock based on model. Our service calls:
   # session.query(Entry).filter(...).update(...)
-  # session.query(FiscalPeriod).filter(...).populate_existing()
-  #   .with_for_update().one_or_none()
+  # session.query(FiscalPeriod).filter(...).one_or_none()
   def _query_dispatch(model):
     name = model.__name__ if hasattr(model, "__name__") else str(model)
     if name == "FiscalPeriod":
@@ -510,8 +502,7 @@ class TestCloseAutoRunsRules:
     bs_exec.fetchone.return_value = bs_row
     schedules_exec = MagicMock()
     schedules_exec.scalars.return_value.all.return_value = schedule_ids
-    # The bounded wait's `SET LOCAL lock_timeout` consumes the first execute.
-    session.execute.side_effect = [MagicMock(), bs_exec, schedules_exec]
+    session.execute.side_effect = [bs_exec, schedules_exec]
 
     eval_patcher = patch(
       "robosystems.operations.information_block.rules.engine."
@@ -585,8 +576,7 @@ class TestCloseAutoRunsRules:
     bs_exec.fetchone.return_value = bs_row
     schedules_exec = MagicMock()
     schedules_exec.scalars.return_value.all.return_value = ["struct_ok", "struct_bad"]
-    # The bounded wait's `SET LOCAL lock_timeout` consumes the first execute.
-    session.execute.side_effect = [MagicMock(), bs_exec, schedules_exec]
+    session.execute.side_effect = [bs_exec, schedules_exec]
 
     from unittest.mock import patch
 
@@ -694,13 +684,7 @@ class TestCloseStampsStatementSets:
   def test_stamp_runs_after_post_and_before_schedule_rules(self):
     """At stamp time the FiscalPeriod is already closed (drafts posted)
     and only the BS-preflight execute has run — the schedule-rule query
-    hasn't happened yet.
-
-    Two executes by then, not one: the period's locked load issues a
-    `SET LOCAL lock_timeout` before the preflight. The assertion is about
-    *ordering* — the schedule-rule query is the one that must not have run
-    yet — so the count moves with the statements that legitimately precede
-    it."""
+    (the second session.execute) hasn't happened yet."""
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
     fp = _fp(status="open")
     observed = {}
@@ -723,7 +707,7 @@ class TestCloseStampsStatementSets:
     )
 
     assert observed["fp_status"] == "closed"
-    assert observed["execute_calls"] == 2  # SET LOCAL, then BS preflight
+    assert observed["execute_calls"] == 1
 
   def test_stamper_receives_period_window_and_actor(self):
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))

--- a/tests/operations/roboledger/fiscal_calendar/test_close_service.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_close_service.py
@@ -91,7 +91,7 @@ def _mock_session_with_fp(fp, debit: int = 0, credit: int = 0, updated: int = 0)
   """Build a mocked session where:
 
   - Entry bulk-update returns `updated`
-  - FiscalPeriod one_or_none() returns `fp`
+  - FiscalPeriod locked load returns `fp`
   - BS equation SUM query returns (debit, credit)
   """
   session = MagicMock()
@@ -102,11 +102,19 @@ def _mock_session_with_fp(fp, debit: int = 0, credit: int = 0, updated: int = 0)
 
   # FiscalPeriod.first() path
   fp_query = MagicMock()
-  fp_query.filter.return_value.one_or_none.return_value = fp
+  # The close loads the period locked and refreshed —
+  # `.filter(...).populate_existing().with_for_update().one_or_none()` — so
+  # two concurrent closes cannot each read it as closeable. Self-returning
+  # links keep this stub independent of the chain's order.
+  fp_filtered = fp_query.filter.return_value
+  fp_filtered.populate_existing.return_value = fp_filtered
+  fp_filtered.with_for_update.return_value = fp_filtered
+  fp_filtered.one_or_none.return_value = fp
 
   # Route session.query to the right mock based on model. Our service calls:
   # session.query(Entry).filter(...).update(...)
-  # session.query(FiscalPeriod).filter(...).one_or_none()
+  # session.query(FiscalPeriod).filter(...).populate_existing()
+  #   .with_for_update().one_or_none()
   def _query_dispatch(model):
     name = model.__name__ if hasattr(model, "__name__") else str(model)
     if name == "FiscalPeriod":
@@ -502,7 +510,8 @@ class TestCloseAutoRunsRules:
     bs_exec.fetchone.return_value = bs_row
     schedules_exec = MagicMock()
     schedules_exec.scalars.return_value.all.return_value = schedule_ids
-    session.execute.side_effect = [bs_exec, schedules_exec]
+    # The bounded wait's `SET LOCAL lock_timeout` consumes the first execute.
+    session.execute.side_effect = [MagicMock(), bs_exec, schedules_exec]
 
     eval_patcher = patch(
       "robosystems.operations.information_block.rules.engine."
@@ -576,7 +585,8 @@ class TestCloseAutoRunsRules:
     bs_exec.fetchone.return_value = bs_row
     schedules_exec = MagicMock()
     schedules_exec.scalars.return_value.all.return_value = ["struct_ok", "struct_bad"]
-    session.execute.side_effect = [bs_exec, schedules_exec]
+    # The bounded wait's `SET LOCAL lock_timeout` consumes the first execute.
+    session.execute.side_effect = [MagicMock(), bs_exec, schedules_exec]
 
     from unittest.mock import patch
 
@@ -684,7 +694,13 @@ class TestCloseStampsStatementSets:
   def test_stamp_runs_after_post_and_before_schedule_rules(self):
     """At stamp time the FiscalPeriod is already closed (drafts posted)
     and only the BS-preflight execute has run — the schedule-rule query
-    (the second session.execute) hasn't happened yet."""
+    hasn't happened yet.
+
+    Two executes by then, not one: the period's locked load issues a
+    `SET LOCAL lock_timeout` before the preflight. The assertion is about
+    *ordering* — the schedule-rule query is the one that must not have run
+    yet — so the count moves with the statements that legitimately precede
+    it."""
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))
     fp = _fp(status="open")
     observed = {}
@@ -707,7 +723,7 @@ class TestCloseStampsStatementSets:
     )
 
     assert observed["fp_status"] == "closed"
-    assert observed["execute_calls"] == 1
+    assert observed["execute_calls"] == 2  # SET LOCAL, then BS preflight
 
   def test_stamper_receives_period_window_and_actor(self):
     fcs = _mock_fcs(gate_result=CloseableGateResult(is_closeable=True))

--- a/tests/operations/roboledger/schedules/test_service.py
+++ b/tests/operations/roboledger/schedules/test_service.py
@@ -1424,6 +1424,15 @@ class TestCreateScheduleMaterializesObligations:
 
 
 class TestCreateClosingEntry:
+  @pytest.fixture(autouse=True)
+  def _open_period(self):
+    """These tests mock execute side-effects for entry/fact lookups.
+    The period fence would consume the first fetchone."""
+    with patch(
+      "robosystems.operations.roboledger.schedules.service.assert_period_not_closed"
+    ):
+      yield
+
   def _mock_schedule_structure(self):
     struct = MagicMock()
     struct.block_type = "schedule"

--- a/tests/operations/test_locking.py
+++ b/tests/operations/test_locking.py
@@ -1,0 +1,80 @@
+"""Unit tests for the period-write fence and lock-connection hygiene."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from robosystems.operations.locking import (
+  RowLockedError,
+  exclusive_period_fence,
+  period_fence_ident,
+)
+
+
+def _pg_error(pgcode: str) -> OperationalError:
+  orig = MagicMock()
+  orig.pgcode = pgcode
+  return OperationalError("lock", {}, orig)
+
+
+class TestExclusivePeriodFence:
+  def _connect(self, mock_engine):
+    conn = MagicMock()
+    mock_engine.return_value.connect.return_value = conn
+    return conn
+
+  @patch("robosystems.db.extensions.get_extensions_engine")
+  def test_unlocks_after_the_body(self, mock_engine):
+    conn = self._connect(mock_engine)
+    with exclusive_period_fence("kgabc", "2026-01", detail="held"):
+      pass
+    sql = " ".join(str(call.args[0]) for call in conn.execute.call_args_list)
+    assert "pg_advisory_lock" in sql
+    assert "pg_advisory_unlock" in sql
+    conn.close.assert_called_once()
+    conn.invalidate.assert_not_called()
+
+  @patch("robosystems.db.extensions.get_extensions_engine")
+  def test_unlocks_when_the_body_raises(self, mock_engine):
+    conn = self._connect(mock_engine)
+    with pytest.raises(RuntimeError, match="boom"):
+      with exclusive_period_fence("kgabc", "2026-01", detail="held"):
+        raise RuntimeError("boom")
+    sql = " ".join(str(call.args[0]) for call in conn.execute.call_args_list)
+    assert "pg_advisory_unlock" in sql
+    conn.close.assert_called_once()
+
+  @patch("robosystems.db.extensions.get_extensions_engine")
+  def test_timeout_is_row_locked_and_does_not_unlock(self, mock_engine):
+    conn = self._connect(mock_engine)
+    conn.execute.side_effect = [None, _pg_error("55P03")]
+    with pytest.raises(RowLockedError, match="held"):
+      with exclusive_period_fence("kgabc", "2026-01", detail="held"):
+        pass
+    sql = " ".join(
+      str(call.args[0]) for call in conn.execute.call_args_list if call.args
+    )
+    assert "pg_advisory_unlock" not in sql
+    conn.close.assert_called_once()
+
+  @patch("robosystems.db.extensions.get_extensions_engine")
+  def test_unlock_failure_invalidates_the_connection(self, mock_engine):
+    conn = self._connect(mock_engine)
+
+    def _execute(statement, *args, **kwargs):
+      if "pg_advisory_unlock" in str(statement):
+        raise RuntimeError("unlock failed")
+      return MagicMock()
+
+    conn.execute.side_effect = _execute
+    with exclusive_period_fence("kgabc", "2026-01", detail="held"):
+      pass
+    conn.invalidate.assert_called_once()
+    conn.close.assert_called_once()
+
+
+def test_period_fence_ident_is_graph_and_period():
+  assert period_fence_ident("kg1", "2026-01") == "kg1:2026-01"

--- a/tests/routers/extensions/roboledger/test_operations.py
+++ b/tests/routers/extensions/roboledger/test_operations.py
@@ -625,6 +625,30 @@ class TestUpdateJournalEntryOp:
     assert exc.value.status_code == 422
     assert "posted" in exc.value.detail
 
+  @pytest.mark.asyncio
+  async def test_409_when_row_locked(self) -> None:
+    from robosystems.operations.locking import RowLockedError
+
+    body = UpdateJournalEntryRequest(entry_id="je_abc", memo="X")
+    with (
+      patch(
+        "robosystems.operations.roboledger.commands.journal_entries.update_journal_entry",
+        side_effect=RowLockedError("Journal entry je_abc is being written"),
+      ),
+      _mock_session_ctx() as mock_session,
+    ):
+      mock_session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+      mock_session.return_value.__exit__ = MagicMock(return_value=False)
+      with pytest.raises(HTTPException) as exc:
+        await update_journal_entry_op(
+          body=body,
+          graph_id=GRAPH_ID,
+          user=_make_user(),
+          idempotency_key=None,
+          cache=_FakeCache(),
+        )
+    assert exc.value.status_code == 409
+
 
 class TestDeleteJournalEntryOp:
   @pytest.mark.asyncio
@@ -676,6 +700,55 @@ class TestDeleteJournalEntryOp:
           cache=_FakeCache(),
         )
     assert exc.value.status_code == 422
+
+  @pytest.mark.asyncio
+  async def test_409_when_row_locked(self) -> None:
+    from robosystems.operations.locking import RowLockedError
+
+    body = DeleteJournalEntryRequest(entry_id="je_draft")
+    with (
+      patch(
+        "robosystems.operations.roboledger.commands.journal_entries.delete_journal_entry",
+        side_effect=RowLockedError("Journal entry je_draft is being written"),
+      ),
+      _mock_session_ctx() as mock_session,
+    ):
+      mock_session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+      mock_session.return_value.__exit__ = MagicMock(return_value=False)
+      with pytest.raises(HTTPException) as exc:
+        await delete_journal_entry_op(
+          body=body,
+          graph_id=GRAPH_ID,
+          user=_make_user(),
+          idempotency_key=None,
+          cache=_FakeCache(),
+        )
+    assert exc.value.status_code == 409
+
+  @pytest.mark.asyncio
+  async def test_422_when_period_closed(self) -> None:
+    from robosystems.operations.roboledger.commands._guards import ClosedPeriodError
+
+    body = DeleteJournalEntryRequest(entry_id="je_draft")
+    with (
+      patch(
+        "robosystems.operations.roboledger.commands.journal_entries.delete_journal_entry",
+        side_effect=ClosedPeriodError("2026-01", date(2026, 1, 15)),
+      ),
+      _mock_session_ctx() as mock_session,
+    ):
+      mock_session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+      mock_session.return_value.__exit__ = MagicMock(return_value=False)
+      with pytest.raises(HTTPException) as exc:
+        await delete_journal_entry_op(
+          body=body,
+          graph_id=GRAPH_ID,
+          user=_make_user(),
+          idempotency_key=None,
+          cache=_FakeCache(),
+        )
+    assert exc.value.status_code == 422
+    assert "closed period" in exc.value.detail
 
 
 # TestReverseJournalEntryOp removed: the `reverse-journal-entry`


### PR DESCRIPTION
## Summary

Sweeping the *writes* rather than the concept — `grep` for assignments to `status`, `closed_at`, `filed_at` and friends across `operations/` — turned up three more instances of the shape #1197 and #1202 have been closing: load a row, branch on a state column, write it back, with nothing held across the decision.

Follows #1202 (merged), whose locking primitives this builds on.

## Changes

**`reverse_journal_entry` double-posted.** `commands/journal_entries.py` read the original entry unlocked, checked `status == 'posted'`, then wrote a full reversing entry with flipped line items. Two concurrent reversals both passed the check and both posted — **the entry got reversed twice.** Each reversing entry is internally balanced, so the trial balance stayed happy while the books sat one entry's worth off in the other direction. Nothing at the database level stopped it: no unique index on `reversal_of`, and the reversing entry carries no `idempotency_key`.

The command now locks the original. **Migration 0032** adds a partial unique index on `reversal_of`, because "an entry is reversed at most once" is a real invariant rather than a concurrency workaround — it should hold against a double-clicked button and against a future caller that forgets to lock, not only against the race.

⚠️ **The migration must be checked against existing data before deploy.** It will fail if any original already has two reversals, and that failure is the correct outcome: it means genuinely double-reversed entries are in the ledger and need an accounting decision, not a schema decision. The query to run per tenant schema is in the migration's docstring.

**`close_period` / `reopen_period`.** Both read the `FiscalPeriod` row unlocked and branched on its status. Two concurrent closes would each run the entire close — promoting drafts, **publishing to QuickBooks**, stamping statements. Parts of that are accidentally idempotent (QB's `request_id` dedup, replace-semantics on stamping); none of it is a guard. A reopen interleaved with a close leaves a period marked closed whose statements were retracted. Both now lock the same row.

**`file_report`.** The mild one — a concurrent double-file overwrites the audit stamp rather than duplicating anything. But `filed_by` and `filed_at` are exactly the fields an auditor reads, so last-writer-wins isn't good enough for them.

**The structural change, which is the point of this PR as much as the three fixes:** the lock policy moves from `operations/event_block/locking.py` to `operations/locking.py`, and `EventLockedError` becomes `RowLockedError`. Filed inside one consumer, the discipline was invisible to every other subsystem with the same shape — which is why instances two through six were each found one at a time by going to look. `lock_by_id` is the one-call version of the correct read (FOR UPDATE, `populate_existing`, a flush first because these sessions are `autoflush=False`, and a bounded wait), so a caller no longer has to remember four separate things to get it right.

## Breaking Changes

None. `RowLockedError` maps to the same 409 as before on the operations that already had it, plus `update-information-block` and `file-report`. Internal rename — no SDK symbol, no request or response shape change.

## Testing

`just test-all` — **13,001 passed, 38 skipped**; quality gate clean. Migration applied locally against the extensions DB.

New DB-backed regressions in `test_state_transition_locks_db.py` (real concurrent sessions, throwaway tenant schema). Each guard verified by removing it:

| Guard removed | Result |
| --- | --- |
| reversal's `lock_by_id` | `test_a_locked_entry_cannot_be_reversed` fails |
| `uq_entries_one_reversal_per_original` from the model | fixture assertion fails (model/migration drift check) |
| reopen's `with_for_update()` | `test_a_locked_period_cannot_be_reopened` fails |

One verification is worth reporting precisely: removing the reopen guard's **wrapper** rather than its `FOR UPDATE` makes the suite hang rather than fail, because dropping `bounded_lock_wait` also drops the `lock_timeout`. That's the bounded wait demonstrating its own purpose, and it's why the isolation test removes the lock while keeping the wrapper.

The reversal tests also pin that the partial index leaves ordinary entries (`reversal_of IS NULL`) unconstrained.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
