### PR TITLE
fix(roboledger): refuse retracted events and paginate teardown purge

### DIFF
--- a/robosystems/operations/aws/s3.py
+++ b/robosystems/operations/aws/s3.py
@@ -6,6 +6,7 @@ import asyncio
 import gzip
 import hashlib
 import json
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
@@ -23,8 +24,9 @@ from robosystems.logger import logger
 class S3Client:
   """Sync S3 client for general object storage (XBRL textblocks, temp files).
 
-  All methods swallow errors and return a falsy value rather than raising,
-  so callers can translate to HTTP without try/except.
+  Most methods swallow errors and return a falsy value rather than raising,
+  so callers can translate to HTTP without try/except. ``iter_object_keys``
+  is the exception: a failed or truncated listing must not look empty.
   """
 
   def __init__(self, region_name: str | None = None, endpoint_url: str | None = None):
@@ -369,6 +371,22 @@ class S3Client:
     except Exception as e:
       logger.error(f"Unexpected error listing objects from S3: {e}")
       return []
+
+  def iter_object_keys(self, bucket: str, prefix: str | None = None) -> Iterator[str]:
+    """Yield every object key under ``prefix``.
+
+    Paginates ``list_objects_v2``. Raises on S3 failure so a caller can
+    tell a failed list from an empty prefix — ``list_objects`` cannot.
+    """
+    paginator = self.s3_client.get_paginator("list_objects_v2")
+    params: dict[str, Any] = {"Bucket": bucket}
+    if prefix:
+      params["Prefix"] = prefix
+    for page in paginator.paginate(**params):
+      for obj in page.get("Contents") or []:
+        key = obj.get("Key")
+        if key:
+          yield key
 
   def batch_upload_strings(
     self,

--- a/robosystems/operations/event_block/__init__.py
+++ b/robosystems/operations/event_block/__init__.py
@@ -9,6 +9,7 @@ from robosystems.operations.locking import RowLockedError
 from .commands import (
   DuplicateEventError,
   EventNotFoundError,
+  EventNotPublishableError,
   InvalidEventTransitionError,
   create_event_block,
   execute_event_block,
@@ -27,6 +28,7 @@ __all__ = [
   "DuplicateEventError",
   "EventLockedError",  # deprecated alias for RowLockedError
   "EventNotFoundError",
+  "EventNotPublishableError",
   "InvalidEventTransitionError",
   "RowLockedError",
   "create_event_block",

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -74,6 +74,20 @@ class InvalidEventTransitionError(Exception):
   pass
 
 
+class EventNotPublishableError(Exception):
+  """Raised when execute is asked to publish a retracted event.
+
+  Terminal states have no outbound transitions. Publishing one would
+  overwrite ``voided`` / ``superseded`` with ``fulfilled`` and post a
+  JournalEntry for work the books already retracted.
+  """
+
+  def __init__(self, event_id: str, status: str) -> None:
+    super().__init__(f"Event {event_id} is {status!r} and cannot be published.")
+    self.event_id = event_id
+    self.status = status
+
+
 class DuplicateEventError(Exception):
   """Raised when (source, external_id) already names an event on this graph.
 
@@ -108,6 +122,11 @@ _VALID_TRANSITIONS: dict[str, frozenset[str]] = {
   "voided": frozenset(),
   "superseded": frozenset(),
 }
+
+# Execute must not post these. ``fulfilled`` is also terminal, but a
+# repeat execute of an already-published event is an idempotent no-op
+# (see ``qb_external_id`` / status checks in ``execute_event_block``).
+_UNPUBLISHABLE_STATUSES = frozenset({"voided", "superseded"})
 
 
 def _resolve_agent_type(session: Session, agent_id: str | None) -> str | None:
@@ -387,6 +406,21 @@ def update_event_block(
   # Bounded, because the conflicting writer is usually a sync or a promotion
   # sweep that runs long — see `locking.bounded_lock_wait`.
   session.flush()  # pairs with populate_existing below; autoflush is off here
+  peek = session.get(Event, body.event_id)
+  if peek is None:
+    raise EventNotFoundError(f"Event not found: {body.event_id}")
+  # Fence before the event row lock — same order as journal update/delete
+  # and as close's exclusive fence. Approving (event lock, then handler
+  # fence) against a closer (exclusive fence, then event lock) used to
+  # sit until lock_timeout and fail close mid-publish.
+  if body.transition_to == "committed":
+    assert_period_not_closed(
+      session,
+      posting_date_for_event(
+        effective_at=peek.effective_at,
+        occurred_at=peek.occurred_at,
+      ),
+    )
   with bounded_lock_wait(
     session,
     f"Event {body.event_id} is being written by another process "
@@ -397,8 +431,8 @@ def update_event_block(
     # event's lock leaves two callers superseding each other in opposite
     # directions (A←B here, B←A there) each holding what the other needs, and
     # the resulting deadlock surfaces at commit rather than here. Ordering by
-    # `id` makes that cycle impossible instead of translating it afterwards —
-    # the same discipline the batch locks use (`locking.ORDERED_LOCK_KEY`).
+    # `ordered_lock_column()` makes that cycle impossible instead of
+    # translating it afterwards.
     #
     # `populate_existing` for the same reason as `execute_event_block`: every
     # production caller opens a fresh session per request, so the identity map
@@ -678,6 +712,8 @@ def execute_event_block(
   session: Session,
   body: ExecuteEventBlockRequest,
   created_by: str,
+  *,
+  acquire_period_fence: bool = True,
 ) -> ExecuteEventBlockResponse:
   """Publish an event to its connection's source-of-truth system.
 
@@ -698,7 +734,14 @@ def execute_event_block(
 
   Idempotency: the QB POST carries `request_id=event.id`. QB's
   ~5-minute RequestId dedup window means our retry-after-network-blip
-  path is safe at the API layer.
+  path is safe at the API layer. An event that already carries
+  ``qb_external_id`` (or is already ``fulfilled``) is returned as-is.
+  ``voided`` / ``superseded`` raise :class:`EventNotPublishableError`
+  before any external write.
+
+  ``acquire_period_fence`` is the request-facing default. Close already
+  holds the exclusive fence on a dedicated connection; taking the
+  shared side here would wait on that exclusive lock and time out.
   """
   # Local imports to avoid pulling QB SDK + platform-DB session into
   # callers that only need create/update/preview.
@@ -733,6 +776,17 @@ def execute_event_block(
   # today; this makes that a property of the function rather than of its
   # callers.
   session.flush()
+  peek = session.get(Event, body.event_id)
+  if peek is None:
+    raise EventNotFoundError(f"Event {body.event_id} not found")
+  if acquire_period_fence:
+    assert_period_not_closed(
+      session,
+      posting_date_for_event(
+        effective_at=peek.effective_at,
+        occurred_at=peek.occurred_at,
+      ),
+    )
   with bounded_lock_wait(
     session,
     f"Event {body.event_id} is being written by another process. Retry in a moment.",
@@ -748,6 +802,24 @@ def execute_event_block(
     raise EventNotFoundError(f"Event {body.event_id} not found")
 
   metadata = dict(event.metadata_ or {})
+  existing_qb_id = metadata.get("qb_external_id")
+  if existing_qb_id:
+    primary = str(existing_qb_id).split(",", 1)[0]
+    return ExecuteEventBlockResponse(
+      event_id=str(event.id),
+      status=str(event.status),
+      qb_external_id=primary,
+      qb_error=None,
+    )
+  if event.status in _UNPUBLISHABLE_STATUSES:
+    raise EventNotPublishableError(str(event.id), str(event.status))
+  if event.status == "fulfilled":
+    return ExecuteEventBlockResponse(
+      event_id=str(event.id),
+      status="fulfilled",
+      qb_external_id=None,
+      qb_error=None,
+    )
   # Caller can override the connection (used by the close-period batch
   # where schedule events don't carry connection_id in metadata).
   connection_id = body.connection_id or metadata.get("connection_id")

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -412,15 +412,25 @@ def update_event_block(
   # Fence before the event row lock — same order as journal update/delete
   # and as close's exclusive fence. Approving (event lock, then handler
   # fence) against a closer (exclusive fence, then event lock) used to
-  # sit until lock_timeout and fail close mid-publish.
+  # sit until lock_timeout and fail close mid-publish. Both the current
+  # posting date and the one ``body.effective_at`` would move it to, as
+  # ``update_journal_entry`` does — the handler posts against the patched
+  # date, and its own fence runs after the lock.
   if body.transition_to == "committed":
-    assert_period_not_closed(
-      session,
+    fence_dates = {
       posting_date_for_event(
         effective_at=peek.effective_at,
         occurred_at=peek.occurred_at,
-      ),
-    )
+      )
+    }
+    if body.effective_at is not None:
+      fence_dates.add(
+        posting_date_for_event(
+          effective_at=body.effective_at,
+          occurred_at=peek.occurred_at,
+        )
+      )
+    assert_period_not_closed(session, *sorted(fence_dates))
   with bounded_lock_wait(
     session,
     f"Event {body.event_id} is being written by another process "

--- a/robosystems/operations/event_block/promotion.py
+++ b/robosystems/operations/event_block/promotion.py
@@ -77,6 +77,7 @@ from robosystems.operations.event_block.python_handlers.types import (
 )
 from robosystems.operations.locking import ordered_lock_column
 from robosystems.operations.roboledger.commands._guards import (
+  ClosedPeriodError,
   assert_period_not_closed,
 )
 
@@ -201,6 +202,51 @@ def find_stranded_obligations(session: Session, *, as_of: datetime) -> list[Even
   return filter_stranded_obligations(session, classified)
 
 
+def _fence_autopilot_write_set(
+  session: Session, candidate_filter: list
+) -> list[tuple[str, str]]:
+  """Take the shared period fence for every obligation autopilot will write.
+
+  The write set is the ``pending`` candidates plus the stranded ``classified``
+  ones — not every classified obligation. Dispatched obligations stay
+  ``classified`` for good (see ``schedule_entry_due``), so fencing the whole
+  candidate set would fence every period that ever held a schedule and fail
+  the sweep on the first one that has since closed.
+
+  Returns ``(event_id, reason)`` for obligations whose period is closed, so
+  the caller can leave them out and report them. A fence that cannot be
+  taken because a closer holds the exclusive side propagates as
+  ``RowLockedError`` — that one is retryable and does apply to the sweep.
+  """
+  preview = session.query(Event).filter(*candidate_filter).all()
+  pending = [evt for evt in preview if evt.status == "pending"]
+  classified = [evt for evt in preview if evt.status == "classified"]
+  write_set = pending + (
+    filter_stranded_obligations(session, classified) if classified else []
+  )
+  if not write_set:
+    return []
+
+  by_date: dict[date, list[Event]] = {}
+  for evt in write_set:
+    posting_date = posting_date_for_event(
+      effective_at=evt.effective_at,
+      occurred_at=evt.occurred_at,
+    )
+    by_date.setdefault(posting_date, []).append(evt)
+
+  closed: list[tuple[str, str]] = []
+  # Sorted so two sweeps fence periods in the same order. Shared fences do
+  # not contend with each other, so this is tidiness rather than a
+  # deadlock guard — the row locks that follow are the ones ordered for that.
+  for posting_date in sorted(by_date):
+    try:
+      assert_period_not_closed(session, posting_date)
+    except ClosedPeriodError as e:
+      closed.extend((evt.id, f"closed period: {e}") for evt in by_date[posting_date])
+  return closed
+
+
 def promote_pending_obligations(
   session: Session,
   graph_id: str,
@@ -232,26 +278,22 @@ def promote_pending_obligations(
   # and (if a tick overruns) its own successor. See `locking` for the
   # bounded-vs-unbounded split: this function is called from both a Dagster
   # sweep and a request handler, and it is the *caller* that bounds the wait.
-  candidate_filter = (
+  candidate_filter = [
     Event.event_type == "schedule_entry_due",
     Event.status.in_(("pending", "classified")),
     Event.occurred_at <= as_of,
-  )
+  ]
+  result = PromotionResult(graph_id=graph_id)
   # Autopilot writes GL, so the period fence has to come *before* the
   # event row locks. Close takes exclusive fence then event locks;
   # locking first and fencing in the handler was the inversion that
-  # failed close mid-publish.
+  # failed close mid-publish. An obligation whose period is already
+  # closed is left out of the sweep and reported, not fatal to it.
   if dispatch_handlers:
-    preview = session.query(Event).filter(*candidate_filter).all()
-    fence_dates = [
-      posting_date_for_event(
-        effective_at=getattr(evt, "effective_at", None),
-        occurred_at=evt.occurred_at,
-      )
-      for evt in preview
-    ]
-    if fence_dates:
-      assert_period_not_closed(session, *fence_dates)
+    closed = _fence_autopilot_write_set(session, candidate_filter)
+    if closed:
+      result.errors.extend(closed)
+      candidate_filter.append(Event.id.notin_([evt_id for evt_id, _ in closed]))
   candidates = (
     session.query(Event)
     .filter(*candidate_filter)
@@ -264,8 +306,6 @@ def promote_pending_obligations(
   )
   pending = [evt for evt in candidates if evt.status == "pending"]
   classified = [evt for evt in candidates if evt.status == "classified"]
-
-  result = PromotionResult(graph_id=graph_id)
 
   stranded = filter_stranded_obligations(session, classified) if classified else []
 

--- a/robosystems/operations/event_block/promotion.py
+++ b/robosystems/operations/event_block/promotion.py
@@ -70,11 +70,15 @@ from robosystems.logger import logger
 from robosystems.models.extensions.roboledger import Structure
 from robosystems.models.extensions.roboledger.entry import Entry
 from robosystems.models.extensions.roboledger.event import Event
+from robosystems.operations.event_block.engine import posting_date_for_event
 from robosystems.operations.event_block.python_handlers import get_python_handler
 from robosystems.operations.event_block.python_handlers.types import (
   HandlerMetadataValidationError,
 )
 from robosystems.operations.locking import ordered_lock_column
+from robosystems.operations.roboledger.commands._guards import (
+  assert_period_not_closed,
+)
 
 
 @dataclass
@@ -228,13 +232,29 @@ def promote_pending_obligations(
   # and (if a tick overruns) its own successor. See `locking` for the
   # bounded-vs-unbounded split: this function is called from both a Dagster
   # sweep and a request handler, and it is the *caller* that bounds the wait.
+  candidate_filter = (
+    Event.event_type == "schedule_entry_due",
+    Event.status.in_(("pending", "classified")),
+    Event.occurred_at <= as_of,
+  )
+  # Autopilot writes GL, so the period fence has to come *before* the
+  # event row locks. Close takes exclusive fence then event locks;
+  # locking first and fencing in the handler was the inversion that
+  # failed close mid-publish.
+  if dispatch_handlers:
+    preview = session.query(Event).filter(*candidate_filter).all()
+    fence_dates = [
+      posting_date_for_event(
+        effective_at=getattr(evt, "effective_at", None),
+        occurred_at=evt.occurred_at,
+      )
+      for evt in preview
+    ]
+    if fence_dates:
+      assert_period_not_closed(session, *fence_dates)
   candidates = (
     session.query(Event)
-    .filter(
-      Event.event_type == "schedule_entry_due",
-      Event.status.in_(("pending", "classified")),
-      Event.occurred_at <= as_of,
-    )
+    .filter(*candidate_filter)
     # Ordered so this and `supersede_pending_obligations` — whose row sets
     # overlap on pending obligations — can never acquire in opposing orders.
     # See `locking.ordered_lock_column`.

--- a/robosystems/operations/graph/deprovision_service.py
+++ b/robosystems/operations/graph/deprovision_service.py
@@ -430,7 +430,11 @@ class GraphDeprovisionService:
 
       deleted = 0
       failed = 0
-      for key in s3.list_objects(bucket, prefix=prefix):
+      # ``iter_object_keys`` paginates and raises on list failure. The
+      # single-page ``list_objects`` treats both an S3 error and a
+      # truncated listing as "prefix empty", which is the one outcome
+      # this step exists to prevent.
+      for key in s3.iter_object_keys(bucket, prefix=prefix):
         if s3.delete_object(bucket, key):
           deleted += 1
         else:

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -1221,11 +1221,21 @@ def delete_report_artifacts(graph_id: str, report_ids: list[str]) -> None:
   s3 = S3Client()
   for report_id in report_ids:
     prefix = get_report_bundle_prefix(graph_id, report_id)
-    for key in s3.list_objects(bucket, prefix=prefix):
-      if not s3.delete_object(bucket, key):
-        logger.warning(
-          "Failed to delete withdrawn report artifact s3://%s/%s.", bucket, key
-        )
+    try:
+      for key in s3.iter_object_keys(bucket, prefix=prefix):
+        if not s3.delete_object(bucket, key):
+          logger.warning(
+            "Failed to delete withdrawn report artifact s3://%s/%s.",
+            bucket,
+            key,
+          )
+    except Exception as exc:
+      logger.warning(
+        "Failed to list withdrawn report artifacts under s3://%s/%s: %s",
+        bucket,
+        prefix,
+        exc,
+      )
 
 
 def _delete_copies_in_session(

--- a/robosystems/operations/roboledger/fiscal_calendar/close_service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_service.py
@@ -16,16 +16,18 @@ from dataclasses import field as dataclass_field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import text
+from sqlalchemy import or_, text
 from sqlalchemy.orm import Session
 
 from robosystems.logger import logger
 from robosystems.models.extensions.roboledger.entry import Entry
+from robosystems.models.extensions.roboledger.event import Event
 from robosystems.models.extensions.roboledger.fiscal_calendar import FiscalCalendar
 from robosystems.models.extensions.roboledger.fiscal_period import FiscalPeriod
 from robosystems.operations.locking import bounded_lock_wait
 
 from .periods import period_date_range
+from .qb_writeback import WRITEBACK_EXCLUDED_EVENT_STATUSES
 from .service import (
   CloseableGateResult,
   FiscalCalendarService,
@@ -300,12 +302,19 @@ class PeriodCloseService:
     # (local-only drafts); the receipt's entries_posted is the sum of
     # both paths.
     now = datetime.now(UTC)
+    retracted_event_ids = session.query(Event.id).filter(
+      Event.status.in_(WRITEBACK_EXCLUDED_EVENT_STATUSES)
+    )
     posted_locally = (
       session.query(Entry)
       .filter(
         Entry.posting_date >= period_start,
         Entry.posting_date <= period_end,
         Entry.status == "draft",
+        or_(
+          Entry.triggered_by_event_id.is_(None),
+          ~Entry.triggered_by_event_id.in_(retracted_event_ids),
+        ),
       )
       .update(
         {Entry.status: "posted", Entry.posted_at: now},
@@ -581,6 +590,7 @@ class PeriodCloseService:
               connection_id=qb_connection_id,
             ),
             created_by=actor_id,
+            acquire_period_fence=False,
           )
         if result.status == "pending":
           # QB rejected — collect for the batch error.

--- a/robosystems/operations/roboledger/fiscal_calendar/qb_writeback.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/qb_writeback.py
@@ -14,7 +14,8 @@ The predicate has two halves:
   ``Connection`` whose ``write_policy`` is qb_authoritative / hybrid.
 - **eligible drafts** (extensions DB): in-period ``draft`` entries whose
   triggering ``Event`` is RL-originated (``source IN ('schedule',
-  'manual')``) and not already in QB (no ``qb_external_id``).
+  'manual')``), not retracted (``status`` not ``voided`` /
+  ``superseded``), and not already in QB (no ``qb_external_id``).
 
 A draft publishes on close iff both hold.
 """
@@ -34,6 +35,11 @@ from robosystems.models.extensions.roboledger.event import Event
 # close. Synced-in QB transactions (``source='quickbooks'``) already live
 # in QB and are excluded.
 WRITEBACK_EVENT_SOURCES = ("schedule", "manual")
+
+# Retracted events keep leftover draft GL rows. Close must not publish
+# or locally-post those drafts — void/supersede already said the work
+# is off the books.
+WRITEBACK_EXCLUDED_EVENT_STATUSES = ("voided", "superseded")
 
 # Connection write policies that publish RL-originated drafts back to the
 # source of truth on close (``native`` does not — RoboSystems is the SoR).
@@ -98,6 +104,7 @@ def select_writeback_eligible_entries(
       Entry.posting_date <= period_end,
       Entry.status == "draft",
       Event.source.in_(WRITEBACK_EVENT_SOURCES),
+      Event.status.notin_(WRITEBACK_EXCLUDED_EVENT_STATUSES),
       Event.metadata_["qb_external_id"].astext.is_(None),
     )
     .all()

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -201,6 +201,7 @@ from robosystems.models.core import User
 from robosystems.operations.event_block import (
   DuplicateEventError,
   EventNotFoundError,
+  EventNotPublishableError,
   InvalidEventTransitionError,
 )
 from robosystems.operations.event_block import (
@@ -1627,6 +1628,9 @@ execute_event_block_op = _registrar.register(
       # Another writer holds the event's row lock. Retryable, and the publish
       # deliberately did not reach QuickBooks.
       RowLockedError: 409,
+      # Voided / superseded — publishing would un-retract the event.
+      EventNotPublishableError: 409,
+      ClosedPeriodError: 422,
       ValueError: 422,
     },
     mark_stale_reason="event_published",

--- a/tests/operations/aws/test_s3_client.py
+++ b/tests/operations/aws/test_s3_client.py
@@ -647,6 +647,60 @@ class TestS3ClientListObjects:
 
 
 @pytest.mark.unit
+class TestS3ClientIterObjectKeys:
+  """iter_object_keys paginates and raises — it must not look like an
+  empty prefix when the listing failed or was truncated."""
+
+  def _make_client(self):
+    with (
+      patch("robosystems.operations.aws.s3.boto3.client"),
+      patch("robosystems.operations.aws.s3.env") as mock_env,
+    ):
+      mock_env.AWS_DEFAULT_REGION = "us-east-1"
+      mock_env.AWS_ENDPOINT_URL = ""
+      mock_env.ENVIRONMENT = "dev"
+      mock_env.AWS_S3_ACCESS_KEY_ID = ""
+      mock_env.AWS_S3_SECRET_ACCESS_KEY = ""
+      client = S3Client()
+    return client
+
+  def test_paginates_until_exhausted(self):
+    client = self._make_client()
+    page1 = {"Contents": [{"Key": "a"}, {"Key": "b"}]}
+    page2 = {"Contents": [{"Key": "c"}]}
+    paginator = MagicMock()
+    paginator.paginate.return_value = [page1, page2]
+    client.s3_client = MagicMock()
+    client.s3_client.get_paginator.return_value = paginator
+
+    assert list(client.iter_object_keys("bucket", prefix="data/")) == [
+      "a",
+      "b",
+      "c",
+    ]
+    paginator.paginate.assert_called_once_with(Bucket="bucket", Prefix="data/")
+
+  def test_empty_prefix_yields_nothing(self):
+    client = self._make_client()
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{}]
+    client.s3_client = MagicMock()
+    client.s3_client.get_paginator.return_value = paginator
+
+    assert list(client.iter_object_keys("bucket")) == []
+
+  def test_list_failure_raises(self):
+    client = self._make_client()
+    paginator = MagicMock()
+    paginator.paginate.side_effect = _make_client_error("AccessDenied")
+    client.s3_client = MagicMock()
+    client.s3_client.get_paginator.return_value = paginator
+
+    with pytest.raises(ClientError):
+      list(client.iter_object_keys("bucket", prefix="data/"))
+
+
+@pytest.mark.unit
 class TestS3ClientBatchUploadStrings:
   """Tests for S3Client.batch_upload_strings with ThreadPoolExecutor."""
 

--- a/tests/operations/event_block/test_commands_update.py
+++ b/tests/operations/event_block/test_commands_update.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -262,6 +262,44 @@ class TestApproveFiresHandler:
     session = _session_with_events(event)
     body = UpdateEventBlockRequest(event_id="evt_qb_001", transition_to="committed")
 
+    order: list[str] = []
+    session.query.return_value.filter.return_value.with_for_update.side_effect = (
+      lambda *a, **k: (
+        order.append("row_lock"),
+        session.query.return_value.filter.return_value,
+      )[1]
+    )
+
+    with (
+      patch(
+        "robosystems.operations.event_block.commands.assert_period_not_closed",
+        side_effect=lambda *a, **k: order.append("fence"),
+      ) as fence,
+      patch(
+        "robosystems.operations.event_block.commands.get_python_handler",
+        return_value=None,
+      ),
+    ):
+      update_event_block(session, body, created_by="usr_test")
+
+    fence.assert_called_once()
+    assert order == ["fence", "row_lock"], order
+    # Fenced on the event's current posting date (occurred_at, no effective_at).
+    assert fence.call_args.args[1:] == (date(2026, 3, 1),)
+    assert event.status == "committed"
+
+  def test_commit_with_effective_at_patch_fences_both_dates(self) -> None:
+    """An approval that also moves ``effective_at`` posts against the new
+    date, so the pre-lock fence must cover the period it is moving *to*
+    as well as the one it is leaving — as ``update_journal_entry`` does."""
+    event = self._journal_event(status="captured")
+    session = _session_with_events(event)
+    body = UpdateEventBlockRequest(
+      event_id="evt_qb_001",
+      transition_to="committed",
+      effective_at=datetime(2026, 4, 30, 23, 59, 59, tzinfo=UTC),
+    )
+
     with (
       patch(
         "robosystems.operations.event_block.commands.assert_period_not_closed"
@@ -274,7 +312,7 @@ class TestApproveFiresHandler:
       update_event_block(session, body, created_by="usr_test")
 
     fence.assert_called_once()
-    assert event.status == "committed"
+    assert fence.call_args.args[1:] == (date(2026, 3, 1), date(2026, 4, 30))
 
   def test_void_does_not_take_period_fence(self) -> None:
     event = self._journal_event(status="captured")

--- a/tests/operations/event_block/test_commands_update.py
+++ b/tests/operations/event_block/test_commands_update.py
@@ -251,6 +251,44 @@ class TestApproveFiresHandler:
     assert event.status == "committed"
     session.commit.assert_called_once()
 
+  def test_commit_takes_period_fence_before_row_lock(self) -> None:
+    """Approval must fence the period before locking the event row.
+
+    Close holds the exclusive fence then the event lock. Taking the
+    event first and the fence in the handler was the inversion that
+    failed close mid-publish.
+    """
+    event = self._journal_event(status="captured")
+    session = _session_with_events(event)
+    body = UpdateEventBlockRequest(event_id="evt_qb_001", transition_to="committed")
+
+    with (
+      patch(
+        "robosystems.operations.event_block.commands.assert_period_not_closed"
+      ) as fence,
+      patch(
+        "robosystems.operations.event_block.commands.get_python_handler",
+        return_value=None,
+      ),
+    ):
+      update_event_block(session, body, created_by="usr_test")
+
+    fence.assert_called_once()
+    assert event.status == "committed"
+
+  def test_void_does_not_take_period_fence(self) -> None:
+    event = self._journal_event(status="captured")
+    session = _session_with_events(event)
+    body = UpdateEventBlockRequest(event_id="evt_qb_001", transition_to="voided")
+
+    with patch(
+      "robosystems.operations.event_block.commands.assert_period_not_closed"
+    ) as fence:
+      update_event_block(session, body, created_by="usr_test")
+
+    fence.assert_not_called()
+    assert event.status == "voided"
+
   def test_classified_to_committed_fires_handler(self) -> None:
     event = self._journal_event(status="classified")
     session = _session_with_events(event)

--- a/tests/operations/event_block/test_execute.py
+++ b/tests/operations/event_block/test_execute.py
@@ -47,8 +47,11 @@ def _make_session(event: MagicMock) -> MagicMock:
 
   The read is locked and refreshed — `.populate_existing().with_for_update()`
   — so the chain is stubbed self-returning rather than pinned to a position.
+  ``session.get`` is the unlocked peek used to take the period fence
+  before that lock.
   """
   session = MagicMock()
+  session.get.return_value = event
   filtered = session.query.return_value.filter.return_value
   filtered.populate_existing.return_value = filtered
   filtered.with_for_update.return_value = filtered
@@ -378,6 +381,106 @@ class TestExecuteEventBlockQBReject:
     assert evt.metadata_["last_outbound_error"] == rejection
     # qb_external_id should NOT be stamped on rejection.
     assert "qb_external_id" not in evt.metadata_
+
+
+@pytest.mark.unit
+class TestExecuteEventBlockRefusesRetracted:
+  """A voided or superseded event must not post to QuickBooks or be
+  stamped fulfilled — that would un-retract work the books already
+  took off. Already-published events are an idempotent skip."""
+
+  def test_voided_event_raises_before_qb_write(self):
+    from robosystems.models.api.event_block import ExecuteEventBlockRequest
+    from robosystems.operations.event_block.commands import (
+      EventNotPublishableError,
+      execute_event_block,
+    )
+
+    evt = _make_event(status="voided")
+    session = _make_session(evt)
+
+    with (
+      patch("robosystems.operations.event_block.qb_writeback.post_event_to_qb") as post,
+      pytest.raises(EventNotPublishableError, match="voided"),
+    ):
+      execute_event_block(
+        session,
+        ExecuteEventBlockRequest(event_id="evt_test_abc"),
+        created_by="user_1",
+      )
+
+    post.assert_not_called()
+    assert evt.status == "voided"
+
+  def test_superseded_event_raises_before_qb_write(self):
+    from robosystems.models.api.event_block import ExecuteEventBlockRequest
+    from robosystems.operations.event_block.commands import (
+      EventNotPublishableError,
+      execute_event_block,
+    )
+
+    evt = _make_event(status="superseded")
+    session = _make_session(evt)
+
+    with (
+      patch("robosystems.operations.event_block.qb_writeback.post_event_to_qb") as post,
+      pytest.raises(EventNotPublishableError, match="superseded"),
+    ):
+      execute_event_block(
+        session,
+        ExecuteEventBlockRequest(event_id="evt_test_abc"),
+        created_by="user_1",
+      )
+
+    post.assert_not_called()
+    assert evt.status == "superseded"
+
+  def test_already_published_skips_qb_write(self):
+    from robosystems.models.api.event_block import ExecuteEventBlockRequest
+    from robosystems.operations.event_block.commands import execute_event_block
+
+    evt = _make_event(
+      status="fulfilled",
+      metadata={
+        "connection_id": "conn_qb_1",
+        "qb_external_id": "JournalEntry_99001,JournalEntry_99002",
+      },
+    )
+    session = _make_session(evt)
+
+    with patch(
+      "robosystems.operations.event_block.qb_writeback.post_event_to_qb"
+    ) as post:
+      result = execute_event_block(
+        session,
+        ExecuteEventBlockRequest(event_id="evt_test_abc"),
+        created_by="user_1",
+      )
+
+    post.assert_not_called()
+    assert result.status == "fulfilled"
+    assert result.qb_external_id == "JournalEntry_99001"
+    assert evt.status == "fulfilled"
+
+  def test_fulfilled_without_qb_id_skips_qb_write(self):
+    from robosystems.models.api.event_block import ExecuteEventBlockRequest
+    from robosystems.operations.event_block.commands import execute_event_block
+
+    evt = _make_event(status="fulfilled")
+    session = _make_session(evt)
+
+    with patch(
+      "robosystems.operations.event_block.qb_writeback.post_event_to_qb"
+    ) as post:
+      result = execute_event_block(
+        session,
+        ExecuteEventBlockRequest(event_id="evt_test_abc"),
+        created_by="user_1",
+      )
+
+    post.assert_not_called()
+    assert result.status == "fulfilled"
+    assert result.qb_external_id is None
 
 
 @pytest.mark.unit

--- a/tests/operations/event_block/test_promotion.py
+++ b/tests/operations/event_block/test_promotion.py
@@ -29,6 +29,7 @@ def _pending_event(
     occurred_at=datetime.combine(
       datetime.fromisoformat(period_end).date(), time(23, 59, 59), tzinfo=UTC
     ),
+    effective_at=None,
     metadata_={
       "schedule_id": schedule_id,
       "posting_date": period_end,
@@ -229,6 +230,55 @@ class TestAutopilotMode:
     # Status flips happened too — autopilot is co-pilot + dispatch
     assert e1.status == "classified"
     assert e2.status == "classified"
+
+  def test_period_fence_is_taken_before_the_row_locks(self) -> None:
+    """Autopilot writes GL, so it fences the period first and locks the
+    obligation rows second — the order close uses (exclusive fence, then
+    event locks). Locking first and fencing in the handler was the
+    inversion that failed close mid-publish. Only the write set is fenced:
+    the pending obligation, not the already-drafted classified one."""
+    pending = _pending_event("evt_pending", period_end="2026-02-28")
+    drafted = _pending_event("evt_done", status="classified", period_end="2026-01-31")
+    session = _session_returning(
+      [pending, drafted],
+      entries=[_entry_row("struct_a", "2026-01-31")],
+    )
+    order: list[str] = []
+    session.event_query.with_for_update.side_effect = lambda *a, **k: (
+      order.append("row_lock"),
+      session.event_query,
+    )[1]
+
+    handler = MagicMock()
+    handler.metadata_schema.model_validate.return_value = MagicMock()
+    with (
+      patch(
+        "robosystems.operations.event_block.promotion.get_python_handler",
+        return_value=handler,
+      ),
+      patch(
+        "robosystems.operations.event_block.promotion.assert_period_not_closed",
+        side_effect=lambda _s, *dates: order.append(f"fence:{dates}"),
+      ),
+    ):
+      promote_pending_obligations(
+        session,
+        "kg_test",
+        as_of=datetime(2026, 3, 1, tzinfo=UTC),
+        dispatch_handlers=True,
+      )
+
+    assert order == [f"fence:{(date(2026, 2, 28),)}", "row_lock"], order
+
+  def test_copilot_does_not_take_the_period_fence(self) -> None:
+    session = _session_returning([_pending_event("evt_1")])
+    with patch(
+      "robosystems.operations.event_block.promotion.assert_period_not_closed"
+    ) as fence:
+      promote_pending_obligations(
+        session, "kg_test", as_of=datetime(2026, 2, 1, tzinfo=UTC)
+      )
+    fence.assert_not_called()
 
   def test_per_event_validation_error_does_not_sink_sweep(self) -> None:
     """A single bad metadata payload is captured; other events still process."""
@@ -562,6 +612,7 @@ class TestStrandedObligations:
       event_type="schedule_entry_due",
       status="classified",
       occurred_at=datetime(2026, 1, 31, 23, 59, 59, tzinfo=UTC),
+      effective_at=None,
       metadata_=None,
     )
     session = _session_returning([opaque])

--- a/tests/operations/event_block/test_promotion_fence_db.py
+++ b/tests/operations/event_block/test_promotion_fence_db.py
@@ -1,0 +1,228 @@
+"""Autopilot promotion's period fence — real Postgres.
+
+Autopilot writes GL, so the sweep takes the shared period fence before it
+locks the obligation rows (the same order as close, which holds the
+exclusive side then locks events). The MagicMock tests in
+``test_promotion.py`` cannot see the fence: ``_period_covering`` returns a
+mock whose ``status`` is never ``"closed"``, so it is a silent no-op there.
+
+What the fence must and must not do is a question of which periods are
+closed, so these run against a throwaway tenant schema in the test
+Postgres. The specific trap: dispatched obligations stay ``classified``
+for good, so a fence over the whole candidate set would fence every
+period that ever held a schedule and fail the sweep on the first one that
+has since closed — on a tenant's *second* month-end.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, date, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+import robosystems.models.extensions  # noqa: F401  (register models on ExtensionsBase)
+from robosystems.db.extensions import ExtensionsBase
+from robosystems.models.extensions import Structure, Taxonomy
+from robosystems.models.extensions.roboledger.entry import Entry
+from robosystems.models.extensions.roboledger.event import Event
+from robosystems.models.extensions.roboledger.fiscal_period import FiscalPeriod
+from robosystems.operations.event_block.promotion import promote_pending_obligations
+
+pytestmark = pytest.mark.unit
+
+GRAPH_ID = "kg0123456789abcdef01"
+TAXONOMY_ID = "tax_sched_fence"
+SCHEDULE_ID = "sch_fence_0001"
+SWEEP_AS_OF = datetime(2026, 7, 5, tzinfo=UTC)
+
+
+@pytest.fixture()
+def ext_session():
+  """Extensions schema in the test Postgres DB, one throwaway schema per test."""
+  database_url = os.environ.get("TEST_DATABASE_URL")
+  if not database_url:
+    pytest.skip("TEST_DATABASE_URL not configured")
+
+  schema = f"ext_promo_{uuid.uuid4().hex[:12]}"
+  engine = create_engine(database_url)
+  with engine.begin() as conn:
+    conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+
+  session = sessionmaker(bind=engine)()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+  ExtensionsBase.metadata.create_all(bind=session.connection())
+  session.commit()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+
+  try:
+    yield session
+  finally:
+    session.rollback()
+    session.close()
+    with engine.begin() as conn:
+      conn.execute(text(f'DROP SCHEMA "{schema}" CASCADE'))
+    engine.dispose()
+
+
+def _seed_calendar(session, *, may_status: str = "closed") -> None:
+  session.add(
+    FiscalPeriod(
+      graph_id=GRAPH_ID,
+      name="2026-05",
+      start_date=date(2026, 5, 1),
+      end_date=date(2026, 5, 31),
+      period_type="month",
+      status=may_status,
+    )
+  )
+  session.add(
+    FiscalPeriod(
+      graph_id=GRAPH_ID,
+      name="2026-06",
+      start_date=date(2026, 6, 1),
+      end_date=date(2026, 6, 30),
+      period_type="month",
+      status="open",
+    )
+  )
+  # The schedule must exist, or the orphan guard voids the obligations.
+  session.add(
+    Taxonomy(
+      id=TAXONOMY_ID, name="Schedules", taxonomy_type="schedule", created_by="usr"
+    )
+  )
+  session.flush()
+  session.add(
+    Structure(
+      id=SCHEDULE_ID,
+      taxonomy_id=TAXONOMY_ID,
+      name="Depreciation",
+      block_type="schedule",
+      created_by="usr",
+    )
+  )
+  session.flush()
+
+
+def _obligation(session, *, status: str, period_end: date) -> Event:
+  event = Event(
+    event_type="schedule_entry_due",
+    event_category="adjustment",
+    occurred_at=datetime.combine(period_end, datetime.min.time(), tzinfo=UTC),
+    source="schedule",
+    status=status,
+    created_by="usr",
+    metadata_={
+      "schedule_id": SCHEDULE_ID,
+      "period_start": period_end.replace(day=1).isoformat(),
+      "period_end": period_end.isoformat(),
+    },
+  )
+  session.add(event)
+  session.flush()
+  return event
+
+
+def _draft_for(session, event: Event) -> Entry:
+  """The closing entry a past autopilot dispatch left behind."""
+  entry = Entry(
+    posting_date=event.occurred_at.date(),
+    status="draft",
+    memo="depreciation",
+    created_by="usr",
+    source_structure_id=SCHEDULE_ID,
+    triggered_by_event_id=event.id,
+  )
+  session.add(entry)
+  session.flush()
+  return entry
+
+
+def _sweep(session):
+  """Autopilot sweep with the handler faked — the fence, not the GL, is under test."""
+  handler = MagicMock()
+  handler.metadata_schema.model_validate.side_effect = lambda m: m
+  with patch(
+    "robosystems.operations.event_block.promotion.get_python_handler",
+    return_value=handler,
+  ):
+    result = promote_pending_obligations(
+      session, GRAPH_ID, as_of=SWEEP_AS_OF, dispatch_handlers=True
+    )
+  return result, handler
+
+
+class TestAutopilotFence:
+  def test_closed_history_does_not_block_the_open_period(self, ext_session):
+    """May was promoted, drafted and closed months ago; its obligation is
+    still `classified` because that is where dispatched obligations rest.
+    The June sweep must not fence May at all."""
+    _seed_calendar(ext_session, may_status="closed")
+    may = _obligation(ext_session, status="classified", period_end=date(2026, 5, 31))
+    _draft_for(ext_session, may)
+    june = _obligation(ext_session, status="pending", period_end=date(2026, 6, 30))
+    ext_session.commit()
+
+    result, handler = _sweep(ext_session)
+
+    assert result.classified_event_ids == [june.id]
+    assert result.dispatched_event_ids == [june.id]
+    assert result.errors == []
+    handler.dispatch.assert_called_once()
+    assert handler.dispatch.call_args.args[1].id == june.id
+    assert ext_session.get(Event, may.id).status == "classified"
+
+  def test_stranded_obligation_in_closed_period_is_reported_not_fatal(
+    self, ext_session
+  ):
+    """A close with allow_stranded_obligations leaves an undrafted
+    `classified` obligation behind in a closed period. It cannot be
+    dispatched (that would write GL into the closed period), but it must
+    not take the open period's obligation down with it."""
+    _seed_calendar(ext_session, may_status="closed")
+    may = _obligation(ext_session, status="classified", period_end=date(2026, 5, 31))
+    june = _obligation(ext_session, status="pending", period_end=date(2026, 6, 30))
+    ext_session.commit()
+
+    result, handler = _sweep(ext_session)
+
+    assert result.dispatched_event_ids == [june.id]
+    assert [eid for eid, _ in result.errors] == [may.id]
+    assert "closed period" in result.errors[0][1]
+    assert "2026-05" in result.errors[0][1]
+    handler.dispatch.assert_called_once()
+    assert ext_session.get(Event, may.id).status == "classified"
+
+  def test_pending_obligation_in_closed_period_stays_pending(self, ext_session):
+    """Left out of the sweep entirely: not flipped to `classified` (which
+    would only strand it), not dispatched, and named in the errors."""
+    _seed_calendar(ext_session, may_status="closed")
+    may = _obligation(ext_session, status="pending", period_end=date(2026, 5, 31))
+    june = _obligation(ext_session, status="pending", period_end=date(2026, 6, 30))
+    ext_session.commit()
+
+    result, _handler = _sweep(ext_session)
+
+    assert result.classified_event_ids == [june.id]
+    assert result.dispatched_event_ids == [june.id]
+    assert [eid for eid, _ in result.errors] == [may.id]
+    assert ext_session.get(Event, may.id).status == "pending"
+
+  def test_open_periods_fence_and_dispatch_normally(self, ext_session):
+    """Sanity: with nothing closed the fence is transparent and both
+    matured obligations dispatch."""
+    _seed_calendar(ext_session, may_status="open")
+    may = _obligation(ext_session, status="pending", period_end=date(2026, 5, 31))
+    june = _obligation(ext_session, status="pending", period_end=date(2026, 6, 30))
+    ext_session.commit()
+
+    result, handler = _sweep(ext_session)
+
+    assert set(result.dispatched_event_ids) == {may.id, june.id}
+    assert result.errors == []
+    assert handler.dispatch.call_count == 2

--- a/tests/operations/graph/test_deprovision_service.py
+++ b/tests/operations/graph/test_deprovision_service.py
@@ -116,7 +116,7 @@ def stub_bundle_purge():
   so the tests that care about the purge can drive it."""
   with patch("robosystems.operations.aws.s3.S3Client") as cls:
     client = MagicMock()
-    client.list_objects.return_value = []
+    client.iter_object_keys.return_value = []
     client.delete_object.return_value = True
     cls.return_value = client
     yield client
@@ -752,7 +752,7 @@ class TestReportBundlePurge:
       f"report-bundles/{test_graph.graph_id}/rpt_a/g1.holon.jsonld",
       f"report-bundles/{test_graph.graph_id}/rpt_b/g2.zip",
     ]
-    stub_bundle_purge.list_objects.return_value = keys
+    stub_bundle_purge.iter_object_keys.return_value = keys
 
     with (
       patch(
@@ -766,7 +766,7 @@ class TestReportBundlePurge:
       )
 
     # Scoped to this graph's prefix — never the whole bucket.
-    _, kwargs = stub_bundle_purge.list_objects.call_args
+    _, kwargs = stub_bundle_purge.iter_object_keys.call_args
     assert kwargs["prefix"] == f"report-bundles/{test_graph.graph_id}/"
 
     assert stub_bundle_purge.delete_object.call_count == 3
@@ -780,7 +780,7 @@ class TestReportBundlePurge:
     """Incomplete disposal is the one outcome this step exists to prevent, so a
     surviving object degrades the teardown to `partial` rather than passing
     quietly. This is deliberately stricter than the sibling purges."""
-    stub_bundle_purge.list_objects.return_value = [
+    stub_bundle_purge.iter_object_keys.return_value = [
       f"report-bundles/{test_graph.graph_id}/rpt_a/g1.jsonld",
       f"report-bundles/{test_graph.graph_id}/rpt_b/g1.jsonld",
     ]
@@ -807,7 +807,7 @@ class TestReportBundlePurge:
   ):
     """Best-effort like its siblings: object storage being unreachable must not
     hold the graph in a half-torn-down state or block the capacity release."""
-    stub_bundle_purge.list_objects.side_effect = RuntimeError("s3 unreachable")
+    stub_bundle_purge.iter_object_keys.side_effect = RuntimeError("s3 unreachable")
 
     with (
       patch(

--- a/tests/operations/roboledger/commands/test_share_controls_db.py
+++ b/tests/operations/roboledger/commands/test_share_controls_db.py
@@ -507,7 +507,7 @@ def test_revoke_withdraws_the_stored_publication_too() -> None:
 
   with patch(f"{_REPORTS_CMD}.S3Client") as s3_cls:
     s3 = s3_cls.return_value
-    s3.list_objects.return_value = [
+    s3.iter_object_keys.return_value = [
       f"report-bundles/{TARGET_GRAPH}/{copy_id}/g1.jsonld",
       f"report-bundles/{TARGET_GRAPH}/{copy_id}/g1.holon.jsonld",
     ]
@@ -520,7 +520,7 @@ def test_revoke_withdraws_the_stored_publication_too() -> None:
     )
 
   # Scoped to the withdrawn copy's own prefix — never the whole graph's.
-  _, list_kwargs = s3.list_objects.call_args
+  _, list_kwargs = s3.iter_object_keys.call_args
   assert list_kwargs["prefix"] == f"report-bundles/{TARGET_GRAPH}/{copy_id}/"
   deleted = {call.args[1] for call in s3.delete_object.call_args_list}
   assert deleted == {

--- a/tests/operations/roboledger/fiscal_calendar/test_close_publish_durability.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_close_publish_durability.py
@@ -137,7 +137,7 @@ class TestPublishMarkerDurability:
     bad_entry, bad_event = _seed_draft(ext_session, "rejected one")
     ext_session.commit()
 
-    def fake_execute(session, request, created_by):
+    def fake_execute(session, request, created_by, **_kwargs):
       if request.event_id == str(bad_event.id):
         return SimpleNamespace(
           status="pending",
@@ -168,7 +168,7 @@ class TestPublishMarkerDurability:
     _bad_entry, bad_event = _seed_draft(ext_session, "rejected one")
     ext_session.commit()
 
-    def first_attempt(session, request, created_by):
+    def first_attempt(session, request, created_by, **_kwargs):
       if request.event_id == str(bad_event.id):
         return SimpleNamespace(status="pending", qb_error={"code": "6000"})
       _mark_published(session, request.event_id, f"qb_{request.event_id[-6:]}")
@@ -180,7 +180,7 @@ class TestPublishMarkerDurability:
 
     published_on_retry: list[str] = []
 
-    def second_attempt(session, request, created_by):
+    def second_attempt(session, request, created_by, **_kwargs):
       published_on_retry.append(request.event_id)
       _mark_published(session, request.event_id, "qb_retry")
       return SimpleNamespace(status="fulfilled", qb_error=None)
@@ -197,7 +197,7 @@ class TestPublishMarkerDurability:
     entry, event = _seed_draft(ext_session, "june depreciation")
     ext_session.commit()
 
-    def fake_execute(session, request, created_by):
+    def fake_execute(session, request, created_by, **_kwargs):
       _mark_published(session, request.event_id, "qb_ok")
       return SimpleNamespace(status="fulfilled", qb_error=None)
 
@@ -220,7 +220,7 @@ class TestPublishMarkerDurability:
     _locked_entry, locked_event = _seed_draft(ext_session, "lock timeout")
     ext_session.commit()
 
-    def fake_execute(session, request, created_by):
+    def fake_execute(session, request, created_by, **_kwargs):
       if request.event_id == str(locked_event.id):
         raise RowLockedError("event is being written")
       _mark_published(session, request.event_id, "qb_ok")
@@ -237,3 +237,27 @@ class TestPublishMarkerDurability:
     assert persisted.metadata_.get("qb_external_id") == "qb_ok"
     ext_session.refresh(ext_session.get(Event, locked_event.id))
     assert not ext_session.get(Event, locked_event.id).metadata_.get("qb_external_id")
+
+  def test_retracted_event_drafts_are_not_published(self, ext_session):
+    """Voiding an event leaves its draft GL rows. Close must not hand
+    those leftovers to execute — that would un-void the event and post
+    a QB JournalEntry for retracted work."""
+    _live_entry, live_event = _seed_draft(ext_session, "still live")
+    _void_entry, void_event = _seed_draft(ext_session, "voided leftover")
+    void_event.status = "voided"
+    _super_entry, super_event = _seed_draft(ext_session, "superseded leftover")
+    super_event.status = "superseded"
+    ext_session.commit()
+
+    published: list[str] = []
+
+    def fake_execute(session, request, created_by, **_kwargs):
+      published.append(request.event_id)
+      _mark_published(session, request.event_id, "qb_ok")
+      return SimpleNamespace(status="fulfilled", qb_error=None)
+
+    _publish(ext_session, fake_execute)
+
+    assert published == [str(live_event.id)], published
+    assert void_event.id not in published
+    assert super_event.id not in published

--- a/tests/operations/roboledger/fiscal_calendar/test_close_service.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_close_service.py
@@ -111,10 +111,16 @@ def _mock_session_with_fp(fp, debit: int = 0, credit: int = 0, updated: int = 0)
   # Route session.query to the right mock based on model. Our service calls:
   # session.query(Entry).filter(...).update(...)
   # session.query(FiscalPeriod).filter(...).one_or_none()
+  # session.query(Event.id).filter(...) — retracted-event exclusion
   def _query_dispatch(model):
-    name = model.__name__ if hasattr(model, "__name__") else str(model)
+    name = getattr(model, "__name__", "")
     if name == "FiscalPeriod":
       return fp_query
+    parent = getattr(model, "class_", None)
+    if name == "Event" or getattr(parent, "__name__", "") == "Event":
+      retracted = MagicMock()
+      retracted.filter.return_value = []
+      return retracted
     return entry_query
 
   session.query.side_effect = _query_dispatch
@@ -857,7 +863,7 @@ class TestClosePrePublishWriteback:
     mock_platform_session.__exit__ = MagicMock(return_value=False)
     mock_platform_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = mock_conn
 
-    def fake_execute(_sess, body, created_by):
+    def fake_execute(_sess, body, created_by, **_kwargs):
       # First event accepts, second rejects.
       if body.event_id == "evt_1":
         return ExecuteEventBlockResponse(

--- a/tests/operations/roboledger/fiscal_calendar/test_publish_savepoint.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_publish_savepoint.py
@@ -69,7 +69,7 @@ def test_a_failed_publish_does_not_cost_the_markers_of_earlier_ones():
 
   published: list[str] = []
 
-  def _fake_execute(session, body, created_by):
+  def _fake_execute(session, body, created_by, **_kwargs):
     if body.event_id == "evt_2":
       raise _AbortedTransaction("current transaction is aborted")
     published.append(body.event_id)

--- a/tests/operations/roboledger/fiscal_calendar/test_qb_writeback.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_qb_writeback.py
@@ -13,8 +13,10 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from robosystems.operations.roboledger.fiscal_calendar.qb_writeback import (
+  WRITEBACK_EXCLUDED_EVENT_STATUSES,
   WritebackConnection,
   resolve_writeback_connection,
+  select_writeback_eligible_entries,
   writeback_eligible_entry_ids,
 )
 
@@ -76,3 +78,20 @@ class TestWritebackEligibleEntryIds:
       writeback_eligible_entry_ids(session, date(2026, 1, 1), date(2026, 1, 31))
       == set()
     )
+
+  def test_predicate_excludes_retracted_event_statuses(self):
+    """Voided / superseded leftovers must not publish. Pinned on the
+    shared predicate so the outbox preview and the close write cannot
+    drift independently of this check."""
+    session = MagicMock()
+    session.query.return_value.join.return_value.filter.return_value.all.return_value = []
+
+    select_writeback_eligible_entries(session, date(2026, 1, 1), date(2026, 1, 31))
+
+    predicates = [
+      str(arg.compile(compile_kwargs={"literal_binds": True}))
+      for arg in session.query.return_value.join.return_value.filter.call_args[0]
+    ]
+    joined = " ".join(predicates)
+    for status in WRITEBACK_EXCLUDED_EVENT_STATUSES:
+      assert status in joined, predicates


### PR DESCRIPTION
## Summary

Follow-up to the v1.9.4–v1.9.5 lock series. `execute-event-block` still posted a retracted event to QuickBooks and stamped it `fulfilled`, and close still selected those leftover drafts — including posting them locally. Teardown also treated a failed or truncated S3 listing as an empty prefix, so published report artifacts could survive deprovision.

## Changes

- **Publish** (`execute_event_block`): after the locked read, refuse `voided` / `superseded` with `EventNotPublishableError` (409) before any QuickBooks write. An existing `qb_external_id` or `fulfilled` status is an idempotent skip. Execute promotes the event's drafts to `posted`, so it now also takes the shared period fence before the row lock and returns `ClosedPeriodError` (422) when the event's posting date is in a closed period — that check runs ahead of the idempotent skips and the native fast-path, so a re-execute in a closed period is a 422 rather than a no-op. Close already holds the exclusive period fence on a dedicated connection, so it calls execute with `acquire_period_fence=False`.
- **Close writeback**: `select_writeback_eligible_entries` excludes retracted event statuses (shared with the outbox preview). The close bulk draft→posted pass uses the same exclusion so leftover drafts are neither published nor posted locally.
- **Lock order**: inbox approval (`transition_to='committed'`) and autopilot promotion take the shared period fence *before* the event row lock, matching journal update/delete and close. Fixes the inversion that could fail close mid-publish after a 3s `lock_timeout`. Approval fences both the event's current posting date and the one a same-call `effective_at` patch moves it to (as `update_journal_entry` does). Autopilot fences only its **write set** — pending obligations plus stranded classified ones — not every classified obligation: dispatched obligations rest at `classified` for good, so fencing the whole candidate set would fence every period that ever held a schedule and fail the sweep on the first one since closed (a tenant's second month-end). An obligation whose period is closed is left out of the sweep and reported in `errors`, not fatal to it.
- **Teardown / withdrawal**: new `S3Client.iter_object_keys` paginates and raises on list failure. Graph deprovision and `delete_report_artifacts` use it instead of the single-page, empty-on-error `list_objects`.
- **Comment**: the stale `ORDERED_LOCK_KEY` reference now points at `ordered_lock_column()`.

Reviewers: the close-vs-execute fence skip (`acquire_period_fence=False`) is load-bearing — taking the shared fence inside close would wait on close's own exclusive lock.

## Breaking Changes

None. `EventNotPublishableError` is a new 409 on `execute-event-block` for a case that previously succeeded incorrectly, and `execute-event-block` now returns 422 (`ClosedPeriodError`) for an event whose posting date is in a closed period (additive; SDK regen opportunity).

## Testing

Targeted suite against local Postgres (not `just test-all`):

- `tests/operations/event_block/test_execute.py`
- `tests/operations/event_block/test_commands_update.py`
- `tests/operations/event_block/test_promotion.py`
- `tests/operations/event_block/test_promotion_fence_db.py` (new — real Postgres: closed history does not block the open period; stranded/pending obligations in a closed period are reported, not fatal)
- `tests/operations/event_block/test_update_locking_db.py`
- `tests/operations/event_block/test_engine.py`
- `tests/operations/roboledger/fiscal_calendar/test_qb_writeback.py`
- `tests/operations/roboledger/fiscal_calendar/test_close_service.py`
- `tests/operations/roboledger/fiscal_calendar/test_publish_savepoint.py`
- `tests/operations/roboledger/fiscal_calendar/test_close_publish_durability.py`
- `tests/operations/roboledger/commands/test_journal_entries.py`
- `tests/operations/roboledger/commands/test_fiscal_calendar.py`
- `tests/operations/roboledger/commands/test_guards.py`
- `tests/operations/roboledger/commands/test_share_controls_db.py`
- `tests/operations/graph/test_deprovision_service.py`
- `tests/operations/aws/test_s3_client.py`
- `tests/operations/test_locking.py`

309 passed. `ruff check` / `ruff format` and `basedpyright` on the changed source files: clean.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

