### PR TITLE
fix: harden the extensions write path — staleness, provisioning, error surfacing, curation guards

### DIFF
--- a/robosystems/dagster/jobs/extensions.py
+++ b/robosystems/dagster/jobs/extensions.py
@@ -11,6 +11,7 @@ Can be triggered:
 - On a schedule (future)
 """
 
+from datetime import UTC, datetime
 from typing import Any
 
 from dagster import (
@@ -105,6 +106,10 @@ def materialize_extensions_to_graph(
         },
       )
 
+    # Stamped before the source is read: a write that marks the graph stale
+    # after this point is not in the snapshot, and mark_fresh must leave the
+    # flag set for it (compare-and-clear).
+    started_at = datetime.now(UTC)
     materializer = ExtensionsMaterializer()
     result = loop.run_until_complete(
       materializer.materialize(
@@ -140,7 +145,12 @@ def materialize_extensions_to_graph(
   try:
     graph_row = db_session.query(Graph).filter(Graph.graph_id == graph_id).first()
     if graph_row:
-      graph_row.mark_fresh(session=db_session)
+      cleared = graph_row.mark_fresh(session=db_session, started_at=started_at)
+      if not cleared:
+        context.log.info(
+          f"{graph_id} was written during the materialization; leaving it stale "
+          "for the next sweep"
+        )
   finally:
     try:
       next(db_gen)

--- a/robosystems/dagster/jobs/graph.py
+++ b/robosystems/dagster/jobs/graph.py
@@ -817,6 +817,9 @@ def materialize_graph_tables(
   )
 
   start_time = time.time()
+  # Compare-and-clear anchor for mark_fresh: a write stamped after this
+  # point is not in this build and must keep the graph stale.
+  started_at = datetime.now(UTC)
   graph_id = config.graph_id
   context.log.info(
     f"Starting graph materialization for {graph_id} "
@@ -1035,7 +1038,10 @@ def materialize_graph_tables(
           )
 
       context.log.info("[95%] Marking graph as fresh")
-      graph_record.mark_fresh(session=session)
+      if not graph_record.mark_fresh(session=session, started_at=started_at):
+        context.log.info(
+          f"{graph_id} was written during the materialization; leaving it stale"
+        )
 
       if config.rebuild:
         graph_metadata = (

--- a/robosystems/db/extensions.py
+++ b/robosystems/db/extensions.py
@@ -388,10 +388,35 @@ def _widen_library_checks(conn, schema: str) -> None:
   )
 
 
+class TenantDeprovisionedError(RuntimeError):
+  """The graph is torn down; nothing may create or write its tenant schema."""
+
+  def __init__(self, graph_id: str) -> None:
+    self.graph_id = graph_id
+    super().__init__(f"Graph {graph_id} is deprovisioned; refusing to provision")
+
+
+def ensure_tenant_schema(graph_id: str) -> bool:
+  """Provision the tenant schema only if it does not exist yet.
+
+  ``provision_tenant_schema`` is idempotent but not free: its CHECK and
+  trigger installs take AccessExclusive locks on every tenant table, so a
+  caller that runs on every sync (the OLTP loader) must not re-run it
+  against a schema that is already there — a concurrent report build or
+  GraphQL read deadlocks against it and either the read or the whole load
+  is aborted. Returns True when a schema was provisioned.
+  """
+  if tenant_schema_exists(graph_id):
+    return False
+  provision_tenant_schema(graph_id)
+  return True
+
+
 def provision_tenant_schema(graph_id: str) -> None:
   """Create all tenant tables in a new PostgreSQL schema for this graph_id.
 
-  Called lazily on first extension access for a graph. Creates the schema
+  Called at graph creation (and by ``ensure_tenant_schema`` when a schema is
+  missing). Creates the schema
   and all tenant-scoped tables (elements, transactions, entries, etc.)
   using ExtensionsBase metadata, then copies the canonical taxonomy
   library from ``public.*`` into the tenant schema per the graph's pin
@@ -420,12 +445,17 @@ def provision_tenant_schema(graph_id: str) -> None:
   # before opening the extensions transaction, since they're separate
   # databases.
   from robosystems.database import platform_session
-  from robosystems.models.core.graph.graph import Graph
+  from robosystems.models.core.graph.graph import Graph, GraphStatus
   from robosystems.taxonomy.pins import resolve_pin
   from robosystems.taxonomy.writer import copy_library_into_tenant
 
   with platform_session() as pdb:
     graph = pdb.get(Graph, graph_id)
+    if graph is not None and graph.status == GraphStatus.DEPROVISIONED.value:
+      # Teardown drops the schema before it deletes the graph's connections,
+      # so a sync still in flight would otherwise re-create the schema and
+      # write ledger rows into a tenant the platform no longer knows about.
+      raise TenantDeprovisionedError(graph_id)
     pin = resolve_pin(graph)
 
   with engine.connect() as conn:

--- a/robosystems/middleware/extensions.py
+++ b/robosystems/middleware/extensions.py
@@ -25,6 +25,7 @@ from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm import Session
 
 from robosystems.database import get_db_session
+from robosystems.logger import logger
 from robosystems.middleware.auth.dependencies import require_graph_write_role
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
 from robosystems.middleware.operations import (
@@ -54,6 +55,17 @@ ErrorMapEntry = int | tuple[int, ErrorDetailFactory]
 # `isinstance`, so subclass entries should come before superclass
 # entries (Python dicts preserve insertion order).
 ErrorMap = dict[type[Exception], ErrorMapEntry]
+
+
+def is_schema_missing(exc: ProgrammingError) -> bool:
+  """Whether a ``ProgrammingError`` is the tenant schema (or a table in it)
+  not existing — the one case that means "not initialized" rather than a
+  bug. Every other programming error (a migration that has not reached this
+  tenant, a SQL fault, a privilege error) must surface, not be translated
+  into a friendly 404 that hides it from the client and the audit log.
+  """
+  msg = str(exc)
+  return "does not exist" in msg and ("schema" in msg or "relation" in msg)
 
 
 # ── OperationSpec ────────────────────────────────────────────────────────
@@ -413,8 +425,14 @@ class OperationRegistrar:
 
       def _runner():
         command = _resolve_command()
+        # Set once the session factory has accepted the graph id, so a
+        # ValueError from the factory (not a tenant-schema id — subgraphs
+        # share their parent's schema) can be told apart from one the
+        # command raised.
+        session_bound = False
         try:
           with _resolve_session_factory()(graph_id) as session:
+            session_bound = True
             try:
               kwargs = {}
               if requires_created_by:
@@ -425,8 +443,26 @@ class OperationRegistrar:
             except tuple(error_map.keys()) as exc:
               _raise_mapped(exc, error_map)
               raise AssertionError("unreachable: _raise_mapped always raises")
-        except (ValueError, ProgrammingError):
-          raise schema_missing_404()
+        except ProgrammingError as exc:
+          # Only a missing schema/relation means "not initialized". Anything
+          # else is a real database fault: log it and let it surface as 500
+          # rather than hiding it behind the friendly 404.
+          if is_schema_missing(exc):
+            raise schema_missing_404()
+          logger.warning(
+            f"{op_name} on {graph_id}: database programming error", exc_info=True
+          )
+          raise
+        except ValueError as exc:
+          if not session_bound:
+            raise schema_missing_404()
+          # A domain refusal the spec's error_map did not name. Surface it as
+          # the validation failure it is (every mapped ValueError is 422),
+          # and log it so the map gets fixed.
+          logger.warning(
+            f"{op_name} on {graph_id}: unmapped {type(exc).__name__}: {exc}"
+          )
+          raise HTTPException(status_code=422, detail=str(exc))
 
       # Bind graph_id into the stale-reason callback so module-level specs
       # can declare the effect without capturing `graph_id` in a closure.
@@ -476,6 +512,7 @@ __all__ = [
   "GraphExtensionContext",
   "OperationRegistrar",
   "OperationSpec",
+  "is_schema_missing",
   "load_graph_metadata",
   "require_graph_extension",
 ]

--- a/robosystems/middleware/mcp/tools/registrar.py
+++ b/robosystems/middleware/mcp/tools/registrar.py
@@ -34,12 +34,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ValidationError
+from sqlalchemy.exc import ProgrammingError
 
 from robosystems.logger import logger
 from robosystems.middleware.extensions import (
   ErrorMap,
   OperationRegistrar,
   OperationSpec,
+  is_schema_missing,
 )
 from robosystems.operations.extensions.staleness import mark_graph_stale
 
@@ -435,8 +437,10 @@ class _RegistrarMCPTool(BaseTool):
     command = self.spec.command
     created_by = self._resolve_created_by(graph_id)
 
+    session_bound = False
     try:
       with session_factory(graph_id) as session:
+        session_bound = True
         kwargs = {}
         if self.spec.requires_created_by:
           kwargs["created_by"] = created_by
@@ -445,14 +449,48 @@ class _RegistrarMCPTool(BaseTool):
         result = command(session, body, **kwargs)
     except tuple(self.spec.error_map.keys()) as exc:
       return translate_error(exc, self.spec.error_map)
+    except ProgrammingError as exc:
+      # A missing schema/relation is "not initialized" — the same answer REST
+      # gives. Any other programming error is a database fault: log the
+      # detail server-side and hand the caller a fixed message; a DBAPI
+      # error's string carries the SQL and its bound parameters, which is
+      # not something to put in front of the LLM.
+      if is_schema_missing(exc):
+        return {
+          "error": "not_initialized",
+          "message": self.registrar.schema_missing_404().detail,
+        }
+      logger.warning(
+        "MCP tool %s hit a database programming error", self.spec.name, exc_info=True
+      )
+      return {
+        "error": "command_failed",
+        "message": f"{self.spec.name} failed on a database error; see server logs",
+      }
+    except ValueError as exc:
+      if not session_bound:
+        # The session factory rejected the graph id — not a tenant-schema id.
+        return {
+          "error": "not_initialized",
+          "message": self.registrar.schema_missing_404().detail,
+        }
+      # A domain refusal the error_map did not name (REST answers 422 with
+      # the same message).
+      logger.warning(
+        "MCP tool %s: unmapped %s: %s", self.spec.name, type(exc).__name__, exc
+      )
+      return {"error": "invalid_request", "message": str(exc)}
     except Exception as exc:
-      # Last-resort: the ops layer raises ValueError / ProgrammingError on
-      # schema-missing. Reuse the REST `schema_missing_404` helper's
-      # message so MCP and REST agree on the surface string.
+      # Anything else is a fault, not a message for the caller: log it with
+      # the traceback and return a fixed string. Raw exception text can carry
+      # SQL, parameters and internal paths.
       logger.warning(
         "MCP tool %s failed unexpectedly: %s", self.spec.name, exc, exc_info=True
       )
-      return {"error": "command_failed", "message": str(exc)}
+      return {
+        "error": "command_failed",
+        "message": f"{self.spec.name} failed unexpectedly; see server logs",
+      }
 
     if self.spec.mark_stale_reason is not None:
       mark_graph_stale(graph_id, self.spec.mark_stale_reason)

--- a/robosystems/models/core/graph/graph.py
+++ b/robosystems/models/core/graph/graph.py
@@ -24,6 +24,8 @@ from sqlalchemy import (
   Integer,
   String,
   UniqueConstraint,
+  or_,
+  update,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import SQLAlchemyError
@@ -633,16 +635,21 @@ class Graph(Model):
     self.graph_stale_at = datetime.now(UTC)
     session.commit()
 
-  def mark_fresh(self, session: Session) -> None:
-    """Mark the graph fresh after materializing from DuckDB.
+  def mark_fresh(self, session: Session, *, started_at: datetime | None = None) -> bool:
+    """Record a completed materialization; clear staleness only if nothing
+    was written after the materialization began.
 
-    Stamps ``last_materialized_at`` and bumps ``materialization_count`` in
-    ``graph_metadata``.
+    ``started_at`` is the moment the materialization snapshotted its source
+    (before staging). A write that lands after that stamps a later
+    ``graph_stale_at`` and is not in the graph, so clearing the flag would
+    lose it until an unrelated later write — the compare-and-clear is done
+    in SQL so a stale identity map cannot mask a newer stamp. Without
+    ``started_at`` the clear is unconditional (legacy callers).
+
+    Always stamps ``last_materialized_at`` and bumps
+    ``materialization_count`` in ``graph_metadata``. Returns True when the
+    staleness flag was cleared.
     """
-    self.graph_stale = False
-    self.graph_stale_reason = None
-    self.graph_stale_at = None
-
     metadata = {**self.graph_metadata} if self.graph_metadata else {}
     metadata["last_materialized_at"] = datetime.now(UTC).isoformat()
 
@@ -652,4 +659,21 @@ class Graph(Model):
       metadata["materialization_count"] = 1
 
     self.graph_metadata = metadata
+    session.flush()
+
+    clear = (
+      update(Graph)
+      .where(Graph.graph_id == self.graph_id)
+      .values(graph_stale=False, graph_stale_reason=None, graph_stale_at=None)
+      .execution_options(synchronize_session=False)
+    )
+    if started_at is not None:
+      clear = clear.where(
+        or_(Graph.graph_stale_at.is_(None), Graph.graph_stale_at <= started_at)
+      )
+    cleared = (session.execute(clear).rowcount or 0) > 0
     session.commit()
+    # The commit expires the instance, so callers reading the stale fields
+    # afterwards see the row as the UPDATE left it, not the pre-clear values.
+    session.refresh(self)
+    return cleared

--- a/robosystems/operations/event_block/promotion.py
+++ b/robosystems/operations/event_block/promotion.py
@@ -64,6 +64,7 @@ from dataclasses import dataclass, field
 from datetime import date, datetime
 
 from pydantic import ValidationError
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 
 from robosystems.logger import logger
@@ -75,7 +76,7 @@ from robosystems.operations.event_block.python_handlers import get_python_handle
 from robosystems.operations.event_block.python_handlers.types import (
   HandlerMetadataValidationError,
 )
-from robosystems.operations.locking import ordered_lock_column
+from robosystems.operations.locking import RowLockedError, ordered_lock_column
 from robosystems.operations.roboledger.commands._guards import (
   ClosedPeriodError,
   assert_period_not_closed,
@@ -447,10 +448,22 @@ def promote_pending_obligations(
       continue
 
     try:
-      handler.dispatch(session, event, typed_metadata, created_by)
+      # Each dispatch runs under its own savepoint: a database-level failure
+      # inside one handler (a constraint violation, say) would otherwise abort
+      # the whole transaction, every later dispatch would fail with "current
+      # transaction is aborted" and be collected as if it were its own error,
+      # and the caller's commit would fail — one poison obligation blocking
+      # every other one on the graph, every tick.
+      with session.begin_nested():
+        handler.dispatch(session, event, typed_metadata, created_by)
       result.dispatched_event_ids.append(event.id)
     except HandlerMetadataValidationError as e:
       result.errors.append((event.id, f"handler validation failed: {e}"))
+    except (RowLockedError, OperationalError):
+      # A lock wait or a connection fault is not "one bad event" — it is the
+      # sweep's own condition, and the caller's bounded wait / retry policy
+      # must see it rather than a per-event error line.
+      raise
     except Exception as e:
       # Catch-all so one bad event doesn't sink the sweep. The status
       # change above stays in the session — caller decides whether to

--- a/robosystems/operations/extensions/loader.py
+++ b/robosystems/operations/extensions/loader.py
@@ -518,7 +518,7 @@ class OLTPLoader:
     """
     import duckdb
 
-    from robosystems.db.extensions import extensions_session, provision_tenant_schema
+    from robosystems.db.extensions import ensure_tenant_schema, extensions_session
     from robosystems.models.extensions import (
       Dimension,
       Element,
@@ -527,7 +527,9 @@ class OLTPLoader:
 
     result = LoadResult(graph_id=graph_id, source=source, connection_id=connection_id)
 
-    provision_tenant_schema(graph_id)
+    # First-time provisioning only. Re-running the DDL on every sync would take
+    # AccessExclusive locks on every tenant table against live readers.
+    ensure_tenant_schema(graph_id)
 
     # fetchall(), not fetchdf(): pyarrow and DuckDB coexisting in the
     # containerized Dagster workers segfault on the dataframe path.
@@ -1882,8 +1884,8 @@ class OLTPLoader:
     """
     from robosystems.db.extensions import extensions_session
     from robosystems.models.extensions import Element, EntityTaxonomy
-    from robosystems.models.extensions.entity import Entity
     from robosystems.models.extensions.roboledger import Structure, Taxonomy
+    from robosystems.operations.roboledger.reads.entity import resolve_parent_entity
     from robosystems.utils.ulid import generate_prefixed_ulid
 
     try:
@@ -1935,7 +1937,7 @@ class OLTPLoader:
         # Ensure the graph's entity is linked to the CoA taxonomy as its
         # primary chart_of_accounts basis. This materializes to
         # ENTITY_HAS_TAXONOMY in the graph.
-        entity = session.query(Entity).first()
+        entity = resolve_parent_entity(session)
         if entity:
           existing_adoption = (
             session.query(EntityTaxonomy)
@@ -2008,7 +2010,7 @@ class OLTPLoader:
     import duckdb
 
     from robosystems.db.extensions import extensions_session
-    from robosystems.models.extensions.entity import Entity
+    from robosystems.operations.roboledger.reads.entity import resolve_parent_entity
 
     try:
       con = duckdb.connect(str(duckdb_path), read_only=True)
@@ -2042,7 +2044,9 @@ class OLTPLoader:
         con.close()
 
       with extensions_session(graph_id) as session:
-        entity = session.query(Entity).first()
+        # The ledger's own entity by predicate — a shared-in `linked`
+        # counterparty must never receive the CompanyInfo overwrite.
+        entity = resolve_parent_entity(session)
         if not entity:
           logger.warning(
             f"No entity found in graph {graph_id}, skipping CompanyInfo update"

--- a/robosystems/operations/graph/engine/direct_materialization.py
+++ b/robosystems/operations/graph/engine/direct_materialization.py
@@ -11,6 +11,7 @@ the worker's request lifetime is the binding constraint.
 """
 
 import time
+from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -47,6 +48,9 @@ async def materialize_graph_directly(
   from .chunked_materialization import materialize_table_chunked
 
   start_time = time.time()
+  # Compare-and-clear anchor for mark_fresh: a write stamped after this
+  # point is not in this build and must keep the graph stale.
+  started_at = datetime.now(UTC)
   manager = get_operation_manager()
 
   logger.info(
@@ -273,7 +277,10 @@ async def materialize_graph_directly(
       logger.info("[95%] Marking graph as fresh")
       if operation_id:
         await manager.emit_progress(operation_id, "Marking graph as fresh...", 95)
-      graph_record.mark_fresh(session=db)
+      if not graph_record.mark_fresh(session=db, started_at=started_at):
+        logger.info(
+          f"{graph_id} was written during the materialization; leaving it stale"
+        )
 
       # Update graph metadata if rebuild was performed
       if rebuild:

--- a/robosystems/operations/graph/tasks/extensions_materialize.py
+++ b/robosystems/operations/graph/tasks/extensions_materialize.py
@@ -8,6 +8,7 @@ second run for the same staleness event.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
 from robosystems.logger import get_logger
@@ -35,6 +36,9 @@ class ExtensionsMaterializeTask(BaseTask):
     db = next(db_gen)
 
     try:
+      # Stamped before the source is read so a write that lands during the
+      # materialization keeps the graph stale (mark_fresh compares).
+      started_at = datetime.now(UTC)
       materializer = ExtensionsMaterializer()
       result = await materializer.materialize(
         graph_id=self.graph_id,
@@ -64,8 +68,11 @@ class ExtensionsMaterializeTask(BaseTask):
 
       # Clear staleness so the Dagster sensor does not re-submit for this event
       graph = db.query(Graph).filter(Graph.graph_id == self.graph_id).first()
-      if graph:
-        graph.mark_fresh(session=db)
+      if graph and not graph.mark_fresh(session=db, started_at=started_at):
+        logger.info(
+          f"{self.graph_id} was written during the materialization; "
+          "leaving it stale for the next sweep"
+        )
 
       logger.info(
         f"Extensions materialization complete for {self.graph_id}: "

--- a/robosystems/operations/operators/implementations/mapping/operator.py
+++ b/robosystems/operations/operators/implementations/mapping/operator.py
@@ -345,16 +345,21 @@ class MappingOperator(Operator):
                 confidence = max(confidence, CONFIDENCE_AUTO_APPROVE)
 
             if target and confidence >= CONFIDENCE_AUTO_APPROVE:
-              mapped += 1
+              outcome = "mapped"
             elif target and confidence >= CONFIDENCE_MIN_MAP:
-              flagged += 1
+              outcome = "flagged"
             else:
               skipped += 1
               continue
 
             # Persist the CoA → rs-gaap arc as the primary mapping target.
+            # Counted only once the write lands: the tool never raises — it
+            # returns `{"error": ...}` for a rejected element, a duplicate,
+            # or a database fault — so counting before the call reported
+            # every failure as a mapping and the summary disagreed with the
+            # books.
             try:
-              await create_tool.execute(
+              written = await create_tool.execute(
                 {
                   "mapping_id": mapping_id,
                   "from_element_id": m["element_id"],
@@ -367,6 +372,19 @@ class MappingOperator(Operator):
               logger.warning(
                 f"rs-gaap mapping create failed for {m['element_id']}: {e}"
               )
+              skipped += 1
+              continue
+            if isinstance(written, dict) and written.get("error"):
+              logger.warning(
+                f"rs-gaap mapping create rejected for {m['element_id']}: "
+                f"{written.get('error')}"
+              )
+              skipped += 1
+              continue
+            if outcome == "mapped":
+              mapped += 1
+            else:
+              flagged += 1
 
         except Exception as e:
           logger.warning(f"Batch mapping failed for {cls}: {e}")

--- a/robosystems/operations/roboledger/commands/entity.py
+++ b/robosystems/operations/roboledger/commands/entity.py
@@ -8,8 +8,10 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from robosystems.models.api.extensions.entity import LedgerEntityResponse
-from robosystems.models.extensions import Entity
-from robosystems.operations.roboledger.reads.entity import entity_to_response
+from robosystems.operations.roboledger.reads.entity import (
+  entity_to_response,
+  resolve_parent_entity,
+)
 
 
 def update_parent_entity(
@@ -21,11 +23,7 @@ def update_parent_entity(
   for the ledger. The caller is expected to have already validated that
   `updates` is non-empty — this function commits whatever it is given.
   """
-  entity = (
-    session.query(Entity)
-    .filter(Entity.is_parent.is_(True), Entity.source != "linked")
-    .first()
-  )
+  entity = resolve_parent_entity(session)
   if entity is None:
     return None
 

--- a/robosystems/operations/roboledger/commands/taxonomies.py
+++ b/robosystems/operations/roboledger/commands/taxonomies.py
@@ -43,12 +43,12 @@ from robosystems.models.extensions import (
   Taxonomy,
   VerificationResult,
 )
-from robosystems.models.extensions.entity import Entity
 from robosystems.operations.roboledger.commands._guards import (
   LibraryImmutableError,
   assert_not_library_origin,
   assert_tenant_taxonomy,
 )
+from robosystems.operations.roboledger.reads.entity import resolve_parent_entity
 from robosystems.utils.ulid import generate_prefixed_ulid
 
 __all__ = [
@@ -557,7 +557,7 @@ def link_entity_taxonomy(
   Raises `EntityNotFoundError` if no entity exists in the graph, or
   `TaxonomyNotFoundError` if the taxonomy doesn't exist.
   """
-  entity = session.execute(select(Entity).limit(1)).scalar_one_or_none()
+  entity = resolve_parent_entity(session)
   if entity is None:
     raise EntityNotFoundError("No entity found in this graph")
 

--- a/robosystems/operations/roboledger/fiscal_calendar/close_service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_service.py
@@ -721,13 +721,19 @@ class PeriodCloseService:
     tally: dict[str, int] = {"pass": 0, "fail": 0, "error": 0, "skipped": 0}
     for sid in structure_ids:
       try:
-        rows = evaluate_rules_for_structure(
-          session,
-          sid,
-          period_start=period_start,
-          period_end=period_end,
-          created_by=actor_id,
-        )
+        # Under a savepoint: rule evaluation writes VerificationResult rows,
+        # and a database-level failure there would otherwise abort the close's
+        # transaction after the QB markers committed — the final commit then
+        # fails on flush pointing at the wrong thing, deterministically, with
+        # QuickBooks already holding the entries.
+        with session.begin_nested():
+          rows = evaluate_rules_for_structure(
+            session,
+            sid,
+            period_start=period_start,
+            period_end=period_end,
+            created_by=actor_id,
+          )
       except Exception as exc:
         logger.warning(f"Rule eval failed for structure {sid} during close: {exc}")
         continue

--- a/robosystems/operations/roboledger/reads/entity.py
+++ b/robosystems/operations/roboledger/reads/entity.py
@@ -52,17 +52,31 @@ def entity_to_response(entity: Entity) -> LedgerEntityResponse:
   )
 
 
+def resolve_parent_entity(session: Session) -> Entity | None:
+  """The ledger's own entity — the row every writer that says "the entity"
+  must mean.
+
+  A tenant that has received a shared report also holds the sender's
+  entity as a ``source='linked'``, ``is_parent=False`` row, and ``entities``
+  has no ordering guarantee, so an unfiltered ``LIMIT 1`` can hand back the
+  counterparty (heap order after updates). Resolved by predicate, ordered by
+  creation so two parents (which should not exist) still resolve stably.
+  """
+  return (
+    session.query(Entity)
+    .filter(Entity.is_parent.is_(True), Entity.source != "linked")
+    .order_by(Entity.created_at.asc())
+    .first()
+  )
+
+
 def get_parent_entity(session: Session) -> LedgerEntityResponse | None:
   """Return the parent (non-linked) entity for this ledger, or None.
 
   Returns `None` when the ledger is initialized but has no entity yet — the
   caller decides whether that's a 404.
   """
-  entity = (
-    session.query(Entity)
-    .filter(Entity.is_parent.is_(True), Entity.source != "linked")
-    .first()
-  )
+  entity = resolve_parent_entity(session)
   if entity is None:
     return None
   return entity_to_response(entity)

--- a/robosystems/operations/roboledger/reports/statement_sets.py
+++ b/robosystems/operations/roboledger/reports/statement_sets.py
@@ -630,15 +630,19 @@ def stamp_canonical_statement_sets(
 
   rule_summary: dict[str, int] | None = None
   try:
-    rule_summary = _evaluate_report_structures(
-      session,
-      facts,
-      element_to_structures,
-      structure_to_factset,
-      period_start,
-      period_end,
-      actor_id,
-    )
+    # Under a savepoint: the evaluation writes VerificationResult rows, and a
+    # database-level failure there must not abort the close's transaction
+    # (the stamp above is already flushed; the close still has to commit).
+    with session.begin_nested():
+      rule_summary = _evaluate_report_structures(
+        session,
+        facts,
+        element_to_structures,
+        structure_to_factset,
+        period_start,
+        period_end,
+        actor_id,
+      )
   except Exception as exc:
     logger.warning(
       f"Statement-rule evaluation failed after close stamp for "

--- a/robosystems/operations/taxonomy_block/cascade.py
+++ b/robosystems/operations/taxonomy_block/cascade.py
@@ -26,6 +26,7 @@ from robosystems.models.extensions import (
   ElementLabel,
   ElementReference,
   ElementTrait,
+  EntityTaxonomy,
   FactSet,
   Rule,
   Structure,
@@ -34,6 +35,7 @@ from robosystems.models.extensions import (
 )
 from robosystems.models.extensions.roboledger.fact import Fact
 from robosystems.models.extensions.roboledger.line_item import LineItem
+from robosystems.operations.taxonomy_block.immutability import assert_facts_deletable
 
 
 @dataclass(frozen=True)
@@ -149,6 +151,11 @@ def cascade_delete_taxonomy(
       .all()
     )
 
+  # Curation never destroys a filed report's snapshot or a closed month's
+  # canonical statement sets — no flag reaches them. Checked before the
+  # first delete so a refusal leaves nothing half-done.
+  assert_facts_deletable(session, structure_ids=structure_ids, element_ids=element_ids)
+
   facts_deleted = 0
   if cascade_facts:
     if element_ids:
@@ -244,6 +251,14 @@ def cascade_delete_taxonomy(
   # Structures.
   if structure_ids:
     session.execute(delete(Structure).where(Structure.id.in_(structure_ids)))
+
+  # The entity's adoption of this taxonomy (a chart of accounts is linked to
+  # the parent entity at creation; `entity_taxonomies.taxonomy_id` is
+  # RESTRICT) — without this the taxonomy DELETE dies on the constraint and
+  # a CoA can never be deleted through the API.
+  session.execute(
+    delete(EntityTaxonomy).where(EntityTaxonomy.taxonomy_id == taxonomy_id)
+  )
 
   # Taxonomy row itself.
   session.execute(delete(Taxonomy).where(Taxonomy.id == taxonomy_id))

--- a/robosystems/operations/taxonomy_block/chart_of_accounts.py
+++ b/robosystems/operations/taxonomy_block/chart_of_accounts.py
@@ -24,12 +24,12 @@ from robosystems.models.extensions import (
   Association,
   Element,
   ElementTrait,
-  Entity,
   EntityTaxonomy,
   Structure,
   Taxonomy,
   Trait,
 )
+from robosystems.operations.roboledger.reads.entity import resolve_parent_entity
 from robosystems.operations.taxonomy_block._helpers import qname_for
 from robosystems.operations.taxonomy_block.auto_rules import (
   emit_auto_rules,
@@ -138,7 +138,7 @@ def _auto_link_entity(session: Session, taxonomy_id: str) -> None:
   one — only one primary CoA per entity at a time. If the link already
   exists but is non-primary, promotes it rather than returning early.
   """
-  entity = session.execute(select(Entity).limit(1)).scalar_one_or_none()
+  entity = resolve_parent_entity(session)
   if entity is None:
     return
 

--- a/robosystems/operations/taxonomy_block/commands.py
+++ b/robosystems/operations/taxonomy_block/commands.py
@@ -104,8 +104,19 @@ def update_taxonomy_block(
   → HTTP 501.
   """
   from robosystems.models.extensions import Taxonomy
+  from robosystems.operations.locking import lock_by_id
 
-  taxonomy = session.get(Taxonomy, body.taxonomy_id)
+  # One envelope update per taxonomy at a time. The apply steps are
+  # delete-then-recreate over the taxonomy's rows (auto rules, associations)
+  # and check-then-insert over unique keys (element qnames); two concurrent
+  # updates under READ COMMITTED each miss the other's rows and leave
+  # duplicated rules or die on the qname index.
+  taxonomy = lock_by_id(
+    session,
+    Taxonomy,
+    body.taxonomy_id,
+    detail=f"taxonomy {body.taxonomy_id!r} is being updated by another request",
+  )
   if taxonomy is None:
     raise ValueError(f"taxonomy_id {body.taxonomy_id!r} not found")
 

--- a/robosystems/operations/taxonomy_block/immutability.py
+++ b/robosystems/operations/taxonomy_block/immutability.py
@@ -1,0 +1,168 @@
+"""What curation may never destroy: filed snapshots and closed-month history.
+
+Two producers write statement FactSets that the rest of the ledger treats as
+immutable — a Report that has been *filed* keeps its publication snapshot
+(``fact_sets.report_id`` set, ``reports.filing_status`` in filed/archived),
+and close mints the *canonical* sets for a month (``report_id IS NULL``,
+``factset_type='report'``, ``scenario_id IS NULL``) which only reopen may
+retract. ``regenerate_report`` and ``delete_report`` refuse a filed report;
+reopen is the only path to a closed month's canonical sets.
+
+The taxonomy-block cascade (``delete-taxonomy-block cascade_facts=true``,
+``update-taxonomy-block structures_to_remove``) deletes facts by element and
+by structure, and reached both kinds of set with no guard. This module is the
+single check both paths run before deleting anything.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from robosystems.models.extensions import FactSet, Report
+from robosystems.models.extensions.roboledger.fact import Fact
+from robosystems.models.extensions.roboledger.fiscal_period import FiscalPeriod
+
+_FILED_STATUSES = ("filed", "archived")
+
+
+class ProtectedFactsError(ValueError):
+  """Curation would delete facts the ledger treats as immutable."""
+
+  def __init__(self, *, filed_report_count: int, closed_period_count: int) -> None:
+    self.filed_report_count = filed_report_count
+    self.closed_period_count = closed_period_count
+    parts = []
+    if filed_report_count:
+      parts.append(
+        f"{filed_report_count} statement set(s) belong to filed reports "
+        "(delete or un-file the report first — its snapshot is immutable)"
+      )
+    if closed_period_count:
+      parts.append(
+        f"{closed_period_count} canonical statement set(s) belong to closed "
+        "periods (reopen the period first — closed history is immutable)"
+      )
+    super().__init__(
+      "refusing to delete facts that the ledger treats as immutable: "
+      + "; ".join(parts)
+    )
+
+
+@dataclass(frozen=True)
+class ProtectedFactSets:
+  filed_report_fact_set_ids: tuple[str, ...]
+  closed_period_fact_set_ids: tuple[str, ...]
+
+  @property
+  def any(self) -> bool:
+    return bool(self.filed_report_fact_set_ids or self.closed_period_fact_set_ids)
+
+
+def _affected_fact_set_ids(
+  session: Session,
+  *,
+  structure_ids: Sequence[str],
+  element_ids: Sequence[str],
+) -> list[str]:
+  """FactSets a cascade over these structures/elements would touch.
+
+  Facts die two ways — by referencing an element being deleted, and by
+  membership in a set attached to (or facts stamped with) a structure being
+  deleted — so the affected sets are the union of both routes.
+  """
+  predicates = []
+  if structure_ids:
+    predicates.append(FactSet.structure_id.in_(structure_ids))
+    predicates.append(
+      FactSet.id.in_(
+        select(Fact.fact_set_id).where(Fact.structure_id.in_(structure_ids))
+      )
+    )
+  if element_ids:
+    predicates.append(
+      FactSet.id.in_(select(Fact.fact_set_id).where(Fact.element_id.in_(element_ids)))
+    )
+  if not predicates:
+    return []
+  clause = predicates[0]
+  for pred in predicates[1:]:
+    clause = clause | pred
+  return list(session.execute(select(FactSet.id).where(clause)).scalars().all())
+
+
+def find_protected_fact_sets(
+  session: Session,
+  *,
+  structure_ids: Sequence[str] = (),
+  element_ids: Sequence[str] = (),
+) -> ProtectedFactSets:
+  """Which of the sets a cascade would delete are immutable."""
+  affected = _affected_fact_set_ids(
+    session, structure_ids=structure_ids, element_ids=element_ids
+  )
+  if not affected:
+    return ProtectedFactSets((), ())
+
+  filed = (
+    session.execute(
+      select(FactSet.id)
+      .join(Report, Report.id == FactSet.report_id)
+      .where(FactSet.id.in_(affected), Report.filing_status.in_(_FILED_STATUSES))
+    )
+    .scalars()
+    .all()
+  )
+
+  closed_period = (
+    select(FiscalPeriod.id)
+    .where(
+      FiscalPeriod.status == "closed",
+      FiscalPeriod.start_date <= FactSet.period_start,
+      FiscalPeriod.end_date >= FactSet.period_end,
+    )
+    .exists()
+  )
+  closed = (
+    session.execute(
+      select(FactSet.id).where(
+        FactSet.id.in_(affected),
+        FactSet.report_id.is_(None),
+        FactSet.scenario_id.is_(None),
+        FactSet.factset_type == "report",
+        FactSet.period_start.is_not(None),
+        closed_period,
+      )
+    )
+    .scalars()
+    .all()
+  )
+  return ProtectedFactSets(tuple(filed), tuple(closed))
+
+
+def assert_facts_deletable(
+  session: Session,
+  *,
+  structure_ids: Sequence[str] = (),
+  element_ids: Sequence[str] = (),
+) -> None:
+  """Raise ``ProtectedFactsError`` if the cascade would reach an immutable set."""
+  protected = find_protected_fact_sets(
+    session, structure_ids=structure_ids, element_ids=element_ids
+  )
+  if protected.any:
+    raise ProtectedFactsError(
+      filed_report_count=len(protected.filed_report_fact_set_ids),
+      closed_period_count=len(protected.closed_period_fact_set_ids),
+    )
+
+
+__all__ = [
+  "ProtectedFactSets",
+  "ProtectedFactsError",
+  "assert_facts_deletable",
+  "find_protected_fact_sets",
+]

--- a/robosystems/operations/taxonomy_block/update_apply.py
+++ b/robosystems/operations/taxonomy_block/update_apply.py
@@ -33,6 +33,7 @@ from robosystems.models.extensions import (
 )
 from robosystems.models.extensions.roboledger.fact import Fact
 from robosystems.operations.taxonomy_block._helpers import structure_from_request
+from robosystems.operations.taxonomy_block.immutability import assert_facts_deletable
 from robosystems.operations.taxonomy_block.rule_persistence import (
   persist_tenant_rules,
 )
@@ -356,14 +357,38 @@ def apply_elements_to_remove(
     .values(parent_id=None)
   )
 
-  session.execute(
-    delete(Association).where(
-      or_(
-        Association.from_element_id.in_(element_ids),
-        Association.to_element_id.in_(element_ids),
+  # Rules targeting the removed elements (or the associations that go with
+  # them) and the classification rows on those associations FK them with no
+  # ON DELETE — the same dependents `cascade_delete_taxonomy` clears; without
+  # this the element DELETE dies on the constraint.
+  association_ids = (
+    session.execute(
+      select(Association.id).where(
+        or_(
+          Association.from_element_id.in_(element_ids),
+          Association.to_element_id.in_(element_ids),
+        )
       )
     )
+    .scalars()
+    .all()
   )
+  rule_filters = [Rule.target_element_id.in_(element_ids)]
+  if association_ids:
+    rule_filters.append(Rule.target_association_id.in_(association_ids))
+  rule_ids = session.execute(select(Rule.id).where(or_(*rule_filters))).scalars().all()
+  if rule_ids:
+    session.execute(
+      delete(VerificationResult).where(VerificationResult.rule_id.in_(rule_ids))
+    )
+    session.execute(delete(Rule).where(Rule.id.in_(rule_ids)))
+  if association_ids:
+    session.execute(
+      delete(AssociationClassification).where(
+        AssociationClassification.association_id.in_(association_ids)
+      )
+    )
+    session.execute(delete(Association).where(Association.id.in_(association_ids)))
 
   session.execute(delete(ElementTrait).where(ElementTrait.element_id.in_(element_ids)))
   session.execute(delete(ElementLabel).where(ElementLabel.element_id.in_(element_ids)))
@@ -428,6 +453,9 @@ def apply_structures_to_remove(
     return
 
   ids = list(payload.structures_to_remove)
+  # Filed snapshots and closed-month canonical sets are immutable against
+  # curation; the validator reports the same condition, this is the backstop.
+  assert_facts_deletable(session, structure_ids=ids)
   association_ids = (
     session.execute(select(Association.id).where(Association.structure_id.in_(ids)))
     .scalars()

--- a/robosystems/operations/taxonomy_block/update_validator.py
+++ b/robosystems/operations/taxonomy_block/update_validator.py
@@ -34,6 +34,10 @@ from robosystems.models.extensions import (
 )
 from robosystems.models.extensions.roboledger.fact import Fact
 from robosystems.models.extensions.roboledger.line_item import LineItem
+from robosystems.operations.taxonomy_block.immutability import (
+  ProtectedFactsError,
+  find_protected_fact_sets,
+)
 from robosystems.operations.taxonomy_block.validators import (
   ValidationIssue,
   validate_create_envelope,
@@ -634,6 +638,30 @@ def _validate_structures_to_remove(
             f"cannot be removed."
           ),
           context={"structure_id": sid},
+        )
+      )
+
+  # Removing a structure cascades its FactSets. A filed report's snapshot
+  # and a closed month's canonical sets are immutable against curation.
+  in_scope = [s for s in payload.structures_to_remove if s in taxonomy_structure_ids]
+  if in_scope:
+    protected = find_protected_fact_sets(session, structure_ids=in_scope)
+    if protected.any:
+      issues.append(
+        ValidationIssue(
+          phase="delta_validation",
+          code="protected_facts",
+          message=str(
+            ProtectedFactsError(
+              filed_report_count=len(protected.filed_report_fact_set_ids),
+              closed_period_count=len(protected.closed_period_fact_set_ids),
+            )
+          ),
+          context={
+            "structure_ids": in_scope,
+            "filed_report_fact_set_ids": list(protected.filed_report_fact_set_ids),
+            "closed_period_fact_set_ids": list(protected.closed_period_fact_set_ids),
+          },
         )
       )
 

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -73,6 +73,7 @@ from robosystems.middleware.extensions import (
   GraphExtensionContext,
   OperationRegistrar,
   OperationSpec,
+  is_schema_missing,
   require_graph_extension,
 )
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
@@ -526,9 +527,9 @@ def _ledger_404() -> HTTPException:
   )
 
 
-def _is_schema_missing(exc: ProgrammingError) -> bool:
-  msg = str(exc)
-  return "does not exist" in msg and ("schema" in msg or "relation" in msg)
+# Shared with the registrar (`middleware/extensions.py`) so both registration
+# styles translate the same, and only the, schema-missing case to 404.
+_is_schema_missing = is_schema_missing
 
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -998,6 +999,8 @@ update_taxonomy_block_op = _registrar.register(
     result_type=TaxonomyBlockEnvelope,
     error_map={
       TaxonomyAuthoringDisabledError: 403,
+      # Another update holds the taxonomy row; retryable.
+      RowLockedError: 409,
       ValueError: 422,
       NotImplementedError: 501,
     },
@@ -1590,6 +1593,15 @@ update_event_block_op = _registrar.register(
       # A running sync holds the event's row lock. Retryable, and the only
       # error here the caller should try again rather than fix.
       RowLockedError: 409,
+      # The rest of what the handler fired on approve can raise — the same
+      # set create-event-block maps, since it fires the same handler over the
+      # captured metadata: a reversal naming an entry that is not posted (or
+      # gone), a disposal whose schedule is gone, and the handlers' own
+      # bare-ValueError validation.
+      DisposalScheduleNotFoundError: 404,
+      JournalEntryNotFoundError: 404,
+      JournalEntryNotPostedError: 422,
+      ValueError: 422,
     },
     mark_stale_reason="event_block_updated",
   )
@@ -1895,6 +1907,9 @@ async def set_close_target_op(
       raise HTTPException(status_code=422, detail=str(e))
     except FiscalCalendarError as e:
       raise HTTPException(status_code=404, detail=str(e))
+    except RowLockedError as e:
+      # A close in flight holds the calendar row; retryable, like its siblings.
+      raise HTTPException(status_code=409, detail=str(e))
     except ProgrammingError as e:
       if _is_schema_missing(e):
         raise _ledger_404()

--- a/tests/db/test_tenant_provisioning.py
+++ b/tests/db/test_tenant_provisioning.py
@@ -1,0 +1,88 @@
+"""Tenant schema provisioning is a first-time act, and never for a torn-down graph.
+
+``provision_tenant_schema`` is idempotent but its CHECK and trigger installs take
+AccessExclusive locks on every tenant table, so a caller that runs on every sync
+(the OLTP loader) goes through ``ensure_tenant_schema`` and only provisions a
+schema that is missing. And teardown drops the schema before it deletes the
+graph's connections, so provisioning refuses a graph the platform has already
+deprovisioned rather than resurrecting its ledger.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import robosystems.db.extensions as ext
+from robosystems.db.extensions import (
+  TenantDeprovisionedError,
+  ensure_tenant_schema,
+  provision_tenant_schema,
+)
+from robosystems.models.core.graph.graph import GraphStatus
+
+pytestmark = pytest.mark.unit
+
+GRAPH = "kg00000000000000aa"
+
+
+class TestEnsureTenantSchema:
+  def test_skips_provisioning_when_the_schema_exists(self):
+    with (
+      patch.object(ext, "tenant_schema_exists", return_value=True) as exists,
+      patch.object(ext, "provision_tenant_schema") as provision,
+    ):
+      assert ensure_tenant_schema(GRAPH) is False
+    exists.assert_called_once_with(GRAPH)
+    provision.assert_not_called()
+
+  def test_provisions_when_the_schema_is_missing(self):
+    with (
+      patch.object(ext, "tenant_schema_exists", return_value=False),
+      patch.object(ext, "provision_tenant_schema") as provision,
+    ):
+      assert ensure_tenant_schema(GRAPH) is True
+    provision.assert_called_once_with(GRAPH)
+
+
+class TestProvisionRefusesDeprovisionedGraph:
+  @staticmethod
+  def _platform_with(graph):
+    @contextmanager
+    def _session():
+      pdb = MagicMock()
+      pdb.get.return_value = graph
+      yield pdb
+
+    return _session
+
+  def test_raises_before_touching_the_extensions_db(self):
+    graph = MagicMock()
+    graph.status = GraphStatus.DEPROVISIONED.value
+    engine = MagicMock()
+    with (
+      patch.object(ext, "_get_engine", return_value=engine),
+      patch("robosystems.database.platform_session", self._platform_with(graph)),
+    ):
+      with pytest.raises(TenantDeprovisionedError) as excinfo:
+        provision_tenant_schema(GRAPH)
+    assert excinfo.value.graph_id == GRAPH
+    engine.connect.assert_not_called()
+
+  def test_missing_graph_row_still_provisions(self):
+    """Scripts provision without a platform row (framework_validate); only a
+    row that says *deprovisioned* refuses."""
+    engine = MagicMock()
+    with (
+      patch.object(ext, "_get_engine", return_value=engine),
+      patch("robosystems.database.platform_session", self._platform_with(None)),
+      patch("robosystems.taxonomy.pins.resolve_pin", return_value="v1"),
+      patch("robosystems.taxonomy.writer.copy_library_into_tenant"),
+      patch.object(ext.ExtensionsBase.metadata, "create_all"),
+      patch.object(ext, "_widen_library_checks"),
+      patch.object(ext, "_install_library_immutability_triggers"),
+    ):
+      provision_tenant_schema(GRAPH)
+    engine.connect.assert_called_once()

--- a/tests/middleware/mcp/test_registrar.py
+++ b/tests/middleware/mcp/test_registrar.py
@@ -526,8 +526,12 @@ class TestRegistrarToolExecute:
 
   @pytest.mark.asyncio
   async def test_unmapped_exception_falls_back_to_command_failed(self) -> None:
+    """A fault is logged server-side and the caller gets a fixed message —
+    raw exception text can carry SQL, bound parameters and internal paths,
+    none of which belongs in front of the LLM."""
+
     def raising_cmd(session, body, created_by: str):
-      raise RuntimeError("boom")
+      raise RuntimeError("boom [SQL: INSERT ...] [parameters: {'secret': 1}]")
 
     tool = _RegistrarMCPTool(
       client=_client(user_id="usr_1"),
@@ -541,7 +545,76 @@ class TestRegistrarToolExecute:
       result = await tool.execute({"id": "x", "value": 0})
 
     assert result["error"] == "command_failed"
-    assert "boom" in result["message"]
+    assert "boom" not in result["message"]
+    assert "parameters" not in result["message"]
+    assert "see server logs" in result["message"]
+
+  @pytest.mark.asyncio
+  async def test_db_programming_error_is_a_fixed_message(self) -> None:
+    from sqlalchemy.exc import ProgrammingError
+
+    def raising_cmd(session, body, created_by: str):
+      raise ProgrammingError(
+        "INSERT INTO t VALUES (%(v)s)", {"v": "secret"}, Exception("syntax error")
+      )
+
+    tool = _RegistrarMCPTool(
+      client=_client(user_id="usr_1"),
+      spec=_spec(command=raising_cmd),
+      registrar=_registrar_stub(),
+    )
+    with patch(
+      "robosystems.middleware.mcp.tools.registrar.require_graph_extension_mcp",
+      return_value=MagicMock(),
+    ):
+      result = await tool.execute({"id": "x", "value": 0})
+
+    assert result["error"] == "command_failed"
+    assert "secret" not in result["message"]
+    assert "INSERT" not in result["message"]
+
+  @pytest.mark.asyncio
+  async def test_schema_missing_is_not_initialized(self) -> None:
+    from sqlalchemy.exc import ProgrammingError
+
+    def raising_cmd(session, body, created_by: str):
+      raise ProgrammingError("stmt", {}, Exception('relation "events" does not exist'))
+
+    reg = _registrar_stub()
+    reg.schema_missing_404.return_value = MagicMock(detail="Ledger not initialized.")
+    tool = _RegistrarMCPTool(
+      client=_client(user_id="usr_1"),
+      spec=_spec(command=raising_cmd),
+      registrar=reg,
+    )
+    with patch(
+      "robosystems.middleware.mcp.tools.registrar.require_graph_extension_mcp",
+      return_value=MagicMock(),
+    ):
+      result = await tool.execute({"id": "x", "value": 0})
+
+    assert result == {"error": "not_initialized", "message": "Ledger not initialized."}
+
+  @pytest.mark.asyncio
+  async def test_unmapped_value_error_keeps_its_message(self) -> None:
+    """A domain refusal the map did not name is a request problem, and its
+    message is the useful part (REST answers 422 with the same text)."""
+
+    def raising_cmd(session, body, created_by: str):
+      raise ValueError("period must be YYYY-MM")
+
+    tool = _RegistrarMCPTool(
+      client=_client(user_id="usr_1"),
+      spec=_spec(command=raising_cmd),
+      registrar=_registrar_stub(),
+    )
+    with patch(
+      "robosystems.middleware.mcp.tools.registrar.require_graph_extension_mcp",
+      return_value=MagicMock(),
+    ):
+      result = await tool.execute({"id": "x", "value": 0})
+
+    assert result == {"error": "invalid_request", "message": "period must be YYYY-MM"}
 
   @pytest.mark.asyncio
   async def test_list_response_is_dumped_per_item(self) -> None:

--- a/tests/models/core/graph/test_graph_model.py
+++ b/tests/models/core/graph/test_graph_model.py
@@ -1076,3 +1076,91 @@ class TestGraphRepositoryFeatures:
     assert repo.graph_type == "repository"
     assert repo.is_repository is True
     assert repo.repository_type == "test"
+
+
+class TestMarkFreshCompareAndClear:
+  """``mark_fresh`` clears staleness only for writes older than the
+  materialization's own snapshot.
+
+  A write that stamps ``graph_stale_at`` after the materialization began is
+  not in the graph; clearing the flag for it would drop the write from the
+  graph until an unrelated later write. The compare is done in SQL so an
+  instance loaded before the write cannot mask the newer stamp.
+  """
+
+  @pytest.fixture
+  def graph(self, test_org, db_session):
+    import uuid
+
+    return Graph.create(
+      graph_id=f"kg_stale_{uuid.uuid4().hex[:8]}",
+      graph_name="Stale Graph",
+      graph_type="entity",
+      org_id=test_org.id,
+      session=db_session,
+      base_schema="base",
+      schema_extensions=["roboledger"],
+      graph_instance_id="cluster1",
+      graph_cluster_region="us-east-1",
+      graph_tier=GraphTier.LADYBUG_STANDARD,
+    )
+
+  def test_clears_when_the_stamp_predates_the_snapshot(self, graph, db_session):
+    from datetime import datetime, timedelta
+
+    graph.mark_stale(db_session, "journal_entry_updated")
+    started_at = datetime.now(UTC) + timedelta(seconds=1)
+
+    assert graph.mark_fresh(db_session, started_at=started_at) is True
+    db_session.refresh(graph)
+    assert graph.graph_stale is False
+    assert graph.graph_stale_at is None
+    assert graph.graph_metadata["materialization_count"] == 1
+
+  def test_keeps_stale_when_a_write_lands_after_the_snapshot(self, graph, db_session):
+    from datetime import datetime, timedelta
+
+    started_at = datetime.now(UTC) - timedelta(seconds=5)
+    graph.mark_stale(db_session, "journal_entry_updated")
+
+    assert graph.mark_fresh(db_session, started_at=started_at) is False
+    db_session.refresh(graph)
+    assert graph.graph_stale is True
+    assert graph.graph_stale_reason == "journal_entry_updated"
+    assert graph.graph_stale_at is not None
+    # The materialization itself is still recorded.
+    assert graph.graph_metadata["materialization_count"] == 1
+    assert "last_materialized_at" in graph.graph_metadata
+
+  def test_compares_against_the_row_not_the_identity_map(self, graph, db_session):
+    """The materializer's session loaded the graph before the concurrent
+    write; the write's newer stamp must still win."""
+    from datetime import datetime, timedelta
+
+    from sqlalchemy import update
+
+    started_at = datetime.now(UTC) - timedelta(seconds=5)
+    # A concurrent writer stamps a newer graph_stale_at behind this session's
+    # back; the instance still carries the pre-write (fresh) values.
+    db_session.execute(
+      update(Graph)
+      .where(Graph.graph_id == graph.graph_id)
+      .values(
+        graph_stale=True,
+        graph_stale_reason="connector_sync",
+        graph_stale_at=datetime.now(UTC),
+      )
+      .execution_options(synchronize_session=False)
+    )
+    assert graph.graph_stale is False  # identity map is stale on purpose
+
+    assert graph.mark_fresh(db_session, started_at=started_at) is False
+    db_session.refresh(graph)
+    assert graph.graph_stale is True
+
+  def test_without_started_at_clears_unconditionally(self, graph, db_session):
+    graph.mark_stale(db_session, "connector_sync")
+
+    assert graph.mark_fresh(db_session) is True
+    db_session.refresh(graph)
+    assert graph.graph_stale is False

--- a/tests/operations/event_block/test_promotion_fence_db.py
+++ b/tests/operations/event_block/test_promotion_fence_db.py
@@ -306,3 +306,69 @@ class TestSweepLocksOnlyTheWriteSet:
     handler.dispatch.assert_not_called()
     ext_session.expire_all()
     assert ext_session.get(Event, june.id).status == "voided"
+
+
+class TestDispatchRunsUnderASavepoint:
+  """A database-level failure inside one handler must not abort the sweep's
+  transaction: the other obligations still dispatch and the caller's commit
+  succeeds. A lock wait is not a per-event error and propagates."""
+
+  def test_a_poison_obligation_does_not_abort_the_others(self, ext_session):
+    from sqlalchemy.exc import IntegrityError
+
+    _seed_calendar(ext_session, may_status="open")
+    may = _obligation(ext_session, status="pending", period_end=date(2026, 5, 31))
+    june = _obligation(ext_session, status="pending", period_end=date(2026, 6, 30))
+    ext_session.commit()
+
+    handler = MagicMock()
+    handler.metadata_schema.model_validate.side_effect = lambda m: m
+
+    def _dispatch(session, event, _typed, _created_by):
+      if event.id == may.id:
+        # A constraint violation from inside the handler — the class of
+        # failure that aborts a Postgres transaction until rollback.
+        session.execute(
+          text("INSERT INTO events (id, event_type) VALUES (:id, NULL)"),
+          {"id": "evt_poison"},
+        )
+        raise AssertionError("unreachable: the INSERT raises")
+
+    handler.dispatch.side_effect = _dispatch
+    with patch(
+      "robosystems.operations.event_block.promotion.get_python_handler",
+      return_value=handler,
+    ):
+      result = promote_pending_obligations(
+        ext_session, GRAPH_ID, as_of=SWEEP_AS_OF, dispatch_handlers=True
+      )
+
+    assert result.dispatched_event_ids == [june.id]
+    assert [eid for eid, _ in result.errors] == [may.id]
+    assert IntegrityError.__name__ in result.errors[0][1]
+    # The transaction is still live: the caller's commit lands.
+    ext_session.commit()
+    ext_session.expire_all()
+    assert ext_session.get(Event, june.id).status == "classified"
+    assert ext_session.get(Event, may.id).status == "classified"
+
+  def test_a_lock_wait_propagates_instead_of_becoming_an_error_line(self, ext_session):
+    from robosystems.operations.locking import RowLockedError
+
+    _seed_calendar(ext_session, may_status="open")
+    _obligation(ext_session, status="pending", period_end=date(2026, 6, 30))
+    ext_session.commit()
+
+    handler = MagicMock()
+    handler.metadata_schema.model_validate.side_effect = lambda m: m
+    handler.dispatch.side_effect = RowLockedError("a closer holds the fence")
+    with (
+      patch(
+        "robosystems.operations.event_block.promotion.get_python_handler",
+        return_value=handler,
+      ),
+      pytest.raises(RowLockedError),
+    ):
+      promote_pending_obligations(
+        ext_session, GRAPH_ID, as_of=SWEEP_AS_OF, dispatch_handlers=True
+      )

--- a/tests/operations/extensions/test_loader.py
+++ b/tests/operations/extensions/test_loader.py
@@ -171,17 +171,19 @@ def _make_duckdb_mock(tables: dict[str, list[dict]]):
 class TestOLTPLoader:
   """Test the OLTPLoader class."""
 
-  @patch("robosystems.db.extensions.provision_tenant_schema")
+  @patch("robosystems.db.extensions.ensure_tenant_schema")
   @patch("robosystems.db.extensions.extensions_session")
   @patch("duckdb.connect")
-  def test_load_calls_provision_tenant_schema(
+  def test_load_ensures_tenant_schema(
     self,
     mock_duckdb_connect,
     mock_ext_session,
     mock_provision,
     mock_duckdb_data,
   ):
-    """Loader provisions the tenant schema before inserting."""
+    """Loader provisions the tenant schema only when it is missing (ensure, not
+    provision: re-running the DDL on every sync would AccessExclusive-lock the
+    tenant tables against live readers)."""
     from robosystems.operations.extensions.loader import OLTPLoader
 
     mock_duckdb_connect.return_value = _make_duckdb_mock({})
@@ -201,7 +203,7 @@ class TestOLTPLoader:
 
     mock_provision.assert_called_once_with("kg0123456789abcdef")
 
-  @patch("robosystems.db.extensions.provision_tenant_schema")
+  @patch("robosystems.db.extensions.ensure_tenant_schema")
   @patch("robosystems.db.extensions.extensions_session")
   @patch("duckdb.connect")
   def test_load_reads_all_tables(
@@ -243,7 +245,7 @@ class TestOLTPLoader:
     # Elements + dimensions + captured event = 4
     assert result.total_rows == 4
 
-  @patch("robosystems.db.extensions.provision_tenant_schema")
+  @patch("robosystems.db.extensions.ensure_tenant_schema")
   @patch("robosystems.db.extensions.extensions_session")
   @patch("duckdb.connect")
   def test_load_full_rebuild_wipes_then_inserts(
@@ -278,7 +280,7 @@ class TestOLTPLoader:
     assert mock_session.query.called
     assert mock_session.flush.called
 
-  @patch("robosystems.db.extensions.provision_tenant_schema")
+  @patch("robosystems.db.extensions.ensure_tenant_schema")
   @patch("robosystems.db.extensions.extensions_session")
   @patch("duckdb.connect")
   def test_load_incremental_skips_pre_sync_wipe(
@@ -324,7 +326,7 @@ class TestOLTPLoader:
       "only full_rebuild=True should wipe."
     )
 
-  @patch("robosystems.db.extensions.provision_tenant_schema")
+  @patch("robosystems.db.extensions.ensure_tenant_schema")
   @patch("robosystems.db.extensions.extensions_session")
   @patch("duckdb.connect")
   def test_load_handles_missing_tables(
@@ -376,7 +378,7 @@ class TestOLTPLoader:
     assert result.entries == 0
     assert result.line_items == 0
 
-  @patch("robosystems.db.extensions.provision_tenant_schema")
+  @patch("robosystems.db.extensions.ensure_tenant_schema")
   @patch("robosystems.db.extensions.extensions_session")
   @patch("duckdb.connect")
   def test_load_silently_drops_orphan_line_items(

--- a/tests/operations/graph/tasks/test_extensions_materialize.py
+++ b/tests/operations/graph/tasks/test_extensions_materialize.py
@@ -124,4 +124,8 @@ class TestPartialBuildNotMarkedFresh:
       result = await task.execute()
 
     assert result["status"] == "success"
-    graph.mark_fresh.assert_called_once_with(session=db)
+    graph.mark_fresh.assert_called_once()
+    assert graph.mark_fresh.call_args.kwargs["session"] is db
+    # Compare-and-clear anchor: the snapshot time travels with the call so a
+    # write that landed during the build keeps the graph stale.
+    assert graph.mark_fresh.call_args.kwargs["started_at"] is not None

--- a/tests/operations/operators/test_mapping_pass_counts.py
+++ b/tests/operations/operators/test_mapping_pass_counts.py
@@ -1,0 +1,123 @@
+"""A mapping is counted once its write lands, not when the model proposed it.
+
+``CreateMappingAssociationTool`` never raises — a rejected element, a duplicate
+arc, or a database fault come back as ``{"error": ...}`` — so the pass used to
+report every failed persist as mapped, and "Mapped N" disagreed with the books.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from robosystems.operations.operators.implementations.mapping.operator import (
+  MappingOperator,
+)
+
+pytestmark = pytest.mark.unit
+
+_MOD = "robosystems.operations.operators.implementations.mapping.operator"
+
+
+class _Tool:
+  def __init__(self, result):
+    self.result = result
+    self.calls: list[dict] = []
+
+  async def execute(self, args):
+    self.calls.append(args)
+    return self.result(args) if callable(self.result) else self.result
+
+
+class _Tools:
+  def __init__(self, by_name):
+    self.by_name = by_name
+
+  def get_tool_instance(self, cls):
+    return self.by_name[cls.__name__]
+
+
+class _Ctx:
+  graph_id = "kg_test"
+  user_id = "user_test"
+
+  def __init__(self, tools):
+    self.extra = {"mapping_id": "map_1"}
+    self.tools = tools
+    self.progress = AsyncMock()
+    self.progress.is_cancelled = AsyncMock(return_value=False)
+
+
+def _elements(n):
+  return [
+    {"id": f"el_{i}", "name": f"Account {i}", "code": str(i), "trait": "Assets"}
+    for i in range(n)
+  ]
+
+
+async def _run(create_result, mappings):
+  create = _Tool(create_result)
+  tools = _Tools(
+    {
+      "GetUnmappedElementsTool": _Tool(
+        {"elements": _elements(len(mappings)), "unmapped_count": len(mappings)}
+      ),
+      "SuggestMappingTool": _Tool({"candidates": [{"id": "rs_cash"}]}),
+      "CreateMappingAssociationTool": create,
+      "GetMappingSummaryTool": _Tool({"error": "not measured"}),
+    }
+  )
+  op = MappingOperator.__new__(MappingOperator)
+  with patch.object(MappingOperator, "_map_batch", AsyncMock(return_value=mappings)):
+    result = await op._run_single_pass(_Ctx(tools))
+  return result, create
+
+
+@pytest.mark.asyncio
+async def test_persisted_mappings_are_counted():
+  mappings = [
+    {"element_id": "el_0", "target_id": "rs_cash", "confidence": 0.95},
+    {"element_id": "el_1", "target_id": "rs_cash", "confidence": 0.75},
+  ]
+  result, create = await _run({"association_id": "assoc_1"}, mappings)
+
+  assert len(create.calls) == 2
+  assert result.metadata["mapped"] == 1
+  assert result.metadata["flagged"] == 1
+  assert result.metadata["skipped"] == 0
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_write_is_skipped_not_mapped():
+  """The tool returned an error dict (element not found, duplicate, DB fault):
+  the element is not mapped, whatever the model's confidence said."""
+  mappings = [
+    {"element_id": "el_0", "target_id": "rs_cash", "confidence": 0.95},
+    {"element_id": "el_1", "target_id": "rs_cash", "confidence": 0.95},
+  ]
+
+  def _create(args):
+    if args["from_element_id"] == "el_1":
+      return {"error": "Element not found: rs_cash"}
+    return {"association_id": "assoc_1"}
+
+  result, _create_tool = await _run(_create, mappings)
+
+  assert result.metadata["mapped"] == 1
+  assert result.metadata["skipped"] == 1
+  assert "Mapped 1" in result.content
+  assert "skipped 1" in result.content
+
+
+@pytest.mark.asyncio
+async def test_a_write_that_raises_is_skipped_not_mapped():
+  mappings = [{"element_id": "el_0", "target_id": "rs_cash", "confidence": 0.95}]
+
+  def _create(_args):
+    raise RuntimeError("database is away")
+
+  result, _ = await _run(_create, mappings)
+
+  assert result.metadata["mapped"] == 0
+  assert result.metadata["skipped"] == 1

--- a/tests/operations/roboledger/reads/test_resolve_parent_entity_db.py
+++ b/tests/operations/roboledger/reads/test_resolve_parent_entity_db.py
@@ -1,0 +1,101 @@
+"""``resolve_parent_entity`` picks the ledger's own entity by predicate — real
+Postgres, because the failure is heap order.
+
+A tenant that has received a shared report holds the sender's entity as a
+``source='linked'``, ``is_parent=False`` row. ``entities`` has no ordering
+guarantee, so ``SELECT ... LIMIT 1`` returns whatever heap order yields — after
+the parent row is updated (new tuple) that is the counterparty. The QuickBooks
+CompanyInfo overwrite, the CoA auto-link and ``link-entity-taxonomy`` all used
+to pick "the entity" that way.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine, select, text
+from sqlalchemy.orm import sessionmaker
+
+import robosystems.models.extensions  # noqa: F401  (register models on ExtensionsBase)
+from robosystems.db.extensions import ExtensionsBase
+from robosystems.models.extensions import Entity
+from robosystems.operations.roboledger.reads.entity import resolve_parent_entity
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def ext_session():
+  database_url = os.environ.get("TEST_DATABASE_URL")
+  if not database_url:
+    pytest.skip("TEST_DATABASE_URL not configured")
+
+  schema = f"ext_entity_{uuid.uuid4().hex[:12]}"
+  engine = create_engine(database_url)
+  with engine.begin() as conn:
+    conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+
+  session = sessionmaker(bind=engine)()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+  ExtensionsBase.metadata.create_all(bind=session.connection())
+  session.commit()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+  try:
+    yield session
+  finally:
+    session.rollback()
+    session.close()
+    with engine.begin() as conn:
+      conn.execute(text(f'DROP SCHEMA "{schema}" CASCADE'))
+    engine.dispose()
+
+
+def _entity(session, *, name, is_parent, source, created_at):
+  row = Entity(
+    name=name,
+    is_parent=is_parent,
+    source=source,
+    created_by="usr_1",
+    created_at=created_at,
+  )
+  session.add(row)
+  session.flush()
+  return row
+
+
+def test_returns_the_parent_even_when_the_linked_row_comes_first(ext_session):
+  t0 = datetime.now(UTC)
+  parent = _entity(
+    ext_session, name="Acme", is_parent=True, source="quickbooks", created_at=t0
+  )
+  linked = _entity(
+    ext_session,
+    name="Sender Co",
+    is_parent=False,
+    source="linked",
+    created_at=t0 + timedelta(seconds=1),
+  )
+  # Rewrite the parent so its live tuple sits after the linked row in the heap
+  # — the state an unordered LIMIT 1 mis-picks in.
+  parent.name = "Acme Holdings"
+  ext_session.commit()
+
+  first_by_heap = ext_session.execute(select(Entity).limit(1)).scalar_one()
+  assert first_by_heap.id == linked.id, "precondition: heap order is the trap"
+
+  assert resolve_parent_entity(ext_session).id == parent.id
+
+
+def test_none_when_only_linked_entities_exist(ext_session):
+  _entity(
+    ext_session,
+    name="Sender Co",
+    is_parent=False,
+    source="linked",
+    created_at=datetime.now(UTC),
+  )
+  ext_session.commit()
+  assert resolve_parent_entity(ext_session) is None

--- a/tests/operations/taxonomy_block/test_cascade_fk_integrity.py
+++ b/tests/operations/taxonomy_block/test_cascade_fk_integrity.py
@@ -257,3 +257,205 @@ class TestApplyStructuresToRemove:
     assert ext_session.query(AssociationClassification).count() == 0
     assert ext_session.get(Taxonomy, built["taxonomy"].id) is not None
     assert ext_session.get(Element, built["elements"][0].id) is not None
+
+
+class TestCurationNeverReachesImmutableSets:
+  """A filed report's snapshot and a closed month's canonical statement sets
+  are immutable against curation: no cascade flag deletes them. Refusal happens
+  before the first delete, so nothing is half-done."""
+
+  @staticmethod
+  def _report(session, taxonomy_id: str, filing_status: str):
+    from robosystems.models.extensions import Report
+
+    report = Report(
+      name="FY26 Notes",
+      taxonomy_id=taxonomy_id,
+      filing_status=filing_status,
+      created_by="usr_1",
+    )
+    session.add(report)
+    session.flush()
+    return report
+
+  def test_delete_refuses_a_filed_reports_snapshot(self, ext_session):
+    from robosystems.operations.taxonomy_block.immutability import (
+      ProtectedFactsError,
+    )
+
+    built = _build_disclosure_taxonomy(ext_session)
+    report = self._report(ext_session, built["taxonomy"].id, "filed")
+    built["fact_set"].report_id = report.id
+    built["fact_set"].factset_type = "report"
+    ext_session.commit()
+
+    with pytest.raises(ProtectedFactsError) as excinfo:
+      cascade_delete_taxonomy(ext_session, built["taxonomy"].id, cascade_facts=True)
+    assert excinfo.value.filed_report_count == 1
+    ext_session.rollback()
+    assert ext_session.get(Taxonomy, built["taxonomy"].id) is not None
+    assert ext_session.query(Fact).count() == 1
+
+  def test_delete_allows_a_draft_reports_snapshot(self, ext_session):
+    built = _build_disclosure_taxonomy(ext_session)
+    report = self._report(ext_session, built["taxonomy"].id, "draft")
+    built["fact_set"].report_id = report.id
+    built["fact_set"].factset_type = "report"
+    ext_session.commit()
+
+    assert (
+      cascade_delete_taxonomy(ext_session, built["taxonomy"].id, cascade_facts=True)
+      == 1
+    )
+
+  def test_delete_refuses_a_closed_periods_canonical_sets(self, ext_session):
+    from robosystems.models.extensions.roboledger.fiscal_period import FiscalPeriod
+    from robosystems.operations.taxonomy_block.immutability import (
+      ProtectedFactsError,
+    )
+
+    built = _build_disclosure_taxonomy(ext_session)
+    built["fact_set"].factset_type = "report"
+    built["fact_set"].period_start = date(2026, 6, 1)
+    ext_session.add(
+      FiscalPeriod(
+        graph_id="kg0123456789abcdef01",
+        name="2026-06",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 6, 30),
+        period_type="month",
+        status="closed",
+      )
+    )
+    ext_session.commit()
+
+    with pytest.raises(ProtectedFactsError) as excinfo:
+      cascade_delete_taxonomy(ext_session, built["taxonomy"].id, cascade_facts=True)
+    assert excinfo.value.closed_period_count == 1
+
+  def test_delete_allows_an_open_periods_canonical_sets(self, ext_session):
+    from robosystems.models.extensions.roboledger.fiscal_period import FiscalPeriod
+
+    built = _build_disclosure_taxonomy(ext_session)
+    built["fact_set"].factset_type = "report"
+    built["fact_set"].period_start = date(2026, 6, 1)
+    ext_session.add(
+      FiscalPeriod(
+        graph_id="kg0123456789abcdef01",
+        name="2026-06",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 6, 30),
+        period_type="month",
+        status="open",
+      )
+    )
+    ext_session.commit()
+
+    assert (
+      cascade_delete_taxonomy(ext_session, built["taxonomy"].id, cascade_facts=True)
+      == 1
+    )
+
+  def test_structure_removal_refuses_and_reports_through_the_validator(
+    self, ext_session
+  ):
+    from robosystems.operations.taxonomy_block.immutability import (
+      ProtectedFactsError,
+    )
+    from robosystems.operations.taxonomy_block.update_validator import (
+      _validate_structures_to_remove,
+    )
+
+    built = _build_disclosure_taxonomy(ext_session)
+    report = self._report(ext_session, built["taxonomy"].id, "filed")
+    built["fact_set"].report_id = report.id
+    built["fact_set"].factset_type = "report"
+    ext_session.commit()
+
+    payload = UpdateTaxonomyBlockRequest(
+      taxonomy_id=built["taxonomy"].id,
+      structures_to_remove=[built["structure"].id],
+    )
+    issues = _validate_structures_to_remove(
+      ext_session, built["taxonomy"], payload, {built["structure"].id}
+    )
+    assert [i.code for i in issues] == ["protected_facts"]
+
+    with pytest.raises(ProtectedFactsError):
+      apply_structures_to_remove(ext_session, built["taxonomy"], payload)
+    ext_session.rollback()
+    assert ext_session.get(Structure, built["structure"].id) is not None
+
+
+class TestDependentsThatUsedToBlock:
+  """Two dependents nothing swept: the parent entity's adoption row for a
+  chart of accounts (``entity_taxonomies.taxonomy_id`` RESTRICT), and tenant
+  rules targeting an element being removed through update."""
+
+  def test_coa_with_an_adopting_entity_is_deletable(self, ext_session):
+    from robosystems.models.extensions import Entity, EntityTaxonomy
+
+    taxonomy = Taxonomy(name="CoA", taxonomy_type="chart_of_accounts")
+    ext_session.add(taxonomy)
+    ext_session.flush()
+    entity = Entity(name="Acme", created_by="usr_1")
+    ext_session.add(entity)
+    ext_session.flush()
+    ext_session.add(
+      EntityTaxonomy(
+        entity_id=entity.id,
+        taxonomy_id=taxonomy.id,
+        basis="chart_of_accounts",
+        is_primary=True,
+      )
+    )
+    ext_session.commit()
+
+    cascade_delete_taxonomy(ext_session, taxonomy.id, cascade_facts=False)
+    ext_session.commit()
+
+    assert ext_session.get(Taxonomy, taxonomy.id) is None
+    assert ext_session.query(EntityTaxonomy).count() == 0
+    assert ext_session.get(Entity, entity.id) is not None
+
+  def test_element_removal_sweeps_rules_targeting_it(self, ext_session):
+    from robosystems.operations.taxonomy_block.update_apply import (
+      apply_elements_to_remove,
+    )
+
+    built = _build_disclosure_taxonomy(ext_session)
+    child = built["elements"][1]
+    child.qname = "x:NoteDetail"
+    # A tenant rule targeting the element, with an evaluation on record.
+    rule = Rule(
+      taxonomy_id=built["taxonomy"].id,
+      rule_category="AutomatedAccountingAndReportingChecks",
+      rule_pattern="GreaterThanOrEqualToZero",
+      rule_expression="value >= 0",
+      target_kind="element",
+      target_element_id=child.id,
+    )
+    ext_session.add(rule)
+    ext_session.flush()
+    ext_session.add(
+      VerificationResult(
+        rule_id=rule.id, structure_id=built["structure"].id, status="pass"
+      )
+    )
+    # Remove the facts first: element removal is refused while facts cite it.
+    ext_session.delete(built["fact"])
+    ext_session.commit()
+
+    child_id, rule_id = child.id, rule.id
+    payload = UpdateTaxonomyBlockRequest(
+      taxonomy_id=built["taxonomy"].id, elements_to_remove=["x:NoteDetail"]
+    )
+    apply_elements_to_remove(
+      ext_session, built["taxonomy"], payload, {"x:NoteDetail": child_id}
+    )
+    ext_session.commit()
+    ext_session.expunge_all()
+
+    assert ext_session.get(Element, child_id) is None
+    assert ext_session.get(Rule, rule_id) is None
+    assert ext_session.query(AssociationClassification).count() == 0

--- a/tests/operations/taxonomy_block/test_chart_of_accounts.py
+++ b/tests/operations/taxonomy_block/test_chart_of_accounts.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from robosystems.operations.taxonomy_block.chart_of_accounts import _auto_link_entity
+
+# The ledger's own entity is resolved by predicate (parent, not `linked`), not
+# by `LIMIT 1`; these tests pin the link logic and stub the resolver.
+_RESOLVER = (
+  "robosystems.operations.taxonomy_block.chart_of_accounts.resolve_parent_entity"
+)
 
 
 def _entity(entity_id: str = "ent_1") -> MagicMock:
@@ -23,19 +31,27 @@ def _entity_taxonomy(taxonomy_id: str = "tx_1", is_primary: bool = True) -> Magi
 
 
 class TestAutoLinkEntity:
+  @pytest.fixture(autouse=True)
+  def _resolver(self):
+    with patch(_RESOLVER) as resolver:
+      self.resolver = resolver
+      yield
+
   def test_no_entity_is_noop(self) -> None:
     """No entity in graph → nothing written."""
     session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.return_value = None
+    self.resolver.return_value = None
     _auto_link_entity(session, "tx_1")
+    session.execute.assert_not_called()
     session.add.assert_not_called()
     session.flush.assert_not_called()
 
   def test_no_prior_link_creates_primary(self) -> None:
     """Entity exists but no CoA link yet → new primary row added."""
     entity = _entity()
+    self.resolver.return_value = entity
     session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.side_effect = [entity, None]
+    session.execute.return_value.scalar_one_or_none.side_effect = [None]
     _auto_link_entity(session, "tx_1")
     session.add.assert_called_once()
     added = session.add.call_args[0][0]
@@ -47,8 +63,9 @@ class TestAutoLinkEntity:
     """Link already exists and is primary → early return, no writes."""
     entity = _entity()
     existing = _entity_taxonomy(taxonomy_id="tx_1", is_primary=True)
+    self.resolver.return_value = entity
     session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.side_effect = [entity, existing]
+    session.execute.return_value.scalar_one_or_none.side_effect = [existing]
     _auto_link_entity(session, "tx_1")
     session.add.assert_not_called()
     session.flush.assert_not_called()
@@ -57,8 +74,9 @@ class TestAutoLinkEntity:
     """Link exists but is non-primary → flip is_primary, no new row."""
     entity = _entity()
     existing = _entity_taxonomy(taxonomy_id="tx_1", is_primary=False)
+    self.resolver.return_value = entity
     session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.side_effect = [entity, existing]
+    session.execute.return_value.scalar_one_or_none.side_effect = [existing]
     _auto_link_entity(session, "tx_1")
     assert existing.is_primary is True
     session.add.assert_not_called()
@@ -67,8 +85,9 @@ class TestAutoLinkEntity:
   def test_new_primary_demotes_old_primary(self) -> None:
     """Creating a new primary link calls query().filter().update() to demote others."""
     entity = _entity()
+    self.resolver.return_value = entity
     session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.side_effect = [entity, None]
+    session.execute.return_value.scalar_one_or_none.side_effect = [None]
     _auto_link_entity(session, "tx_new")
     session.query.assert_called()
     update_call = session.query.return_value.filter.return_value.update
@@ -80,13 +99,9 @@ class TestAutoLinkEntity:
     """Calling _auto_link_entity twice for the same taxonomy is a no-op on second call."""
     entity = _entity()
     existing = _entity_taxonomy(taxonomy_id="tx_1", is_primary=True)
+    self.resolver.return_value = entity
     session = MagicMock()
-    session.execute.return_value.scalar_one_or_none.side_effect = [
-      entity,
-      existing,
-      entity,
-      existing,
-    ]
+    session.execute.return_value.scalar_one_or_none.side_effect = [existing, existing]
     _auto_link_entity(session, "tx_1")
     _auto_link_entity(session, "tx_1")
     session.add.assert_not_called()

--- a/tests/operations/taxonomy_block/test_update.py
+++ b/tests/operations/taxonomy_block/test_update.py
@@ -425,14 +425,18 @@ class TestApplyElementsToRemove:
     )
 
     session = MagicMock()
+    # No associations touch the removed elements and no rules target them.
+    session.execute.return_value.scalars.return_value.all.return_value = []
     taxonomy = _fake_taxonomy("custom_ontology")
     payload = UpdateTaxonomyBlockRequest(
       taxonomy_id="tax_42", elements_to_remove=["x:A", "x:B"]
     )
     apply_elements_to_remove(session, taxonomy, payload, {"x:A": "e_a", "x:B": "e_b"})
 
-    # 1 UPDATE + 5 DELETEs (associations + 3 side tables + elements) = 6 calls
-    assert session.execute.call_count == 6
+    # 1 UPDATE (parent unlink) + 2 SELECTs (associations, rules targeting the
+    # removed elements — dependents that FK them with no ON DELETE) + 3 side
+    # tables + elements = 7 calls; nothing to sweep, so no dependent DELETEs.
+    assert session.execute.call_count == 7
     session.flush.assert_called_once()
 
   def test_noop_when_nothing_to_remove(self) -> None:

--- a/tests/routers/extensions/roboinvestor/test_operations.py
+++ b/tests/routers/extensions/roboinvestor/test_operations.py
@@ -241,7 +241,85 @@ class TestCreatePortfolioBlockOp:
 
     with patch(
       SESSION_FACTORY,
-      side_effect=ProgrammingError("stmt", {}, Exception("schema missing")),
+      side_effect=ProgrammingError(
+        "stmt", {}, Exception('relation "portfolios" does not exist')
+      ),
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await create_portfolio_block_op(
+          body=body,
+          graph_id=GRAPH_ID,
+          user=_make_user(),
+          _ext=_entity_meta(),
+          idempotency_key=None,
+          cache=_FakeCache(),
+        )
+    assert exc.value.status_code == 404
+    assert "not initialized" in exc.value.detail
+
+  @pytest.mark.asyncio
+  async def test_other_programming_errors_surface(self) -> None:
+    """Only a missing schema/relation is "not initialized". A migration that
+    has not reached this tenant, or a SQL fault, must not hide behind the
+    friendly 404 — it surfaces (500) and is logged."""
+    from sqlalchemy.exc import ProgrammingError
+
+    body = CreatePortfolioBlockRequest(
+      portfolio=PortfolioBlockPortfolioFields(name="X"),
+    )
+    fault = ProgrammingError(
+      "stmt", {}, Exception("column portfolios.tags does not exist")
+    )
+    with (
+      patch(f"{PORTFOLIO_BLOCK}.create_portfolio_block", side_effect=fault),
+      patch(SESSION_FACTORY, return_value=_mock_session_ctx()[0]),
+    ):
+      with pytest.raises(ProgrammingError):
+        await create_portfolio_block_op(
+          body=body,
+          graph_id=GRAPH_ID,
+          user=_make_user(),
+          _ext=_entity_meta(),
+          idempotency_key=None,
+          cache=_FakeCache(),
+        )
+
+  @pytest.mark.asyncio
+  async def test_unmapped_value_error_is_a_422_not_a_404(self) -> None:
+    """A domain refusal the error_map did not name is a validation failure
+    with its own message, not "not initialized"."""
+    body = CreatePortfolioBlockRequest(
+      portfolio=PortfolioBlockPortfolioFields(name="X"),
+    )
+    with (
+      patch(
+        f"{PORTFOLIO_BLOCK}.create_portfolio_block",
+        side_effect=ValueError("quantity must be positive"),
+      ),
+      patch(SESSION_FACTORY, return_value=_mock_session_ctx()[0]),
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await create_portfolio_block_op(
+          body=body,
+          graph_id=GRAPH_ID,
+          user=_make_user(),
+          _ext=_entity_meta(),
+          idempotency_key=None,
+          cache=_FakeCache(),
+        )
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "quantity must be positive"
+
+  @pytest.mark.asyncio
+  async def test_graph_id_the_factory_rejects_is_a_404(self) -> None:
+    """The session factory refuses ids that are not tenant-schema ids; that
+    is still the "not initialized" answer, told apart from a command's own
+    ValueError by whether the session was ever bound."""
+    body = CreatePortfolioBlockRequest(
+      portfolio=PortfolioBlockPortfolioFields(name="X"),
+    )
+    with patch(
+      SESSION_FACTORY, side_effect=ValueError("Invalid graph_id for schema name")
     ):
       with pytest.raises(HTTPException) as exc:
         await create_portfolio_block_op(


### PR DESCRIPTION
## Summary

Follow-on to #1205–#1208: the rest of the OLTP mutation path (REST operations, MCP tools, operators, background jobs) reviewed for writes that could land wrong, be lost, or hide a database failure. This PR is the pressing set; the remainder is queued as follow-up patches (design notes: `specs/extensions/oltp-write-path-hardening.md`, `specs/ledger/ledger-write-guards.md`).

### Extensions platform (`5444084e`)
- **`Graph.mark_fresh` compares before it clears.** A write that lands during a materialization stamps a later `graph_stale_at`; clearing unconditionally dropped it from the graph until an unrelated later write. The compare runs in SQL (immune to a stale identity map); all four materializers pass their snapshot time.
- **Tenant provisioning is a first-time act.** The OLTP loader ran the full CHECK/TRIGGER DDL under AccessExclusive locks on every sync; it now provisions only a missing schema (`ensure_tenant_schema`), and provisioning refuses a deprovisioned graph instead of resurrecting its schema.
- **Database faults surface.** The registrar translated every `ProgrammingError` and unmapped `ValueError` to "not initialized" 404 with only that text audited. Now only a missing schema/relation is 404; other programming errors are logged and surface; an unmapped `ValueError` is the 422 it is. `set-close-target` answers 409 on a held calendar row; `update-event-block` maps what its handler can raise on approve, as `create-event-block` does.
- **MCP registrar tools** return fixed messages for unmapped errors (detail logged server-side) rather than DBAPI strings.
- **Mapping operator** counts a mapping once the write lands; a rejected/failed persist is skipped, not reported as mapped.

### Ledger (`85559ecc`)
- **Savepoints in the ledger's loops.** The promotion sweep dispatches each obligation under `begin_nested()` and re-raises lock waits — a DB-level failure in one handler no longer aborts the transaction (one poison obligation blocked every other one each tick, and the commit failed with "transaction is aborted" instead of `RowLockedError`). The close's rule evaluations get the same treatment.
- **Curation never reaches immutable facts.** `delete-taxonomy-block cascade_facts=true` and `update-taxonomy-block structures_to_remove` refuse before the first delete when a filed report's snapshot or a closed month's canonical statement sets would go; the validator reports the same condition.
- **The ledger's own entity is resolved by predicate** (parent, not `linked`) at the four sites that used `LIMIT 1` — the QuickBooks CompanyInfo overwrite, the CoA auto-link, `link-entity-taxonomy` — so a shared-in counterparty can never receive them.
- **A chart of accounts is deletable again** (the cascade sweeps the entity's adoption row — RESTRICT FK); element removal through update sweeps the rules/classifications that FK the removed atoms.
- **`update-taxonomy-block` locks the taxonomy row** (409 on contention), so concurrent envelope updates cannot duplicate auto rules or race the qname index.

## Behavior notes
- Registrar ops: unmapped `ProgrammingError` → 500 (was 404), unmapped `ValueError` → 422 with message (was 404). MCP registrar tools: `not_initialized` / `invalid_request` / fixed `command_failed` (was raw `str(exc)`).
- `delete-taxonomy-block` / `update-taxonomy-block`: new 422 refusal (`protected_facts`) when the cascade would reach a filed report or closed period.

## Test plan
- New real-Postgres tests: `mark_fresh` compare-and-clear (incl. stale identity map), sweep savepoint (poison obligation + lock propagation), immutability refusals (filed/draft, closed/open, validator + apply), CoA-with-adoption delete, element removal with targeting rules, parent-entity resolver under heap-order mis-pick; MCP registrar error surfacing; provisioning ensure/refuse; mapping operator counts. Load-bearing new tests verified to fail on `main`.
- 3,444 tests across the touched suites pass; `just test-code` clean.