### PR TITLE
fix(roboledger): finish the lock hardening — fence-first deletes, calendar pointers, publish the ledger rows

### DIFF
--- a/robosystems/operations/event_block/qb_writeback.py
+++ b/robosystems/operations/event_block/qb_writeback.py
@@ -191,14 +191,14 @@ def _build_qb_journal_entry(
 
 
 def _entries_from_draft_rows(session: Session, event_id: str) -> list[dict[str, Any]]:
-  """Build nested-shape entry dicts from the draft GL rows linked to an event.
+  """Build nested-shape entry dicts from the GL rows linked to an event.
 
-  Handler-materialized closing entries (schedule_entry_due, manual closing
-  entries) keep their GL lines on the draft ``Entry`` / ``LineItem`` rows
-  (linked by ``triggered_by_event_id``), NOT in ``event.metadata`` — unlike
-  ``journal_entry_recorded`` events, whose lines ride in metadata. Without
-  this fallback the write-back posts an empty QB JournalEntry and QB rejects
-  it ("2020 Required param missing"). Returns one entry dict per linked Entry.
+  These rows are the ledger's version of the event — the drafts close will
+  post — and so the thing to publish. Every handler materializes them
+  (``journal_entry_recorded`` via `create_journal_entry`,
+  ``schedule_entry_due`` / ``asset_disposed`` via the schedule service);
+  ``event.metadata`` is the capture, which a draft correction leaves behind.
+  Returns one entry dict per linked Entry, in creation order.
   """
   entries = (
     session.query(Entry)
@@ -252,15 +252,25 @@ def post_event_to_qb(
   metadata = dict(event.metadata_ or {})
   qb_txn_ids: list[str] = []
 
-  # Resolve the entries to post, in priority order:
-  #   1. metadata["entries"]      — nested shape (one dict per entry)
-  #   2. metadata["line_items"]   — flat shape (a single entry in metadata)
-  #   3. draft Entry/LineItem rows — handler-materialized closing entries
-  #      (schedule_entry_due, manual) whose lines live on the GL rows, not
-  #      in metadata. Without (3) these post an empty JE → QB 2020 reject.
-  nested_entries = metadata.get("entries")
-  if not (isinstance(nested_entries, list) and nested_entries):
-    if metadata.get("line_items"):
+  # Resolve the entries to post. The ledger rows come first: what publishes
+  # to QuickBooks must be what the ledger posts, and the rows are what
+  # `execute` promotes to `posted` a few lines later. `event.metadata` is
+  # the *capture* — a draft corrected through `update-journal-entry` before
+  # close has moved on from it, and publishing the capture would put the
+  # original in QuickBooks and the correction in the ledger.
+  #   1. Entry/LineItem rows linked by ``triggered_by_event_id`` — every
+  #      handler materializes these (journal_entry_recorded via
+  #      `create_journal_entry`; schedule_entry_due / asset_disposed via the
+  #      schedule service).
+  #   2. metadata["entries"]      — nested shape, for an event that never
+  #      materialized rows
+  #   3. metadata["line_items"]   — flat shape, same case
+  nested_entries = _entries_from_draft_rows(session, str(event.id))
+  if not nested_entries:
+    captured = metadata.get("entries")
+    if isinstance(captured, list) and captured:
+      nested_entries = captured
+    elif metadata.get("line_items"):
       nested_entries = [
         {
           "posting_date": metadata.get("posting_date"),
@@ -268,8 +278,6 @@ def post_event_to_qb(
           "line_items": metadata.get("line_items"),
         }
       ]
-    else:
-      nested_entries = _entries_from_draft_rows(session, str(event.id))
 
   if not nested_entries:
     raise QBWritebackError(

--- a/robosystems/operations/extensions/loader.py
+++ b/robosystems/operations/extensions/loader.py
@@ -601,6 +601,23 @@ class OLTPLoader:
         entry_subq = session.query(Entry.id).filter(
           Entry.triggered_by_event_id.in_(events_to_wipe_subq)
         )
+        # Fence before the deletes take their row locks — the order every
+        # ledger writer keeps against close. Nothing here should sit in a
+        # closed month (close posts every live draft), so a refusal means
+        # a closer holds the fence right now; the sync fails this batch and
+        # the next tick retries, rather than holding rows close is about
+        # to update.
+        from robosystems.operations.roboledger.commands._guards import (
+          assert_period_not_closed,
+        )
+
+        wipe_dates = (
+          session.query(Entry.posting_date)
+          .filter(Entry.triggered_by_event_id.in_(events_to_wipe_subq))
+          .distinct()
+          .all()
+        )
+        assert_period_not_closed(session, *(d for (d,) in wipe_dates))
         session.query(LineItem).filter(LineItem.entry_id.in_(entry_subq)).delete(
           synchronize_session=False
         )

--- a/robosystems/operations/roboledger/commands/journal_entries.py
+++ b/robosystems/operations/roboledger/commands/journal_entries.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import select, text
+from sqlalchemy import func, select, text
 from sqlalchemy.orm import Session
 
 from robosystems.logger import logger
@@ -50,6 +50,7 @@ from robosystems.models.api.extensions.journal_entries import (
   UpdateJournalEntryRequest,
 )
 from robosystems.models.extensions.roboledger.entry import Entry
+from robosystems.models.extensions.roboledger.event import Event
 from robosystems.models.extensions.roboledger.line_item import LineItem
 from robosystems.models.extensions.roboledger.transaction import Transaction
 from robosystems.operations.locking import RowLockedError, lock_by_id
@@ -103,6 +104,52 @@ class JournalEntryAlreadyReversedError(ValueError):
     )
     self.entry_id = entry_id
     self.reversing_entry_id = reversing_entry_id
+
+
+class JournalEntryOwnedByEventError(ValueError):
+  """Raised when a delete would leave a live event with no ledger rows.
+
+  A draft is the ledger's version of its event; the event is the record of
+  what happened. Deleting the last draft of an event that has not been
+  retracted leaves a committed event `execute` will still publish, with
+  nothing behind it in the books. The retraction belongs on the event —
+  void or supersede it — after which its leftover drafts are deletable.
+  Multi-entry events keep the surface: deleting one of several drafts is a
+  correction, and the rows that remain are what publishes.
+  """
+
+  def __init__(self, entry_id: str, event_id: str, event_status: str) -> None:
+    super().__init__(
+      f"Journal entry {entry_id} is the only ledger entry of event {event_id} "
+      f"(status {event_status!r}). Void or supersede the event instead of "
+      "deleting its draft; a retracted event's drafts can then be deleted."
+    )
+    self.entry_id = entry_id
+    self.event_id = event_id
+    self.event_status = event_status
+
+
+_RETRACTED_EVENT_STATUSES = frozenset({"voided", "superseded"})
+
+
+def _lock_owning_event(session: Session, entry: Entry) -> Event | None:
+  """Lock the event a draft belongs to, before the draft's own row.
+
+  `execute_event_block` and close both take the event row and then write its
+  entries; a correction that took the entry first and the event never (or
+  second) would either interleave with a publish — QuickBooks receiving the
+  version from before the correction — or acquire in the opposite order.
+  Event, then entry, everywhere. Bounded like the entry lock.
+  """
+  if entry.triggered_by_event_id is None:
+    return None
+  return lock_by_id(
+    session,
+    Event,
+    entry.triggered_by_event_id,
+    f"Event {entry.triggered_by_event_id} is being written by another "
+    "process. Retry in a moment.",
+  )
 
 
 class JournalEntryNotPostedError(ValueError):
@@ -424,6 +471,10 @@ def update_journal_entry(
     dates.append(body.posting_date)
   assert_period_not_closed(session, *dates)
 
+  # Event before entry — the order `execute` and close use — so a
+  # correction and a publish serialize, and QuickBooks receives the rows as
+  # corrected rather than the version a concurrent publish read first.
+  _lock_owning_event(session, peek)
   entry = lock_by_id(
     session,
     Entry,
@@ -494,11 +545,16 @@ def delete_journal_entry(session: Session, body: DeleteJournalEntryRequest) -> d
       period.
     `RowLockedError` (409) if another writer holds the entry, or if the
       posting date moved under us (retry so locks are acquired in order).
+    `JournalEntryOwnedByEventError` (422) if this is the last ledger entry
+      of an event that has not been voided or superseded.
   """
   peek = _load_entry_or_404(session, body.entry_id)
   peeked_date = peek.posting_date
   assert_period_not_closed(session, peeked_date)
 
+  # Event before entry — see `_lock_owning_event`. Under the event lock the
+  # sibling count below cannot change before the delete.
+  owner = _lock_owning_event(session, peek)
   entry = lock_by_id(
     session,
     Entry,
@@ -511,6 +567,17 @@ def delete_journal_entry(session: Session, body: DeleteJournalEntryRequest) -> d
   _raise_if_posting_date_moved(entry, peeked_date)
   if entry.status != "draft":
     raise JournalEntryNotDraftError(entry.id, entry.status)
+
+  if owner is not None and owner.status not in _RETRACTED_EVENT_STATUSES:
+    siblings = session.execute(
+      select(func.count())
+      .select_from(Entry)
+      .where(Entry.triggered_by_event_id == owner.id)
+    ).scalar_one()
+    if siblings <= 1:
+      raise JournalEntryOwnedByEventError(
+        str(entry.id), str(owner.id), str(owner.status)
+      )
 
   session.delete(entry)
   session.flush()

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -696,11 +696,34 @@ def rebuild_schedule(
 
   service = ScheduleService()
 
+  # Fence first, then rows — the order every other ledger writer keeps. The
+  # rebuild deletes this schedule's draft closing entries below and re-drafts
+  # them through `create_closing_entry`, whose own fence would otherwise be
+  # the first, taken *after* the deletes had already locked the rows.
+  # A closer holding the exclusive side (or a closed month with a stale
+  # draft still in it) is refused here, before anything is touched.
+  from robosystems.operations.roboledger.commands._guards import (
+    assert_period_not_closed,
+  )
+
+  draft_dates = (
+    session.execute(
+      text(
+        "SELECT DISTINCT posting_date FROM entries "
+        "WHERE source_structure_id = :sid AND status = 'draft'"
+      ),
+      {"sid": structure.id},
+    )
+    .scalars()
+    .all()
+  )
+  assert_period_not_closed(session, *draft_dates)
+
   # Void the old pending obligation chain so the regenerated chain doesn't
   # double-count and the old pending events can't trip the close gate.
   # Bounded for the same reason as `delete_schedule`: request-facing, and
   # it contends with the promotion sweep over these rows.
-  from robosystems.operations.locking import bounded_lock_wait
+  from robosystems.operations.locking import bounded_lock_wait, lock_by_id
 
   with bounded_lock_wait(
     session,
@@ -782,7 +805,17 @@ def rebuild_schedule(
     and new_schedule_created_event_id
     and old_schedule_created_event_id != new_schedule_created_event_id
   ):
-    old_evt = session.get(Event, old_schedule_created_event_id)
+    # Locked: this is a status write off a read, like every other event
+    # transition. An inbox transition on the originator is the only thing
+    # that could race it, and it should lose cleanly rather than be
+    # overwritten.
+    old_evt = lock_by_id(
+      session,
+      Event,
+      old_schedule_created_event_id,
+      f"Event {old_schedule_created_event_id} is being written by another "
+      "process. Retry in a moment.",
+    )
     if old_evt is not None:
       old_evt.status = "voided"
       old_evt.replaced_by_event_id = new_schedule_created_event_id

--- a/robosystems/operations/roboledger/fiscal_calendar/service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/service.py
@@ -167,6 +167,41 @@ class FiscalCalendarService:
       )
     return calendar
 
+  def require_locked(self, session: Session, graph_id: str) -> FiscalCalendar:
+    """`require`, with the calendar row locked for the write that follows.
+
+    The pointer writers — set-close-target, close's advance, reopen's
+    retreat — are read-decide-write over ``closed_through_period`` /
+    ``close_target_period``. Close and reopen already run under the
+    exclusive period fence and the FiscalPeriod row lock, but
+    set-close-target takes neither, so an operator moving the target while
+    a close auto-advances it was a lost update on whichever wrote second.
+    Locking the calendar row serializes the three; taken after the
+    FiscalPeriod row where both are held, so the order is one-directional.
+    Bounded, because every caller is request-facing.
+    """
+    from robosystems.operations.locking import bounded_lock_wait
+
+    session.flush()
+    with bounded_lock_wait(
+      session,
+      f"The fiscal calendar for graph {graph_id} is being written by another "
+      "process. Retry in a moment.",
+    ):
+      calendar = (
+        session.query(FiscalCalendar)
+        .filter(FiscalCalendar.graph_id == graph_id)
+        .populate_existing()
+        .with_for_update()
+        .one_or_none()
+      )
+    if calendar is None:
+      raise FiscalCalendarError(
+        f"Fiscal calendar not initialized for graph {graph_id}. "
+        "Call POST /extensions/roboledger/{graph_id}/operations/initialize first."
+      )
+    return calendar
+
   # ── Create / initialize ─────────────────────────────────────────────────
 
   def get_or_create(
@@ -307,7 +342,7 @@ class FiscalCalendarService:
     except ValueError as e:
       raise InvalidCloseTargetError(str(e)) from e
 
-    calendar = self.require(session, graph_id)
+    calendar = self.require_locked(session, graph_id)
 
     last_valid = last_completed_period()
     if period > last_valid:
@@ -425,7 +460,7 @@ class FiscalCalendarService:
     Raises ``AdvanceSequenceError`` if `period` is not the next sequential
     period.
     """
-    calendar = self.require(session, graph_id)
+    calendar = self.require_locked(session, graph_id)
 
     if calendar.closed_through_period:
       expected: str | None = next_period(calendar.closed_through_period)
@@ -506,7 +541,7 @@ class FiscalCalendarService:
     shouldn't shift it either. We just bump `last_close_at` and emit a
     `period_closed` event for the audit trail.
     """
-    calendar = self.require(session, graph_id)
+    calendar = self.require_locked(session, graph_id)
     calendar.last_close_at = datetime.now(UTC)
     calendar.updated_by = actor_id
     session.flush()
@@ -554,7 +589,7 @@ class FiscalCalendarService:
     if not reason:
       raise FiscalCalendarError("reopen requires a non-empty reason")
 
-    calendar = self.require(session, graph_id)
+    calendar = self.require_locked(session, graph_id)
     previous_closed_through = calendar.closed_through_period
 
     if calendar.closed_through_period == reopened_period:

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -1635,6 +1635,23 @@ class ScheduleService:
         "not clear this guard."
       )
 
+    # Fence before the deletes below take their row locks — the order every
+    # ledger writer keeps against close (exclusive fence, then rows).
+    stale_dates = (
+      session.execute(
+        text("""
+          SELECT DISTINCT posting_date FROM entries
+          WHERE source_structure_id = :sid
+            AND status = 'draft'
+            AND posting_date > :new_end
+        """),
+        {"sid": structure_id, "new_end": new_end_date},
+      )
+      .scalars()
+      .all()
+    )
+    assert_period_not_closed(session, *stale_dates)
+
     # Delete any draft entries that fall past the new end date (they're now stale)
     session.execute(
       text("""

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -317,6 +317,7 @@ from robosystems.operations.roboledger.commands.journal_entries import (
   JournalEntryNotDraftError,
   JournalEntryNotFoundError,
   JournalEntryNotPostedError,
+  JournalEntryOwnedByEventError,
   UnbalancedJournalEntryError,
 )
 from robosystems.operations.roboledger.commands.journal_entries import (
@@ -1755,6 +1756,8 @@ delete_journal_entry_op = _registrar.register(
     error_map={
       JournalEntryNotFoundError: 404,
       JournalEntryNotDraftError: 422,
+      # The last draft of a live event: retract the event, not the draft.
+      JournalEntryOwnedByEventError: 422,
       ClosedPeriodError: 422,
       RowLockedError: 409,
     },

--- a/tests/operations/event_block/test_qb_writeback_payload.py
+++ b/tests/operations/event_block/test_qb_writeback_payload.py
@@ -1,0 +1,194 @@
+"""What publishes to QuickBooks is the ledger's rows — real Postgres.
+
+An event's ``metadata`` is the capture; its ``Entry`` / ``LineItem`` rows are
+what the ledger posts at close. A draft corrected through
+`update-journal-entry` moves the rows and leaves the capture behind, so
+publishing the capture would put the original in QuickBooks and the
+correction in the books. `post_event_to_qb` publishes the rows whenever any
+exist and falls back to the capture only for an event that never
+materialized rows.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, date, datetime
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+import robosystems.models.extensions  # noqa: F401  (register models on ExtensionsBase)
+from robosystems.db.extensions import ExtensionsBase
+from robosystems.models.extensions import Element
+from robosystems.models.extensions.roboledger.entry import Entry
+from robosystems.models.extensions.roboledger.event import Event
+from robosystems.models.extensions.roboledger.line_item import LineItem
+from robosystems.operations.event_block.qb_writeback import post_event_to_qb
+
+pytestmark = pytest.mark.unit
+
+_MODULE = "robosystems.operations.event_block.qb_writeback"
+
+
+@pytest.fixture()
+def ext_session():
+  database_url = os.environ.get("TEST_DATABASE_URL")
+  if not database_url:
+    pytest.skip("TEST_DATABASE_URL not configured")
+
+  schema = f"ext_qbpay_{uuid.uuid4().hex[:12]}"
+  engine = create_engine(database_url)
+  with engine.begin() as conn:
+    conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+
+  session = sessionmaker(bind=engine)()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+  ExtensionsBase.metadata.create_all(bind=session.connection())
+  session.commit()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+
+  try:
+    yield session
+  finally:
+    session.rollback()
+    session.close()
+    with engine.begin() as conn:
+      conn.execute(text(f'DROP SCHEMA "{schema}" CASCADE'))
+    engine.dispose()
+
+
+_CAPTURED_LINES = [
+  {"element_id": "elem_cash", "debit_amount": 10_000, "credit_amount": 0},
+  {"element_id": "elem_rev", "debit_amount": 0, "credit_amount": 10_000},
+]
+
+
+def _elements(session) -> None:
+  session.add_all(
+    [
+      Element(id="elem_cash", name="Cash", code="1000", balance_type="debit"),
+      Element(id="elem_rev", name="Revenue", code="4000", balance_type="credit"),
+    ]
+  )
+  session.flush()
+
+
+def _event(session, *, with_capture: bool) -> Event:
+  _elements(session)
+  metadata = {"connection_id": "conn_qb"}
+  if with_capture:
+    metadata.update(
+      {
+        "posting_date": "2026-06-15",
+        "memo": "as captured",
+        "line_items": _CAPTURED_LINES,
+      }
+    )
+  event = Event(
+    event_type="journal_entry_recorded",
+    event_category="adjustment",
+    occurred_at=datetime(2026, 6, 15, tzinfo=UTC),
+    source="manual",
+    status="committed",
+    created_by="usr_test",
+    metadata_=metadata,
+  )
+  session.add(event)
+  session.flush()
+  return event
+
+
+def _corrected_rows(session, event: Event) -> Entry:
+  """The draft as the operator corrected it: different memo, date, amounts."""
+  entry = Entry(
+    posting_date=date(2026, 6, 20),
+    status="draft",
+    memo="as corrected",
+    created_by="usr_test",
+    triggered_by_event_id=event.id,
+  )
+  session.add(entry)
+  session.flush()
+  session.add_all(
+    [
+      LineItem(
+        entry_id=entry.id,
+        element_id="elem_cash",
+        debit_amount=12_500,
+        credit_amount=0,
+        line_order=1,
+        description="corrected debit",
+      ),
+      LineItem(
+        entry_id=entry.id,
+        element_id="elem_rev",
+        debit_amount=0,
+        credit_amount=12_500,
+        line_order=2,
+        description="corrected credit",
+      ),
+    ]
+  )
+  session.flush()
+  return entry
+
+
+def _publish(session, event: Event) -> list[dict]:
+  """Run the publish with the QB boundary faked; return the built payloads."""
+  built: list[dict] = []
+
+  def _fake_build(session_, *, posting_date, memo, line_items):
+    built.append({"posting_date": posting_date, "memo": memo, "line_items": line_items})
+    return object()
+
+  with (
+    patch(f"{_MODULE}._build_qb_journal_entry", side_effect=_fake_build),
+    patch(f"{_MODULE}._save_with_retry", return_value="77"),
+  ):
+    ids = post_event_to_qb(session, event, qb_client=object())
+  assert ids == ["JournalEntry_77"]
+  return built
+
+
+def test_publishes_the_ledger_rows_not_the_capture(ext_session):
+  """Capture and rows both present → the rows are what QuickBooks receives."""
+  event = _event(ext_session, with_capture=True)
+  entry = _corrected_rows(ext_session, event)
+  ext_session.commit()
+
+  (payload,) = _publish(ext_session, event)
+
+  assert payload["posting_date"] == entry.posting_date == date(2026, 6, 20)
+  assert payload["memo"] == "as corrected"
+  assert [
+    (li["element_id"], li["debit_amount"], li["credit_amount"])
+    for li in payload["line_items"]
+  ] == [
+    ("elem_cash", 12_500, 0),
+    ("elem_rev", 0, 12_500),
+  ]
+
+
+def test_falls_back_to_the_capture_when_no_rows_exist(ext_session):
+  """An event that never materialized rows still publishes its capture."""
+  event = _event(ext_session, with_capture=True)
+  ext_session.commit()
+
+  (payload,) = _publish(ext_session, event)
+
+  assert payload["memo"] == "as captured"
+  assert payload["line_items"] == _CAPTURED_LINES
+
+
+def test_nothing_to_publish_is_a_rejection(ext_session):
+  from robosystems.operations.event_block.qb_writeback import QBWritebackError
+
+  event = _event(ext_session, with_capture=False)
+  ext_session.commit()
+
+  with pytest.raises(QBWritebackError) as excinfo:
+    _publish(ext_session, event)
+  assert excinfo.value.payload["code"] == "no_line_items"

--- a/tests/operations/roboledger/commands/test_journal_entries.py
+++ b/tests/operations/roboledger/commands/test_journal_entries.py
@@ -78,6 +78,9 @@ def _mock_entry(
   e.provenance = "manual_entry"
   e.reversal_of = None
   e.posted_at = None
+  # A standalone draft (no owning event) unless a test says otherwise; the
+  # owned-by-event paths build their own owner.
+  e.triggered_by_event_id = None
   return e
 
 
@@ -628,6 +631,63 @@ class TestDeleteJournalEntry:
     kwargs = session.get.call_args.kwargs
     assert kwargs.get("with_for_update") is True
     assert kwargs.get("populate_existing") is True
+
+  def _owned(self, *, owner_status: str, siblings: int):
+    """A draft owned by an event, with ``siblings`` ledger rows on that event.
+    ``session.get`` serves the event lock first (event → entry order), then
+    the entry lock; the sibling count rides ``execute(...).scalar_one()``."""
+    entry = _mock_entry(status="draft")
+    entry.triggered_by_event_id = "evt_owner"
+    owner = MagicMock()
+    owner.id = "evt_owner"
+    owner.status = owner_status
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.return_value = entry
+    session.execute.return_value.scalar_one.return_value = siblings
+    session.get.side_effect = lambda model, ident, **_k: (
+      owner if ident == "evt_owner" else entry
+    )
+    return session, entry, owner
+
+  @patch(f"{MODULE}.assert_period_not_closed")
+  def test_last_draft_of_a_live_event_is_refused(self, mock_guard):
+    """The event is the record; its retraction happens on the event. Deleting
+    the last draft would leave a committed event `execute` still publishes,
+    with nothing behind it in the books."""
+    from robosystems.operations.roboledger.commands.journal_entries import (
+      JournalEntryOwnedByEventError,
+    )
+
+    session, _entry, _owner = self._owned(owner_status="committed", siblings=1)
+    with pytest.raises(JournalEntryOwnedByEventError, match="evt_owner"):
+      delete_journal_entry(session, DeleteJournalEntryRequest(entry_id="entry_01"))
+    session.delete.assert_not_called()
+
+  @patch(f"{MODULE}.assert_period_not_closed")
+  def test_one_of_several_drafts_may_be_deleted(self, mock_guard):
+    session, entry, _owner = self._owned(owner_status="committed", siblings=3)
+    delete_journal_entry(session, DeleteJournalEntryRequest(entry_id="entry_01"))
+    session.delete.assert_called_once_with(entry)
+
+  @patch(f"{MODULE}.assert_period_not_closed")
+  def test_retracted_events_leftover_draft_may_be_deleted(self, mock_guard):
+    """Void or supersede first, then the leftover draft is deletable — the
+    same drafts close leaves alone."""
+    for status in ("voided", "superseded"):
+      session, entry, _owner = self._owned(owner_status=status, siblings=1)
+      delete_journal_entry(session, DeleteJournalEntryRequest(entry_id="entry_01"))
+      session.delete.assert_called_once_with(entry)
+
+  @patch(f"{MODULE}.assert_period_not_closed")
+  def test_owning_event_is_locked_before_the_entry(self, mock_guard):
+    """Event, then entry — the order `execute` and close use."""
+    session, _entry, _owner = self._owned(owner_status="committed", siblings=2)
+    delete_journal_entry(session, DeleteJournalEntryRequest(entry_id="entry_01"))
+    idents = [c.args[1] for c in session.get.call_args_list]
+    assert idents == ["evt_owner", "entry_01"], idents
+    for c in session.get.call_args_list:
+      assert c.kwargs.get("with_for_update") is True
+      assert c.kwargs.get("populate_existing") is True
 
   @patch(f"{MODULE}.assert_period_not_closed")
   def test_moved_posting_date_is_retryable_not_refenced(self, mock_guard):

--- a/tests/operations/roboledger/commands/test_schedules.py
+++ b/tests/operations/roboledger/commands/test_schedules.py
@@ -389,19 +389,27 @@ def _rebuild_structure() -> MagicMock:
 
 
 def _rebuild_session(
-  structure: MagicMock, *, posted_count: int = 0, old_event=None
+  structure: MagicMock,
+  *,
+  posted_count: int = 0,
+  old_event=None,
+  originator_changes: bool = False,
 ) -> tuple[MagicMock, list[type]]:
   """Wire a MagicMock session for the rebuild orchestration.
 
   execute call order:
     1. _load_schedule_or_404 → scalar_one_or_none → structure
     2. posted-entry guard → fetchone → MagicMock(c=posted_count)
-    3. SET LOCAL lock_timeout (bounded wait around the obligation void)
-    4. select(Rule.id) for cascade delete → scalars().all()
-    5. DELETE line_items (draft sweep) → execute (result unused)
-    6. DELETE entries (draft sweep) → execute (result unused)
-    7. count facts → fetchone
-    8. count distinct periods → fetchone
+    3. draft posting dates for the period fence → scalars().all() (empty)
+    4. SET LOCAL lock_timeout (bounded wait around the obligation void)
+    5. select(Rule.id) for cascade delete → scalars().all()
+    6. DELETE line_items (draft sweep) → execute (result unused)
+    7. DELETE entries (draft sweep) → execute (result unused)
+    8. SET LOCAL lock_timeout (bounded wait around the originator lock) —
+       only when ``originator_changes`` (the regenerated chain stamped a new
+       ``schedule_created_event_id``, so the old originator is voided)
+    9. count facts → fetchone
+    10. count distinct periods → fetchone
   query().filter().delete() captures the deleted models in order.
   _calendar_closed_through_date uses session.query(FiscalCalendar).first().
   session.get(Event, ...) returns ``old_event`` (the supersede path).
@@ -411,12 +419,17 @@ def _rebuild_session(
   session.execute.side_effect = [
     _exec_result(row=structure),  # _load_schedule_or_404
     _exec_result(fetchone_row=MagicMock(c=posted_count)),  # posted-entry guard
+    # Draft posting dates for the period fence, taken before any row lock.
+    # Empty → no fence statement follows.
+    _exec_result(scalars_all=[]),
     # The void of the old obligation chain bounds its wait for the rows the
     # promotion sweep may hold, so a `SET LOCAL lock_timeout` lands here.
     _exec_result(),
     _exec_result(scalars_all=["rule_old_1"]),  # select(Rule.id)
     _exec_result(),  # DELETE line_items (draft sweep)
     _exec_result(),  # DELETE entries (draft sweep)
+    # The originator void locks its row (`lock_by_id`) — another bounded wait.
+    *([_exec_result()] if originator_changes else []),
     _exec_result(fetchone_row=MagicMock(cnt=6)),  # count facts
     _exec_result(fetchone_row=MagicMock(cnt=3)),  # count distinct periods
   ]
@@ -650,7 +663,7 @@ def test_rebuild_schedule_supersedes_old_originator() -> None:
   old_evt.id = "evt_old_origin"
   old_evt.status = "committed"
   old_evt.replaced_by_event_id = None
-  session, _ = _rebuild_session(structure, old_event=old_evt)
+  session, _ = _rebuild_session(structure, old_event=old_evt, originator_changes=True)
 
   # create_schedule re-stamps the originator on the in-place structure. Mutate
   # metadata inside the mock so the OLD id is still readable when rebuild_schedule
@@ -687,7 +700,11 @@ def test_rebuild_schedule_supersedes_old_originator() -> None:
   # Old originator loaded by id, voided, and linked to its replacement.
   from robosystems.models.extensions.roboledger.event import Event
 
-  session.get.assert_called_once_with(Event, "evt_old_origin")
+  # Locked and refreshed — a status write off a read, like every other event
+  # transition.
+  session.get.assert_called_once_with(
+    Event, "evt_old_origin", with_for_update=True, populate_existing=True
+  )
   assert old_evt.status == "voided"
   assert old_evt.replaced_by_event_id == "evt_new_origin"
 

--- a/tests/operations/roboledger/commands/test_state_transition_locks_db.py
+++ b/tests/operations/roboledger/commands/test_state_transition_locks_db.py
@@ -488,3 +488,48 @@ class TestFileReportLock:
       with extensions_session(GRAPH) as other:
         with pytest.raises(RowLockedError, match=self.REPORT_ID):
           delete_report(other, self.REPORT_ID, "usr_seed")
+
+
+class TestCalendarPointerLock:
+  """The calendar's pointers are read-decide-write: set-close-target, close's
+  advance and reopen's retreat all load the row, check it, and write it.
+  Close and reopen ran under the exclusive fence and the FiscalPeriod row
+  lock; set-close-target took neither, so an operator moving the target
+  while a close auto-advanced it was a lost update. All three now lock the
+  calendar row.
+  """
+
+  @pytest.fixture(autouse=True)
+  def calendar(self, tenant):
+    from robosystems.operations.roboledger.fiscal_calendar.service import (
+      FiscalCalendarService,
+    )
+
+    with extensions_session(GRAPH) as session:
+      FiscalCalendarService().initialize(
+        session, GRAPH, closed_through="2025-12", actor_id="usr_seed"
+      )
+    yield
+
+  def test_set_close_target_waits_behind_a_held_calendar_row(self, tenant):
+    from robosystems.operations.roboledger.fiscal_calendar.service import (
+      FiscalCalendarService,
+    )
+
+    with extensions_session(GRAPH) as holder:
+      holder.execute(
+        text("SELECT id FROM fiscal_calendar WHERE graph_id = :g FOR UPDATE"),
+        {"g": GRAPH},
+      )
+      with extensions_session(GRAPH) as setter:
+        with pytest.raises(RowLockedError, match="fiscal calendar"):
+          FiscalCalendarService().set_close_target(
+            setter, GRAPH, "2026-01", actor_id="usr_op"
+          )
+
+    # Released → the same call goes through.
+    with extensions_session(GRAPH) as setter:
+      calendar = FiscalCalendarService().set_close_target(
+        setter, GRAPH, "2026-01", actor_id="usr_op"
+      )
+      assert calendar.close_target_period == "2026-01"

--- a/tests/operations/roboledger/fiscal_calendar/test_service.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_service.py
@@ -42,12 +42,19 @@ class _InMemorySession:
   def __init__(self):
     self._objects: dict[type, list] = {}
     self.flush_count = 0
+    self.executed: list = []
 
   def add(self, obj) -> None:
     self._objects.setdefault(type(obj), []).append(obj)
 
   def flush(self) -> None:
     self.flush_count += 1
+
+  def execute(self, *args, **kwargs):
+    # `require_locked` bounds its wait with `SET LOCAL lock_timeout`; the
+    # statement is recorded and otherwise inert here.
+    self.executed.append(args[0] if args else None)
+    return None
 
   def query(self, model):
     return _Query(self, model)
@@ -120,6 +127,14 @@ class _Query:
     return len(self._apply_filters(list(self._session._objects.get(self._model, []))))
 
   def order_by(self, *args):
+    return self
+
+  # `require_locked` reads the calendar row `FOR UPDATE`, refreshed; both are
+  # no-ops on the in-memory rows.
+  def populate_existing(self):
+    return self
+
+  def with_for_update(self, *args, **kwargs):
     return self
 
   def limit(self, n):

--- a/tests/operations/roboledger/schedules/test_service.py
+++ b/tests/operations/roboledger/schedules/test_service.py
@@ -873,6 +873,14 @@ class TestCreateScheduleSourceTransactionId:
     assert structure.artifact_mechanics["source_transaction_id"] is None
 
 
+def _no_stale_dates() -> MagicMock:
+  """Result of `truncate_schedule`'s stale-draft posting-date read (the period
+  fence taken before its deletes): no drafts past the new end."""
+  result = MagicMock()
+  result.scalars.return_value.all.return_value = []
+  return result
+
+
 def _locked_ids(n: int) -> MagicMock:
   """Result of the ordered ``SELECT … FOR UPDATE`` that precedes the void
   UPDATE: ``.scalars()`` yields the pending ids."""
@@ -1904,9 +1912,13 @@ class TestTruncateSchedule:
     # The sequence of session.execute calls:
     # 1. bounds (SELECT) — fetchone
     # 2. overlap (SELECT) — fetchone
-    # 3. DELETE line_items (draft stale)
-    # 4. DELETE entries (draft stale)
-    # 5. DELETE facts → rowcount=15
+    # 3. stale-draft posting dates (SELECT DISTINCT) — scalars().all(), for
+    #    the period fence taken before the deletes lock any rows
+    # 4. DELETE line_items (draft stale)
+    # 5. DELETE entries (draft stale)
+    # 6. DELETE facts → rowcount=15
+    stale_dates = MagicMock()
+    stale_dates.scalars.return_value.all.return_value = []
     session.execute.side_effect = [
       MagicMock(
         fetchone=MagicMock(
@@ -1916,6 +1928,7 @@ class TestTruncateSchedule:
         )
       ),
       MagicMock(fetchone=MagicMock(return_value=MagicMock(c=0))),
+      stale_dates,
       MagicMock(),  # delete line_items
       MagicMock(),  # delete entries
       delete_result,  # delete facts
@@ -1976,6 +1989,7 @@ class TestTruncateSchedule:
         )
       ),
       MagicMock(fetchone=MagicMock(return_value=MagicMock(c=0))),
+      _no_stale_dates(),  # period fence read before the deletes
       MagicMock(),
       MagicMock(),
       MagicMock(rowcount=10),
@@ -2003,6 +2017,7 @@ class TestTruncateSchedule:
         )
       ),
       MagicMock(fetchone=MagicMock(return_value=MagicMock(c=0))),
+      _no_stale_dates(),  # period fence read before the deletes
       MagicMock(),
       MagicMock(),
       MagicMock(rowcount=10),


### PR DESCRIPTION
## Summary

Closes out the lock-discipline residuals from the whole-range review of v1.9.3→v1.9.5 (after #1205, #1206, #1207), so the patch release carries the complete set. Two commits.

## Changes

**Fence before the schedule deletes; lock the calendar pointers** (`2bb7cc55`)
- `rebuild_schedule`'s draft sweep, `truncate_schedule`, and the loader's full-rebuild wipe took row locks before any period fence — the inversion every other ledger writer avoids against close (it degraded to a bounded retry, never a deadlock, but it was the shape). Each now fences the affected drafts' posting dates first.
- `rebuild_schedule` voids the superseded `schedule_created` originator through `lock_by_id`, like every other event transition.
- `FiscalCalendarService.require_locked()`: `set_close_target`, `advance_closed_through`, `record_reclose`, `retreat_closed_through` lock the calendar row. `set-close-target` took neither the fence nor a lock, so a target moved while a close auto-advanced it was a lost update. Taken after the FiscalPeriod row where both are held, so the order is one-directional. New real-Postgres test in `test_state_transition_locks_db.py`.

**Publish the ledger rows; retract events on the event** (`2785d453`)
- `post_event_to_qb` published `event.metadata` (the capture) ahead of the draft rows, falling back to rows only for handler-materialized entries. A draft corrected through `update-journal-entry` before close therefore posted the correction to the ledger and the *original* to QuickBooks. The rows — what `execute` promotes to `posted` — now publish whenever any exist; the capture is the fallback for an event that never materialized rows. New real-Postgres tests (`test_qb_writeback_payload.py`): rows-over-capture (fails on `main`), capture fallback, nothing-to-publish rejection.
- `update-journal-entry` / `delete-journal-entry` lock the owning event **before** the entry — the order `execute` and close use — so a correction and a publish serialize instead of interleaving.
- `delete-journal-entry` refuses to remove the **last** draft of a live event (`JournalEntryOwnedByEventError` → 422: void or supersede the event instead). Deleting one of several drafts stays a correction; a voided/superseded event's leftover drafts stay deletable — the same drafts close leaves alone since #1205.

## Breaking Changes

None. Additive: `delete-journal-entry` gains a 422 for the last-draft-of-a-live-event case (previously succeeded and left a committed event with no ledger rows); `rebuild-schedule` / `set-close-target` / `delete-information-block` can return 409 on a lock conflict that previously blocked. QuickBooks now receives the corrected draft rather than the capture when a draft was edited before close — a behavior change in the operator's favor, worth a release-note line.

## Testing

Targeted, against local Postgres (not `just test-all`): `tests/operations/{roboledger,event_block,extensions}`, `tests/routers/extensions`, `tests/middleware/mcp`, `tests/dagster`, `tests/db` — 2,204 passed; integration lock suites (`test_state_transition_locks_db.py`, `test_update_locking_db.py`) — 22 passed. `ruff check` / `ruff format` / `basedpyright` on changed files: clean.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
