### PR TITLE
fix(close): isolate each QuickBooks publish in a savepoint

### DIFF
--- a/robosystems/operations/roboledger/fiscal_calendar/close_service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_service.py
@@ -525,14 +525,29 @@ class PeriodCloseService:
     failed_events: list[dict] = []
     for entry, event in drafts_to_publish:
       try:
-        result = execute_event_block(
-          session,
-          ExecuteEventBlockRequest(
-            event_id=str(event.id),
-            connection_id=qb_connection_id,
-          ),
-          created_by=actor_id,
-        )
+        # Each publish runs in its own SAVEPOINT so a database error here
+        # cannot take the whole batch down with it.
+        #
+        # `execute_event_block` bounds its wait for the event's row lock, so a
+        # conflicting writer surfaces as an error over an **aborted**
+        # transaction rather than as a block. Without a savepoint the loop
+        # would carry on collecting failures while every later statement failed
+        # on that aborted transaction, and the `session.commit()` below — the
+        # one whose entire purpose is to make the qb_external_id markers
+        # durable — would go down with it. QuickBooks would be holding journal
+        # entries the ledger has no record of sending, and the retried close
+        # would publish them a second time once QB's RequestId dedup window
+        # expired. The savepoint keeps a failed publish to the one entry that
+        # failed, so the markers for entries that did reach QB still commit.
+        with session.begin_nested():
+          result = execute_event_block(
+            session,
+            ExecuteEventBlockRequest(
+              event_id=str(event.id),
+              connection_id=qb_connection_id,
+            ),
+            created_by=actor_id,
+          )
         if result.status == "pending":
           # QB rejected — collect for the batch error.
           failed_events.append(

--- a/tests/operations/roboledger/fiscal_calendar/test_publish_savepoint.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_publish_savepoint.py
@@ -1,0 +1,116 @@
+"""The close's QuickBooks pre-publish must not lose dedupe markers.
+
+`_publish_drafts_to_qb` commits deliberately: the `qb_external_id` markers
+record journal entries that now exist in QuickBooks, so they have to survive
+whatever happens to the rest of the close. Otherwise a retried close republishes
+them once QB's RequestId dedup window expires, and the customer's books get
+duplicate entries.
+
+`execute_event_block` bounds its wait for the event's row lock, so a conflicting
+writer surfaces as an error over an **aborted** PostgreSQL transaction rather
+than as a block. Each publish therefore needs its own SAVEPOINT — without one
+the first such failure poisons the transaction and takes the markers of every
+entry that already reached QuickBooks down with it.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_MODULE = "robosystems.operations.roboledger.fiscal_calendar.close_service"
+_QB = "robosystems.operations.roboledger.fiscal_calendar.qb_writeback"
+
+
+class _AbortedTransaction(Exception):
+  """Stands in for the database error a bounded lock wait raises."""
+
+
+def _draft(event_id: str):
+  entry = MagicMock(id=f"entry_{event_id}", memo="m", posting_date=date(2026, 1, 31))
+  event = MagicMock(id=event_id)
+  return entry, event
+
+
+def _session():
+  """Session whose `begin_nested` behaves like a PostgreSQL SAVEPOINT.
+
+  The savepoint absorbs the failure and the outer transaction stays usable —
+  which is the whole property under test, so it is modelled rather than mocked
+  away.
+  """
+  session = MagicMock()
+  session.journal = []
+
+  class _Savepoint:
+    def __enter__(self):
+      session.journal.append("begin")
+      return self
+
+    def __exit__(self, exc_type, exc, tb):
+      session.journal.append("rollback" if exc_type else "release")
+      return False
+
+  session.begin_nested.side_effect = lambda: _Savepoint()
+  session.commit.side_effect = lambda: session.journal.append("commit")
+  return session
+
+
+def test_a_failed_publish_does_not_cost_the_markers_of_earlier_ones():
+  """Entry 2 fails on a database error; 1 and 3 reached QB and still commit."""
+  from robosystems.operations.roboledger.fiscal_calendar.close_service import (
+    PeriodCloseService,
+    WritebackFailed,
+  )
+
+  published: list[str] = []
+
+  def _fake_execute(session, body, created_by):
+    if body.event_id == "evt_2":
+      raise _AbortedTransaction("current transaction is aborted")
+    published.append(body.event_id)
+    return MagicMock(status="fulfilled", qb_error=None)
+
+  session = _session()
+  drafts = [_draft("evt_1"), _draft("evt_2"), _draft("evt_3")]
+
+  with (
+    patch(
+      "robosystems.operations.event_block.commands.execute_event_block", _fake_execute
+    ),
+    patch("robosystems.database.SessionFactory"),
+    patch(
+      f"{_QB}.resolve_writeback_connection",
+      return_value=MagicMock(connection_id="conn_1"),
+    ),
+    patch(f"{_QB}.select_writeback_eligible_entries", return_value=drafts),
+  ):
+    with pytest.raises(WritebackFailed) as exc:
+      PeriodCloseService(MagicMock())._publish_drafts_to_qb(
+        session,
+        "kg_test",
+        date(2026, 1, 1),
+        date(2026, 1, 31),
+        actor_id="usr_1",
+      )
+
+  # The two that reached QuickBooks did so, and the batch error names only the
+  # one that failed.
+  assert published == ["evt_1", "evt_3"]
+  assert [f["event_id"] for f in exc.value.failed_events] == ["evt_2"]
+
+  # The decisive part: the failure was contained in its own savepoint and the
+  # markers were committed before WritebackFailed was raised.
+  assert session.journal == [
+    "begin",
+    "release",
+    "begin",
+    "rollback",
+    "begin",
+    "release",
+    "commit",
+  ]


### PR DESCRIPTION
## Summary

Regression from `v1.9.4`, currently deployed to production.

`execute_event_block` gained a bounded lock wait in #1202, so a conflicting writer now surfaces there as an error over an **aborted** PostgreSQL transaction rather than blocking. The close's QuickBooks pre-publish loop catches broadly and continues, which meant every later statement failed on that aborted transaction and the `session.commit()` at the end of the loop failed with them — the commit whose entire purpose is to make the `qb_external_id` markers durable.

That produces exactly the failure the commit exists to prevent: **QuickBooks holds journal entries the ledger has no record of sending, and the retried close publishes them a second time** once QB's RequestId dedup window expires. Duplicate entries in a customer's books.

## Changes

`_publish_drafts_to_qb` opens a `SAVEPOINT` per entry, so a failure is contained to the entry that failed and the markers for entries that already reached QuickBooks still commit. Same pattern the loader's auto-commit pass already uses for the same reason.

Nothing else changes — no new locks, no error-mapping changes, no schema.

## Breaking Changes

None.

## Testing

`tests/operations/roboledger/fiscal_calendar/test_publish_savepoint.py` drives the real `_publish_drafts_to_qb` with a database error on the middle of three entries and asserts both halves of the property: the other two published, and their markers committed *before* `WritebackFailed` was raised. It models `begin_nested()` the way PostgreSQL behaves — the savepoint absorbs the failure and the outer transaction stays usable — because that behaviour is the thing under test rather than an incidental detail.

**Verified to fail without the fix**: removing the savepoint leaves `session.journal == ['commit']` instead of the begin/release/begin/rollback/begin/release/commit sequence.

`tests/operations/roboledger` + `tests/operations/event_block`: 993 passed. `just test-code`: clean.

Full-gate note: three consecutive `just test-all` runs on the parent branch failed on three *different* tests, two of them in areas untouched by any of this work, each passing in isolation and in its own module. That flakiness is pre-existing and worth its own attention — `pytest.ini` sets `-x`, so a flaky early failure masks everything after it, which is how a real break in the parent branch hid for one round.

## Deployment

This should go out ahead of the remaining locking work. The exposure needs a concurrent writer holding an event row during a close — a sync finishing as a close begins is enough, and the close gate's staleness check encourages that ordering.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
