### PR TITLE
fix(roboledger): lock only the sweep's write set and order the obligation void

### DIFF
--- a/robosystems/operations/event_block/promotion.py
+++ b/robosystems/operations/event_block/promotion.py
@@ -202,31 +202,34 @@ def find_stranded_obligations(session: Session, *, as_of: datetime) -> list[Even
   return filter_stranded_obligations(session, classified)
 
 
-def _fence_autopilot_write_set(
+def _preview_write_set(
   session: Session, candidate_filter: list
-) -> list[tuple[str, str]]:
-  """Take the shared period fence for every obligation autopilot will write.
+) -> tuple[list[Event], list[Event]]:
+  """Unlocked read of what this sweep will write: the ``pending`` candidates
+  and the stranded ``classified`` ones.
 
-  The write set is the ``pending`` candidates plus the stranded ``classified``
-  ones — not every classified obligation. Dispatched obligations stay
-  ``classified`` for good (see ``schedule_entry_due``), so fencing the whole
-  candidate set would fence every period that ever held a schedule and fail
-  the sweep on the first one that has since closed.
+  Dispatched obligations rest at ``classified`` for good (see
+  ``schedule_entry_due``), so the classified candidate set is the schedule's
+  whole history. Only the stranded subset is written; the rest is neither
+  fenced nor locked — locking it would hold every historical obligation for
+  the length of the sweep and fail close's publish against them, and fencing
+  it would fence every period that ever held a schedule.
+  """
+  preview = session.query(Event).filter(*candidate_filter).all()
+  pending = [evt for evt in preview if evt.status == "pending"]
+  classified = [evt for evt in preview if evt.status == "classified"]
+  stranded = filter_stranded_obligations(session, classified) if classified else []
+  return pending, stranded
+
+
+def _fence_write_set(session: Session, write_set: list[Event]) -> list[tuple[str, str]]:
+  """Take the shared period fence for every obligation autopilot will write.
 
   Returns ``(event_id, reason)`` for obligations whose period is closed, so
   the caller can leave them out and report them. A fence that cannot be
   taken because a closer holds the exclusive side propagates as
   ``RowLockedError`` — that one is retryable and does apply to the sweep.
   """
-  preview = session.query(Event).filter(*candidate_filter).all()
-  pending = [evt for evt in preview if evt.status == "pending"]
-  classified = [evt for evt in preview if evt.status == "classified"]
-  write_set = pending + (
-    filter_stranded_obligations(session, classified) if classified else []
-  )
-  if not write_set:
-    return []
-
   by_date: dict[date, list[Event]] = {}
   for evt in write_set:
     posting_date = posting_date_for_event(
@@ -284,26 +287,53 @@ def promote_pending_obligations(
     Event.occurred_at <= as_of,
   ]
   result = PromotionResult(graph_id=graph_id)
+  # Unlocked preview of the write set, then lock exactly that — not the whole
+  # candidate set. See `_preview_write_set` for why the classified history
+  # stays out of both the fence and the lock.
+  preview_pending, preview_stranded = _preview_write_set(session, candidate_filter)
+  write_set = preview_pending + preview_stranded
   # Autopilot writes GL, so the period fence has to come *before* the
   # event row locks. Close takes exclusive fence then event locks;
   # locking first and fencing in the handler was the inversion that
   # failed close mid-publish. An obligation whose period is already
   # closed is left out of the sweep and reported, not fatal to it.
-  if dispatch_handlers:
-    closed = _fence_autopilot_write_set(session, candidate_filter)
+  if dispatch_handlers and write_set:
+    closed = _fence_write_set(session, write_set)
     if closed:
       result.errors.extend(closed)
-      candidate_filter.append(Event.id.notin_([evt_id for evt_id, _ in closed]))
+      closed_ids = {evt_id for evt_id, _ in closed}
+      write_set = [evt for evt in write_set if evt.id not in closed_ids]
+  if not write_set:
+    return result
+
+  # The preview above put these rows in the identity map, so the locked
+  # read must `populate_existing` — otherwise it takes the lock and hands
+  # back the status the preview saw, and a void or approval that committed
+  # in between is acted on as if it never happened. Flush first: this
+  # factory is `autoflush=False`, and a refresh would otherwise discard an
+  # in-flight change without a word (nothing is pending here today; this
+  # keeps it a property of the read rather than of its callers).
+  session.flush()
   candidates = (
     session.query(Event)
-    .filter(*candidate_filter)
-    # Ordered so this and `supersede_pending_obligations` — whose row sets
-    # overlap on pending obligations — can never acquire in opposing orders.
-    # See `locking.ordered_lock_column`.
+    .filter(
+      Event.id.in_([evt.id for evt in write_set]),
+      # Re-checked under the lock: a row that left the candidate set while
+      # we waited is not returned at all — the same guard the bulk updates
+      # below carry, and independent of the refresh.
+      Event.status.in_(("pending", "classified")),
+    )
+    # Ordered so this and `supersede_pending_obligations` / the schedule
+    # void — whose row sets overlap on pending obligations — can never
+    # acquire in opposing orders. See `locking.ordered_lock_column`.
     .order_by(ordered_lock_column())
+    .populate_existing()
     .with_for_update()
     .all()
   )
+  # Re-derived from the locked rows: status is decided here, not by the
+  # preview. A row that moved between the two reads (voided, approved,
+  # drafted) drops out on its own.
   pending = [evt for evt in candidates if evt.status == "pending"]
   classified = [evt for evt in candidates if evt.status == "classified"]
 

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -468,12 +468,21 @@ def delete_schedule(session: Session, body: DeleteScheduleRequest) -> dict:
   structure = _load_schedule_or_404(session, body.structure_id)
   # Void any pending obligations first so they can't outlive their
   # `schedule_created` originator and trip the close-period gate
-  # after the schedule is gone.
-  ScheduleService().void_pending_obligations(
+  # after the schedule is gone. Request-facing, and the void locks the
+  # same pending rows the promotion sweep holds — bound the wait rather
+  # than hold this request for the length of a background tick.
+  from robosystems.operations.locking import bounded_lock_wait
+
+  with bounded_lock_wait(
     session,
-    structure=structure,
-    void_reason="schedule_deleted",
-  )
+    "This schedule's pending obligations are being written by another "
+    "process. Retry in a moment.",
+  ):
+    ScheduleService().void_pending_obligations(
+      session,
+      structure=structure,
+      void_reason="schedule_deleted",
+    )
   association_ids = (
     session.execute(
       select(Association.id).where(Association.structure_id == structure.id)
@@ -689,11 +698,20 @@ def rebuild_schedule(
 
   # Void the old pending obligation chain so the regenerated chain doesn't
   # double-count and the old pending events can't trip the close gate.
-  service.void_pending_obligations(
+  # Bounded for the same reason as `delete_schedule`: request-facing, and
+  # it contends with the promotion sweep over these rows.
+  from robosystems.operations.locking import bounded_lock_wait
+
+  with bounded_lock_wait(
     session,
-    structure=structure,
-    void_reason="schedule_rebuilt",
-  )
+    "This schedule's pending obligations are being written by another "
+    "process. Retry in a moment.",
+  ):
+    service.void_pending_obligations(
+      session,
+      structure=structure,
+      void_reason="schedule_rebuilt",
+    )
 
   # Cascade-delete the old facts, FactSets, and SumEquals rule(s) — mirror
   # delete_schedule's cascade, but NOT the Structure, Associations, or

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -864,16 +864,36 @@ class ScheduleService:
     if not schedule_created_event_id:
       return 0
 
+    from robosystems.operations.locking import ordered_lock_column
+
+    # Lock first, in the shared order, then update by id. A bare multi-row
+    # UPDATE takes its row locks in scan order, and the promotion sweep holds
+    # these same pending rows in `id` order — two orders over one row set is
+    # the deadlock the ordered discipline exists to rule out, and it would
+    # surface at flush, outside any lock-wait translation. The status
+    # predicate stays on the UPDATE: it is the invariant that a row this
+    # call did not lock as `pending` is never voided.
+    pending_ids = list(
+      session.execute(
+        select(Event.id)
+        .where(
+          Event.obligated_by_event_id == schedule_created_event_id,
+          Event.status == "pending",
+        )
+        .order_by(ordered_lock_column())
+        .with_for_update()
+      ).scalars()
+    )
+    if not pending_ids:
+      return 0
+
     update_values: dict[str, object] = {"status": "voided"}
     if voided_by_event_id is not None:
       update_values["replaced_by_event_id"] = voided_by_event_id
 
     result = session.execute(
       update(Event)
-      .where(
-        Event.obligated_by_event_id == schedule_created_event_id,
-        Event.status == "pending",
-      )
+      .where(Event.id.in_(pending_ids), Event.status == "pending")
       .values(**update_values)
     )
     voided_count = int(result.rowcount or 0)

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -1281,6 +1281,9 @@ delete_information_block_op = _registrar.register(
     request_model=DeleteInformationBlockRequest,
     result_type=DeleteInformationBlockResponse,
     error_map={
+      # Deleting a schedule voids its pending obligations, which the
+      # promotion sweep may be holding. Retryable.
+      RowLockedError: 409,
       ValueError: 422,
       NotImplementedError: 501,
       ScheduleNotFoundError: 404,
@@ -1817,6 +1820,9 @@ rebuild_schedule_op = _registrar.register(
     result_type=ScheduleCreatedResponse,
     error_map={
       ScheduleNotFoundError: 404,
+      # The rebuild voids the schedule's pending obligations, which the
+      # promotion sweep may be holding. Retryable.
+      RowLockedError: 409,
       ValueError: 422,
     },
     mark_stale_reason="schedule_rebuilt",

--- a/tests/operations/event_block/python_handlers/test_asset_disposed.py
+++ b/tests/operations/event_block/python_handlers/test_asset_disposed.py
@@ -293,8 +293,10 @@ class TestVoidPendingObligationsForSchedule:
 
     session = MagicMock()
     session.get.return_value = self._structure_with_event("evt_schedule_created")
+    locked = MagicMock()
+    locked.scalars.return_value = iter([f"evt_due_{i}" for i in range(11)])
     update_result = MagicMock(rowcount=11)
-    session.execute.return_value = update_result
+    session.execute.side_effect = [locked, update_result]
 
     voided = _void_pending_obligations_for_schedule(
       session,
@@ -303,10 +305,16 @@ class TestVoidPendingObligationsForSchedule:
     )
 
     assert voided == 11
-    # The execute call carries the right WHERE clause + SET values.
-    update_stmt = session.execute.call_args.args[0]
+    # The locking select targets pending events on the schedule's originator
+    # chain, in the shared lock order; the UPDATE then goes by id.
+    lock_stmt = session.execute.call_args_list[0].args[0]
+    lock_sql = str(lock_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "events.obligated_by_event_id = 'evt_schedule_created'" in lock_sql
+    assert "events.status = 'pending'" in lock_sql
+    assert "FOR UPDATE" in lock_sql and "ORDER BY events.id" in lock_sql
+    update_stmt = session.execute.call_args_list[1].args[0]
     rendered = str(update_stmt.compile(compile_kwargs={"literal_binds": True}))
-    assert "events.obligated_by_event_id = 'evt_schedule_created'" in rendered
+    assert "events.id IN (" in rendered
     assert "events.status = 'pending'" in rendered
     assert "status='voided'" in rendered.replace(" = ", "=")
     assert "replaced_by_event_id='evt_disposal'" in rendered.replace(" = ", "=")

--- a/tests/operations/event_block/test_promotion.py
+++ b/tests/operations/event_block/test_promotion.py
@@ -79,6 +79,7 @@ def _session_returning(
   # locks. Self-returning like `.filter` so the chain stays
   # position-independent.
   event_query.order_by.return_value = event_query
+  event_query.populate_existing.return_value = event_query
   event_query.with_for_update.return_value = event_query
   event_query.all.return_value = events
   entry_query = MagicMock()
@@ -127,9 +128,10 @@ class TestCoPilotMode:
 
     assert set(result.classified_event_ids) == {"evt_1", "evt_2"}
     assert result.dispatched_count == 0  # co-pilot — no dispatch
-    # Three .query() calls now: load candidates, the orphan-guard structure
-    # existence check, and the bulk classify-update by id.
-    assert session.query.call_count == 3
+    # Four .query() calls: the unlocked write-set preview, the locked read of
+    # exactly those ids, the orphan-guard structure existence check, and the
+    # bulk classify-update by id.
+    assert session.query.call_count == 4
     bulk_update_call = session.event_query.filter.return_value.update
     bulk_update_call.assert_called_once_with(
       {"status": "classified"}, synchronize_session="fetch"

--- a/tests/operations/event_block/test_promotion_fence_db.py
+++ b/tests/operations/event_block/test_promotion_fence_db.py
@@ -17,6 +17,7 @@ has since closed — on a tenant's *second* month-end.
 from __future__ import annotations
 
 import os
+import time
 import uuid
 from datetime import UTC, date, datetime
 from unittest.mock import MagicMock, patch
@@ -226,3 +227,82 @@ class TestAutopilotFence:
     assert set(result.dispatched_event_ids) == {may.id, june.id}
     assert result.errors == []
     assert handler.dispatch.call_count == 2
+
+
+class TestSweepLocksOnlyTheWriteSet:
+  """The sweep locks what it writes — pending + stranded — not the classified
+  history, and it decides status from the locked read, not the preview."""
+
+  def test_does_not_lock_the_classified_history(self, ext_session):
+    """Close's publish holds schedule-sourced events FOR UPDATE while it posts
+    to QuickBooks. A dispatched, drafted May obligation is exactly such a row;
+    the June sweep must not wait behind it."""
+    from robosystems.operations.locking import bounded_lock_wait
+
+    _seed_calendar(ext_session, may_status="open")
+    may = _obligation(ext_session, status="classified", period_end=date(2026, 5, 31))
+    _draft_for(ext_session, may)
+    june = _obligation(ext_session, status="pending", period_end=date(2026, 6, 30))
+    ext_session.commit()
+
+    schema = ext_session.execute(text("select current_schema()")).scalar()
+    holder = ext_session.get_bind().connect()
+    try:
+      holder.execute(text(f'SET search_path TO "{schema}"'))
+      holder.execute(
+        text("SELECT id FROM events WHERE id = :id FOR UPDATE"), {"id": may.id}
+      )
+      # Bounded so a sweep that does try the May row fails in 3s instead of
+      # hanging the test behind the holder.
+      with bounded_lock_wait(ext_session, "sweep blocked on the classified history"):
+        result, handler = _sweep(ext_session)
+    finally:
+      holder.rollback()
+      holder.close()
+
+    assert result.dispatched_event_ids == [june.id]
+    assert result.errors == []
+    handler.dispatch.assert_called_once()
+
+  def test_locked_read_sees_a_void_that_landed_after_the_preview(self, ext_session):
+    """The unlocked preview puts the rows in the identity map. Without
+    ``populate_existing`` the locked read hands back the preview's status,
+    and a void that committed while the sweep waited on the lock is acted on
+    as if it never happened — the lost update the lock exists to prevent."""
+    import threading
+
+    _seed_calendar(ext_session, may_status="open")
+    june = _obligation(ext_session, status="pending", period_end=date(2026, 6, 30))
+    ext_session.commit()
+    schema = ext_session.execute(text("select current_schema()")).scalar()
+
+    holder = ext_session.get_bind().connect()
+    holder.execute(text(f'SET search_path TO "{schema}"'))
+    holder.execute(
+      text("SELECT id FROM events WHERE id = :id FOR UPDATE"), {"id": june.id}
+    )
+    swept = threading.Event()
+
+    def _void_then_release():
+      # Let the sweep preview `pending` and block on the row lock, then void.
+      swept.wait(timeout=5)
+      time.sleep(0.5)
+      holder.execute(
+        text("UPDATE events SET status = 'voided' WHERE id = :id"), {"id": june.id}
+      )
+      holder.commit()
+      holder.close()
+
+    voider = threading.Thread(target=_void_then_release)
+    voider.start()
+    swept.set()
+    try:
+      result, handler = _sweep(ext_session)
+    finally:
+      voider.join(timeout=10)
+
+    assert result.classified_event_ids == []
+    assert result.dispatched_event_ids == []
+    handler.dispatch.assert_not_called()
+    ext_session.expire_all()
+    assert ext_session.get(Event, june.id).status == "voided"

--- a/tests/operations/roboledger/commands/test_schedules.py
+++ b/tests/operations/roboledger/commands/test_schedules.py
@@ -61,6 +61,9 @@ def test_delete_schedule_removes_information_block_dependents_before_structure()
   session = MagicMock()
   session.execute.side_effect = [
     _exec_result(row=structure),
+    # The pending-obligation void bounds its wait, so a `SET LOCAL
+    # lock_timeout` lands here.
+    _exec_result(),
     _exec_result(scalars_all=["assoc_1", "assoc_2"]),
     _exec_result(scalars_all=["rule_1"]),
   ]
@@ -100,6 +103,7 @@ def test_delete_schedule_voids_pending_obligations_before_deletion() -> None:
   session = MagicMock()
   session.execute.side_effect = [
     _exec_result(row=structure),
+    _exec_result(),  # SET LOCAL lock_timeout around the void
     _exec_result(scalars_all=[]),
     _exec_result(scalars_all=[]),
   ]
@@ -392,11 +396,12 @@ def _rebuild_session(
   execute call order:
     1. _load_schedule_or_404 → scalar_one_or_none → structure
     2. posted-entry guard → fetchone → MagicMock(c=posted_count)
-    3. select(Rule.id) for cascade delete → scalars().all()
-    4. DELETE line_items (draft sweep) → execute (result unused)
-    5. DELETE entries (draft sweep) → execute (result unused)
-    6. count facts → fetchone
-    7. count distinct periods → fetchone
+    3. SET LOCAL lock_timeout (bounded wait around the obligation void)
+    4. select(Rule.id) for cascade delete → scalars().all()
+    5. DELETE line_items (draft sweep) → execute (result unused)
+    6. DELETE entries (draft sweep) → execute (result unused)
+    7. count facts → fetchone
+    8. count distinct periods → fetchone
   query().filter().delete() captures the deleted models in order.
   _calendar_closed_through_date uses session.query(FiscalCalendar).first().
   session.get(Event, ...) returns ``old_event`` (the supersede path).
@@ -406,6 +411,9 @@ def _rebuild_session(
   session.execute.side_effect = [
     _exec_result(row=structure),  # _load_schedule_or_404
     _exec_result(fetchone_row=MagicMock(c=posted_count)),  # posted-entry guard
+    # The void of the old obligation chain bounds its wait for the rows the
+    # promotion sweep may hold, so a `SET LOCAL lock_timeout` lands here.
+    _exec_result(),
     _exec_result(scalars_all=["rule_old_1"]),  # select(Rule.id)
     _exec_result(),  # DELETE line_items (draft sweep)
     _exec_result(),  # DELETE entries (draft sweep)

--- a/tests/operations/roboledger/schedules/test_service.py
+++ b/tests/operations/roboledger/schedules/test_service.py
@@ -873,6 +873,14 @@ class TestCreateScheduleSourceTransactionId:
     assert structure.artifact_mechanics["source_transaction_id"] is None
 
 
+def _locked_ids(n: int) -> MagicMock:
+  """Result of the ordered ``SELECT … FOR UPDATE`` that precedes the void
+  UPDATE: ``.scalars()`` yields the pending ids."""
+  result = MagicMock()
+  result.scalars.return_value = iter([f"evt_pending_{i}" for i in range(n)])
+  return result
+
+
 class TestCreateScheduleMaterializesObligations:
   """Stream 2.A — schedule creation emits 1 schedule_created + N pending events."""
 
@@ -1132,7 +1140,7 @@ class TestCreateScheduleMaterializesObligations:
 
     session = MagicMock()
     update_result = MagicMock(rowcount=12)
-    session.execute.return_value = update_result
+    session.execute.side_effect = [_locked_ids(12), update_result]
     session.get.return_value = originator
 
     svc = ScheduleService()
@@ -1143,6 +1151,16 @@ class TestCreateScheduleMaterializesObligations:
     )
 
     assert voided == 12
+    # Locked first, in the shared order, then updated by id — the void and
+    # the promotion sweep hold these same rows and must acquire alike.
+    lock_stmt = session.execute.call_args_list[0].args[0]
+    lock_sql = str(lock_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "FOR UPDATE" in lock_sql
+    assert "ORDER BY events.id" in lock_sql
+    update_stmt = session.execute.call_args_list[1].args[0]
+    update_sql = str(update_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "events.id IN (" in update_sql
+    assert "events.status = 'pending'" in update_sql
     assert originator.metadata_["pending_event_count"] == 0
     assert len(originator.metadata_["void_history"]) == 1
     assert originator.metadata_["void_history"][0]["voided_count"] == 12
@@ -1158,7 +1176,7 @@ class TestCreateScheduleMaterializesObligations:
     originator.metadata_ = {"pending_event_count": 6}
 
     session = MagicMock()
-    session.execute.return_value = MagicMock(rowcount=4)
+    session.execute.side_effect = [_locked_ids(4), MagicMock(rowcount=4)]
     session.get.return_value = originator
 
     svc = ScheduleService()
@@ -1218,7 +1236,7 @@ class TestCreateScheduleMaterializesObligations:
     recovery = MagicMock()
     recovery.scalar.return_value = "evt_origin_recovered"
     update_result = MagicMock(rowcount=5)
-    session.execute.side_effect = [recovery, update_result]
+    session.execute.side_effect = [recovery, _locked_ids(5), update_result]
     session.get.return_value = originator
 
     svc = ScheduleService()
@@ -1228,7 +1246,8 @@ class TestCreateScheduleMaterializesObligations:
 
     assert voided == 5
     assert originator.metadata_["pending_event_count"] == 0
-    assert session.execute.call_count == 2  # recovery select + UPDATE
+    # recovery select + locked select + UPDATE
+    assert session.execute.call_count == 3
 
   def test_void_pending_obligations_no_op_when_no_pending_rows(self):
     """When the UPDATE matches zero rows, originator metadata is untouched."""
@@ -1236,7 +1255,7 @@ class TestCreateScheduleMaterializesObligations:
     structure.metadata_ = {"schedule_created_event_id": "evt_origin"}
 
     session = MagicMock()
-    session.execute.return_value = MagicMock(rowcount=0)
+    session.execute.side_effect = [_locked_ids(0)]
 
     svc = ScheduleService()
     voided = svc.void_pending_obligations(
@@ -1244,7 +1263,8 @@ class TestCreateScheduleMaterializesObligations:
     )
 
     assert voided == 0
-    # session.get not called since we short-circuit before the originator load
+    # Nothing to lock → no UPDATE, and no originator load.
+    assert session.execute.call_count == 1
     session.get.assert_not_called()
 
   def test_supersede_no_op_when_schedule_predates_stream_2a(self):


### PR DESCRIPTION
## Summary

Follow-up to the v1.9.4–v1.9.5 lock series (#1197–#1205), from a review of that range. Three lock-discipline gaps in the schedule/obligation paths — none a data-integrity bug today, all the shape the series exists to rule out.

## Changes

- **Promotion sweep locks its write set, not the history** (`event_block/promotion.py`). The candidate load FOR UPDATEd every `pending` and `classified` obligation each tick, and `classified` is the schedule's whole history (dispatched obligations rest there for good). Close's `execute_event_block` on schedule-sourced events waited ≤3 s behind that and failed the close whenever a sweep was running. The sweep now previews the write set (pending + stranded) unlocked, fences it (autopilot), and locks exactly those ids in the shared `id` order. The locked read carries `populate_existing()` and re-checks status — the preview put those rows in the identity map, so without the refresh a void or approval that committed while the sweep waited on the lock would have been acted on as if it never happened.
- **`void_pending_obligations` locks in the shared order first** (`schedules/service.py`). It issued a bare multi-row `UPDATE … WHERE status='pending'` over the same rows the sweep holds in `id` order; a bulk UPDATE takes its row locks in scan order, and two orders over one row set is the deadlock the ordered discipline exists to prevent (and it would surface at flush, outside any lock-wait translation). It now `SELECT … ORDER BY id FOR UPDATE`s the pending ids, then updates by id with the status predicate kept.
- **Request-facing void callers bound their wait** (`commands/schedules.py`): `delete_schedule` and `rebuild_schedule` wrap the void in `bounded_lock_wait`, matching `update_schedule`'s supersede; `rebuild-schedule` and `delete-information-block` map `RowLockedError → 409`.

## Breaking Changes

None. `rebuild-schedule` / `delete-information-block` gain a 409 for a lock conflict that previously blocked (additive).

## Testing

Targeted, against local Postgres (not `just test-all`): `tests/operations/event_block`, `tests/operations/roboledger/{schedules,commands,fiscal_calendar}`, `tests/routers/extensions`, `tests/dagster`, `tests/middleware/mcp` — 1647 passed. New in `tests/operations/event_block/test_promotion_fence_db.py` (real Postgres): a foreign `FOR UPDATE` on a drafted historical obligation no longer stalls the sweep (fails on `main` with `RowLockedError`), and a void that lands after the preview is seen by the locked read (fails without `populate_existing`). Mock tests pin the lock-then-update SQL shape of the void. `ruff check` / `ruff format` / `basedpyright` on changed files: clean.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
