### PR TITLE
fix(extensions): OLTP write-path hardening — tiers B and C

### DIFF
--- a/migrations/extensions/env.py
+++ b/migrations/extensions/env.py
@@ -7,10 +7,12 @@ This is separate from the platform alembic/env.py because:
   tenant schemas created at runtime by schema_provisioner)
 """
 
+import sys
+import time
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import engine_from_config, pool, text
 
 from robosystems.db.extensions import ExtensionsBase, get_extensions_database_url
 
@@ -48,6 +50,31 @@ def run_migrations_offline() -> None:
     context.run_migrations()
 
 
+# Extensions migrations fan out over every tenant schema, and they run at
+# daemon boot while the previous release's API tasks are still serving those
+# tenants. Two things follow:
+#
+# - `transaction_per_migration`: each migration commits on its own, so a
+#   fan-out that fails on tenant N leaves the migrations before it applied
+#   (and `alembic_version` advanced) instead of rolling back an hour of DDL,
+#   and the retry starts from the failed migration rather than from scratch.
+# - `lock_timeout`: a per-tenant `ALTER TABLE` takes an ACCESS EXCLUSIVE lock;
+#   behind one long-running reader it would otherwise wait forever, holding
+#   the locks it already took on every earlier tenant and stalling their
+#   requests. With a bound the migration fails fast on that tenant, releases
+#   everything, and is retried after a pause. Statements can raise their own
+#   `SET LOCAL lock_timeout` when they know better.
+MIGRATION_LOCK_TIMEOUT = "30s"
+MIGRATION_LOCK_RETRIES = 5
+MIGRATION_LOCK_RETRY_PAUSE_SECONDS = 10.0
+
+
+def _is_lock_timeout(exc: BaseException) -> bool:
+  """psycopg2 raises `lock_not_available` (55P03) for a lock_timeout."""
+  orig = getattr(exc, "orig", None)
+  return getattr(orig, "pgcode", None) == "55P03"
+
+
 def run_migrations_online() -> None:
   """Run migrations in 'online' mode."""
   connectable = engine_from_config(
@@ -56,11 +83,31 @@ def run_migrations_online() -> None:
     poolclass=pool.NullPool,
   )
 
-  with connectable.connect() as connection:
-    context.configure(connection=connection, target_metadata=target_metadata)
-
-    with context.begin_transaction():
-      context.run_migrations()
+  attempt = 0
+  while True:
+    attempt += 1
+    try:
+      with connectable.connect() as connection:
+        connection.execute(text(f"SET lock_timeout = '{MIGRATION_LOCK_TIMEOUT}'"))
+        connection.commit()
+        context.configure(
+          connection=connection,
+          target_metadata=target_metadata,
+          transaction_per_migration=True,
+        )
+        with context.begin_transaction():
+          context.run_migrations()
+      return
+    except Exception as exc:
+      if not _is_lock_timeout(exc) or attempt >= MIGRATION_LOCK_RETRIES:
+        raise
+      print(
+        f"extensions migration hit lock_timeout ({MIGRATION_LOCK_TIMEOUT}) on "
+        f"attempt {attempt}/{MIGRATION_LOCK_RETRIES}; retrying in "
+        f"{MIGRATION_LOCK_RETRY_PAUSE_SECONDS:.0f}s",
+        file=sys.stderr,
+      )
+      time.sleep(MIGRATION_LOCK_RETRY_PAUSE_SECONDS)
 
 
 if context.is_offline_mode():

--- a/migrations/extensions/versions/0033_events_qb_external_id_index_backfill.py
+++ b/migrations/extensions/versions/0033_events_qb_external_id_index_backfill.py
@@ -1,0 +1,73 @@
+"""events qb_external_id index for tenants provisioned after 0014
+
+0014 fanned ``idx_{schema}_events_qb_external_id`` — the partial expression
+index on ``metadata->>'qb_external_id'`` that the QuickBooks writeback marker
+lookups filter on — out to every tenant that existed when it ran. It never
+reached the ``Event`` model, so every tenant provisioned by ``create_all``
+since then has no such index and each marker lookup in the loader and the
+close's writeback is a sequential scan of ``events``.
+
+The model now declares the index as ``idx_events_qb_external_id``. This
+migration creates it in every tenant that holds neither name — the 0014
+tenants keep their schema-prefixed copy (same definition; a second one would
+only cost writes), and tenants provisioned from here on get it from the model.
+Public gets it too, so the template matches the model.
+
+Revision ID: 0033
+Revises: 0032
+Create Date: 2026-08-18
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+from migrations.extensions.helpers import for_each_tenant_schema
+
+revision = "0033"
+down_revision = "0032"
+branch_labels = None
+depends_on = None
+
+_INDEX = "idx_events_qb_external_id"
+
+
+def _legacy_index_exists(conn: Connection, schema: str) -> bool:
+  return (
+    conn.execute(
+      text("SELECT 1 FROM pg_indexes WHERE schemaname = :schema AND indexname = :name"),
+      {"schema": schema, "name": f"idx_{schema}_events_qb_external_id"},
+    ).first()
+    is not None
+  )
+
+
+def _create(conn: Connection, schema: str) -> None:
+  if schema != "public" and _legacy_index_exists(conn, schema):
+    return
+  conn.execute(
+    text(
+      f'CREATE INDEX IF NOT EXISTS "{_INDEX}" '
+      f"ON \"{schema}\".events ((metadata->>'qb_external_id')) "
+      "WHERE metadata->>'qb_external_id' IS NOT NULL"
+    )
+  )
+
+
+def _drop(conn: Connection, schema: str) -> None:
+  conn.execute(text(f'DROP INDEX IF EXISTS "{schema}"."{_INDEX}"'))
+
+
+def upgrade() -> None:
+  conn = op.get_bind()
+  _create(conn, "public")
+  for_each_tenant_schema(conn, _create)
+
+
+def downgrade() -> None:
+  conn = op.get_bind()
+  _drop(conn, "public")
+  for_each_tenant_schema(conn, _drop)

--- a/robosystems/admin/commands/graphs.py
+++ b/robosystems/admin/commands/graphs.py
@@ -126,6 +126,30 @@ def deprovision_graph(client, graph_id, force, skip_backup):
       click.echo(f"    - {warning}")
 
 
+@graphs.command("orphan-schemas")
+@click.option("--drop", is_flag=True, help="Drop the orphan schemas (irreversible)")
+@click.option("--force", is_flag=True, help="Skip confirmation prompt")
+@click.pass_obj
+def orphan_schemas(client, drop, force):
+  """List (or drop) extensions tenant schemas that no live graph owns."""
+  if drop and not force:
+    click.confirm(
+      "This will DROP every extensions tenant schema with no live graph. Continue?",
+      abort=True,
+    )
+  result = client._make_request(
+    "POST" if drop else "GET", "/admin/v1/graphs/orphan-schemas"
+  )
+  orphans = result.get("orphan_schemas") or []
+  if not orphans:
+    click.echo("No orphan tenant schemas.")
+    return
+  click.echo(f"Orphan tenant schemas ({len(orphans)}):")
+  for schema in orphans:
+    marker = " (dropped)" if schema in (result.get("dropped") or []) else ""
+    click.echo(f"  {schema}{marker}")
+
+
 @graphs.command("analytics")
 @click.option("--tier", help="Filter by tier")
 @click.pass_obj

--- a/robosystems/db/extensions.py
+++ b/robosystems/db/extensions.py
@@ -24,6 +24,11 @@ from robosystems.config import env
 # but we re-validate here for defense in depth against SQL injection.
 _VALID_SCHEMA_PATTERN = re.compile(r"^kg[0-9a-f]{16,}$")
 
+# Five minutes: longer than any legitimate pause inside an extensions
+# transaction (a close's QuickBooks publish is the slowest, and it commits
+# between batches), far shorter than "until the ECS task is replaced".
+IDLE_IN_TRANSACTION_TIMEOUT_MS = 5 * 60 * 1000
+
 
 # Sentinel used in place of a real graph_id when the caller is routing to
 # the taxonomy library. `extensions_session(LIBRARY_GRAPH_ID)` binds the
@@ -66,6 +71,19 @@ def _create_extensions_engine():
     pool_recycle=TuningConfig.get_database_pool_recycle(),
     pool_pre_ping=True,
     echo=env.DATABASE_ECHO,
+    # A session that opened a transaction, took row locks (`FOR UPDATE`, the
+    # period fence's row locks) and then went idle — a task killed mid-request,
+    # a leaked connection — blocked every writer of those rows for as long as
+    # the connection lived. Postgres closes such a session after this long.
+    # Idle *inside* a transaction only; a busy statement (a long loader sync)
+    # is untouched, and so is a pooled connection idle between transactions.
+    # No `statement_timeout` here on purpose: loader syncs and materialization
+    # reads legitimately run long, and a wrong value there is an outage.
+    connect_args={
+      "options": (
+        f"-c idle_in_transaction_session_timeout={IDLE_IN_TRANSACTION_TIMEOUT_MS}"
+      )
+    },
   )
 
 
@@ -269,85 +287,27 @@ def _install_library_immutability_triggers(conn, schema: str) -> None:
 
 
 def _widen_library_checks(conn, schema: str) -> None:
-  """Align tenant-template CHECKs with the library's widened vocabulary.
+  """Align tenant-template CHECKs with the library's vocabulary.
 
   Matches the widening applied in the 0002 migration so a fresh provision
-  lands in the same state as a backfilled tenant (admits ``equivalence``,
-  ``general-special``, ``essence-alias``, ``has-part`` association types
-  and the ``fac``/``rs-gaap``/``cm`` element sources, the rules taxonomy
-  type, and the full Information Block structure-type vocabulary that the
-  library uses).
+  lands in the same state as a backfilled tenant. The vocabularies come from
+  the models — one source for the CHECK the model declares and the CHECK
+  this installs, so the two cannot drift again (they had: the model lists
+  were missing values this function admitted).
   """
-  widened_assoc = (
-    "association_type IN ("
-    "'presentation', 'calculation', 'mapping', "
-    "'equivalence', 'general-special', 'essence-alias', "
-    # 'definition' arcs land from rs-gaap-disclosure-mechanics,
-    # rs-gaap-reporting-checklist, and rs-gaap-reporting-styles.
-    "'definition', "
-    # 'derivation' arcs map BS leaves to their CF default change tags
-    # (rs-gaap-calculations).
-    "'derivation', "
-    # 'has-part' arcs declare cm:Debit/cm:Credit posting legs on schedule
-    # structures (the cm framework).
-    "'has-part'"
-    ")"
-  )
-  widened_source = (
-    "source IN ("
-    "'fac', 'rs-gaap', 'us-gaap', 'ifrs', "
-    "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
-    # rs-gaap framework extension packages anchored to
-    # sibling namespaces of rs-gaap.
-    "'disclosures', 'checklist', 'styles', 'rs-metric', 'rs-driver', "
-    # cm — Conceptual Model framework (cm:Debit/cm:Credit posting roles),
-    # tenant-copied with the default pin.
-    "'cm', "
-    # linked — concepts that arrived with a report shared from another
-    # graph (see Element.source). Not a CoA source.
-    "'linked'"
-    ")"
-  )
-  widened_taxonomy_type = (
-    "taxonomy_type IN ("
-    # 'reporting' retained transitionally for any rows copied from an
-    # un-backfilled public schema; tenant writes use
-    # 'reporting_standard' / 'reporting_extension' / 'custom_ontology'.
-    "'chart_of_accounts', 'reporting', 'mapping', 'schedule', "
-    "'trait-vocabulary', 'trait-assignment', "
-    "'classification-vocabulary', 'classification-assignment', 'rules', "
-    "'reporting_standard', 'reporting_extension', 'custom_ontology'"
-    ")"
-  )
-  # Must stay in sync with both the SQLAlchemy model
-  # (``models/extensions/structure.py``) and the platform migration
-  # (``migrations/extensions/versions/0002_taxonomy_library.py``).
-  # ``copy_library_into_tenant`` mirrors rows from ``public.structures``
-  # — a tenant-side CHECK narrower than public's silently fails graph
-  # creation when the library introduces a new block_type value.
-  widened_block_type = (
-    "block_type IN ("
-    # Renderable financial-statement presentations
-    "'income_statement', 'balance_sheet', "
-    "'cash_flow_statement', 'equity_statement', "
-    "'comprehensive_income', "
-    # Domain-specific working-paper / schedule patterns
-    "'schedule', 'rollforward', 'reconciliation', 'policy', 'metric', "
-    # Forecast — authored scenario container (FP&A engine, 0024).
-    "'forecast', "
-    # CoA + CoA→GAAP mapping
-    "'chart_of_accounts', 'coa_mapping', "
-    # Reference-taxonomy structure kinds (XBRL network roles distinct
-    # from presentation): formal calculation rules, named SEC/regulatory
-    # disclosures, crosswalks between taxonomies.
-    "'validation_rules', 'regulatory_disclosure', 'taxonomy_mapping', "
-    # Reporting Style — the bundle a company picks;
-    # composes Networks per statement_type via reporting_style_networks.
-    "'reporting_style', "
-    # Escape hatch
-    "'custom'"
-    ")"
-  )
+  # Function-level import: the models import `ExtensionsBase` from here.
+  from robosystems.models.extensions.association import ASSOCIATION_TYPE_VALUES
+  from robosystems.models.extensions.element import ELEMENT_SOURCE_VALUES
+  from robosystems.models.extensions.structure import BLOCK_TYPE_VALUES
+  from robosystems.models.extensions.taxonomy import TAXONOMY_TYPE_VALUES
+
+  def _in(column: str, values: tuple[str, ...]) -> str:
+    return f"{column} IN (" + ", ".join(f"'{v}'" for v in values) + ")"
+
+  widened_assoc = _in("association_type", ASSOCIATION_TYPE_VALUES)
+  widened_source = _in("source", ELEMENT_SOURCE_VALUES)
+  widened_taxonomy_type = _in("taxonomy_type", TAXONOMY_TYPE_VALUES)
+  widened_block_type = _in("block_type", BLOCK_TYPE_VALUES)
   conn.execute(
     text(
       f'ALTER TABLE "{schema}".associations '

--- a/robosystems/db/extensions.py
+++ b/robosystems/db/extensions.py
@@ -458,10 +458,15 @@ def provision_tenant_schema(graph_id: str) -> None:
 
   with platform_session() as pdb:
     graph = pdb.get(Graph, graph_id)
-    if graph is not None and graph.status == GraphStatus.DEPROVISIONED.value:
+    if graph is not None and (
+      graph.status == GraphStatus.DEPROVISIONED.value or graph.deleted_at is not None
+    ):
       # Teardown drops the schema before it deletes the graph's connections,
       # so a sync still in flight would otherwise re-create the schema and
       # write ledger rows into a tenant the platform no longer knows about.
+      # `deleted_at` is stamped (and committed) at the start of teardown,
+      # before any data is dropped, so the window between the drop and the
+      # final status flip is covered too.
       raise TenantDeprovisionedError(graph_id)
     pin = resolve_pin(graph)
 
@@ -498,6 +503,26 @@ def provision_tenant_schema(graph_id: str) -> None:
     _install_library_immutability_triggers(conn, schema)
 
     conn.commit()
+
+
+def list_tenant_schemas() -> list[str]:
+  """Every tenant schema present in the extensions database.
+
+  Schemas whose name matches the tenant grammar (``kg`` + hex). Used by the
+  orphan sweep — a schema with no live platform ``Graph`` row is a ghost a
+  partial teardown left behind. Empty when no extension domain is enabled.
+  """
+  if not env.EXTENSIONS_ENABLED:
+    return []
+  engine = _get_engine()
+  with engine.connect() as conn:
+    rows = conn.execute(
+      text(
+        "SELECT schema_name FROM information_schema.schemata "
+        "WHERE schema_name ~ '^kg[0-9a-f]{16,}$' ORDER BY schema_name"
+      )
+    ).all()
+  return [row[0] for row in rows]
 
 
 def tenant_schema_exists(graph_id: str) -> bool:

--- a/robosystems/db/extensions.py
+++ b/robosystems/db/extensions.py
@@ -12,6 +12,7 @@ land) with schema-per-graph tenancy.
 """
 
 import re
+import threading
 from contextlib import contextmanager
 
 from sqlalchemy import create_engine, event, text
@@ -68,22 +69,27 @@ def _create_extensions_engine():
   )
 
 
-# Lazy engine — created on first use
+# Lazy engine — created on first use. Guarded by a lock: operation runners,
+# Dagster sensor threads and the MCP server can all reach a cold engine at
+# once, and without the lock each loser of the race builds (and leaks) a pool.
 _engine = None
 _session_factory = None
+_engine_lock = threading.Lock()
 
 
 def _get_engine():
   global _engine
   if _engine is None:
-    if not env.EXTENSIONS_ENABLED:
-      raise RuntimeError(
-        "Extensions database access attempted but no extension domain is "
-        "enabled. Set ROBOLEDGER_ENABLED=true or ROBOINVESTOR_ENABLED=true "
-        "to enable the extensions OLTP database (the EXTENSIONS_ENABLED "
-        "value is now derived from the per-domain flags)."
-      )
-    _engine = _create_extensions_engine()
+    with _engine_lock:
+      if _engine is None:
+        if not env.EXTENSIONS_ENABLED:
+          raise RuntimeError(
+            "Extensions database access attempted but no extension domain is "
+            "enabled. Set ROBOLEDGER_ENABLED=true or ROBOINVESTOR_ENABLED=true "
+            "to enable the extensions OLTP database (the EXTENSIONS_ENABLED "
+            "value is now derived from the per-domain flags)."
+          )
+        _engine = _create_extensions_engine()
   return _engine
 
 
@@ -103,9 +109,10 @@ def get_extensions_engine():
 def _get_session_factory():
   global _session_factory
   if _session_factory is None:
-    _session_factory = sessionmaker(
-      autocommit=False, autoflush=False, bind=_get_engine()
-    )
+    engine = _get_engine()
+    with _engine_lock:
+      if _session_factory is None:
+        _session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
   return _session_factory
 
 

--- a/robosystems/db/integrity.py
+++ b/robosystems/db/integrity.py
@@ -1,0 +1,41 @@
+"""Name the constraint an ``IntegrityError`` violated.
+
+A command that pre-checks for a conflict and then inserts still loses the
+occasional race to a concurrent identical insert; the database answers with
+an ``IntegrityError``, and the command translates it into the same typed
+conflict its pre-check raises. That translation must be *specific*: catching
+every ``IntegrityError`` as "duplicate" would report an unrelated fault — a
+foreign key to a row that vanished, a CHECK on a bad value — as a benign
+conflict and hide it. So the sites ask which constraint fired.
+
+psycopg2 exposes it on ``exc.orig.diag.constraint_name``; when the driver
+does not carry a diagnostic (a stub in tests, another driver), the message
+is parsed for the ``"name"`` PostgreSQL quotes after ``constraint``/``index``.
+"""
+
+from __future__ import annotations
+
+import re
+
+from sqlalchemy.exc import IntegrityError
+
+_QUOTED_NAME = re.compile(r'(?:constraint|index) "([^"]+)"')
+
+
+def violated_constraint(exc: IntegrityError) -> str | None:
+  """The name of the constraint or unique index ``exc`` reports, if any."""
+  orig = getattr(exc, "orig", None)
+  diag = getattr(orig, "diag", None)
+  name = getattr(diag, "constraint_name", None) if diag is not None else None
+  if name:
+    return str(name)
+  match = _QUOTED_NAME.search(str(orig) if orig is not None else str(exc))
+  return match.group(1) if match else None
+
+
+def violates(exc: IntegrityError, *names: str) -> bool:
+  """Whether ``exc`` fired one of the named constraints/indexes."""
+  return violated_constraint(exc) in names
+
+
+__all__ = ["violated_constraint", "violates"]

--- a/robosystems/middleware/extensions.py
+++ b/robosystems/middleware/extensions.py
@@ -28,6 +28,7 @@ from robosystems.database import get_db_session
 from robosystems.logger import logger
 from robosystems.middleware.auth.dependencies import require_graph_write_role
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
+from robosystems.middleware.graph.utils.subgraph import is_subgraph
 from robosystems.middleware.operations import (
   IdempotencyCache,
   OperationContext,
@@ -66,6 +67,50 @@ def is_schema_missing(exc: ProgrammingError) -> bool:
   """
   msg = str(exc)
   return "does not exist" in msg and ("schema" in msg or "relation" in msg)
+
+
+def guard_command_runner(
+  runner: Callable[[], Any],
+  *,
+  op_name: str,
+  graph_id: str,
+  schema_missing_404: Callable[[], HTTPException],
+) -> Callable[[], Any]:
+  """Give a hand-written command runner the registrar runner's error policy.
+
+  Wraps ``runner`` as the outermost layer, so the handler's own typed
+  ``except`` clauses (inside the runner) always win. What is left when the
+  runner raises:
+
+  - ``HTTPException`` — already translated; passes through.
+  - ``ProgrammingError`` — a missing tenant schema/relation is the
+    domain's "not initialized" 404. Anything else is a real database fault:
+    logged with its traceback and re-raised (500), never hidden behind the
+    friendly 404.
+  - ``ValueError`` — a domain refusal the handler did not map. Surfaced as
+    422 with its message (the shape every mapped ``ValueError`` already
+    takes) and logged so the map gets fixed. The extension dependency has
+    already refused subgraph and repository ids, so a ``ValueError`` here is
+    never the session factory rejecting the graph id.
+  """
+
+  def _guarded() -> Any:
+    try:
+      return runner()
+    except HTTPException:
+      raise
+    except ProgrammingError as exc:
+      if is_schema_missing(exc):
+        raise schema_missing_404()
+      logger.warning(
+        f"{op_name} on {graph_id}: database programming error", exc_info=True
+      )
+      raise
+    except ValueError as exc:
+      logger.warning(f"{op_name} on {graph_id}: unmapped {type(exc).__name__}: {exc}")
+      raise HTTPException(status_code=422, detail=str(exc))
+
+  return _guarded
 
 
 # ── OperationSpec ────────────────────────────────────────────────────────
@@ -213,6 +258,20 @@ def require_graph_extension(extension: str) -> Callable[..., GraphExtensionConte
     graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
     session: Session = Depends(get_db_session),
   ) -> GraphExtensionContext:
+    # A subgraph is a modality container, not an extensions target: it has
+    # no tenant schema of its own. The route pattern admits `{parent}_{name}`
+    # ids (so the same routers serve graph-scoped reads), so refuse them
+    # here — the same answer the GraphQL endpoint gives — instead of letting
+    # the session factory reject the id deep inside a handler, where it
+    # surfaced as a 404 or a 500 depending on which handler caught it.
+    if is_subgraph(graph_id):
+      raise HTTPException(
+        status_code=403,
+        detail=(
+          f"Subgraph '{graph_id}' is not addressable via {extension} "
+          "operations; target the parent graph."
+        ),
+      )
     meta = load_graph_metadata(graph_id, session)
     if meta.is_repository or meta.graph_type == "repository":
       raise HTTPException(
@@ -512,6 +571,7 @@ __all__ = [
   "GraphExtensionContext",
   "OperationRegistrar",
   "OperationSpec",
+  "guard_command_runner",
   "is_schema_missing",
   "load_graph_metadata",
   "require_graph_extension",

--- a/robosystems/middleware/mcp/tools/_errors.py
+++ b/robosystems/middleware/mcp/tools/_errors.py
@@ -1,0 +1,50 @@
+"""Database-fault translation for hand-written MCP tools.
+
+The registrar-published tools already answer a missing tenant schema with
+``not_initialized`` and any other database fault with a fixed message. The
+hand-written tools each carried a catch-all that returned ``str(exc)`` — for a
+DBAPI error that string carries the SQL and its bound parameters, which is not
+something to put in front of the LLM. Every hand-written tool routes its
+``SQLAlchemyError`` arm through here so both tool families answer alike; the
+domain catch-alls that follow keep their messages, since those are domain
+text, not driver output.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.exc import ProgrammingError, SQLAlchemyError
+
+from robosystems.logger import logger
+from robosystems.middleware.extensions import is_schema_missing
+
+LEDGER_NOT_INITIALIZED = "Ledger not initialized. Connect a data source first."
+
+
+def database_failure(
+  tool_name: str,
+  exc: SQLAlchemyError,
+  *,
+  not_initialized_message: str | None = LEDGER_NOT_INITIALIZED,
+) -> dict[str, Any]:
+  """The MCP answer for a database error raised inside a tool.
+
+  ``not_initialized_message`` is the tenant-schema-missing answer; pass
+  ``None`` for tools that read the platform database, where a missing
+  relation is never "not initialized".
+  """
+  if (
+    not_initialized_message is not None
+    and isinstance(exc, ProgrammingError)
+    and is_schema_missing(exc)
+  ):
+    return {"error": "not_initialized", "message": not_initialized_message}
+  logger.warning("MCP tool %s hit a database error", tool_name, exc_info=True)
+  return {
+    "error": "command_failed",
+    "message": f"{tool_name} failed on a database error; see server logs",
+  }
+
+
+__all__ = ["LEDGER_NOT_INITIALIZED", "database_failure"]

--- a/robosystems/middleware/mcp/tools/_gate.py
+++ b/robosystems/middleware/mcp/tools/_gate.py
@@ -28,6 +28,7 @@ from robosystems.middleware.extensions import (
   GraphExtensionContext,
   load_graph_metadata,
 )
+from robosystems.middleware.graph.utils.subgraph import is_subgraph
 
 if TYPE_CHECKING:
   from sqlalchemy.orm import Session
@@ -89,6 +90,19 @@ def require_graph_extension_mcp(
   Raises:
       MCPExtensionGateError: repo write, missing extension, or access denied.
   """
+  # A subgraph is a modality container with no tenant schema; refuse it here
+  # (the same answer the REST extension dependency and the GraphQL endpoint
+  # give) instead of letting the session factory reject the id inside the
+  # tool as a 404 or a 500.
+  if is_subgraph(graph_id):
+    raise MCPExtensionGateError(
+      code="subgraph_not_addressable",
+      message=(
+        f"Subgraph '{graph_id}' is not addressable via {extension} tools; "
+        "target the parent graph."
+      ),
+    )
+
   if meta is None:
     try:
       meta = _load_with_short_lived_session(graph_id)

--- a/robosystems/middleware/mcp/tools/agent_tools.py
+++ b/robosystems/middleware/mcp/tools/agent_tools.py
@@ -14,8 +14,11 @@ from __future__ import annotations
 
 from typing import Any
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from robosystems.db.extensions import extensions_session
 from robosystems.logger import logger
+from robosystems.middleware.operations import run_off_loop
 from robosystems.operations.roboledger.reads.agent import (
   get_agent as ops_get_agent,
 )
@@ -25,6 +28,8 @@ from robosystems.operations.roboledger.reads.agent import (
 from robosystems.operations.roboledger.reads.agent import (
   list_agents as ops_list_agents,
 )
+
+from ._errors import database_failure
 
 
 class GetAgentTool:
@@ -67,6 +72,9 @@ source/external_id provenance, and is_active status.
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
     agent_id = arguments["id"]
 
@@ -76,6 +84,8 @@ source/external_id provenance, and is_active status.
         if agent is None:
           return {"error": "not_found", "message": f"Agent not found: {agent_id}"}
         return agent.model_dump(mode="json")
+    except SQLAlchemyError as exc:
+      return database_failure("get-agent", exc)
     except Exception as exc:
       logger.warning(f"get-agent failed: {exc}")
       return {"error": "command_failed", "message": str(exc)}
@@ -120,6 +130,9 @@ List of AgentResponse objects ordered by name.""",
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
     limit = int(arguments.get("limit", 50))
     offset = int(arguments.get("offset", 0))
@@ -154,6 +167,8 @@ List of AgentResponse objects ordered by name.""",
           "agent_count": len(agents),
           "agents": [a.model_dump(mode="json") for a in agents],
         }
+    except SQLAlchemyError as exc:
+      return database_failure("list-agents", exc)
     except Exception as exc:
       logger.warning(f"list-agents failed: {exc}")
       return {"error": "command_failed", "message": str(exc)}
@@ -200,6 +215,9 @@ class AgentActivityTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
     agent_id = arguments["id"]
     limit = int(arguments.get("limit", 100))
@@ -216,6 +234,8 @@ class AgentActivityTool:
         if activity is None:
           return {"error": "not_found", "message": f"Agent not found: {agent_id}"}
         return activity.model_dump(mode="json")
+    except SQLAlchemyError as exc:
+      return database_failure("agent-activity", exc)
     except Exception as exc:
       logger.warning(f"agent-activity failed: {exc}")
       return {"error": "command_failed", "message": str(exc)}

--- a/robosystems/middleware/mcp/tools/document_tools.py
+++ b/robosystems/middleware/mcp/tools/document_tools.py
@@ -50,8 +50,11 @@ def _resolve_tier(graph_id: str) -> str | None:
 
 
 def _resolve_graph_owner(graph_id: str) -> str | None:
-  """Resolve the owner user_id for a graph (first admin, or any member)."""
+  """Resolve a fallback actor for a graph: its earliest admin, else its
+  earliest member. Only for callers that carry no authenticated user."""
   try:
+    from sqlalchemy import case
+
     from robosystems.database import SessionFactory
     from robosystems.models.core.graph.graph_user import GraphUser
 
@@ -60,7 +63,10 @@ def _resolve_graph_owner(graph_id: str) -> str | None:
       graph_user = (
         session.query(GraphUser)
         .filter(GraphUser.graph_id == graph_id)
-        .order_by(GraphUser.created_at.asc())
+        .order_by(
+          case((GraphUser.role == "admin", 0), else_=1),
+          GraphUser.created_at.asc(),
+        )
         .first()
       )
       return graph_user.user_id if graph_user else None
@@ -68,6 +74,21 @@ def _resolve_graph_owner(graph_id: str) -> str | None:
       session.close()
   except Exception:
     return None
+
+
+def _resolve_acting_user(client: Any, graph_id: str) -> str | None:
+  """Who a write should be stamped with.
+
+  The MCP handler attaches the authenticated user's id to the client
+  (``client.user_id``); that is the actor. Only when no user is threaded
+  through — an in-process tool driven by a background operator — does this
+  fall back to the graph's admin, so the write is at least attributed to an
+  accountable owner rather than to whichever member happened to join first.
+  """
+  user_id = getattr(client, "user_id", None)
+  if user_id:
+    return str(user_id)
+  return _resolve_graph_owner(graph_id)
 
 
 def _block_shared_repository(graph_id: str) -> dict | None:
@@ -198,7 +219,7 @@ class CreateDocumentTool:
         tags=tags,
         folder=folder,
       )
-      owner_id = _resolve_graph_owner(graph_id)
+      owner_id = _resolve_acting_user(self.client, graph_id)
       if not owner_id:
         return {
           "success": False,

--- a/robosystems/middleware/mcp/tools/document_tools.py
+++ b/robosystems/middleware/mcp/tools/document_tools.py
@@ -14,7 +14,12 @@ Discovery (search) is handled by the existing search-documents tool.
 
 from typing import Any
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from robosystems.logger import logger
+from robosystems.middleware.operations import run_off_loop
+
+from ._errors import database_failure
 
 
 def _get_platform_session():
@@ -154,6 +159,9 @@ class CreateDocumentTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     from robosystems.models.api.search import DocumentUploadRequest
     from robosystems.operations.document_service import DocumentService
 
@@ -215,6 +223,8 @@ class CreateDocumentTool:
       }
     except (ValueError, KeyError) as e:
       return {"error": "create_failed", "message": str(e)}
+    except SQLAlchemyError as e:
+      return database_failure("create-document", e, not_initialized_message=None)
     except Exception as e:
       logger.error(f"create-document failed for graph_id={graph_id}: {e}")
       return {"error": "create_failed", "message": str(e)}
@@ -270,6 +280,9 @@ Content changes are automatically re-indexed in OpenSearch.""",
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     from robosystems.operations.document_service import DocumentService
 
     graph_id = self.client.graph_id
@@ -317,6 +330,8 @@ Content changes are automatically re-indexed in OpenSearch.""",
       }
     except KeyError as e:
       return {"error": "not_found", "message": str(e)}
+    except SQLAlchemyError as e:
+      return database_failure("update-document", e, not_initialized_message=None)
     except Exception as e:
       logger.error(f"update-document failed for graph_id={graph_id}: {e}")
       return {"error": "update_failed", "message": str(e)}
@@ -357,6 +372,9 @@ class GetDocumentTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     from robosystems.operations.document_service import DocumentService
 
     graph_id = self.client.graph_id
@@ -389,6 +407,8 @@ class GetDocumentTool:
         "created_at": str(doc.created_at),
         "updated_at": str(doc.updated_at),
       }
+    except SQLAlchemyError as e:
+      return database_failure("get-document", e, not_initialized_message=None)
     except Exception as e:
       logger.error(f"get-document failed for graph_id={graph_id}: {e}")
       return {"error": "retrieval_failed", "message": str(e)}
@@ -426,6 +446,9 @@ from OpenSearch. This is permanent — use get-document to review before deletin
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     from robosystems.operations.document_service import DocumentService
 
     graph_id = self.client.graph_id
@@ -452,6 +475,8 @@ from OpenSearch. This is permanent — use get-document to review before deletin
         "deleted": True,
         "message": "Document deleted from PostgreSQL and OpenSearch",
       }
+    except SQLAlchemyError as e:
+      return database_failure("delete-document", e, not_initialized_message=None)
     except Exception as e:
       logger.error(f"delete-document failed for graph_id={graph_id}: {e}")
       return {"error": "delete_failed", "message": str(e)}
@@ -496,6 +521,9 @@ class ListDocumentsTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     from robosystems.operations.document_service import DocumentService
 
     graph_id = self.client.graph_id
@@ -532,6 +560,8 @@ class ListDocumentsTool:
           for d in docs
         ],
       }
+    except SQLAlchemyError as e:
+      return database_failure("list-documents", e, not_initialized_message=None)
     except Exception as e:
       logger.error(f"list-documents failed for graph_id={graph_id}: {e}")
       return {"error": "list_failed", "message": str(e)}

--- a/robosystems/middleware/mcp/tools/event_block_tools.py
+++ b/robosystems/middleware/mcp/tools/event_block_tools.py
@@ -13,14 +13,19 @@ from __future__ import annotations
 
 from typing import Any
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from robosystems.db.extensions import extensions_session
 from robosystems.logger import logger
+from robosystems.middleware.operations import run_off_loop
 from robosystems.operations.roboledger.reads.event_block import (
   get_event_block as ops_get_event_block,
 )
 from robosystems.operations.roboledger.reads.event_block import (
   list_event_blocks as ops_list_event_blocks,
 )
+
+from ._errors import database_failure
 
 
 class GetEventBlockTool:
@@ -69,6 +74,9 @@ An EventBlockEnvelope with:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
     event_id = arguments["id"]
 
@@ -78,6 +86,8 @@ An EventBlockEnvelope with:
         if envelope is None:
           return {"error": "not_found", "message": f"Event Block not found: {event_id}"}
         return envelope.model_dump(mode="json")
+    except SQLAlchemyError as exc:
+      return database_failure("get-event-block", exc)
     except Exception as exc:
       logger.warning(f"get-event-block failed: {exc}")
       return {"error": "command_failed", "message": str(exc)}
@@ -159,6 +169,9 @@ class ListEventBlocksTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
     limit = int(arguments.get("limit", 50))
     offset = int(arguments.get("offset", 0))
@@ -196,6 +209,8 @@ class ListEventBlocksTool:
           "event_count": len(events),
           "events": events,
         }
+    except SQLAlchemyError as exc:
+      return database_failure("list-event-blocks", exc)
     except Exception as exc:
       logger.warning(f"list-event-blocks failed: {exc}")
       return {"error": "command_failed", "message": str(exc)}

--- a/robosystems/middleware/mcp/tools/event_handler_tools.py
+++ b/robosystems/middleware/mcp/tools/event_handler_tools.py
@@ -14,14 +14,19 @@ from __future__ import annotations
 
 from typing import Any
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from robosystems.db.extensions import extensions_session
 from robosystems.logger import logger
+from robosystems.middleware.operations import run_off_loop
 from robosystems.operations.roboledger.reads.event_handler import (
   get_event_handler as ops_get_event_handler,
 )
 from robosystems.operations.roboledger.reads.event_handler import (
   list_event_handlers as ops_list_event_handlers,
 )
+
+from ._errors import database_failure
 
 
 class GetEventHandlerTool:
@@ -65,6 +70,9 @@ is_active, origin, and AI provenance fields.
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
     handler_id = arguments["id"]
 
@@ -77,6 +85,8 @@ is_active, origin, and AI provenance fields.
             "message": f"EventHandler not found: {handler_id}",
           }
         return handler.model_dump(mode="json")
+    except SQLAlchemyError as exc:
+      return database_failure("get-event-handler", exc)
     except Exception as exc:
       logger.warning(f"get-event-handler failed: {exc}")
       return {"error": "command_failed", "message": str(exc)}
@@ -124,6 +134,9 @@ List of EventHandlerResponse objects ordered by priority descending then name.""
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
     limit = int(arguments.get("limit", 50))
     offset = int(arguments.get("offset", 0))
@@ -162,6 +175,8 @@ List of EventHandlerResponse objects ordered by priority descending then name.""
           "handler_count": len(handlers),
           "handlers": [h.model_dump(mode="json") for h in handlers],
         }
+    except SQLAlchemyError as exc:
+      return database_failure("list-event-handlers", exc)
     except Exception as exc:
       logger.warning(f"list-event-handlers failed: {exc}")
       return {"error": "command_failed", "message": str(exc)}

--- a/robosystems/middleware/mcp/tools/financial_statement_tools.py
+++ b/robosystems/middleware/mcp/tools/financial_statement_tools.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from robosystems.config.shared_repositories import is_shared_repository_or_subgraph
 from robosystems.db.extensions import extensions_session
+from robosystems.middleware.operations import run_off_loop
 from robosystems.operations.roboledger.reads.reports import (
   ANALYSIS_STATEMENT_TYPES,
   LIVE_STATEMENT_TYPES,
@@ -100,6 +101,9 @@ Facts with element qnames, names, classifications, values across current + prior
     }
 
   async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> dict[str, Any]:
     self._log_tool_execution("live-financial-statement", arguments)
 
     statement_type = (arguments.get("statement_type") or "").strip()

--- a/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
+++ b/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
@@ -24,6 +24,8 @@ share one source of truth for both behavior and wire shape.
 
 from typing import Any
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from robosystems.db.extensions import extensions_session
 from robosystems.db.platform import platform_session as _platform_session
 from robosystems.logger import logger
@@ -31,6 +33,7 @@ from robosystems.middleware.mcp.tools._gate import (
   MCPExtensionGateError,
   require_graph_extension_mcp,
 )
+from robosystems.middleware.operations import run_off_loop
 from robosystems.models.api.extensions.fiscal_calendar import (
   BackfillPlanHistoryRequest,
 )
@@ -67,6 +70,8 @@ from robosystems.operations.roboledger.reads.fiscal_calendar import (
 from robosystems.operations.roboledger.reports.statement_sets import (
   StatementStampError,
 )
+
+from ._errors import database_failure
 
 
 def _calendar_dict(session, graph_id: str, calendar, service) -> dict[str, Any]:
@@ -145,6 +150,9 @@ class GetFiscalCalendarTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
     svc = FiscalCalendarService()
 
@@ -160,6 +168,8 @@ class GetFiscalCalendarTool:
             ),
           }
         return _calendar_dict(session, graph_id, calendar, svc)
+    except SQLAlchemyError as exc:
+      return database_failure("get-fiscal-calendar", exc)
     except Exception as exc:
       logger.warning(f"get-fiscal-calendar failed: {exc}")
       return {"error": str(exc)}
@@ -282,6 +292,9 @@ class ClosePeriodTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
 
     try:
@@ -407,6 +420,8 @@ class ClosePeriodTool:
       }
     except FiscalCalendarError as exc:
       return {"error": "calendar_error", "message": str(exc)}
+    except SQLAlchemyError as exc:
+      return database_failure("close-period", exc)
     except Exception as exc:
       logger.warning(f"close-period failed: {exc}")
       return {"error": str(exc)}
@@ -484,6 +499,9 @@ class ReopenPeriodTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
 
     try:
@@ -543,6 +561,8 @@ class ReopenPeriodTool:
         }
     except FiscalCalendarError as exc:
       return {"error": "calendar_error", "message": str(exc)}
+    except SQLAlchemyError as exc:
+      return database_failure("reopen-period", exc)
     except Exception as exc:
       logger.warning(f"reopen-period failed: {exc}")
       return {"error": str(exc)}
@@ -679,6 +699,9 @@ class BackfillPlanHistoryTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
 
     try:
@@ -731,6 +754,8 @@ class BackfillPlanHistoryTool:
       return {"error": exc.code, "message": str(exc)}
     except FiscalCalendarError as exc:
       return {"error": "calendar_error", "message": str(exc)}
+    except SQLAlchemyError as exc:
+      return database_failure("backfill-plan-history", exc)
     except Exception as exc:
       logger.warning(f"backfill-plan-history failed: {exc}")
       return {"error": str(exc)}

--- a/robosystems/middleware/mcp/tools/information_block_tools.py
+++ b/robosystems/middleware/mcp/tools/information_block_tools.py
@@ -19,14 +19,19 @@ from __future__ import annotations
 
 from typing import Any
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from robosystems.db.extensions import LIBRARY_GRAPH_ID, extensions_session
 from robosystems.logger import logger
+from robosystems.middleware.operations import run_off_loop
 from robosystems.operations.information_block import (
   get_information_block as ops_get_information_block,
 )
 from robosystems.operations.information_block import (
   list_information_blocks as ops_list_information_blocks,
 )
+
+from ._errors import database_failure
 
 # ────────────────────────────────────────────────────────────────────────────
 # get-information-block
@@ -124,6 +129,9 @@ were retired in favor of this pair.""",
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
     block_id = arguments["id"]
     scenario_id = arguments.get("scenario_id")
@@ -147,6 +155,8 @@ were retired in favor of this pair.""",
             "message": f"Information Block not found: {block_id}",
           }
         return envelope.model_dump(mode="json")
+    except SQLAlchemyError as exc:
+      return database_failure("get-information-block", exc)
     except Exception as exc:
       logger.warning(f"get-information-block failed: {exc}")
       return {"error": "command_failed", "message": str(exc)}
@@ -244,6 +254,9 @@ class ListInformationBlocksTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
     block_type = arguments.get("block_type")
     category = arguments.get("category")
@@ -293,6 +306,8 @@ class ListInformationBlocksTool:
     except ValueError as exc:
       # Raised on unknown block_type — surface as an argument-level error.
       return {"error": "invalid_arguments", "message": str(exc)}
+    except SQLAlchemyError as exc:
+      return database_failure("list-information-blocks", exc)
     except Exception as exc:
       logger.warning(f"list-information-blocks failed: {exc}")
       return {"error": "command_failed", "message": str(exc)}

--- a/robosystems/middleware/mcp/tools/registrar.py
+++ b/robosystems/middleware/mcp/tools/registrar.py
@@ -31,6 +31,7 @@ registrar internals.
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ValidationError
@@ -43,7 +44,13 @@ from robosystems.middleware.extensions import (
   OperationSpec,
   is_schema_missing,
 )
-from robosystems.middleware.operations import run_off_loop
+from robosystems.middleware.operations import (
+  fingerprint_body,
+  generate_operation_id,
+  get_idempotency_cache,
+  log_operation_audit,
+  run_off_loop,
+)
 from robosystems.operations.extensions.staleness import mark_graph_stale
 
 from ._gate import MCPExtensionGateError, require_graph_extension_mcp
@@ -54,6 +61,13 @@ if TYPE_CHECKING:
 
 
 # ── Input schema derivation ─────────────────────────────────────────────────
+
+
+# Prefix of the reservation slot MCP calls claim in the idempotency cache. REST
+# requests reserve under their caller-supplied Idempotency-Key; MCP has none,
+# so a call claims `<prefix>:<argument fingerprint>` per (user, graph, tool) —
+# two calls are "identical" when their arguments fingerprint the same.
+_MCP_INFLIGHT_KEY = "mcp-inflight"
 
 
 def derive_input_schema(request_model: type[BaseModel]) -> dict[str, Any]:
@@ -437,12 +451,65 @@ class _RegistrarMCPTool(BaseTool):
     # The command is synchronous database work; it runs in a worker thread
     # (like every REST operation runner) so the MCP server's event loop keeps
     # serving other tools — and `/v1/status` — while it executes.
-    return await run_off_loop(self._run_command, graph_id, body)
+    #
+    # MCP carries no Idempotency-Key, so there is no replay. What can be
+    # prevented is the concurrent duplicate: an identical call (same user,
+    # graph, tool, arguments) that arrives while the first is still running
+    # is refused rather than executed alongside it. The claim is keyed by
+    # the argument fingerprint and released when the run ends, so a later
+    # identical call — a deliberate repeat — executes normally.
+    created_by = self._resolve_created_by(graph_id)
+    fingerprint = fingerprint_body(body)
+    inflight_key = f"{_MCP_INFLIGHT_KEY}:{fingerprint}"
+    cache = get_idempotency_cache()
+    claimed = await cache.reserve(
+      created_by, graph_id, self.spec.name, inflight_key, fingerprint
+    )
+    if not claimed:
+      log_operation_audit(
+        operation_name=self.spec.name,
+        operation_id=generate_operation_id(),
+        user_id=created_by,
+        graph_id=graph_id,
+        duration_ms=0.0,
+        status="failed",
+        error="duplicate call while an identical one is in progress",
+        surface="mcp",
+      )
+      return {
+        "error": "in_progress",
+        "message": (
+          f"An identical {self.spec.name} call is still in progress; wait for "
+          "its result instead of repeating it."
+        ),
+      }
 
-  def _run_command(self, graph_id: str, body: BaseModel) -> Any:
+    start = time.monotonic()
+    try:
+      result = await run_off_loop(self._run_command, graph_id, body, created_by)
+    finally:
+      await cache.release(created_by, graph_id, self.spec.name, inflight_key)
+    duration_ms = (time.monotonic() - start) * 1000
+
+    # One audit line per tool call, the same shape and stream as the REST
+    # operation routes — a write reached through MCP was previously invisible
+    # to the "who did what" review.
+    failed = isinstance(result, dict) and "error" in result
+    log_operation_audit(
+      operation_name=self.spec.name,
+      operation_id=generate_operation_id(),
+      user_id=created_by,
+      graph_id=graph_id,
+      duration_ms=duration_ms,
+      status="failed" if failed else "completed",
+      error=str(result.get("error")) if failed else None,
+      surface="mcp",
+    )
+    return result
+
+  def _run_command(self, graph_id: str, body: BaseModel, created_by: str) -> Any:
     session_factory = self.registrar.session_factory
     command = self.spec.command
-    created_by = self._resolve_created_by(graph_id)
 
     session_bound = False
     try:

--- a/robosystems/middleware/mcp/tools/registrar.py
+++ b/robosystems/middleware/mcp/tools/registrar.py
@@ -43,6 +43,7 @@ from robosystems.middleware.extensions import (
   OperationSpec,
   is_schema_missing,
 )
+from robosystems.middleware.operations import run_off_loop
 from robosystems.operations.extensions.staleness import mark_graph_stale
 
 from ._gate import MCPExtensionGateError, require_graph_extension_mcp
@@ -433,6 +434,12 @@ class _RegistrarMCPTool(BaseTool):
         return {"error": "invalid_arguments", "message": str(detail)}
 
     # ── 4. Resolve command, call it inside the session ─────────────────
+    # The command is synchronous database work; it runs in a worker thread
+    # (like every REST operation runner) so the MCP server's event loop keeps
+    # serving other tools — and `/v1/status` — while it executes.
+    return await run_off_loop(self._run_command, graph_id, body)
+
+  def _run_command(self, graph_id: str, body: BaseModel) -> Any:
     session_factory = self.registrar.session_factory
     command = self.spec.command
     created_by = self._resolve_created_by(graph_id)

--- a/robosystems/middleware/mcp/tools/schedule_tools.py
+++ b/robosystems/middleware/mcp/tools/schedule_tools.py
@@ -24,13 +24,18 @@ within one. Where the per-schedule operations live:
 from datetime import date
 from typing import Any
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from robosystems.db.extensions import extensions_session
 from robosystems.logger import logger
+from robosystems.middleware.operations import run_off_loop
 from robosystems.operations.roboledger.reads.period_drafts import list_period_drafts
 from robosystems.operations.roboledger.reads.schedules import (
   get_period_close_status as ops_get_period_close_status,
 )
 from robosystems.operations.roboledger.schedules import ScheduleService
+
+from ._errors import database_failure
 
 # ────────────────────────────────────────────────────────────────────────────
 # get-period-close-status
@@ -77,6 +82,9 @@ class GetPeriodCloseStatusTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
     period_start = date.fromisoformat(arguments["period_start"])
     period_end = date.fromisoformat(arguments["period_end"])
@@ -98,6 +106,8 @@ class GetPeriodCloseStatusTool:
             "details": [s.model_dump(mode="json") for s in response.schedules],
           },
         }
+    except SQLAlchemyError as exc:
+      return database_failure("get-period-close-status", exc)
     except Exception as exc:
       logger.warning(f"get-period-close-status failed: {exc}")
       return {"error": str(exc)}
@@ -166,6 +176,9 @@ class ListPeriodDraftsTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     from robosystems.db.platform import platform_session
     from robosystems.operations.roboledger.fiscal_calendar.qb_writeback import (
       resolve_writeback_connection,
@@ -180,6 +193,8 @@ class ListPeriodDraftsTool:
       with extensions_session(graph_id) as session:
         response = list_period_drafts(session, period, writeback=writeback)
         return response.model_dump(mode="json")
+    except SQLAlchemyError as exc:
+      return database_failure("list-period-drafts", exc)
     except Exception as exc:
       logger.warning(f"list-period-drafts failed: {exc}")
       return {"error": str(exc)}

--- a/robosystems/middleware/mcp/tools/taxonomy_tools.py
+++ b/robosystems/middleware/mcp/tools/taxonomy_tools.py
@@ -513,8 +513,12 @@ class CreateMappingAssociationTool:
         association_type=arguments.get("association_type", "mapping"),
         suggested_by="mapping-agent",
       )
+      # `suggested_by` names the suggester (the mapping operator); `created_by`
+      # is the accountable user — the caller when one is threaded through,
+      # otherwise the operator's own tag.
+      created_by = str(getattr(self.client, "user_id", None) or "mapping-agent")
       with extensions_session(graph_id) as session:
-        result = create_mapping_association(session, body, created_by="mapping-agent")
+        result = create_mapping_association(session, body, created_by=created_by)
       # The registrar-published tools get this from `OperationSpec`; this one
       # is hand-written and reaches the command directly, so it has to mark
       # the graph itself. Associations are materialized, and `auto-map-elements`

--- a/robosystems/middleware/mcp/tools/taxonomy_tools.py
+++ b/robosystems/middleware/mcp/tools/taxonomy_tools.py
@@ -19,8 +19,11 @@ MCP, GraphQL, and the REST read surface share one source of truth.
 
 from typing import Any
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from robosystems.db.extensions import extensions_session
 from robosystems.logger import logger
+from robosystems.middleware.operations import run_off_loop
 from robosystems.models.api.extensions.taxonomies import (
   CreateMappingAssociationOperation,
 )
@@ -37,6 +40,8 @@ from robosystems.operations.roboledger.reads.taxonomies import (
   list_unmapped_elements,
   suggest_mapping_candidates,
 )
+
+from ._errors import database_failure
 
 
 class ListMappingStructuresTool:
@@ -79,6 +84,9 @@ will have several.""",
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
 
     try:
@@ -96,6 +104,8 @@ will have several.""",
           ],
           "count": len(result.structures),
         }
+    except SQLAlchemyError as exc:
+      return database_failure("list-mapping-structures", exc)
     except Exception as exc:
       logger.warning(f"list-mapping-structures failed: {exc}")
       return {"error": str(exc)}
@@ -140,6 +150,9 @@ class GetUnmappedElementsTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
     mapping_id = arguments.get("mapping_id")
 
@@ -152,6 +165,8 @@ class GetUnmappedElementsTool:
           "total_coa_elements": total_coa,
           "elements": [e.model_dump(mode="json") for e in unmapped],
         }
+    except SQLAlchemyError as exc:
+      return database_failure("get-unmapped-elements", exc)
     except Exception as exc:
       logger.warning(f"get-unmapped-elements failed: {exc}")
       return {"error": str(exc)}
@@ -212,6 +227,9 @@ class SuggestMappingTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     from robosystems.operations.roboledger.reports.network_picker import (
       load_primary_reporting_style,
     )
@@ -285,6 +303,8 @@ class SuggestMappingTool:
             for c in candidates
           ],
         }
+    except SQLAlchemyError as exc:
+      return database_failure("suggest-mapping", exc)
     except Exception as exc:
       logger.warning(f"suggest-mapping failed: {exc}")
       return {"error": str(exc)}
@@ -323,6 +343,9 @@ class GetMappingSummaryTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
     mapping_id = arguments["mapping_id"]
 
@@ -357,6 +380,8 @@ class GetMappingSummaryTool:
             for u in coverage.unreachable
           ],
         }
+    except SQLAlchemyError as exc:
+      return database_failure("get-mapping-summary", exc)
     except Exception as exc:
       logger.warning(f"get-mapping-summary failed: {exc}")
       return {"error": str(exc)}
@@ -394,6 +419,9 @@ rs-gaap parent, then return rs-gaap-type-subtype children as specific filing-lev
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     from robosystems.operations.roboledger.reports.network_picker import (
       load_primary_reporting_style,
     )
@@ -414,6 +442,8 @@ rs-gaap parent, then return rs-gaap-type-subtype children as specific filing-lev
         if result is None:
           return {"error": f"No fac-to-rs-gaap equivalence found for {fac_element_id}"}
         return result
+    except SQLAlchemyError as exc:
+      return database_failure("expand-to-rs-gaap-candidates", exc)
     except Exception as exc:
       logger.warning(f"expand-to-rs-gaap-candidates failed: {exc}")
       return {"error": str(exc)}
@@ -470,6 +500,9 @@ class CreateMappingAssociationTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
     try:
       body = CreateMappingAssociationOperation(
@@ -494,6 +527,8 @@ class CreateMappingAssociationTool:
         "to_element_id": result.to_element_id,
         "confidence": result.confidence,
       }
+    except SQLAlchemyError as exc:
+      return database_failure("create-mapping-association", exc)
     except Exception as exc:
       logger.warning(f"create-mapping-association failed: {exc}")
       return {"error": str(exc)}

--- a/robosystems/middleware/mcp/tools/text_block_tools.py
+++ b/robosystems/middleware/mcp/tools/text_block_tools.py
@@ -19,7 +19,7 @@ from .document_tools import (
   _block_shared_repository,
   _check_graph_access,
   _get_platform_session,
-  _resolve_graph_owner,
+  _resolve_acting_user,
 )
 
 
@@ -115,7 +115,7 @@ class BindTextBlockTool:
     except ValidationError as e:
       return {"error": "invalid_input", "message": str(e)}
 
-    owner_id = _resolve_graph_owner(graph_id)
+    owner_id = _resolve_acting_user(self.client, graph_id)
     if not owner_id:
       return {
         "error": "access_denied",

--- a/robosystems/middleware/mcp/tools/text_block_tools.py
+++ b/robosystems/middleware/mcp/tools/text_block_tools.py
@@ -8,9 +8,13 @@ platform session nor the trusted-path ``graph_id``.
 
 from typing import Any
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from robosystems.db.extensions import extensions_session
 from robosystems.logger import logger
+from robosystems.middleware.operations import run_off_loop
 
+from ._errors import database_failure
 from .document_tools import (
   _block_shared_repository,
   _check_graph_access,
@@ -84,6 +88,9 @@ class BindTextBlockTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> Any:
+    return await run_off_loop(self._execute_sync, arguments)
+
+  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     from pydantic import ValidationError
 
     from robosystems.models.api.extensions.text_blocks import BindTextBlockRequest
@@ -131,6 +138,8 @@ class BindTextBlockTool:
       return {"error": "not_found", "message": str(e)}
     except ValueError as e:
       return {"error": "invalid_input", "message": str(e)}
+    except SQLAlchemyError as e:
+      return database_failure("bind-text-block", e)
     except Exception as e:
       logger.error(f"bind-text-block failed for graph_id={graph_id}: {e}")
       return {"error": "command_failed", "message": str(e)}

--- a/robosystems/middleware/operations.py
+++ b/robosystems/middleware/operations.py
@@ -17,6 +17,7 @@ SSE endpoint accepts.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import inspect
 import json
@@ -809,83 +810,119 @@ async def execute_operation(
       # treat it like the in-progress case rather than looping.
       raise IdempotencyInProgressError(ctx.operation_name)
 
-  # HTTPException and bare Exception are caught separately: the former
-  # propagates with its original status/detail, the latter still produces a
-  # failed audit line before re-raising, so a buggy command can never 500
-  # with no audit record. Either way the reservation is released so the
-  # caller's retry can run.
-  start = time.monotonic()
-  try:
-    result = await run_off_loop(runner)
-  except HTTPException as exc:
-    if use_idempotency:
-      await idempotency_cache.release(
-        ctx.user_id, ctx.graph_id, ctx.operation_name, ctx.idempotency_key
-      )
-    duration_ms = (time.monotonic() - start) * 1000
-    log_operation_audit(
-      operation_name=ctx.operation_name,
-      operation_id=generate_operation_id(),
-      user_id=ctx.user_id,
-      graph_id=ctx.graph_id,
-      duration_ms=duration_ms,
-      status="failed",
-      idempotency_key=ctx.idempotency_key,
-      error=str(exc.detail),
-    )
-    raise
-  except Exception as exc:
-    if use_idempotency:
-      await idempotency_cache.release(
-        ctx.user_id, ctx.graph_id, ctx.operation_name, ctx.idempotency_key
-      )
-    duration_ms = (time.monotonic() - start) * 1000
-    log_operation_audit(
-      operation_name=ctx.operation_name,
-      operation_id=generate_operation_id(),
-      user_id=ctx.user_id,
-      graph_id=ctx.graph_id,
-      duration_ms=duration_ms,
-      status="failed",
-      idempotency_key=ctx.idempotency_key,
-      error=f"{type(exc).__name__}: {exc}",
-    )
-    raise
-
-  duration_ms = (time.monotonic() - start) * 1000
-
-  # The hook runs before caching: if it raises, the failure aborts the
-  # request without poisoning the idempotency cache with a stuck envelope
-  # (the reservation is released for the same reason).
-  envelope = wrap_completed(ctx.operation_name, result, created_by=ctx.user_id)
-  if on_fresh_success is not None:
+  async def _run_and_record() -> OperationEnvelope:
+    # HTTPException and bare Exception are caught separately: the former
+    # propagates with its original status/detail, the latter still produces a
+    # failed audit line before re-raising, so a buggy command can never 500
+    # with no audit record. The reservation is released on every exit that
+    # did not store the envelope — including a hook failure and a
+    # cancellation — so the caller's retry can run.
+    start = time.monotonic()
+    recorded = False
     try:
-      await run_off_loop(on_fresh_success, envelope)
-    except Exception:
+      try:
+        result = await run_off_loop(runner)
+      except HTTPException as exc:
+        log_operation_audit(
+          operation_name=ctx.operation_name,
+          operation_id=generate_operation_id(),
+          user_id=ctx.user_id,
+          graph_id=ctx.graph_id,
+          duration_ms=(time.monotonic() - start) * 1000,
+          status="failed",
+          idempotency_key=ctx.idempotency_key,
+          error=str(exc.detail),
+        )
+        raise
+      except Exception as exc:
+        log_operation_audit(
+          operation_name=ctx.operation_name,
+          operation_id=generate_operation_id(),
+          user_id=ctx.user_id,
+          graph_id=ctx.graph_id,
+          duration_ms=(time.monotonic() - start) * 1000,
+          status="failed",
+          idempotency_key=ctx.idempotency_key,
+          error=f"{type(exc).__name__}: {exc}",
+        )
+        raise
+
+      duration_ms = (time.monotonic() - start) * 1000
+
+      # The hook runs before caching: if it raises, the failure aborts the
+      # request without poisoning the idempotency cache with a stuck
+      # envelope. A write whose command succeeded but whose post-hook failed
+      # is still audited, as failed, so it never reaches the client as a 500
+      # with no record.
+      envelope = wrap_completed(ctx.operation_name, result, created_by=ctx.user_id)
+      if on_fresh_success is not None:
+        try:
+          await run_off_loop(on_fresh_success, envelope)
+        except Exception as exc:
+          log_operation_audit(
+            operation_name=ctx.operation_name,
+            operation_id=envelope.operation_id,
+            user_id=ctx.user_id,
+            graph_id=ctx.graph_id,
+            duration_ms=(time.monotonic() - start) * 1000,
+            status="failed",
+            idempotency_key=ctx.idempotency_key,
+            error=f"on_fresh_success: {type(exc).__name__}: {exc}",
+          )
+          raise
       if use_idempotency:
+        await idempotency_cache.put(
+          ctx.user_id,
+          ctx.graph_id,
+          ctx.operation_name,
+          ctx.idempotency_key,
+          envelope,
+          ctx.body_fingerprint,
+        )
+      recorded = True
+      log_operation_audit(
+        operation_name=ctx.operation_name,
+        operation_id=envelope.operation_id,
+        user_id=ctx.user_id,
+        graph_id=ctx.graph_id,
+        duration_ms=duration_ms,
+        status="completed",
+        idempotency_key=ctx.idempotency_key,
+      )
+      return envelope
+    finally:
+      if use_idempotency and not recorded:
         await idempotency_cache.release(
           ctx.user_id, ctx.graph_id, ctx.operation_name, ctx.idempotency_key
         )
-      raise
-  if use_idempotency:
-    await idempotency_cache.put(
-      ctx.user_id,
-      ctx.graph_id,
-      ctx.operation_name,
-      ctx.idempotency_key,
-      envelope,
-      ctx.body_fingerprint,
+
+  # Shielded from cancellation. The runner's write commits in its worker
+  # thread whether or not the request is still connected (a disconnected
+  # client cannot un-commit it), so the recording half — hook, cache, audit
+  # — must finish too: otherwise a client that dropped mid-write leaves a
+  # committed operation with no cached envelope, and its retry with the same
+  # key either re-executes the write or is refused as in progress. The
+  # cancellation is honored the moment the shielded work completes.
+  work = asyncio.ensure_future(_run_and_record())
+  try:
+    return await asyncio.shield(work)
+  except asyncio.CancelledError:
+    # Nothing awaits `work` any more; retrieve its outcome when it lands so
+    # a late failure is logged rather than reported as never retrieved.
+    work.add_done_callback(_log_abandoned_outcome)
+    raise
+
+
+def _log_abandoned_outcome(task: asyncio.Future) -> None:
+  if task.cancelled():
+    return
+  exc = task.exception()
+  if exc is not None:
+    logger.warning(
+      "operation finished after its request was cancelled and failed: %s: %s",
+      type(exc).__name__,
+      exc,
     )
-  log_operation_audit(
-    operation_name=ctx.operation_name,
-    operation_id=envelope.operation_id,
-    user_id=ctx.user_id,
-    graph_id=ctx.graph_id,
-    duration_ms=duration_ms,
-    status="completed",
-    idempotency_key=ctx.idempotency_key,
-  )
-  return envelope
 
 
 __all__ = [

--- a/robosystems/middleware/operations.py
+++ b/robosystems/middleware/operations.py
@@ -46,6 +46,13 @@ OperationStatus = Literal["completed", "pending", "failed"]
 
 IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60
 
+# How long a key stays reserved while its first request is still running.
+# Long enough for the slowest legitimate operation (a close with QuickBooks
+# writeback), short enough that a request that died mid-flight does not block
+# its own retry for a day. A run that outlives the reservation simply loses
+# the in-flight guard — the same behavior as before reservations existed.
+IDEMPOTENCY_RESERVATION_TTL_SECONDS = 5 * 60
+
 
 def generate_operation_id() -> str:
   """Return a fresh `op_`-prefixed ULID."""
@@ -221,6 +228,26 @@ class IdempotencyKeyConflictError(Exception):
     self.operation_name = operation_name
 
 
+class IdempotencyInProgressError(IdempotencyKeyConflictError):
+  """Raised when a caller replays an idempotency key whose first request is
+  still executing.
+
+  Without this, two requests with the same key that arrive inside the first
+  one's run time both miss the cache and both execute — the double-submit
+  the key exists to prevent. The route layer already maps the parent class
+  to HTTP 409, so this needs no new mapping; the message says to retry.
+  """
+
+  def __init__(self, operation_name: str) -> None:
+    Exception.__init__(
+      self,
+      f"A request with this Idempotency-Key for operation "
+      f"{operation_name!r} is still in progress. Retry after it completes "
+      "to receive its result.",
+    )
+    self.operation_name = operation_name
+
+
 def compute_idempotency_cache_key(
   user_id: str,
   graph_id: str,
@@ -324,8 +351,15 @@ class IdempotencyCache:
       return None
     try:
       stored = json.loads(raw)
-      cached_envelope = OperationEnvelope.model_validate(stored["envelope"])
       cached_fingerprint = stored["body_fingerprint"]
+      if stored.get("pending"):
+        # The first request with this key is still running.
+        if cached_fingerprint != body_fingerprint:
+          raise IdempotencyKeyConflictError(operation_name)
+        raise IdempotencyInProgressError(operation_name)
+      cached_envelope = OperationEnvelope.model_validate(stored["envelope"])
+    except IdempotencyKeyConflictError:
+      raise
     except Exception as exc:  # pragma: no cover - defensive
       logger.warning(
         "Idempotency cache payload was invalid; evicting",
@@ -343,6 +377,74 @@ class IdempotencyCache:
       raise IdempotencyKeyConflictError(operation_name)
 
     return cached_envelope
+
+  async def reserve(
+    self,
+    user_id: str,
+    graph_id: str,
+    operation_name: str,
+    idempotency_key: str,
+    body_fingerprint: str,
+  ) -> bool:
+    """Claim the key for an in-flight run.
+
+    Atomic ``SET NX`` of a pending marker carrying the body fingerprint. Returns
+    ``True`` when this call now holds the key, ``False`` when another request
+    already holds it (pending or completed) — the caller re-reads with
+    ``get`` to learn which. A cache outage answers ``True``: idempotency is
+    best-effort here exactly as it is for ``get``/``put``, and a Valkey blip
+    must not turn every write into a 5xx.
+    """
+    cache_key = compute_idempotency_cache_key(
+      user_id, graph_id, operation_name, idempotency_key
+    )
+    payload = json.dumps({"pending": True, "body_fingerprint": body_fingerprint})
+    try:
+      claimed = await self._client.set(
+        cache_key, payload, ex=IDEMPOTENCY_RESERVATION_TTL_SECONDS, nx=True
+      )
+    except Exception as exc:  # pragma: no cover - defensive
+      logger.warning(
+        "Idempotency cache reserve failed",
+        extra={
+          "cache_key": cache_key,
+          "operation": operation_name,
+          "graph_id": graph_id,
+          "error": str(exc),
+        },
+      )
+      return True
+    return bool(claimed)
+
+  async def release(
+    self,
+    user_id: str,
+    graph_id: str,
+    operation_name: str,
+    idempotency_key: str,
+  ) -> None:
+    """Drop a pending marker after the run failed, so a retry can execute.
+
+    Removes the key only while it still holds a pending marker — never a
+    completed envelope another request may have stored in the meantime.
+    """
+    cache_key = compute_idempotency_cache_key(
+      user_id, graph_id, operation_name, idempotency_key
+    )
+    try:
+      raw = await self._client.get(cache_key)
+      if raw is not None and json.loads(raw).get("pending"):
+        await self._client.delete(cache_key)
+    except Exception as exc:  # pragma: no cover - defensive
+      logger.warning(
+        "Idempotency cache release failed",
+        extra={
+          "cache_key": cache_key,
+          "operation": operation_name,
+          "graph_id": graph_id,
+          "error": str(exc),
+        },
+      )
 
   async def put(
     self,
@@ -395,6 +497,7 @@ def log_operation_audit(
   idempotent_replay: bool = False,
   error: str | None = None,
   event: str = "extensions.operation",
+  surface: str = "rest",
 ) -> None:
   """Emit one structured audit-log line per operation call.
 
@@ -404,7 +507,9 @@ def log_operation_audit(
 
   ``event`` names the event in the audit payload and log message:
   ``"extensions.operation"`` for extension ops, ``"graph.operation"`` for
-  graph lifecycle ops.
+  graph lifecycle ops. ``surface`` names the entry point — ``"rest"`` for
+  the HTTP operation routes, ``"mcp"`` for tool calls — so the same command
+  reached two ways is distinguishable in the stream.
   """
   payload: dict[str, Any] = {
     "event": event,
@@ -412,6 +517,7 @@ def log_operation_audit(
     "operation_id": operation_id,
     "user_id": user_id,
     "graph_id": graph_id,
+    "surface": surface,
     "duration_ms": round(duration_ms, 2),
     "status": status,
     "idempotent_replay": idempotent_replay,
@@ -602,7 +708,10 @@ async def execute_operation(
      both present. On match, return the cached envelope with an
      `idempotent_replay=True` audit line and never call the runner. On
      fingerprint mismatch, raise `IdempotencyKeyConflictError` for the
-     route to map to HTTP 409.
+     route to map to HTTP 409. On a miss, **reserve** the key: a second
+     request with the same key that arrives while this one runs gets
+     `IdempotencyInProgressError` (also 409) instead of executing too. The
+     reservation is released if the run fails, so a retry can execute.
   2. **Run + time** the runner; wall-clock duration excludes the lookup.
   3. **Side-effect hook** — `on_fresh_success(envelope)` runs ONLY on a
      fresh execution, and BEFORE the envelope is cached, so a hook failure
@@ -664,15 +773,55 @@ async def execute_operation(
         idempotent_replay=True,
       )
       return cached
+    # Miss: claim the key before running, so a second request with the same
+    # key that lands during this run is told "in progress" (409) instead of
+    # executing alongside it. Losing the claim means another request took
+    # the key between our read and our write — read again to replay its
+    # result or report it in progress.
+    if not await idempotency_cache.reserve(
+      ctx.user_id,
+      ctx.graph_id,
+      ctx.operation_name,
+      ctx.idempotency_key,
+      ctx.body_fingerprint,
+    ):
+      raced = await idempotency_cache.get(
+        ctx.user_id,
+        ctx.graph_id,
+        ctx.operation_name,
+        ctx.idempotency_key,
+        ctx.body_fingerprint,
+      )
+      if raced is not None:
+        raced = raced.model_copy(update={"idempotent_replay": True})
+        log_operation_audit(
+          operation_name=ctx.operation_name,
+          operation_id=raced.operation_id,
+          user_id=ctx.user_id,
+          graph_id=ctx.graph_id,
+          duration_ms=0.0,
+          status=raced.status,
+          idempotency_key=ctx.idempotency_key,
+          idempotent_replay=True,
+        )
+        return raced
+      # The other holder released between our two reads (its run failed);
+      # treat it like the in-progress case rather than looping.
+      raise IdempotencyInProgressError(ctx.operation_name)
 
   # HTTPException and bare Exception are caught separately: the former
   # propagates with its original status/detail, the latter still produces a
   # failed audit line before re-raising, so a buggy command can never 500
-  # with no audit record.
+  # with no audit record. Either way the reservation is released so the
+  # caller's retry can run.
   start = time.monotonic()
   try:
     result = await run_off_loop(runner)
   except HTTPException as exc:
+    if use_idempotency:
+      await idempotency_cache.release(
+        ctx.user_id, ctx.graph_id, ctx.operation_name, ctx.idempotency_key
+      )
     duration_ms = (time.monotonic() - start) * 1000
     log_operation_audit(
       operation_name=ctx.operation_name,
@@ -686,6 +835,10 @@ async def execute_operation(
     )
     raise
   except Exception as exc:
+    if use_idempotency:
+      await idempotency_cache.release(
+        ctx.user_id, ctx.graph_id, ctx.operation_name, ctx.idempotency_key
+      )
     duration_ms = (time.monotonic() - start) * 1000
     log_operation_audit(
       operation_name=ctx.operation_name,
@@ -702,10 +855,18 @@ async def execute_operation(
   duration_ms = (time.monotonic() - start) * 1000
 
   # The hook runs before caching: if it raises, the failure aborts the
-  # request without poisoning the idempotency cache with a stuck envelope.
+  # request without poisoning the idempotency cache with a stuck envelope
+  # (the reservation is released for the same reason).
   envelope = wrap_completed(ctx.operation_name, result, created_by=ctx.user_id)
   if on_fresh_success is not None:
-    await run_off_loop(on_fresh_success, envelope)
+    try:
+      await run_off_loop(on_fresh_success, envelope)
+    except Exception:
+      if use_idempotency:
+        await idempotency_cache.release(
+          ctx.user_id, ctx.graph_id, ctx.operation_name, ctx.idempotency_key
+        )
+      raise
   if use_idempotency:
     await idempotency_cache.put(
       ctx.user_id,
@@ -728,9 +889,11 @@ async def execute_operation(
 
 
 __all__ = [
+  "IDEMPOTENCY_RESERVATION_TTL_SECONDS",
   "IDEMPOTENCY_TTL_SECONDS",
   "AsyncOperationRunner",
   "IdempotencyCache",
+  "IdempotencyInProgressError",
   "IdempotencyKeyConflictError",
   "OperationContext",
   "OperationEnvelope",

--- a/robosystems/middleware/operations.py
+++ b/robosystems/middleware/operations.py
@@ -18,6 +18,7 @@ SSE endpoint accepts.
 from __future__ import annotations
 
 import hashlib
+import inspect
 import json
 import time
 from collections.abc import Awaitable, Callable
@@ -25,6 +26,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Generic, Literal, TypeVar
 
+import anyio
 from fastapi import HTTPException
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -537,11 +539,60 @@ async def check_idempotency(
   return None
 
 
+# ── Runner execution ─────────────────────────────────────────────────────
+
+_runner_limiter: anyio.CapacityLimiter | None = None
+
+
+def _get_runner_limiter() -> anyio.CapacityLimiter:
+  """Bound on operation runners executing concurrently in worker threads.
+
+  Sized to the extensions OLTP pool (``pool_size + max_overflow``): every
+  sync runner opens one tenant session, so a wider limiter would only turn
+  a burst into ``QueuePool limit ... reached`` after ``pool_timeout`` where
+  the pre-threadpool code merely queued the request on the event loop.
+  Excess runners wait on the limiter instead — same latency shape as before,
+  without freezing the loop while they wait.
+  """
+  global _runner_limiter
+  if _runner_limiter is None:
+    from robosystems.config.tuning import TuningConfig
+
+    total = (
+      TuningConfig.get_extensions_pool_size()
+      + TuningConfig.get_extensions_max_overflow()
+    )
+    _runner_limiter = anyio.CapacityLimiter(max(1, total))
+  return _runner_limiter
+
+
+async def run_off_loop(func: Callable[..., Any], *args: Any) -> Any:
+  """Run ``func`` without blocking the event loop.
+
+  A coroutine function is awaited directly. Anything else is a sync callable
+  doing database or network work — it runs in a worker thread (with the
+  request's contextvars, so the platform request-scoped session resolves the
+  same way it does on the loop) under the runner limiter. A sync callable that
+  hands back an awaitable gets that awaited on the loop.
+
+  This is what keeps ``/v1/status`` answering while a close posts to
+  QuickBooks or a bounded lock wait sits on a busy row: the API runs one
+  uvicorn worker, and before this every operation's SQL and HTTP ran inline
+  on the loop.
+  """
+  if inspect.iscoroutinefunction(func):
+    return await func(*args)
+  result = await anyio.to_thread.run_sync(func, *args, limiter=_get_runner_limiter())
+  if inspect.isawaitable(result):
+    result = await result
+  return result
+
+
 async def execute_operation(
   ctx: OperationContext,
   runner: OperationRunner | AsyncOperationRunner,
   idempotency_cache: IdempotencyCache | None = None,
-  on_fresh_success: Callable[[OperationEnvelope], None] | None = None,
+  on_fresh_success: Callable[[OperationEnvelope], None | Awaitable[None]] | None = None,
 ) -> OperationEnvelope:
   """Run an operation and return its `OperationEnvelope`.
 
@@ -564,10 +615,10 @@ async def execute_operation(
   The `runner` opens its own database session, performs business
   validation beyond FastAPI's parsing, calls the ops layer, and
   translates domain exceptions into `HTTPException`. Sync and async
-  runners are both accepted.
+  runners are both accepted; a sync runner (and a sync `on_fresh_success`
+  hook) executes in a worker thread so its database and network work never
+  blocks the event loop.
   """
-  import inspect
-
   # Requires both a key AND a fingerprint so a route handler can't request
   # idempotency without the fingerprint that protects against key reuse.
   use_idempotency = (
@@ -620,11 +671,7 @@ async def execute_operation(
   # with no audit record.
   start = time.monotonic()
   try:
-    maybe_result = runner()
-    if inspect.isawaitable(maybe_result):
-      result = await maybe_result
-    else:
-      result = maybe_result
+    result = await run_off_loop(runner)
   except HTTPException as exc:
     duration_ms = (time.monotonic() - start) * 1000
     log_operation_audit(
@@ -658,7 +705,7 @@ async def execute_operation(
   # request without poisoning the idempotency cache with a stuck envelope.
   envelope = wrap_completed(ctx.operation_name, result, created_by=ctx.user_id)
   if on_fresh_success is not None:
-    on_fresh_success(envelope)
+    await run_off_loop(on_fresh_success, envelope)
   if use_idempotency:
     await idempotency_cache.put(
       ctx.user_id,
@@ -696,6 +743,7 @@ __all__ = [
   "generate_operation_id",
   "get_idempotency_cache",
   "log_operation_audit",
+  "run_off_loop",
   "wrap_completed",
   "wrap_failed",
   "wrap_pending",

--- a/robosystems/models/api/admin/__init__.py
+++ b/robosystems/models/api/admin/__init__.py
@@ -24,6 +24,7 @@ from .graphs import (
   GraphInfrastructureResponse,
   GraphResponse,
   GraphStorageResponse,
+  OrphanTenantSchemasResponse,
 )
 from .invoice import InvoiceLineItemResponse, InvoiceResponse
 from .orgs import OrgGraphInfo, OrgResponse, OrgUpdateRequest, OrgUserInfo
@@ -72,6 +73,7 @@ __all__ = [
   "OrgResponse",
   "OrgUpdateRequest",
   "OrgUserInfo",
+  "OrphanTenantSchemasResponse",
   "RepositoryCreditPoolResponse",
   "ResetCreditPoolRequest",
   "ScimBootstrapRequest",

--- a/robosystems/models/api/admin/graphs.py
+++ b/robosystems/models/api/admin/graphs.py
@@ -76,6 +76,13 @@ class GraphDeprovisionResponse(BaseModel):
   warnings: list[str] | None = None
 
 
+class OrphanTenantSchemasResponse(BaseModel):
+  """Extensions tenant schemas that no live graph owns."""
+
+  orphan_schemas: list[str]
+  dropped: list[str] = []
+
+
 class GraphAnalyticsResponse(BaseModel):
   """Response with cross-graph analytics."""
 

--- a/robosystems/models/extensions/association.py
+++ b/robosystems/models/extensions/association.py
@@ -22,6 +22,26 @@ from sqlalchemy.dialects.postgresql import JSONB
 from robosystems.db.extensions import ExtensionsBase
 from robosystems.utils.ulid import generate_prefixed_ulid
 
+# The `associations.association_type` vocabulary — the single source for the
+# model CHECK and the tenant-provisioning widen step.
+# 'definition' arcs land from rs-gaap-disclosure-mechanics,
+# rs-gaap-reporting-checklist and rs-gaap-reporting-styles.
+# 'derivation' arcs map BS leaves to their CF default change tags.
+# 'has-part' — Conceptual Model posting arcs: cm:Debit/cm:Credit ─has-part→ a
+# CoA element, declaring the debit/credit legs of a schedule's posting
+# template as first-class atoms.
+ASSOCIATION_TYPE_VALUES: tuple[str, ...] = (
+  "presentation",
+  "calculation",
+  "mapping",
+  "equivalence",
+  "general-special",
+  "essence-alias",
+  "definition",
+  "derivation",
+  "has-part",
+)
+
 
 class Association(ExtensionsBase):
   __tablename__ = "associations"
@@ -44,13 +64,8 @@ class Association(ExtensionsBase):
     ),
     CheckConstraint(
       "association_type IN ("
-      "'presentation', 'calculation', 'mapping', 'derivation', "
-      "'equivalence', 'general-special', 'essence-alias', "
-      # 'has-part' — Conceptual Model posting arcs: cm:Debit/cm:Credit
-      # ─has-part→ a CoA element, declaring the debit/credit legs of a
-      # schedule's posting template as first-class atoms.
-      "'has-part'"
-      ")",
+      + ", ".join(f"'{v}'" for v in ASSOCIATION_TYPE_VALUES)
+      + ")",
       name="check_association_type",
     ),
   )

--- a/robosystems/models/extensions/element.py
+++ b/robosystems/models/extensions/element.py
@@ -32,6 +32,44 @@ from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from robosystems.db.extensions import ExtensionsBase
 from robosystems.utils.ulid import generate_prefixed_ulid
 
+# The `elements.source` vocabulary — the single source for the model CHECK and
+# for the tenant-provisioning widen step (`db.extensions._widen_library_checks`),
+# which used to carry its own copy that drifted from this one.
+#
+# 'system' is reserved for internal FK-anchor elements created by the taxonomy
+# seed (e.g., struct_balance_sheet) and is intentionally NOT in COA_SOURCES so
+# those rows never appear in the Chart of Accounts.
+# 'disclosures' / 'checklist' / 'styles' — rs-gaap framework extension packages
+# anchored to sibling namespaces of rs-gaap.
+# 'cm' — Conceptual Model posting-role concepts (cm:Debit/cm:Credit),
+# tenant-copied with the default pin so schedule has-part arcs resolve.
+# 'rs-metric' — the metric catalog package (seeded at 0002 on fresh databases,
+# backfilled by 0022 on existing ones).
+# 'rs-driver' — the forecast lever catalog package (seeded at 0024).
+# 'linked' — a concept that arrived with a report shared from another graph.
+# Deliberately NOT in COA_SOURCES: the sender's reporting extension has to
+# exist here for their facts to mean anything, but their revenue accounts are
+# not the recipient's chart of accounts. Mirrors Entity.source='linked'.
+ELEMENT_SOURCE_VALUES: tuple[str, ...] = (
+  "fac",
+  "rs-gaap",
+  "us-gaap",
+  "ifrs",
+  "quickbooks",
+  "xero",
+  "plaid",
+  "native",
+  "import",
+  "system",
+  "disclosures",
+  "checklist",
+  "styles",
+  "rs-metric",
+  "rs-driver",
+  "cm",
+  "linked",
+)
+
 
 class Element(ExtensionsBase):
   __tablename__ = "elements"
@@ -99,22 +137,7 @@ class Element(ExtensionsBase):
       name="check_element_type",
     ),
     CheckConstraint(
-      # 'system' is reserved for internal FK-anchor elements created by the
-      # taxonomy seed (e.g., struct_balance_sheet) and is intentionally NOT
-      # in COA_SOURCES so those rows never appear in the Chart of Accounts.
-      "source IN ('fac', 'rs-gaap', 'us-gaap', 'ifrs', "
-      "'quickbooks', 'xero', 'plaid', 'native', 'import', 'system', "
-      # 'cm' — Conceptual Model posting-role concepts (cm:Debit/cm:Credit),
-      # tenant-copied with the default pin so schedule has-part arcs resolve.
-      # 'rs-metric' — the metric catalog package (seeded at 0002 on fresh
-      # databases, backfilled by 0022 on existing ones).
-      # 'rs-driver' — the forecast lever catalog package (seeded at 0024).
-      # 'linked' — a concept that arrived with a report shared from another
-      # graph. Deliberately NOT in COA_SOURCES: the sender's reporting
-      # extension has to exist here for their facts to mean anything, but
-      # their revenue accounts are not the recipient's chart of accounts.
-      # Mirrors Entity.source='linked' for the same reason.
-      "'cm', 'rs-metric', 'rs-driver', 'linked')",
+      "source IN (" + ", ".join(f"'{v}'" for v in ELEMENT_SOURCE_VALUES) + ")",
       name="check_element_source",
     ),
   )

--- a/robosystems/models/extensions/roboledger/event.py
+++ b/robosystems/models/extensions/roboledger/event.py
@@ -31,6 +31,7 @@ from sqlalchemy import (
   DateTime,
   Index,
   String,
+  text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 
@@ -110,6 +111,17 @@ class Event(ExtensionsBase):
       "external_id",
       unique=True,
       postgresql_where="external_id IS NOT NULL",
+    ),
+    # QuickBooks writeback marker lookups (`loader.py`, `qb_writeback.py`)
+    # filter on `metadata->>'qb_external_id'`. Migration 0014 fanned this
+    # index out to the tenants that existed then (under a schema-prefixed
+    # name); tenants provisioned by `create_all` afterwards had no index at
+    # all — every marker lookup was a sequential scan of `events`. Declared
+    # here so a fresh tenant gets it; 0033 backfills the ones in between.
+    Index(
+      "idx_events_qb_external_id",
+      text("(metadata->>'qb_external_id')"),
+      postgresql_where=text("metadata->>'qb_external_id' IS NOT NULL"),
     ),
     CheckConstraint(
       "status IN ('captured', 'classified', 'committed', 'pending', 'fulfilled', 'voided', 'superseded')",

--- a/robosystems/models/extensions/structure.py
+++ b/robosystems/models/extensions/structure.py
@@ -67,6 +67,47 @@ TEXT_BLOCK_CAPS: frozenset[str] = frozenset(
 )
 
 
+# The `structures.block_type` vocabulary — the single source for the model
+# CHECK and the tenant-provisioning widen step (`copy_library_into_tenant`
+# mirrors rows from `public.structures`; a tenant-side CHECK narrower than
+# public's silently fails graph creation when the library adds a value).
+BLOCK_TYPE_VALUES: tuple[str, ...] = (
+  # Renderable financial-statement presentations (the user-facing forms)
+  "income_statement",
+  "balance_sheet",
+  "cash_flow_statement",
+  "equity_statement",
+  "comprehensive_income",
+  # Domain-specific working-paper / schedule patterns
+  "schedule",
+  "rollforward",
+  "reconciliation",
+  "policy",
+  "metric",
+  # Forecast — the authored scenario container (FP&A engine): lever
+  # assertions + scenario identity; derived forward facts land in the
+  # existing statement/metric block types stamped with fact_sets.scenario_id.
+  "forecast",
+  # Chart-of-accounts and CoA→GAAP mapping
+  "chart_of_accounts",
+  "coa_mapping",
+  # Reference-taxonomy structure kinds (XBRL network roles distinct from
+  # presentation): formal calculation/business rules, named SEC/regulatory
+  # disclosures, crosswalks between taxonomies. Filtered out of the
+  # report-package render path; consumed by the rule engine, disclosure
+  # registry and mapping resolver.
+  "validation_rules",
+  "regulatory_disclosure",
+  "taxonomy_mapping",
+  # Reporting Style — the bundle a company picks; pinned per entity via
+  # entities.reporting_style_id and composed per statement_type via
+  # reporting_style_networks.
+  "reporting_style",
+  # Escape hatch
+  "custom",
+)
+
+
 class Structure(ExtensionsBase):
   __tablename__ = "structures"
   __table_args__ = (
@@ -80,37 +121,7 @@ class Structure(ExtensionsBase):
       sqlalchemy_text("(metadata->>'role_uri')"),
     ),
     CheckConstraint(
-      "block_type IN ("
-      # Renderable financial-statement presentations (the user-facing forms)
-      "'income_statement', 'balance_sheet', "
-      "'cash_flow_statement', 'equity_statement', "
-      "'comprehensive_income', "
-      # Domain-specific working-paper / schedule patterns
-      "'schedule', 'rollforward', 'reconciliation', 'policy', 'metric', "
-      # Forecast — the authored scenario container (FP&A engine): lever
-      # assertions + scenario identity; derived forward facts land in
-      # the EXISTING statement/metric block types stamped with
-      # fact_sets.scenario_id, never in a parallel forecast statement.
-      "'forecast', "
-      # Chart-of-accounts and CoA→GAAP mapping
-      "'chart_of_accounts', 'coa_mapping', "
-      # Reference-taxonomy structure kinds (XBRL network roles distinct
-      # from presentation): formal calculation/business rules expressed
-      # as a network (FAC's "Assets = L + E"), named SEC/regulatory
-      # disclosures (rs-gaap-type-subtype's 991xxx schedules), and crosswalks
-      # between taxonomies (fac-to-rs-gaap concordances). Filtered out
-      # of the report-package render path; surfaced through their own
-      # consumption paths (rule engine, disclosure registry, mapping
-      # resolver).
-      "'validation_rules', 'regulatory_disclosure', 'taxonomy_mapping', "
-      # Reporting Style — the bundle a company picks (Charlie Hoffman's
-      # term). Pinned per entity via entities.reporting_style_id (set at
-      # provision from the entity's legal form); composes Networks per
-      # statement_type via the reporting_style_networks table.
-      "'reporting_style', "
-      # Escape hatch for everything that doesn't fit the above
-      "'custom'"
-      ")",
+      "block_type IN (" + ", ".join(f"'{v}'" for v in BLOCK_TYPE_VALUES) + ")",
       name="check_block_type",
     ),
     # Concept Arrangement Pattern (CAP). Vocabulary from

--- a/robosystems/models/extensions/taxonomy.py
+++ b/robosystems/models/extensions/taxonomy.py
@@ -40,6 +40,25 @@ from sqlalchemy.dialects.postgresql import JSONB
 from robosystems.db.extensions import ExtensionsBase
 from robosystems.utils.ulid import generate_prefixed_ulid
 
+# The `taxonomies.taxonomy_type` vocabulary — the single source for the model
+# CHECK and the tenant-provisioning widen step. 'reporting' is retained
+# transitionally for rows copied from an un-backfilled public schema; tenant
+# writes use 'reporting_standard' / 'reporting_extension' / 'custom_ontology'.
+TAXONOMY_TYPE_VALUES: tuple[str, ...] = (
+  "chart_of_accounts",
+  "reporting",
+  "mapping",
+  "schedule",
+  "trait-vocabulary",
+  "trait-assignment",
+  "classification-vocabulary",
+  "classification-assignment",
+  "rules",
+  "reporting_standard",
+  "reporting_extension",
+  "custom_ontology",
+)
+
 
 class Taxonomy(ExtensionsBase):
   __tablename__ = "taxonomies"
@@ -56,11 +75,7 @@ class Taxonomy(ExtensionsBase):
       postgresql_where="parent_taxonomy_id IS NOT NULL",
     ),
     CheckConstraint(
-      "taxonomy_type IN ("
-      "'chart_of_accounts', 'mapping', 'schedule', "
-      "'classification-vocabulary', 'classification-assignment', 'rules', "
-      "'reporting_standard', 'reporting_extension', 'custom_ontology'"
-      ")",
+      "taxonomy_type IN (" + ", ".join(f"'{v}'" for v in TAXONOMY_TYPE_VALUES) + ")",
       name="check_taxonomy_type",
     ),
     CheckConstraint(

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from robosystems.logger import logger
@@ -162,6 +163,24 @@ def _assert_not_duplicate(session: Session, body: CreateEventBlockRequest) -> No
     raise DuplicateEventError(body.source, body.external_id)
 
 
+def _flush_new_event(
+  session: Session, event: Event, body: CreateEventBlockRequest
+) -> None:
+  """Flush a freshly added Event, translating the partial unique index on
+  ``(source, external_id)`` into ``DuplicateEventError``.
+
+  ``_assert_not_duplicate`` ran first, but two identical posts racing past
+  it both reach the insert; the index is the truth and its answer is the
+  same one the pre-check gives — not a 500.
+  """
+  try:
+    session.flush()
+  except IntegrityError as exc:
+    if body.external_id and "external_id" in str(exc.orig):
+      raise DuplicateEventError(body.source, body.external_id) from exc
+    raise
+
+
 def _validate_event_source(source: str, graph_id: str) -> None:
   """A source is valid iff it's platform-emitted or registered on the graph.
 
@@ -274,7 +293,7 @@ def create_event_block(
 
       event = _build_event_row(body, created_by, status=python_handler.target_status)
       session.add(event)
-      session.flush()
+      _flush_new_event(session, event, body)
 
       if body.dimension_ids:
         session.execute(
@@ -309,7 +328,7 @@ def create_event_block(
 
     event = _build_event_row(body, created_by, status="classified")
     session.add(event)
-    session.flush()
+    _flush_new_event(session, event, body)
 
     if body.dimension_ids:
       session.execute(
@@ -328,7 +347,7 @@ def create_event_block(
   # Capture-only path (apply_handlers=False)
   event = _build_event_row(body, created_by, status="captured")
   session.add(event)
-  session.flush()
+  _flush_new_event(session, event, body)
 
   if body.dimension_ids:
     session.execute(

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -21,6 +21,7 @@ from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from robosystems.db.integrity import violates
 from robosystems.logger import logger
 from robosystems.models.api.event_block import (
   CreateEventBlockRequest,
@@ -176,7 +177,7 @@ def _flush_new_event(
   try:
     session.flush()
   except IntegrityError as exc:
-    if body.external_id and "external_id" in str(exc.orig):
+    if body.external_id and violates(exc, "idx_events_source_external"):
       raise DuplicateEventError(body.source, body.external_id) from exc
     raise
 

--- a/robosystems/operations/event_block/qb_writeback.py
+++ b/robosystems/operations/event_block/qb_writeback.py
@@ -28,7 +28,7 @@ so a multi-entry RL event becomes N round-trips. The returned
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import requests
@@ -356,7 +356,7 @@ def _save_with_retry(
       "code": "qb_transport_error" if is_network else "qb_validation_error",
       "message": str(e),
       "qb_error_code": getattr(e, "error_code", None) if not is_network else None,
-      "qb_response_at": datetime.now().isoformat(),
+      "qb_response_at": datetime.now(UTC).isoformat(),
       "event_id": event_id,
       "request_id": request_id,
     }

--- a/robosystems/operations/graph/deprovision_service.py
+++ b/robosystems/operations/graph/deprovision_service.py
@@ -45,7 +45,17 @@ class DeprovisionResult:
     if self.status == "not_found":
       return f"Graph {self.graph_id} not found"
     if self.status == "already_deprovisioned":
-      return f"Graph {self.graph_id} is already deprovisioned"
+      redone = []
+      if self.extensions_schema_dropped:
+        redone.append("extensions schema dropped")
+      if self.search_purged:
+        redone.append("search index purged")
+      if self.report_bundles_deleted:
+        redone.append(f"{self.report_bundles_deleted} report bundle(s) deleted")
+      suffix = (
+        f"; residual data disposal re-run ({', '.join(redone)})" if redone else ""
+      )
+      return f"Graph {self.graph_id} is already deprovisioned{suffix}"
     if self.status == "rejected":
       return (
         self.errors[0]
@@ -63,6 +73,46 @@ class DeprovisionResult:
     if self.subgraphs_deleted > 0:
       parts.append(f"({self.subgraphs_deleted} subgraphs removed)")
     return " ".join(parts)
+
+
+def find_orphan_tenant_schemas(session: Session) -> list[str]:
+  """Tenant schemas in the extensions database that no live graph owns.
+
+  A schema is an orphan when its graph id has no platform ``Graph`` row, or
+  the row is deprovisioned / soft-deleted. Every ``for_each_tenant_schema``
+  migration keeps operating on such a schema, and the data in it belongs to
+  a tenant the platform no longer serves. Read-only; ``purge_orphan_tenant_schemas``
+  drops them.
+  """
+  from ...db.extensions import list_tenant_schemas
+  from ...models.core.graph import Graph, GraphStatus
+
+  schemas = list_tenant_schemas()
+  if not schemas:
+    return []
+  live = {
+    graph_id
+    for (graph_id,) in session.query(Graph.graph_id)
+    .filter(
+      Graph.graph_id.in_(schemas),
+      Graph.status != GraphStatus.DEPROVISIONED.value,
+      Graph.deleted_at.is_(None),
+    )
+    .all()
+  }
+  return [schema for schema in schemas if schema not in live]
+
+
+def purge_orphan_tenant_schemas(session: Session) -> list[str]:
+  """Drop every orphan tenant schema. Returns the ids that were dropped."""
+  from ...db.extensions import drop_tenant_schema
+
+  dropped: list[str] = []
+  for graph_id in find_orphan_tenant_schemas(session):
+    if drop_tenant_schema(graph_id):
+      logger.info(f"Dropped orphan extensions schema {graph_id}")
+      dropped.append(graph_id)
+  return dropped
 
 
 class GraphDeprovisionService:
@@ -105,8 +155,16 @@ class GraphDeprovisionService:
       return result
 
     if graph.status == GraphStatus.DEPROVISIONED.value:
+      # The status flipped even when a data-disposal step failed (`partial`),
+      # and there was no way back in: a ghost tenant schema, index documents,
+      # or report bundles stayed behind for good, and every per-tenant
+      # migration kept operating on the ghost. Re-running the disposal steps
+      # is idempotent — DROP SCHEMA IF EXISTS, delete-by-graph, prefix
+      # delete — so an already-deprovisioned graph re-runs exactly those and
+      # nothing else (no backup, no database, no registry, no status change).
       result.status = "already_deprovisioned"
       result.previous_status = graph.status
+      self._dispose_residual_data(graph_id, result)
       return result
 
     # Shared repositories (SEC, etc.) are platform-managed and must never
@@ -123,6 +181,15 @@ class GraphDeprovisionService:
 
     result.previous_status = graph.status or "active"
 
+    # --- 0. Mark the graph as leaving, and make it visible now ---
+    # `deleted_at` is stamped and committed before anything is dropped, so
+    # a QuickBooks sync already in flight cannot re-provision the tenant
+    # schema between step 3b (drop) and step 7 (status flip): the schema
+    # provisioner refuses a graph with `deleted_at` set. Status stays as it
+    # was until teardown ends, so a partial run still reads as unfinished.
+    graph.deleted_at = datetime.now(UTC)
+    session.commit()
+
     # --- 1. Create final backup ---
     if create_backup and not skip_backup_check:
       await self._create_final_backup(graph, session, result)
@@ -133,14 +200,11 @@ class GraphDeprovisionService:
     # --- 3. Delete parent database ---
     await self._delete_database(graph_id, result)
 
-    # --- 3b. Drop extensions OLTP schema (financial-data removal) ---
-    self._drop_extensions_schema(graph_id, result)
-
-    # --- 3c. Purge documents from the shared search index ---
-    self._purge_search_index(graph_id, result)
-
-    # --- 3d. Purge published report artifacts from object storage ---
-    self._purge_report_bundles(graph_id, result)
+    # --- 3b-3d. Dispose of the tenant's data outside the graph database:
+    # the extensions OLTP schema, the shared search index, and the published
+    # report artifacts. Idempotent, so a re-run on an already-deprovisioned
+    # graph can finish what a partial teardown left behind.
+    self._dispose_residual_data(graph_id, result)
 
     # --- 4. Deallocate DynamoDB registry ---
     await self._deallocate_registry(graph_id, result)
@@ -151,8 +215,7 @@ class GraphDeprovisionService:
     # --- 6. Update subscription metadata ---
     self._update_subscription_metadata(graph_id, session, result)
 
-    # --- 7. Soft-delete and transition status ---
-    graph.deleted_at = datetime.now(UTC)
+    # --- 7. Transition status (soft-delete stamp landed in step 0) ---
     graph.transition_status(GraphStatus.DEPROVISIONED, session)
 
     if result.errors:
@@ -353,6 +416,12 @@ class GraphDeprovisionService:
       error_msg = f"Database deletion failed: {e}"
       result.errors.append(error_msg)
       logger.warning(error_msg, extra={"graph_id": graph_id})
+
+  def _dispose_residual_data(self, graph_id: str, result: DeprovisionResult) -> None:
+    """The three data-disposal steps that are safe to repeat."""
+    self._drop_extensions_schema(graph_id, result)
+    self._purge_search_index(graph_id, result)
+    self._purge_report_bundles(graph_id, result)
 
   def _drop_extensions_schema(self, graph_id: str, result: DeprovisionResult) -> None:
     """Drop the tenant's extensions OLTP schema (financial-data removal).

--- a/robosystems/operations/information_block/forecast.py
+++ b/robosystems/operations/information_block/forecast.py
@@ -34,6 +34,7 @@ from datetime import date
 from typing import TYPE_CHECKING
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
 from robosystems.models.api.fact_provenance import AssertedProvenance
 from robosystems.models.api.information_block import (
@@ -473,8 +474,19 @@ def _ensure_scenario_dimension(session: Session, scenario_id: str, name: str) ->
     name=name,
     value=scenario_id,
   )
-  session.add(dimension)
-  session.flush()
+  try:
+    # Savepoint: the get-or-create is racy across two concurrent first
+    # writers of the same scenario; the loser reads the row that won.
+    with session.begin_nested():
+      session.add(dimension)
+      session.flush()
+  except IntegrityError:
+    return session.execute(
+      select(Dimension.id).where(
+        Dimension.dimension_type == "scenario",
+        Dimension.value == scenario_id,
+      )
+    ).scalar_one()
   return dimension.id
 
 
@@ -626,7 +638,18 @@ def create(
 
 
 def _load_forecast_or_404(session: Session, structure_id: str) -> Structure:
-  structure = session.get(Structure, structure_id)
+  # Locked: `update` merges into the `artifact_mechanics` JSON read here, so
+  # two concurrent updates on an unlocked row would each write the version
+  # they read. `delete` decides from the same read. `RowLockedError` on
+  # contention, mapped to 409 by the surface.
+  from robosystems.operations.locking import lock_by_id
+
+  structure = lock_by_id(
+    session,
+    Structure,
+    structure_id,
+    f"Forecast {structure_id} is being written by another process. Retry in a moment.",
+  )
   if structure is None or structure.block_type != FORECAST_BLOCK_TYPE:
     raise ValueError(
       f"Forecast structure_id={structure_id!r} not found (or wrong block_type)."

--- a/robosystems/operations/information_block/forecast.py
+++ b/robosystems/operations/information_block/forecast.py
@@ -36,6 +36,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
+from robosystems.db.integrity import violates
 from robosystems.models.api.fact_provenance import AssertedProvenance
 from robosystems.models.api.information_block import (
   ArtifactResponse,
@@ -480,13 +481,18 @@ def _ensure_scenario_dimension(session: Session, scenario_id: str, name: str) ->
     with session.begin_nested():
       session.add(dimension)
       session.flush()
-  except IntegrityError:
-    return session.execute(
+  except IntegrityError as exc:
+    if not violates(exc, "uq_dimension_type_value"):
+      raise
+    winner = session.execute(
       select(Dimension.id).where(
         Dimension.dimension_type == "scenario",
         Dimension.value == scenario_id,
       )
-    ).scalar_one()
+    ).scalar_one_or_none()
+    if winner is None:
+      raise
+    return winner
   return dimension.id
 
 

--- a/robosystems/operations/information_block/rollforward.py
+++ b/robosystems/operations/information_block/rollforward.py
@@ -154,7 +154,18 @@ def create(
 
 
 def _load_rollforward_or_404(session: Session, structure_id: str) -> Structure:
-  structure = session.get(Structure, structure_id)
+  # Locked: `update` merges into the `artifact_mechanics` JSON read here, so
+  # two concurrent updates on an unlocked row would each write the version
+  # they read. `delete` decides from the same read. `RowLockedError` on
+  # contention, mapped to 409 by the surface.
+  from robosystems.operations.locking import lock_by_id
+
+  structure = lock_by_id(
+    session,
+    Structure,
+    structure_id,
+    f"Rollforward {structure_id} is being written by another process. Retry in a moment.",
+  )
   if structure is None or structure.block_type != ROLLFORWARD_BLOCK_TYPE:
     raise ValueError(
       f"Rollforward structure_id={structure_id!r} not found (or wrong block_type)."

--- a/robosystems/operations/locking.py
+++ b/robosystems/operations/locking.py
@@ -224,7 +224,9 @@ def exclusive_period_fence(graph_id: str, period: str, *, detail: str):
       if getattr(exc.orig, "pgcode", None) in _RETRYABLE_LOCK_STATES:
         raise RowLockedError(detail) from exc
       raise
-    conn.execute(text("SET lock_timeout = 0"))
+    # RESET, not `SET ... = 0`: restore whatever the connection's default is
+    # (an engine-level setting, say) rather than pin it to "wait forever".
+    conn.execute(text("RESET lock_timeout"))
     conn.commit()
     yield
   finally:

--- a/robosystems/operations/locking.py
+++ b/robosystems/operations/locking.py
@@ -221,6 +221,15 @@ def exclusive_period_fence(graph_id: str, period: str, *, detail: str):
       )
       acquired = True
     except OperationalError as exc:
+      # The failed statement aborted the transaction; roll it back and clear
+      # the session-level timeout before the connection goes back to the
+      # pool, or the next borrower inherits a 3s lock_timeout it never set.
+      try:
+        conn.rollback()
+        conn.execute(text("RESET lock_timeout"))
+        conn.commit()
+      except Exception:
+        conn.invalidate()
       if getattr(exc.orig, "pgcode", None) in _RETRYABLE_LOCK_STATES:
         raise RowLockedError(detail) from exc
       raise

--- a/robosystems/operations/operators/__init__.py
+++ b/robosystems/operations/operators/__init__.py
@@ -41,6 +41,7 @@ from robosystems.operations.operators.base import (
   OperatorResponse,
   OperatorResult,
   OperatorSpec,
+  enforce_operator_graph_scope,
   enforce_operator_write_role,
   matches_graph_scope,
 )
@@ -116,6 +117,7 @@ __all__ = [
   "SessionCreditConsumer",
   "ToolAccess",
   "TrackedAIClient",
+  "enforce_operator_graph_scope",
   "enforce_operator_write_role",
   # Registry
   "get_operator",

--- a/robosystems/operations/operators/adapters/api.py
+++ b/robosystems/operations/operators/adapters/api.py
@@ -14,6 +14,7 @@ from robosystems.operations.operators.ai_client import AIClient
 from robosystems.operations.operators.base import (
   OperatorMode,
   OperatorResult,
+  enforce_operator_graph_scope,
   enforce_operator_write_role,
 )
 from robosystems.operations.operators.credit_consumer import SessionCreditConsumer
@@ -53,6 +54,7 @@ async def run_operator_api(
   # identity, so this is the only point at which the caller's graph role can
   # be checked on this path.
   enforce_operator_write_role(operator, graph_id, str(user.id))
+  enforce_operator_graph_scope(operator, graph_id)
 
   # Credits are consumed after each Bedrock call returns, so this pre-flight is
   # what bounds spend. The SSE and background-queue strategies reach this

--- a/robosystems/operations/operators/adapters/api.py
+++ b/robosystems/operations/operators/adapters/api.py
@@ -63,7 +63,9 @@ async def run_operator_api(
   # The tool surface must not exceed what the role gate above checked for:
   # a read-only operator skips the write-role gate, so it must also get a
   # read-only tool surface.
-  tools = HttpToolAccess(graph_id, read_only=operator.spec.read_only)
+  tools = HttpToolAccess(
+    graph_id, read_only=operator.spec.read_only, user_id=str(user.id)
+  )
   ai_client = AIClient()
 
   if db_session is None:

--- a/robosystems/operations/operators/adapters/worker.py
+++ b/robosystems/operations/operators/adapters/worker.py
@@ -61,7 +61,7 @@ async def run_operator_worker(
   finally:
     preflight_session.close()
 
-  tools = DirectToolAccess(graph_id)
+  tools = DirectToolAccess(graph_id, user_id=user_id)
   ai_client = AIClient()
   credit_consumer = FactoryCreditConsumer()
 

--- a/robosystems/operations/operators/adapters/worker.py
+++ b/robosystems/operations/operators/adapters/worker.py
@@ -15,6 +15,7 @@ from robosystems.logger import logger
 from robosystems.operations.operators.ai_client import AIClient
 from robosystems.operations.operators.base import (
   OperatorMode,
+  enforce_operator_graph_scope,
   enforce_operator_write_role,
 )
 from robosystems.operations.operators.credit_consumer import FactoryCreditConsumer
@@ -54,6 +55,7 @@ async def run_operator_worker(
   # have been revoked — or the balance spent — in between. Same reasoning as
   # `GraphCreationService._validate_org`.
   enforce_operator_write_role(operator, graph_id, user_id)
+  enforce_operator_graph_scope(operator, graph_id)
 
   preflight_session = SessionFactory()
   try:

--- a/robosystems/operations/operators/base.py
+++ b/robosystems/operations/operators/base.py
@@ -477,3 +477,35 @@ def enforce_operator_write_role(
   from robosystems.middleware.auth.dependencies import require_graph_write_role
 
   require_graph_write_role(user_id, graph_id)
+
+
+def enforce_operator_graph_scope(operator: Operator, graph_id: str) -> None:
+  """Refuse to run an operator on a graph outside its declared ``graph_scope``.
+
+  The orchestrator applies ``matches_graph_scope`` when it routes, but the
+  SSE, background-queue and worker paths call the execution adapters directly
+  and skipped it: a mapping operator scoped to ``roboledger`` could be started
+  on a graph with no ledger tenant, and its tools would then fail one by one
+  against a missing schema. Checked in the adapters, next to the write-role
+  gate, so every entry point inherits it. No-op for operators without a scope.
+
+  Raises:
+      HTTPException: 403 when the graph does not match the operator's scope.
+  """
+  scope = operator.spec.graph_scope
+  if scope is None:
+    return
+
+  from fastapi import HTTPException
+
+  from robosystems.middleware.mcp.tools.manager import resolve_schema_extensions
+
+  extensions = resolve_schema_extensions(graph_id)
+  if not matches_graph_scope(scope, graph_id, extensions):
+    raise HTTPException(
+      status_code=403,
+      detail=(
+        f"Operator '{operator.spec.name}' is not available on graph {graph_id}: "
+        "the graph is outside the operator's declared scope."
+      ),
+    )

--- a/robosystems/operations/operators/tool_access.py
+++ b/robosystems/operations/operators/tool_access.py
@@ -48,9 +48,12 @@ class HttpToolAccess:
   path. Defaults to read-only so a caller has to opt in to writes.
   """
 
-  def __init__(self, graph_id: str, read_only: bool = True) -> None:
+  def __init__(
+    self, graph_id: str, read_only: bool = True, user_id: str | None = None
+  ) -> None:
     self._graph_id = graph_id
     self._read_only = read_only
+    self._user_id = user_id
     self._client = None
     self._tools = None
 
@@ -67,6 +70,10 @@ class HttpToolAccess:
     from robosystems.middleware.mcp.tools.manager import resolve_schema_extensions
 
     self._client = await create_graph_mcp_client(graph_id=self._graph_id)
+    # The registrar tools stamp `created_by` from `client.user_id`; without it
+    # every write an operator makes is attributed to `mcp:{graph_id}`.
+    if self._user_id:
+      self._client.user_id = self._user_id
     schema_extensions = resolve_schema_extensions(self._graph_id)
     self._tools = GraphMCPTools(
       self._client,
@@ -152,13 +159,20 @@ class DirectToolAccess:
       result = await unmapped_tool.execute({"mapping_id": "..."})
   """
 
-  def __init__(self, graph_id: str) -> None:
+  def __init__(self, graph_id: str, user_id: str | None = None) -> None:
     self._graph_id = graph_id
+    self._user_id = user_id
     self._tool_instances: dict[str, Any] = {}
 
   @property
   def graph_id(self) -> str:
     return self._graph_id
+
+  @property
+  def user_id(self) -> str | None:
+    """The acting user, read by tools as ``client.user_id`` for
+    ``created_by`` — the operator's caller, not a fixed agent tag."""
+    return self._user_id
 
   def get_tool_instance(self, tool_class: type) -> Any:
     """Get or create a tool instance by class.

--- a/robosystems/operations/roboinvestor/commands/portfolio_block.py
+++ b/robosystems/operations/roboinvestor/commands/portfolio_block.py
@@ -183,14 +183,11 @@ def update_portfolio_block(
   for field, value in portfolio_patch.items():
     setattr(portfolio, field, value)
 
-  for spec in body.positions.add:
-    _add_position(session, body.portfolio_id, spec, created_by)
-
-  for patch in body.positions.update:
-    row = position_map[patch.id]
-    for field, value in patch.model_dump(exclude_unset=True, exclude={"id"}).items():
-      setattr(row, field, value)
-
+  # Disposals and patches first, adds last. `_add_position` flushes each add
+  # so a duplicate active position surfaces as its typed error — and the
+  # partial unique index is on *active* positions, so disposing a security's
+  # current position and re-adding it in the same call is legitimate only if
+  # the disposal has reached the database before the add is flushed.
   for spec in body.positions.dispose:
     row = position_map[spec.id]
     row.status = "disposed"
@@ -199,6 +196,16 @@ def update_portfolio_block(
       meta = dict(row.metadata_) if isinstance(row.metadata_, dict) else {}
       meta["disposition_reason"] = spec.disposition_reason
       row.metadata_ = meta
+
+  for patch in body.positions.update:
+    row = position_map[patch.id]
+    for field, value in patch.model_dump(exclude_unset=True, exclude={"id"}).items():
+      setattr(row, field, value)
+
+  session.flush()
+
+  for spec in body.positions.add:
+    _add_position(session, body.portfolio_id, spec, created_by)
 
   # Bump updated_at on the portfolio so the envelope reflects this write
   # even when only positions changed.

--- a/robosystems/operations/roboledger/commands/agent.py
+++ b/robosystems/operations/roboledger/commands/agent.py
@@ -73,7 +73,17 @@ def update_agent(
   body: UpdateAgentRequest,
   created_by: str,
 ) -> LedgerAgentResponse:
-  agent = session.get(Agent, body.agent_id)
+  # Locked: `metadata_patch` is a read-modify-write of a JSON blob, and two
+  # concurrent patches on an unlocked row would each merge into the version
+  # they read — the loser's keys silently gone.
+  from robosystems.operations.locking import lock_by_id
+
+  agent = lock_by_id(
+    session,
+    Agent,
+    body.agent_id,
+    f"Agent {body.agent_id} is being written by another process. Retry in a moment.",
+  )
   if agent is None:
     raise AgentNotFoundError(body.agent_id)
 

--- a/robosystems/operations/roboledger/commands/blocked_source_graphs.py
+++ b/robosystems/operations/roboledger/commands/blocked_source_graphs.py
@@ -11,6 +11,7 @@ from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from robosystems.db.integrity import violates
 from robosystems.models.api.extensions.blocked_source_graphs import (
   BlockedSourceGraphResponse,
   BlockSourceGraphRequest,
@@ -100,7 +101,9 @@ def block_source_graph(
       with session.begin_nested():
         session.add(existing)
         session.flush()
-    except IntegrityError:
+    except IntegrityError as exc:
+      if not violates(exc, "uq_blocked_source_graphs_source"):
+        raise
       existing = session.execute(
         select(BlockedSourceGraph).where(
           BlockedSourceGraph.source_graph_id == body.source_graph_id

--- a/robosystems/operations/roboledger/commands/blocked_source_graphs.py
+++ b/robosystems/operations/roboledger/commands/blocked_source_graphs.py
@@ -8,6 +8,7 @@ the deny list lives there rather than in the platform DB.
 from __future__ import annotations
 
 from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from robosystems.models.api.extensions.blocked_source_graphs import (
@@ -92,8 +93,20 @@ def block_source_graph(
       blocked_by=created_by,
       reason=body.reason,
     )
-    session.add(existing)
-    session.flush()
+    try:
+      # Savepoint: a concurrent block of the same source between the read
+      # above and this insert trips the unique key; that is the idempotent
+      # case, not a fault, so fall back to the row that won.
+      with session.begin_nested():
+        session.add(existing)
+        session.flush()
+    except IntegrityError:
+      existing = session.execute(
+        select(BlockedSourceGraph).where(
+          BlockedSourceGraph.source_graph_id == body.source_graph_id
+        )
+      ).scalar_one()
+      already_blocked = True
 
   purged_ids: list[str] = []
   if body.purge:
@@ -168,10 +181,11 @@ def _purge_shared_reports(session: Session, source_graph_id: str) -> list[str]:
   if not report_ids:
     return []
 
-  session.execute(
-    text("DELETE FROM fact_sets WHERE report_id = ANY(:report_ids)"),
-    {"report_ids": report_ids},
+  from robosystems.operations.roboledger.commands.reports import (
+    delete_report_fact_sets,
   )
+
+  delete_report_fact_sets(session, report_ids)
   session.execute(
     text("DELETE FROM reports WHERE id = ANY(:report_ids)"),
     {"report_ids": report_ids},

--- a/robosystems/operations/roboledger/commands/elements.py
+++ b/robosystems/operations/roboledger/commands/elements.py
@@ -22,6 +22,7 @@ from sqlalchemy import or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from robosystems.db.integrity import violates
 from robosystems.models.api.extensions.taxonomies import (
   CreateElementRequest,
   DeleteElementRequest,
@@ -268,7 +269,7 @@ def create_element(
     # Partial unique index `idx_elements_qname` fires when two CamelCased
     # account names collapse to the same qname. Translate to a domain
     # exception so the API layer can return 409 instead of 500.
-    if "idx_elements_qname" in str(exc.orig):
+    if violates(exc, "idx_elements_qname"):
       raise ElementQNameConflictError(resolved_qname) from exc
     raise
 

--- a/robosystems/operations/roboledger/commands/elements.py
+++ b/robosystems/operations/roboledger/commands/elements.py
@@ -210,13 +210,14 @@ def create_element(
 ) -> ElementResponse:
   """Create a new element within a taxonomy.
 
-  Internal helper. Tenant writes go through the taxonomy block surface
-  (``create-taxonomy-block`` / ``update-taxonomy-block``); this is
-  invoked indirectly by those operations.
+  Internal primitive, not mounted on any surface. Tenant element writes go
+  through the taxonomy block surface (``create-taxonomy-block`` /
+  ``update-taxonomy-block``), which has its own element path; this stays as
+  the single-element primitive for scripts and future callers.
 
   Raises `TaxonomyNotFoundError` if `body.taxonomy_id` does not exist,
-  or `ElementNotFoundError` if `body.parent_id` is set but the parent
-  does not exist.
+  `ElementNotFoundError` if `body.parent_id` is set but the parent does not
+  exist, or `ElementQNameConflictError` when the derived qname is taken.
   """
   taxonomy = session.execute(
     select(Taxonomy).where(Taxonomy.id == body.taxonomy_id)
@@ -257,14 +258,16 @@ def create_element(
     is_active=True,
     created_by=created_by,
   )
-  session.add(element)
   try:
-    session.flush()
+    # Under a savepoint: a qname collision must not roll back the caller's
+    # whole transaction — only this insert.
+    with session.begin_nested():
+      session.add(element)
+      session.flush()
   except IntegrityError as exc:
     # Partial unique index `idx_elements_qname` fires when two CamelCased
     # account names collapse to the same qname. Translate to a domain
     # exception so the API layer can return 409 instead of 500.
-    session.rollback()
     if "idx_elements_qname" in str(exc.orig):
       raise ElementQNameConflictError(resolved_qname) from exc
     raise

--- a/robosystems/operations/roboledger/commands/event_handler.py
+++ b/robosystems/operations/roboledger/commands/event_handler.py
@@ -91,7 +91,17 @@ def update_event_handler(
   body: UpdateEventHandlerRequest,
   created_by: str,
 ) -> EventHandlerResponse:
-  handler = session.get(EventHandler, body.event_handler_id)
+  # Locked: `metadata_patch` merges into the JSON blob read here, and the
+  # approve/template fields are decided from the row as read.
+  from robosystems.operations.locking import lock_by_id
+
+  handler = lock_by_id(
+    session,
+    EventHandler,
+    body.event_handler_id,
+    f"Event handler {body.event_handler_id} is being written by another "
+    "process. Retry in a moment.",
+  )
   if handler is None:
     raise EventHandlerNotFoundError(body.event_handler_id)
 

--- a/robosystems/operations/roboledger/commands/fiscal_calendar.py
+++ b/robosystems/operations/roboledger/commands/fiscal_calendar.py
@@ -287,69 +287,16 @@ def reopen_period(
   # concurrent reopens cannot both retract the same month's statements,
   # and a reopen cannot interleave with a close (that used to leave a
   # period marked closed whose statements had been retracted).
-  with exclusive_period_fence(
-    graph_id,
-    period,
-    detail=(
-      f"Period {period} is being closed or reopened by another process. "
-      "Retry in a moment."
-    ),
-  ):
-    session.flush()
-    with bounded_lock_wait(
-      session,
-      f"Period {period} is being closed or reopened by another process. "
-      "Retry in a moment.",
-    ):
-      fp = (
-        session.query(FiscalPeriod)
-        .filter(FiscalPeriod.graph_id == graph_id, FiscalPeriod.name == period)
-        .populate_existing()
-        .with_for_update()
-        .one_or_none()
-      )
-    if fp is None:
-      raise PeriodNotFoundInLedgerError(period)
-    if fp.status != "closed":
-      raise PeriodNotClosedError(period, fp.status)
-
-    fp.status = "closing"
-    fp.closed_at = None
-    fp.closed_by = None
-    session.flush()
-
-    calendar = service.retreat_closed_through(
+  with exclusive_period_fence(graph_id, period, detail=_fence_detail(period)):
+    calendar, retracted = _reopen_under_fence(
       session,
       graph_id,
       period,
-      reason=reason,
       actor_id=actor_id,
-      actor_type=actor_type,
+      reason=reason,
       note=note,
-    )
-    # Re-stamp schedule facts the retreated boundary has re-opened: the
-    # reopened window's facts were tagged 'historical' at generation and
-    # must return to 'in_scope' so the roll-forward carry-in and the
-    # re-close see the movement. Function-level import — commands.schedules
-    # ↔ information_block.schedule form a module-load cycle that a
-    # top-level import here would trip.
-    from robosystems.operations.roboledger.commands.schedules import (
-      reinstate_reopened_schedule_scopes,
-    )
-
-    reinstate_reopened_schedule_scopes(session)
-
-    # Retract the reopened month's canonical statement sets.
-    # Function-level import — statement_sets pulls in information-block
-    # machinery this module otherwise never loads (same posture as the
-    # schedules import above).
-    from robosystems.operations.roboledger.reports.statement_sets import (
-      retract_canonical_statement_sets,
-    )
-
-    ps, pe = period_date_range(period)
-    retracted = retract_canonical_statement_sets(
-      session, period_start=ps, period_end=pe
+      service=service,
+      actor_type=actor_type,
     )
     session.commit()
 
@@ -366,6 +313,84 @@ def reopen_period(
     ),
     statement_sets_retracted=len(retracted),
   )
+
+
+def _fence_detail(period: str) -> str:
+  return (
+    f"Period {period} is being closed or reopened by another process. "
+    "Retry in a moment."
+  )
+
+
+def _reopen_under_fence(
+  session: Session,
+  graph_id: str,
+  period: str,
+  *,
+  actor_id: str,
+  reason: str,
+  note: str | None,
+  service: FiscalCalendarService,
+  actor_type: str,
+):
+  """The reopen's writes, flushed but not committed.
+
+  Caller holds the exclusive period fence and owns the commit. Split out so
+  the backfill can run a reopen and the re-close as one transaction: on
+  its own, a committed reopen followed by a failing close left closed
+  history open with its statements retracted.
+  """
+  session.flush()
+  with bounded_lock_wait(session, _fence_detail(period)):
+    fp = (
+      session.query(FiscalPeriod)
+      .filter(FiscalPeriod.graph_id == graph_id, FiscalPeriod.name == period)
+      .populate_existing()
+      .with_for_update()
+      .one_or_none()
+    )
+  if fp is None:
+    raise PeriodNotFoundInLedgerError(period)
+  if fp.status != "closed":
+    raise PeriodNotClosedError(period, fp.status)
+
+  fp.status = "closing"
+  fp.closed_at = None
+  fp.closed_by = None
+  session.flush()
+
+  calendar = service.retreat_closed_through(
+    session,
+    graph_id,
+    period,
+    reason=reason,
+    actor_id=actor_id,
+    actor_type=actor_type,
+    note=note,
+  )
+  # Re-stamp schedule facts the retreated boundary has re-opened: the
+  # reopened window's facts were tagged 'historical' at generation and
+  # must return to 'in_scope' so the roll-forward carry-in and the
+  # re-close see the movement. Function-level import — commands.schedules
+  # ↔ information_block.schedule form a module-load cycle that a
+  # top-level import here would trip.
+  from robosystems.operations.roboledger.commands.schedules import (
+    reinstate_reopened_schedule_scopes,
+  )
+
+  reinstate_reopened_schedule_scopes(session)
+
+  # Retract the reopened month's canonical statement sets.
+  # Function-level import — statement_sets pulls in information-block
+  # machinery this module otherwise never loads (same posture as the
+  # schedules import above).
+  from robosystems.operations.roboledger.reports.statement_sets import (
+    retract_canonical_statement_sets,
+  )
+
+  ps, pe = period_date_range(period)
+  retracted = retract_canonical_statement_sets(session, period_start=ps, period_end=pe)
+  return calendar, retracted
 
 
 def backfill_plan_history(
@@ -490,30 +515,42 @@ def backfill_plan_history(
     )
     try:
       if fp.status == "closed":
-        reopen_period(
+        # Reopen and re-close as ONE transaction under ONE exclusive fence.
+        # `reopen_period` commits inside its own fence; if the close that
+        # followed then failed, closed history was left open with its
+        # statements retracted, and the rollback below could not undo it.
+        # The window has no drafts (checked above), so the close's only
+        # mid-flow commit — the QuickBooks marker commit inside
+        # `_publish_drafts_to_qb` — has nothing to publish and never runs;
+        # the reopen's writes and the re-close therefore commit together or
+        # roll back together.
+        close_result = _restamp_closed_period(
           session,
           platform_db,
           graph_id,
           period,
           actor_id=actor_id,
-          reason="plan history backfill",
           note=body.note,
           service=service,
+          close_service=close_service,
           actor_type=actor_type,
+          allow_stale_sync=body.allow_stale_sync,
+          allow_stranded_obligations=body.allow_stranded_obligations,
         )
-      close_result = close_period(
-        session,
-        platform_db,
-        graph_id,
-        period,
-        actor_id=actor_id,
-        allow_stale_sync=body.allow_stale_sync,
-        note=body.note,
-        service=service,
-        close_service=close_service,
-        actor_type=actor_type,
-        allow_stranded_obligations=body.allow_stranded_obligations,
-      )
+      else:
+        close_result = close_period(
+          session,
+          platform_db,
+          graph_id,
+          period,
+          actor_id=actor_id,
+          allow_stale_sync=body.allow_stale_sync,
+          note=body.note,
+          service=service,
+          close_service=close_service,
+          actor_type=actor_type,
+          allow_stranded_obligations=body.allow_stranded_obligations,
+        )
       processed.append(
         BackfillPeriodOutcome(
           period=period,
@@ -555,4 +592,74 @@ def backfill_plan_history(
     period_rows_created=rows_created,
     processed=processed,
     remaining_periods=remaining,
+  )
+
+
+def _restamp_closed_period(
+  session: Session,
+  platform_db: Session,
+  graph_id: str,
+  period: str,
+  *,
+  actor_id: str,
+  note: str | None,
+  service: FiscalCalendarService,
+  close_service: PeriodCloseService,
+  actor_type: str,
+  allow_stale_sync: bool,
+  allow_stranded_obligations: bool,
+) -> ClosePeriodResponse:
+  """Reopen a closed period and close it again in one transaction.
+
+  Used by the backfill to re-stamp a month's canonical statements. Holds the
+  exclusive period fence across both halves and commits once, so a failure
+  anywhere — close gate, unbalanced ledger, statement stamp — rolls the
+  reopen back with it and the period stays exactly as it was.
+  """
+  has_sync, last_sync_at = qb_sync_state(platform_db, graph_id)
+  with exclusive_period_fence(graph_id, period, detail=_fence_detail(period)):
+    _reopen_under_fence(
+      session,
+      graph_id,
+      period,
+      actor_id=actor_id,
+      reason="plan history backfill",
+      note=note,
+      service=service,
+      actor_type=actor_type,
+    )
+    result = close_service.close(
+      session,
+      graph_id,
+      period,
+      actor_id=actor_id,
+      actor_type=actor_type,
+      has_sync_connection=has_sync,
+      last_sync_at=last_sync_at,
+      allow_stale_sync=allow_stale_sync,
+      allow_stranded_obligations=allow_stranded_obligations,
+      note=note,
+    )
+    session.commit()
+
+  from robosystems.operations.extensions.staleness import mark_graph_stale
+
+  mark_graph_stale(graph_id, "period_closed")
+
+  fc_response = build_fiscal_calendar_response(
+    session, graph_id, result.calendar, has_sync, last_sync_at, service
+  )
+  return ClosePeriodResponse(
+    fiscal_calendar=fc_response,
+    period=result.period,
+    entries_posted=result.entries_posted,
+    entries_published_to_qb=result.entries_published_to_qb,
+    entries_posted_locally=result.entries_posted_locally,
+    target_auto_advanced=result.target_auto_advanced,
+    rule_summary=result.rule_summary,
+    evaluated_structure_ids=list(result.evaluated_structure_ids),
+    statements_stamped=result.statements_stamped,
+    statement_stamp_note=result.statement_stamp_note,
+    stamped_statement_sets=dict(result.stamped_statement_sets),
+    statement_rule_summary=result.statement_rule_summary,
   )

--- a/robosystems/operations/roboledger/commands/publish_lists.py
+++ b/robosystems/operations/roboledger/commands/publish_lists.py
@@ -153,17 +153,26 @@ def add_publish_list_members(
 ) -> list[PublishListMemberResponse]:
   """Add target graphs to a publish list.
 
-  Validates that target graphs exist and have the `roboledger`
-  extension, prevents self-add, and rejects duplicates.
+  Only the list's owner may change its membership — the same rule
+  ``update_publish_list`` / ``delete_publish_list`` apply — since the list
+  decides where that owner's next share is delivered. Validates that target
+  graphs exist and can receive a share (they hold an extensions tenant:
+  ``roboledger`` or ``roboinvestor``, the same rule ``share_report``
+  applies to a recipient), prevents self-add, and rejects duplicates.
   """
   from robosystems.db.platform import SessionFactory
   from robosystems.models.core import Graph
+  from robosystems.operations.roboledger.commands.reports import (
+    _RECEIVING_EXTENSIONS,
+  )
 
   publish_list = session.execute(
     select(PublishList).where(PublishList.id == list_id)
   ).scalar_one_or_none()
   if publish_list is None:
     raise PublishListNotFoundError(list_id)
+  if publish_list.created_by != added_by:
+    raise PublishListNotAuthorizedError("Not authorized to modify this publish list.")
 
   with SessionFactory() as platform_session:
     graphs = (
@@ -181,7 +190,7 @@ def add_publish_list_members(
 
     for g in graphs:
       extensions = g.schema_extensions or []
-      if "roboledger" not in extensions:
+      if not any(ext in extensions for ext in _RECEIVING_EXTENSIONS):
         raise TargetGraphMissingExtensionError(str(g.graph_id))
 
   if current_graph_id in body.target_graph_ids:
@@ -214,11 +223,21 @@ def add_publish_list_members(
   return enrich_members(added)
 
 
-def remove_publish_list_member(session: Session, list_id: str, member_id: str) -> bool:
+def remove_publish_list_member(
+  session: Session, list_id: str, member_id: str, acting_user_id: str
+) -> bool:
   """Remove a member from a publish list.
 
-  Returns False if the member was not found in this list.
+  Returns False if the member was not found in this list. Raises
+  ``PublishListNotAuthorizedError`` if the caller does not own the list.
   """
+  publish_list = session.execute(
+    select(PublishList).where(PublishList.id == list_id)
+  ).scalar_one_or_none()
+  if publish_list is None:
+    return False
+  if publish_list.created_by != acting_user_id:
+    raise PublishListNotAuthorizedError("Not authorized to modify this publish list.")
   row = session.execute(
     select(PublishListMember).where(
       PublishListMember.id == member_id,

--- a/robosystems/operations/roboledger/commands/publish_lists.py
+++ b/robosystems/operations/roboledger/commands/publish_lists.py
@@ -218,7 +218,12 @@ def add_publish_list_members(
     )
     session.add(member)
     added.append(member)
-  session.flush()
+  try:
+    session.flush()
+  except IntegrityError as exc:
+    # A concurrent add of the same recipient slipped between the check above
+    # and this insert; the unique key says so. Same answer as the check.
+    raise MembersAlreadyPresentError(list(body.target_graph_ids)) from exc
 
   return enrich_members(added)
 

--- a/robosystems/operations/roboledger/commands/publish_lists.py
+++ b/robosystems/operations/roboledger/commands/publish_lists.py
@@ -6,6 +6,7 @@ from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from robosystems.db.integrity import violates
 from robosystems.models.api.extensions.publish_lists import (
   AddMembersRequest,
   CreatePublishListRequest,
@@ -223,6 +224,8 @@ def add_publish_list_members(
   except IntegrityError as exc:
     # A concurrent add of the same recipient slipped between the check above
     # and this insert; the unique key says so. Same answer as the check.
+    if not violates(exc, "uq_publish_list_members_pair"):
+      raise
     raise MembersAlreadyPresentError(list(body.target_graph_ids)) from exc
 
   return enrich_members(added)

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -7,6 +7,7 @@ here because it's only used by `share_report`.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import Any
 
@@ -593,13 +594,8 @@ def regenerate_report(
     taxonomy_id=report_def.taxonomy_id,
   )
   # Stale rows from the prior generation must clear before fresh ULIDs
-  # land. The FK `facts.fact_set_id → fact_sets.id` is ON DELETE CASCADE,
-  # so dropping the parent fact_sets cleans the child facts in one
-  # statement.
-  session.execute(
-    text("DELETE FROM fact_sets WHERE report_id = :report_id"),
-    {"report_id": report_def.id},
-  )
+  # land — facts by cascade, verification results by the sweep.
+  delete_report_fact_sets(session, [report_def.id])
   _pre_create_report_fact_sets(
     session,
     report_def.id,
@@ -849,11 +845,7 @@ def delete_report(
       f"retiring; deletion is only available for 'draft' or 'under_review'."
     )
 
-  # Facts cascade from their parent fact_sets on delete.
-  session.execute(
-    text("DELETE FROM fact_sets WHERE report_id = :report_id"),
-    {"report_id": report_id},
-  )
+  delete_report_fact_sets(session, [report_id])
   session.delete(report_def)
   session.commit()
   return True
@@ -1237,6 +1229,30 @@ def _copy_publication_artifacts(
     )
 
 
+def delete_report_fact_sets(session: Session, report_ids: Sequence[str]) -> None:
+  """Delete the statement sets of these reports, and what hangs off them.
+
+  Facts cascade from ``fact_sets`` at the DB level. ``verification_results``
+  only *loosely* references a set (``fact_set_id`` carries no FK), so it has
+  to be swept here or every regenerate, delete, purge and re-share leaves the
+  evaluated rule results of the removed snapshot behind as orphans.
+  """
+  ids = list(report_ids)
+  if not ids:
+    return
+  session.execute(
+    text(
+      "DELETE FROM verification_results WHERE fact_set_id IN "
+      "(SELECT id FROM fact_sets WHERE report_id = ANY(:report_ids))"
+    ),
+    {"report_ids": ids},
+  )
+  session.execute(
+    text("DELETE FROM fact_sets WHERE report_id = ANY(:report_ids)"),
+    {"report_ids": ids},
+  )
+
+
 def delete_report_artifacts(graph_id: str, report_ids: list[str]) -> None:
   """Remove the object-store artifacts of reports whose rows are gone.
 
@@ -1257,7 +1273,13 @@ def delete_report_artifacts(graph_id: str, report_ids: list[str]) -> None:
   if not report_ids:
     return
   bucket = env.USER_DATA_BUCKET
-  s3 = S3Client()
+  try:
+    s3 = S3Client()
+  except Exception as exc:
+    # Runs after the row deletion committed; a storage client that cannot be
+    # built must not turn a completed withdrawal into a failed request.
+    logger.warning("Object store unavailable; leaving report artifacts: %s", exc)
+    return
   for report_id in report_ids:
     prefix = get_report_bundle_prefix(graph_id, report_id)
     try:
@@ -1301,11 +1323,7 @@ def _delete_copies_in_session(
   if not copy_ids:
     return []
 
-  # Facts cascade from their parent fact_sets, so the fact_sets go first.
-  target_session.execute(
-    text("DELETE FROM fact_sets WHERE report_id = ANY(:report_ids)"),
-    {"report_ids": copy_ids},
-  )
+  delete_report_fact_sets(target_session, copy_ids)
   target_session.execute(
     text("DELETE FROM reports WHERE id = ANY(:report_ids)"),
     {"report_ids": copy_ids},

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -477,6 +477,27 @@ def create_report(
   return resp
 
 
+def _assert_report_mutable_by(
+  report_def: Report, acting_user_id: str, verb: str
+) -> None:
+  """The one rule for who may change a report's content or lifecycle.
+
+  A report is mutable by its author. A copy shared in from another graph
+  (``source_graph_id`` set) is a read-only snapshot in this graph for
+  everyone — including the sender, who may be a member here too and whose
+  ``created_by`` the copy carries; the way to change it is to re-share from
+  the source. Removing a shared-in copy is the recipient graph admin's call
+  and is widened separately in ``delete_report``.
+  """
+  if report_def.source_graph_id is not None:
+    raise NotAuthorizedError(
+      f"Report '{report_def.id}' is a copy shared in from another graph and "
+      f"cannot be changed here; re-share it from the source graph instead."
+    )
+  if report_def.created_by != acting_user_id:
+    raise NotAuthorizedError(f"Not authorized to {verb} this report.")
+
+
 def regenerate_report(
   session: Session,
   graph_id: str,
@@ -521,8 +542,7 @@ def regenerate_report(
   )
   if report_def is None:
     raise ReportNotFoundError(report_id)
-  if report_def.created_by != acting_user_id:
-    raise NotAuthorizedError("Not authorized to modify this report.")
+  _assert_report_mutable_by(report_def, acting_user_id, "modify")
   if report_def.filing_status in {"filed", "archived"}:
     raise InvalidFilingTransitionError(
       f"Report '{report_id}' is in '{report_def.filing_status}'; "
@@ -656,8 +676,10 @@ def file_report(session: Session, report_id: str, filed_by: str) -> ReportRespon
   Allowed from ``draft`` or ``under_review`` and only when generation
   has reached ``published``. Stamps ``filed_at`` and ``filed_by`` for
   audit. Raises :class:`ReportNotFoundError` when the Report doesn't
-  exist and :class:`InvalidFilingTransitionError` when the current
-  filing or generation status isn't a legal source for filing.
+  exist, :class:`NotAuthorizedError` when ``filed_by`` is not the report's
+  author (or the report is a shared-in copy), and
+  :class:`InvalidFilingTransitionError` when the current filing or
+  generation status isn't a legal source for filing.
 
   ``filing_status`` and ``generation_status`` are orthogonal axes, but
   filing an in-progress or failed report would lock an empty / partial
@@ -685,6 +707,7 @@ def file_report(session: Session, report_id: str, filed_by: str) -> ReportRespon
   )
   if report_def is None:
     raise ReportNotFoundError(report_id)
+  _assert_report_mutable_by(report_def, filed_by, "file")
 
   if report_def.filing_status not in {"draft", "under_review"}:
     raise InvalidFilingTransitionError(
@@ -713,13 +736,14 @@ def file_report(session: Session, report_id: str, filed_by: str) -> ReportRespon
 
 
 def transition_filing_status(
-  session: Session, report_id: str, target_status: str
+  session: Session, report_id: str, target_status: str, acting_user_id: str
 ) -> ReportResponse:
   """Move a Report along the non-file legs of the filing lifecycle.
 
   Use :func:`file_report` to reach ``filed`` (so audit fields land).
   Other transitions (submit for review, withdraw, archive) are routed
-  through here so the legal-transition graph stays in one place.
+  through here so the legal-transition graph stays in one place. Same
+  actor rule as filing: the report's author, never a shared-in copy.
   """
   # Locked with the rest of the report lifecycle. Unlocked, this reads a status,
   # waits behind a concurrent file, and then writes its own over the top —
@@ -739,6 +763,7 @@ def transition_filing_status(
   )
   if report_def is None:
     raise ReportNotFoundError(report_id)
+  _assert_report_mutable_by(report_def, acting_user_id, "change the status of")
 
   legal_targets = _LEGAL_NON_FILE_TRANSITIONS.get(report_def.filing_status, set())
   if target_status not in legal_targets:
@@ -846,10 +871,22 @@ def share_report(
   sessions (source graph + each target graph + platform DB) as the
   share workflow requires. Raises `PublishListNotFoundError`,
   `PublishListEmptyError`, `ReportNotFoundError`,
-  `NotAuthorizedError`, or `ReportNotPublishedError` — caller
-  translates to appropriate HTTP status codes.
+  `NotAuthorizedError`, `ReportNotPublishedError`, or `RowLockedError`
+  — caller translates to appropriate HTTP status codes.
+
+  The source report stays row-locked for the whole share — snapshot,
+  copies into every recipient, and the ``ReportShare`` rows — in one
+  source transaction. That is what keeps the seam consistent: a
+  concurrent ``delete_report`` / ``regenerate_report`` / ``file_report``
+  waits (bounded) instead of removing or rewriting the report between the
+  snapshot and the share rows, a second share of the same report cannot
+  interleave its copies with this one, and the two snapshot reads see one
+  version of the facts. The lock is held across the S3 read and the
+  recipient writes deliberately; a share is seconds, and the alternative was
+  recipients holding copies the sender could no longer revoke.
   """
   from robosystems.db.extensions import extensions_session
+  from robosystems.operations.locking import lock_by_id
 
   results: list[ShareResultItem] = []
 
@@ -874,7 +911,12 @@ def share_report(
 
     target_graph_ids = [m.target_graph_id for m in members]
 
-    report_def = source_session.get(Report, report_id)
+    report_def = lock_by_id(
+      source_session,
+      Report,
+      report_id,
+      f"Report {report_id} is being written by another process. Retry in a moment.",
+    )
     if report_def is None:
       raise ReportNotFoundError(report_id)
     # Strict ownership, deliberately — NOT the graph-admin widening that
@@ -937,29 +979,26 @@ def share_report(
     ).fetchall()
     source_facts = [row._asdict() for row in fact_rows]
 
-  # Read once, after the sender's session closes — S3 round-trips have no
-  # business holding a database connection open — and reused for every target,
-  # since each gets the same bytes.
-  publication_artifacts = _load_publication_artifacts(
-    graph_id, report_id, int(report_snapshot["generation_count"])
-  )
-
-  for target_graph_id in target_graph_ids:
-    result = _share_to_target(
-      source_graph_id=graph_id,
-      report_snapshot=report_snapshot,
-      source_fact_sets=source_fact_sets,
-      source_facts=source_facts,
-      publication_artifacts=publication_artifacts,
-      target_graph_id=target_graph_id,
-      shared_by=acting_user_id,
+    # Read once and reused for every target, since each gets the same bytes.
+    publication_artifacts = _load_publication_artifacts(
+      graph_id, report_id, int(report_snapshot["generation_count"])
     )
-    results.append(result)
 
-  successful = [r for r in results if r.status == "shared"]
-  if successful:
-    now = datetime.now(UTC)
-    with extensions_session(graph_id) as source_session:
+    for target_graph_id in target_graph_ids:
+      result = _share_to_target(
+        source_graph_id=graph_id,
+        report_snapshot=report_snapshot,
+        source_fact_sets=source_fact_sets,
+        source_facts=source_facts,
+        publication_artifacts=publication_artifacts,
+        target_graph_id=target_graph_id,
+        shared_by=acting_user_id,
+      )
+      results.append(result)
+
+    successful = [r for r in results if r.status == "shared"]
+    if successful:
+      now = datetime.now(UTC)
       for result in successful:
         # One active share row per (report, recipient). A re-share replaces
         # the recipient's copy rather than adding a second, so the record of
@@ -992,7 +1031,7 @@ def share_report(
               fact_count=result.fact_count,
             )
           )
-      source_session.commit()
+    source_session.commit()
 
   return ShareReportResponse(report_id=report_id, results=results)
 
@@ -1550,6 +1589,16 @@ def _share_to_target(
 
       _ensure_linked_entity(target_session, source_graph_id, shared_by)
 
+      # Checked again at the end of the copy: a block that committed while
+      # this copy was being written must still win, or the recipient's purge
+      # (which ran after their block) leaves this copy behind.
+      if is_source_blocked(target_session, source_graph_id):
+        target_session.rollback()
+        return ShareResultItem(
+          target_graph_id=target_graph_id,
+          status="error",
+          error="Recipient has blocked shares from this graph.",
+        )
       target_session.commit()
 
     # After the commit, and only for the ids the replace actually removed — the

--- a/robosystems/operations/roboledger/commands/taxonomies.py
+++ b/robosystems/operations/roboledger/commands/taxonomies.py
@@ -16,6 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from robosystems.db.integrity import violates
 from robosystems.models.api.common import DeleteResult
 from robosystems.models.api.extensions.taxonomies import (
   AssociationResponse,
@@ -285,7 +286,10 @@ def create_mapping_association(
     session.flush()
   except IntegrityError as exc:
     # The pre-check above lost a race with a concurrent identical insert; the
-    # unique key is the truth. Same answer as the check.
+    # unique key is the truth. Same answer as the check. Any other constraint
+    # is a real fault and keeps its identity.
+    if not violates(exc, "uq_association_structure_elements_type"):
+      raise
     raise MappingAssociationExistsError(
       body.mapping_id, body.from_element_id, body.to_element_id
     ) from exc
@@ -622,6 +626,8 @@ def link_entity_taxonomy(
     # Concurrent identical adoption, or a concurrent primary for the same
     # basis (`idx_entity_taxonomies_primary`) landing between the clear above
     # and this insert. Both are "already linked", not a fault.
+    if not violates(exc, "uq_entity_taxonomy_combo", "idx_entity_taxonomies_primary"):
+      raise
     raise EntityTaxonomyConflictError(
       f"Entity {entity.id} already has a {body.basis!r} link to taxonomy "
       f"{body.taxonomy_id!r} (or another primary for that basis landed "

--- a/robosystems/operations/roboledger/commands/taxonomies.py
+++ b/robosystems/operations/roboledger/commands/taxonomies.py
@@ -13,6 +13,7 @@ all delegate here.
 from __future__ import annotations
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from robosystems.models.api.common import DeleteResult
@@ -112,6 +113,10 @@ class ElementNotFoundError(LookupError):
     super().__init__(f"{side} element not found: {element_id}")
     self.side = side  # "source" or "target"
     self.element_id = element_id
+
+
+class EntityTaxonomyConflictError(ValueError):
+  """An entity↔taxonomy adoption collided with a concurrent identical link."""
 
 
 class MappingAssociationExistsError(ValueError):
@@ -276,7 +281,14 @@ def create_mapping_association(
     created_by=created_by,
   )
   session.add(assoc)
-  session.flush()
+  try:
+    session.flush()
+  except IntegrityError as exc:
+    # The pre-check above lost a race with a concurrent identical insert; the
+    # unique key is the truth. Same answer as the check.
+    raise MappingAssociationExistsError(
+      body.mapping_id, body.from_element_id, body.to_element_id
+    ) from exc
 
   return AssociationResponse(
     id=assoc.id,
@@ -604,7 +616,17 @@ def link_entity_taxonomy(
     adoption_context=body.adoption_context,
   )
   session.add(adoption)
-  session.flush()
+  try:
+    session.flush()
+  except IntegrityError as exc:
+    # Concurrent identical adoption, or a concurrent primary for the same
+    # basis (`idx_entity_taxonomies_primary`) landing between the clear above
+    # and this insert. Both are "already linked", not a fault.
+    raise EntityTaxonomyConflictError(
+      f"Entity {entity.id} already has a {body.basis!r} link to taxonomy "
+      f"{body.taxonomy_id!r} (or another primary for that basis landed "
+      "concurrently). Retry to read the current state."
+    ) from exc
 
   return EntityTaxonomyResponse(
     entity_id=adoption.entity_id,

--- a/robosystems/operations/roboledger/fiscal_calendar/service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/service.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime, time
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from robosystems.logger import logger
@@ -229,7 +230,14 @@ class FiscalCalendarService:
       updated_by=created_by,
     )
     session.add(calendar)
-    session.flush()
+    try:
+      session.flush()
+    except IntegrityError as exc:
+      # Two initializations racing past the `get` above: the second one
+      # trips `uq_fiscal_calendar_graph`. Say what happened instead of 500.
+      raise CalendarAlreadyInitializedError(
+        f"Fiscal calendar for graph {graph_id} was initialized concurrently."
+      ) from exc
     logger.info(
       f"Created fiscal calendar for graph {graph_id} "
       f"(fiscal_year_start_month={fiscal_year_start_month})"

--- a/robosystems/operations/roboledger/fiscal_calendar/service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/service.py
@@ -30,6 +30,7 @@ from datetime import UTC, date, datetime, time
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from robosystems.db.integrity import violates
 from robosystems.logger import logger
 from robosystems.models.extensions.roboledger.event import Event
 from robosystems.models.extensions.roboledger.fiscal_calendar import (
@@ -235,6 +236,8 @@ class FiscalCalendarService:
     except IntegrityError as exc:
       # Two initializations racing past the `get` above: the second one
       # trips `uq_fiscal_calendar_graph`. Say what happened instead of 500.
+      if not violates(exc, "uq_fiscal_calendar_graph"):
+        raise
       raise CalendarAlreadyInitializedError(
         f"Fiscal calendar for graph {graph_id} was initialized concurrently."
       ) from exc

--- a/robosystems/operations/taxonomy_block/chart_of_accounts.py
+++ b/robosystems/operations/taxonomy_block/chart_of_accounts.py
@@ -9,6 +9,7 @@ handler writes every atom in one transaction.
 from __future__ import annotations
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from robosystems.models.api.taxonomy_block import (
@@ -178,7 +179,16 @@ def _auto_link_entity(session: Session, taxonomy_id: str) -> None:
       is_primary=True,
     )
   )
-  session.flush()
+  try:
+    session.flush()
+  except IntegrityError as exc:
+    # A concurrent CoA create linked the entity between the clear above and
+    # this insert (`idx_entity_taxonomies_primary`). Two CoA creates racing
+    # is a caller conflict, not a fault: say so.
+    raise ValueError(
+      "Another chart of accounts was linked to the entity concurrently; "
+      "retry after it completes."
+    ) from exc
 
 
 def create(

--- a/robosystems/operations/taxonomy_block/chart_of_accounts.py
+++ b/robosystems/operations/taxonomy_block/chart_of_accounts.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from robosystems.db.integrity import violates
 from robosystems.models.api.taxonomy_block import (
   CreateTaxonomyBlockRequest,
   DeleteTaxonomyBlockRequest,
@@ -185,6 +186,8 @@ def _auto_link_entity(session: Session, taxonomy_id: str) -> None:
     # A concurrent CoA create linked the entity between the clear above and
     # this insert (`idx_entity_taxonomies_primary`). Two CoA creates racing
     # is a caller conflict, not a fault: say so.
+    if not violates(exc, "idx_entity_taxonomies_primary", "uq_entity_taxonomy_combo"):
+      raise
     raise ValueError(
       "Another chart of accounts was linked to the entity concurrently; "
       "retry after it completes."

--- a/robosystems/routers/admin/graphs.py
+++ b/robosystems/routers/admin/graphs.py
@@ -16,6 +16,7 @@ from ...models.api.admin import (
   GraphInfrastructureResponse,
   GraphResponse,
   GraphStorageResponse,
+  OrphanTenantSchemasResponse,
 )
 from ...models.core import Graph, User
 from ...models.core.graph.graph_backup import GraphBackup
@@ -251,6 +252,46 @@ async def get_graph_analytics(
     session.close()
 
 
+@router.get("/orphan-schemas", response_model=OrphanTenantSchemasResponse)
+@require_admin(permissions=["graphs:read"])
+async def list_orphan_tenant_schemas(request: Request):
+  """Extensions tenant schemas with no live graph — what a partial teardown
+  left behind. Read-only; POST to the same path to drop them."""
+  from ...operations.graph.deprovision_service import find_orphan_tenant_schemas
+
+  session = next(get_db_session())
+  try:
+    return OrphanTenantSchemasResponse(
+      orphan_schemas=find_orphan_tenant_schemas(session)
+    )
+  finally:
+    session.close()
+
+
+@router.post("/orphan-schemas", response_model=OrphanTenantSchemasResponse)
+@require_admin(permissions=["graphs:write"])
+async def purge_orphan_tenant_schemas(request: Request):
+  """Drop every orphan tenant schema (see GET). Irreversible."""
+  from ...operations.graph.deprovision_service import (
+    find_orphan_tenant_schemas,
+  )
+  from ...operations.graph.deprovision_service import (
+    purge_orphan_tenant_schemas as _purge,
+  )
+
+  session = next(get_db_session())
+  try:
+    orphans = find_orphan_tenant_schemas(session)
+    dropped = _purge(session)
+    logger.info(
+      f"Admin purged {len(dropped)} orphan extensions schema(s)",
+      extra={"admin_key_id": request.state.admin_key_id, "dropped": dropped},
+    )
+    return OrphanTenantSchemasResponse(orphan_schemas=orphans, dropped=dropped)
+  finally:
+    session.close()
+
+
 @router.get("/{graph_id}", response_model=GraphResponse)
 @require_admin(permissions=["graphs:read"])
 async def get_graph(request: Request, graph_id: str):
@@ -346,12 +387,6 @@ async def deprovision_graph(
         detail=f"Graph {graph_id} not found",
       )
 
-    if result.status == "already_deprovisioned":
-      raise HTTPException(
-        status_code=status.HTTP_409_CONFLICT,
-        detail=f"Graph {graph_id} is already deprovisioned",
-      )
-
     if result.status == "rejected":
       raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
@@ -368,9 +403,18 @@ async def deprovision_graph(
       },
     )
 
+    # An already-deprovisioned graph is not an error: the call re-ran the
+    # idempotent data-disposal steps (extensions schema, search index, report
+    # bundles), which is how a partial teardown gets finished. The message
+    # says what, if anything, was still there.
     return GraphDeprovisionResponse(
       graph_id=graph_id,
       previous_status=result.previous_status,
+      status=(
+        "already_deprovisioned"
+        if result.status == "already_deprovisioned"
+        else "deprovisioned"
+      ),
       database_deleted=result.database_deleted,
       backup_created=result.backup_created,
       subgraphs_deleted=result.subgraphs_deleted,

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -408,6 +408,7 @@ from robosystems.operations.roboledger.commands.taxonomies import (
   AssociationNotFoundError,
   ElementNotFoundError,
   EntityNotFoundError,
+  EntityTaxonomyConflictError,
   MappingAssociationExistsError,
   MappingStructureNotFoundError,
 )
@@ -1044,6 +1045,7 @@ link_entity_taxonomy_op = _registrar.register(
     error_map={
       EntityNotFoundError: 404,
       TaxonomyMissingError: 404,
+      EntityTaxonomyConflictError: 409,
     },
     mark_stale_reason="entity_taxonomy_linked",
     requires_created_by=False,
@@ -1493,7 +1495,7 @@ update_agent_op = _registrar.register(
     command=cmd_update_agent,
     request_model=UpdateAgentRequest,
     result_type=LedgerAgentResponse,
-    error_map={AgentNotFoundError: 404, ValueError: 422},
+    error_map={AgentNotFoundError: 404, RowLockedError: 409, ValueError: 422},
     mark_stale_reason="agent_updated",
   )
 )
@@ -1689,6 +1691,7 @@ update_event_handler_op = _registrar.register(
     error_map={
       EventHandlerNotFoundError: 404,
       TemplateValidationError: 422,
+      RowLockedError: 409,
       ValueError: 422,
     },
   )
@@ -2413,11 +2416,18 @@ async def delete_report_op(
   # The OLAP projection is a full rebuild from OLTP, so a deleted report leaves
   # the graph only once the graph is marked stale. Without this the recipient's
   # delete is cosmetic — the report stays queryable by their AI operators.
+  # The report's published artifacts go after the rows commit, never before
+  # (see `delete_report_artifacts`); a native report's bundles were the one
+  # withdrawal that used to leave them in the bucket.
+  def _finish_delete(_env) -> None:
+    mark_graph_stale(graph_id, "report_deleted")
+    delete_report_artifacts(graph_id, [body.report_id])
+
   return await _dispatch(
     ctx,
     _runner,
     cache,
-    on_fresh_success=lambda _env: mark_graph_stale(graph_id, "report_deleted"),
+    on_fresh_success=_finish_delete,
   )
 
 

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -2481,6 +2481,9 @@ async def share_report_op(
       raise HTTPException(
         status_code=422, detail="Only published reports can be shared."
       )
+    except RowLockedError as e:
+      # Another lifecycle write (or another share) holds the report.
+      raise HTTPException(status_code=409, detail=str(e))
 
   def _mark_recipients_stale(envelope) -> None:
     # A share writes rows into each recipient's OLTP schema, but their
@@ -2613,6 +2616,8 @@ async def file_report_op(
         raise HTTPException(
           status_code=404, detail=f"Report '{body.report_id}' not found."
         )
+      except NotAuthorizedError as e:
+        raise HTTPException(status_code=403, detail=str(e))
       except InvalidFilingTransitionError as e:
         raise HTTPException(status_code=422, detail=str(e))
 
@@ -2656,11 +2661,15 @@ async def transition_filing_status_op(
   def _runner():
     with extensions_session(graph_id) as session:
       try:
-        return cmd_transition_filing_status(session, body.report_id, body.target_status)
+        return cmd_transition_filing_status(
+          session, body.report_id, body.target_status, acting_user_id=str(user.id)
+        )
       except ReportNotFoundError:
         raise HTTPException(
           status_code=404, detail=f"Report '{body.report_id}' not found."
         )
+      except NotAuthorizedError as e:
+        raise HTTPException(status_code=403, detail=str(e))
       except InvalidFilingTransitionError as e:
         raise HTTPException(status_code=422, detail=str(e))
       except RowLockedError as e:
@@ -2856,6 +2865,8 @@ async def add_publish_list_members_op(
         )
       except PublishListNotFoundError:
         raise HTTPException(status_code=404, detail="Publish list not found.")
+      except PublishListNotAuthorizedError as e:
+        raise HTTPException(status_code=403, detail=str(e))
       except TargetGraphsNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
       except TargetGraphMissingExtensionError as e:
@@ -2902,7 +2913,12 @@ async def remove_publish_list_member_op(
 
   def _runner():
     with extensions_session(graph_id) as session:
-      deleted = cmd_remove_publish_list_member(session, body.list_id, body.member_id)
+      try:
+        deleted = cmd_remove_publish_list_member(
+          session, body.list_id, body.member_id, acting_user_id=str(user.id)
+        )
+      except PublishListNotAuthorizedError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     if not deleted:
       raise HTTPException(status_code=404, detail="Member not found in this list.")
     return DeleteResult(deleted=True)

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -58,7 +58,6 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Path
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm import Session
 
 from robosystems.adapters.quickbooks.client.api import QBAuthFailedError
@@ -73,7 +72,7 @@ from robosystems.middleware.extensions import (
   GraphExtensionContext,
   OperationRegistrar,
   OperationSpec,
-  is_schema_missing,
+  guard_command_runner,
   require_graph_extension,
 )
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
@@ -498,10 +497,22 @@ async def _dispatch(
   cache: IdempotencyCache,
   on_fresh_success=None,
 ) -> OperationEnvelope:
-  """Run `execute_operation` and translate idempotency conflicts to 409."""
+  """Run `execute_operation` and translate idempotency conflicts to 409.
+
+  Every hand-written runner below is wrapped in `guard_command_runner`, so
+  the registrar's error policy (schema-missing → 404, other database faults
+  → logged 500, unmapped `ValueError` → 422) applies to both registration
+  styles identically. Handlers keep only their domain-specific mappings.
+  """
+  guarded = guard_command_runner(
+    runner,
+    op_name=ctx.operation_name,
+    graph_id=ctx.graph_id,
+    schema_missing_404=_ledger_404,
+  )
   try:
     return await execute_operation(
-      ctx, runner, idempotency_cache=cache, on_fresh_success=on_fresh_success
+      ctx, guarded, idempotency_cache=cache, on_fresh_success=on_fresh_success
     )
   except IdempotencyKeyConflictError as exc:
     raise HTTPException(status_code=409, detail=str(exc))
@@ -525,11 +536,6 @@ def _ledger_404() -> HTTPException:
     status_code=404,
     detail="Ledger not initialized. Connect a data source first.",
   )
-
-
-# Shared with the registrar (`middleware/extensions.py`) so both registration
-# styles translate the same, and only the, schema-missing case to 404.
-_is_schema_missing = is_schema_missing
 
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -848,10 +854,6 @@ async def initialize_op(
       raise HTTPException(status_code=409, detail=str(e))
     except InvalidCloseTargetError as e:
       raise HTTPException(status_code=422, detail=str(e))
-    except ProgrammingError as e:
-      if _is_schema_missing(e):
-        raise _ledger_404()
-      raise
 
   return await _dispatch(ctx, _runner, cache)
 
@@ -894,11 +896,8 @@ async def update_entity_op(
   def _runner():
     if not updates:
       raise HTTPException(status_code=400, detail="No fields provided for update.")
-    try:
-      with extensions_session(graph_id) as session:
-        result = update_parent_entity(session, updates)
-    except (ValueError, ProgrammingError):
-      raise _ledger_404()
+    with extensions_session(graph_id) as session:
+      result = update_parent_entity(session, updates)
     if result is None:
       raise HTTPException(
         status_code=404, detail="No entity found. Create an entity graph first."
@@ -1449,10 +1448,6 @@ async def bind_text_block_op(
     except ValueError as e:
       # SectionNotFound / TextBlockStructure / TextBlockElement / size cap
       raise HTTPException(status_code=422, detail=str(e))
-    except ProgrammingError as e:
-      if _is_schema_missing(e):
-        raise _ledger_404()
-      raise
 
   return await _dispatch(
     ctx,
@@ -1910,10 +1905,6 @@ async def set_close_target_op(
     except RowLockedError as e:
       # A close in flight holds the calendar row; retryable, like its siblings.
       raise HTTPException(status_code=409, detail=str(e))
-    except ProgrammingError as e:
-      if _is_schema_missing(e):
-        raise _ledger_404()
-      raise
 
   return await _dispatch(ctx, _runner, cache)
 
@@ -2074,10 +2065,6 @@ async def close_period_op(
       )
     except FiscalCalendarError as e:
       raise HTTPException(status_code=404, detail=str(e))
-    except ProgrammingError as e:
-      if _is_schema_missing(e):
-        raise _ledger_404()
-      raise
 
   return await _dispatch(ctx, _runner, cache)
 
@@ -2156,10 +2143,6 @@ async def reopen_period_op(
       raise HTTPException(status_code=422, detail=str(e))
     except FiscalCalendarError as e:
       raise HTTPException(status_code=404, detail=str(e))
-    except ProgrammingError as e:
-      if _is_schema_missing(e):
-        raise _ledger_404()
-      raise
 
   return await _dispatch(ctx, _runner, cache)
 
@@ -2230,10 +2213,6 @@ async def backfill_plan_history_op(
       )
     except FiscalCalendarError as e:
       raise HTTPException(status_code=404, detail=str(e))
-    except ProgrammingError as e:
-      if _is_schema_missing(e):
-        raise _ledger_404()
-      raise
 
   return await _dispatch(ctx, _runner, cache)
 
@@ -2277,24 +2256,19 @@ async def create_report_op(
     raise HTTPException(status_code=422, detail="period_end must be >= period_start")
 
   def _runner():
-    try:
-      with extensions_session(graph_id) as session:
-        try:
-          return cmd_create_report(session, graph_id, body, created_by=str(user.id))
-        except TaxonomyNotFoundError as e:
-          raise HTTPException(status_code=422, detail=f"Taxonomy '{e}' not found.")
-        except NoEntityError as e:
-          raise HTTPException(status_code=422, detail=str(e))
-        except BundleUploadError as e:
-          # S3 unavailable during the publish-time bundle stamp. Publish
-          # aborted by ``_stamp_report_bundle`` to keep the invariant
-          # "every published Report has a stored bundle artifact"; surface
-          # as 502 (upstream failure) so the client can retry.
-          raise HTTPException(status_code=502, detail=str(e))
-    except (ValueError, ProgrammingError) as e:
-      if isinstance(e, ProgrammingError) and not _is_schema_missing(e):
-        raise
-      raise _ledger_404()
+    with extensions_session(graph_id) as session:
+      try:
+        return cmd_create_report(session, graph_id, body, created_by=str(user.id))
+      except TaxonomyNotFoundError as e:
+        raise HTTPException(status_code=422, detail=f"Taxonomy '{e}' not found.")
+      except NoEntityError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+      except BundleUploadError as e:
+        # S3 unavailable during the publish-time bundle stamp. Publish
+        # aborted by ``_stamp_report_bundle`` to keep the invariant
+        # "every published Report has a stored bundle artifact"; surface
+        # as 502 (upstream failure) so the client can retry.
+        raise HTTPException(status_code=502, detail=str(e))
 
   return await _dispatch(
     ctx,
@@ -2339,35 +2313,32 @@ async def regenerate_report_op(
   )
 
   def _runner():
-    try:
-      with extensions_session(graph_id) as session:
-        try:
-          return cmd_regenerate_report(
-            session, graph_id, body.report_id, body, acting_user_id=str(user.id)
-          )
-        except RowLockedError as e:
-          # A concurrent writer holds the rows this needs. Retryable, and the
-          # same 409 the registrar-driven operations return.
-          raise HTTPException(status_code=409, detail=str(e))
-        except ReportNotFoundError:
-          raise HTTPException(
-            status_code=404, detail=f"Report '{body.report_id}' not found."
-          )
-        except NotAuthorizedError:
-          raise HTTPException(
-            status_code=403, detail="Not authorized to modify this report."
-          )
-        except InvalidFilingTransitionError as e:
-          raise HTTPException(status_code=422, detail=str(e))
-        except BundleUploadError as e:
-          # Same fail-loud semantics as create-report: a regenerate
-          # without a stamped bundle would publish a Report whose
-          # ``bundle_url`` lags the regenerated facts.
-          raise HTTPException(status_code=502, detail=str(e))
-        except ValueError as e:
-          raise HTTPException(status_code=422, detail=str(e))
-    except (ValueError, ProgrammingError):
-      raise _ledger_404()
+    with extensions_session(graph_id) as session:
+      try:
+        return cmd_regenerate_report(
+          session, graph_id, body.report_id, body, acting_user_id=str(user.id)
+        )
+      except RowLockedError as e:
+        # A concurrent writer holds the rows this needs. Retryable, and the
+        # same 409 the registrar-driven operations return.
+        raise HTTPException(status_code=409, detail=str(e))
+      except ReportNotFoundError:
+        raise HTTPException(
+          status_code=404, detail=f"Report '{body.report_id}' not found."
+        )
+      except NotAuthorizedError:
+        raise HTTPException(
+          status_code=403, detail="Not authorized to modify this report."
+        )
+      except InvalidFilingTransitionError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+      except BundleUploadError as e:
+        # Same fail-loud semantics as create-report: a regenerate
+        # without a stamped bundle would publish a Report whose
+        # ``bundle_url`` lags the regenerated facts.
+        raise HTTPException(status_code=502, detail=str(e))
+      except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
 
   return await _dispatch(
     ctx,
@@ -2415,27 +2386,24 @@ async def delete_report_op(
   )
 
   def _runner():
-    try:
-      with extensions_session(graph_id) as session:
-        try:
-          deleted = cmd_delete_report(
-            session,
-            body.report_id,
-            str(user.id),
-            acting_user_is_graph_admin=user_is_graph_admin(str(user.id), graph_id),
-          )
-        except NotAuthorizedError:
-          raise HTTPException(
-            status_code=403, detail="Not authorized to delete this report."
-          )
-        except ReportHasActiveSharesError as e:
-          raise HTTPException(status_code=409, detail=str(e))
-        except ReportNotFiledError as e:
-          raise HTTPException(status_code=422, detail=str(e))
-        except RowLockedError as e:
-          raise HTTPException(status_code=409, detail=str(e))
-    except (ValueError, ProgrammingError):
-      raise _ledger_404()
+    with extensions_session(graph_id) as session:
+      try:
+        deleted = cmd_delete_report(
+          session,
+          body.report_id,
+          str(user.id),
+          acting_user_is_graph_admin=user_is_graph_admin(str(user.id), graph_id),
+        )
+      except NotAuthorizedError:
+        raise HTTPException(
+          status_code=403, detail="Not authorized to delete this report."
+        )
+      except ReportHasActiveSharesError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+      except ReportNotFiledError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+      except RowLockedError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     if not deleted:
       raise HTTPException(
         status_code=404, detail=f"Report '{body.report_id}' not found."
@@ -2513,8 +2481,6 @@ async def share_report_op(
       raise HTTPException(
         status_code=422, detail="Only published reports can be shared."
       )
-    except (ValueError, ProgrammingError):
-      raise _ledger_404()
 
   def _mark_recipients_stale(envelope) -> None:
     # A share writes rows into each recipient's OLTP schema, but their
@@ -2592,8 +2558,6 @@ async def revoke_report_share_op(
       raise HTTPException(
         status_code=403, detail="Not authorized to revoke shares of this report."
       )
-    except (ValueError, ProgrammingError):
-      raise _ledger_404()
 
   def _mark_recipient_stale(envelope) -> None:
     # Same reasoning as the share path: the copy leaves the recipient's graph
@@ -2638,22 +2602,19 @@ async def file_report_op(
   )
 
   def _runner():
-    try:
-      with extensions_session(graph_id) as session:
-        try:
-          return cmd_file_report(session, body.report_id, filed_by=str(user.id))
-        except RowLockedError as e:
-          # Another lifecycle write holds the report. Retryable, same 409 the
-          # registrar-driven operations return.
-          raise HTTPException(status_code=409, detail=str(e))
-        except ReportNotFoundError:
-          raise HTTPException(
-            status_code=404, detail=f"Report '{body.report_id}' not found."
-          )
-        except InvalidFilingTransitionError as e:
-          raise HTTPException(status_code=422, detail=str(e))
-    except (ValueError, ProgrammingError):
-      raise _ledger_404()
+    with extensions_session(graph_id) as session:
+      try:
+        return cmd_file_report(session, body.report_id, filed_by=str(user.id))
+      except RowLockedError as e:
+        # Another lifecycle write holds the report. Retryable, same 409 the
+        # registrar-driven operations return.
+        raise HTTPException(status_code=409, detail=str(e))
+      except ReportNotFoundError:
+        raise HTTPException(
+          status_code=404, detail=f"Report '{body.report_id}' not found."
+        )
+      except InvalidFilingTransitionError as e:
+        raise HTTPException(status_code=422, detail=str(e))
 
   return await _dispatch(ctx, _runner, cache)
 
@@ -2693,22 +2654,17 @@ async def transition_filing_status_op(
   )
 
   def _runner():
-    try:
-      with extensions_session(graph_id) as session:
-        try:
-          return cmd_transition_filing_status(
-            session, body.report_id, body.target_status
-          )
-        except ReportNotFoundError:
-          raise HTTPException(
-            status_code=404, detail=f"Report '{body.report_id}' not found."
-          )
-        except InvalidFilingTransitionError as e:
-          raise HTTPException(status_code=422, detail=str(e))
-        except RowLockedError as e:
-          raise HTTPException(status_code=409, detail=str(e))
-    except (ValueError, ProgrammingError):
-      raise _ledger_404()
+    with extensions_session(graph_id) as session:
+      try:
+        return cmd_transition_filing_status(session, body.report_id, body.target_status)
+      except ReportNotFoundError:
+        raise HTTPException(
+          status_code=404, detail=f"Report '{body.report_id}' not found."
+        )
+      except InvalidFilingTransitionError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+      except RowLockedError as e:
+        raise HTTPException(status_code=409, detail=str(e))
 
   return await _dispatch(ctx, _runner, cache)
 
@@ -2752,14 +2708,11 @@ async def create_publish_list_op(
   )
 
   def _runner():
-    try:
-      with extensions_session(graph_id) as session:
-        try:
-          return cmd_create_publish_list(session, body, created_by=str(user.id))
-        except PublishListNameConflictError as e:
-          raise HTTPException(status_code=409, detail=str(e))
-    except ProgrammingError:
-      raise _ledger_404()
+    with extensions_session(graph_id) as session:
+      try:
+        return cmd_create_publish_list(session, body, created_by=str(user.id))
+      except PublishListNameConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
 
   return await _dispatch(ctx, _runner, cache)
 
@@ -2795,20 +2748,17 @@ async def update_publish_list_op(
   )
 
   def _runner():
-    try:
-      with extensions_session(graph_id) as session:
-        try:
-          return cmd_update_publish_list(
-            session, body.list_id, body, acting_user_id=str(user.id)
-          )
-        except PublishListNotFoundError:
-          raise HTTPException(status_code=404, detail="Publish list not found.")
-        except PublishListNotAuthorizedError as e:
-          raise HTTPException(status_code=403, detail=str(e))
-        except PublishListNameConflictError as e:
-          raise HTTPException(status_code=409, detail=str(e))
-    except ProgrammingError:
-      raise _ledger_404()
+    with extensions_session(graph_id) as session:
+      try:
+        return cmd_update_publish_list(
+          session, body.list_id, body, acting_user_id=str(user.id)
+        )
+      except PublishListNotFoundError:
+        raise HTTPException(status_code=404, detail="Publish list not found.")
+      except PublishListNotAuthorizedError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+      except PublishListNameConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
 
   return await _dispatch(ctx, _runner, cache)
 
@@ -2848,14 +2798,11 @@ async def delete_publish_list_op(
   )
 
   def _runner():
-    try:
-      with extensions_session(graph_id) as session:
-        try:
-          deleted = cmd_delete_publish_list(session, body.list_id, str(user.id))
-        except PublishListNotAuthorizedError as e:
-          raise HTTPException(status_code=403, detail=str(e))
-    except ProgrammingError:
-      raise _ledger_404()
+    with extensions_session(graph_id) as session:
+      try:
+        deleted = cmd_delete_publish_list(session, body.list_id, str(user.id))
+      except PublishListNotAuthorizedError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     if not deleted:
       raise HTTPException(status_code=404, detail="Publish list not found.")
     return DeleteResult(deleted=True)
@@ -2902,26 +2849,23 @@ async def add_publish_list_members_op(
   add_body = AddMembersRequest(target_graph_ids=body.target_graph_ids)
 
   def _runner():
-    try:
-      with extensions_session(graph_id) as session:
-        try:
-          return cmd_add_publish_list_members(
-            session, body.list_id, graph_id, add_body, added_by=str(user.id)
-          )
-        except PublishListNotFoundError:
-          raise HTTPException(status_code=404, detail="Publish list not found.")
-        except TargetGraphsNotFoundError as e:
-          raise HTTPException(status_code=404, detail=str(e))
-        except TargetGraphMissingExtensionError as e:
-          raise HTTPException(status_code=422, detail=str(e))
-        except SelfAddError:
-          raise HTTPException(
-            status_code=422, detail="Cannot add your own graph to a publish list."
-          )
-        except MembersAlreadyPresentError as e:
-          raise HTTPException(status_code=409, detail=str(e))
-    except ProgrammingError:
-      raise _ledger_404()
+    with extensions_session(graph_id) as session:
+      try:
+        return cmd_add_publish_list_members(
+          session, body.list_id, graph_id, add_body, added_by=str(user.id)
+        )
+      except PublishListNotFoundError:
+        raise HTTPException(status_code=404, detail="Publish list not found.")
+      except TargetGraphsNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+      except TargetGraphMissingExtensionError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+      except SelfAddError:
+        raise HTTPException(
+          status_code=422, detail="Cannot add your own graph to a publish list."
+        )
+      except MembersAlreadyPresentError as e:
+        raise HTTPException(status_code=409, detail=str(e))
 
   return await _dispatch(ctx, _runner, cache)
 
@@ -2957,11 +2901,8 @@ async def remove_publish_list_member_op(
   )
 
   def _runner():
-    try:
-      with extensions_session(graph_id) as session:
-        deleted = cmd_remove_publish_list_member(session, body.list_id, body.member_id)
-    except ProgrammingError:
-      raise _ledger_404()
+    with extensions_session(graph_id) as session:
+      deleted = cmd_remove_publish_list_member(session, body.list_id, body.member_id)
     if not deleted:
       raise HTTPException(status_code=404, detail="Member not found in this list.")
     return DeleteResult(deleted=True)
@@ -3017,22 +2958,19 @@ async def block_source_graph_op(
   )
 
   def _runner():
-    try:
-      with extensions_session(graph_id) as session:
-        try:
-          return cmd_block_source_graph(
-            session,
-            body,
-            created_by=str(user.id),
-            graph_id=graph_id,
-            acting_user_is_graph_admin=user_is_graph_admin(str(user.id), graph_id),
-          )
-        except SelfBlockError as e:
-          raise HTTPException(status_code=422, detail=str(e))
-        except AdminRoleRequiredError as e:
-          raise HTTPException(status_code=403, detail=str(e))
-    except (ValueError, ProgrammingError):
-      raise _ledger_404()
+    with extensions_session(graph_id) as session:
+      try:
+        return cmd_block_source_graph(
+          session,
+          body,
+          created_by=str(user.id),
+          graph_id=graph_id,
+          acting_user_is_graph_admin=user_is_graph_admin(str(user.id), graph_id),
+        )
+      except SelfBlockError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+      except AdminRoleRequiredError as e:
+        raise HTTPException(status_code=403, detail=str(e))
 
   def _finish_purge(envelope) -> None:
     # Only a purge changes queryable content, and the OLAP projection is a
@@ -3098,20 +3036,17 @@ async def unblock_source_graph_op(
   )
 
   def _runner():
-    try:
-      with extensions_session(graph_id) as session:
-        try:
-          return cmd_unblock_source_graph(
-            session,
-            body,
-            acting_user_is_graph_admin=user_is_graph_admin(str(user.id), graph_id),
-          )
-        except AdminRoleRequiredError as e:
-          raise HTTPException(status_code=403, detail=str(e))
-        except SourceGraphNotBlockedError as e:
-          raise HTTPException(status_code=404, detail=str(e))
-    except (ValueError, ProgrammingError):
-      raise _ledger_404()
+    with extensions_session(graph_id) as session:
+      try:
+        return cmd_unblock_source_graph(
+          session,
+          body,
+          acting_user_is_graph_admin=user_is_graph_admin(str(user.id), graph_id),
+        )
+      except AdminRoleRequiredError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+      except SourceGraphNotBlockedError as e:
+        raise HTTPException(status_code=404, detail=str(e))
 
   return await _dispatch(ctx, _runner, cache)
 

--- a/robosystems/routers/graphs/mcp/handlers.py
+++ b/robosystems/routers/graphs/mcp/handlers.py
@@ -85,6 +85,17 @@ async def validate_mcp_access(
       # Write/admin tools require the 'member' or 'admin' role; 'viewer' is
       # read-only. Bare membership is not sufficient for mutations.
       if not GraphUser.user_has_write_access(current_user.id, graph_id, db):
+        # Same detective-control audit the REST write gate emits
+        # (`require_graph_write_role`), so an under-privileged MCP write
+        # attempt is visible in the security stream, not only in a 403.
+        from robosystems.security import SecurityAuditLogger
+
+        SecurityAuditLogger.log_authorization_denied(
+          user_id=str(current_user.id),
+          resource=graph_id,
+          action="write",
+          endpoint="mcp",
+        )
         raise HTTPException(
           status_code=403,
           detail=f"Write access denied to graph {graph_id}; your role is read-only.",

--- a/tests/db/test_tenant_provisioning.py
+++ b/tests/db/test_tenant_provisioning.py
@@ -71,6 +71,24 @@ class TestProvisionRefusesDeprovisionedGraph:
     assert excinfo.value.graph_id == GRAPH
     engine.connect.assert_not_called()
 
+  def test_raises_while_teardown_is_in_flight(self):
+    """Teardown stamps `deleted_at` (committed) before it drops anything and
+    flips the status only at the end; a sync in that window must not
+    re-create the schema."""
+    from datetime import UTC, datetime
+
+    graph = MagicMock()
+    graph.status = GraphStatus.ACTIVE.value
+    graph.deleted_at = datetime.now(UTC)
+    engine = MagicMock()
+    with (
+      patch.object(ext, "_get_engine", return_value=engine),
+      patch("robosystems.database.platform_session", self._platform_with(graph)),
+    ):
+      with pytest.raises(TenantDeprovisionedError):
+        provision_tenant_schema(GRAPH)
+    engine.connect.assert_not_called()
+
   def test_missing_graph_row_still_provisions(self):
     """Scripts provision without a platform row (framework_validate); only a
     row that says *deprovisioned* refuses."""

--- a/tests/db/test_tenant_provisioning.py
+++ b/tests/db/test_tenant_provisioning.py
@@ -104,3 +104,22 @@ class TestProvisionRefusesDeprovisionedGraph:
     ):
       provision_tenant_schema(GRAPH)
     engine.connect.assert_called_once()
+
+
+class TestEngineSessionGuards:
+  def test_engine_sets_an_idle_in_transaction_timeout(self):
+    """A leaked idle-in-transaction session holding FOR UPDATE blocked writers
+    for as long as the connection lived; Postgres now closes it."""
+    from unittest.mock import patch
+
+    with (
+      patch.object(ext, "create_engine") as create_engine,
+      patch.object(ext, "get_extensions_database_url", return_value="postgresql://x"),
+    ):
+      ext._create_extensions_engine()
+    kwargs = create_engine.call_args.kwargs
+    assert (
+      f"idle_in_transaction_session_timeout={ext.IDLE_IN_TRANSACTION_TIMEOUT_MS}"
+      in kwargs["connect_args"]["options"]
+    )
+    assert "statement_timeout" not in kwargs["connect_args"]["options"]

--- a/tests/infrastructure/test_userdata_refresh.py
+++ b/tests/infrastructure/test_userdata_refresh.py
@@ -68,9 +68,12 @@ esac
 exit 0
 """
 
+# `login` drains stdin: the script pipes the ECR token into it under pipefail,
+# and a stub that exits before the producer writes turns the run into a SIGPIPE
+# (141) "ECR login failed" on a loaded runner.
 DOCKER_STUB = """#!/bin/bash
 case "$1" in
-  login) exit 0 ;;
+  login) cat >/dev/null; exit 0 ;;
   pull) echo "$2" >> "$STUB_PULL_LOG"; exit ${STUB_PULL_EXIT:-0} ;;
   image)
     case "$2" in

--- a/tests/middleware/mcp/test_gate.py
+++ b/tests/middleware/mcp/test_gate.py
@@ -58,6 +58,22 @@ class TestRequireGraphExtensionMCP:
     assert result.graph_type == "entity"
     assert "roboledger" in result.schema_extensions
 
+  def test_rejects_subgraph_ids_before_loading_metadata(self) -> None:
+    """A subgraph has no tenant schema. The REST extension dependency and the
+    GraphQL endpoint refuse it up front; the MCP gate must too, or a write
+    tool called with a subgraph id fails inside the tool as a 404 or a 500."""
+    with patch(
+      "robosystems.middleware.mcp.tools._gate._load_with_short_lived_session"
+    ) as loader:
+      with pytest.raises(MCPExtensionGateError) as exc:
+        require_graph_extension_mcp(
+          extension="roboledger",
+          graph_id="kg0123456789abcdef01_dev",
+        )
+    assert exc.value.code == "subgraph_not_addressable"
+    assert "target the parent graph" in exc.value.message
+    loader.assert_not_called()
+
   def test_rejects_repository_graph(self) -> None:
     with pytest.raises(MCPExtensionGateError) as exc:
       require_graph_extension_mcp(

--- a/tests/middleware/mcp/test_registrar.py
+++ b/tests/middleware/mcp/test_registrar.py
@@ -365,6 +365,125 @@ class TestRegistrarToolDefinition:
     assert defn["description"] == "Demo Op"
 
 
+class _InflightCache:
+  """In-memory stand-in for the idempotency cache's reserve/release pair."""
+
+  def __init__(self) -> None:
+    self.held: dict[tuple[str, str, str, str], str] = {}
+
+  async def reserve(self, user_id, graph_id, op, key, fingerprint) -> bool:
+    k = (user_id, graph_id, op, key)
+    if k in self.held:
+      return False
+    self.held[k] = fingerprint
+    return True
+
+  async def release(self, user_id, graph_id, op, key) -> None:
+    self.held.pop((user_id, graph_id, op, key), None)
+
+
+@pytest.fixture(autouse=True)
+def _inflight_cache():
+  cache = _InflightCache()
+  with patch(
+    "robosystems.middleware.mcp.tools.registrar.get_idempotency_cache",
+    return_value=cache,
+  ):
+    yield cache
+
+
+class TestRegistrarToolAuditAndInflight:
+  @pytest.mark.asyncio
+  async def test_every_call_emits_an_operation_audit_line(self) -> None:
+    tool = _RegistrarMCPTool(
+      client=_client(graph_id="kg_audit", user_id="usr_42"),
+      spec=_spec(),
+      registrar=_registrar_stub(),
+    )
+    with (
+      patch(
+        "robosystems.middleware.mcp.tools.registrar.require_graph_extension_mcp",
+        return_value=MagicMock(),
+      ),
+      patch("robosystems.middleware.mcp.tools.registrar.log_operation_audit") as audit,
+    ):
+      await tool.execute({"id": "x", "value": 3})
+
+    audit.assert_called_once()
+    kwargs = audit.call_args.kwargs
+    assert kwargs["operation_name"] == "demo-op"
+    assert kwargs["user_id"] == "usr_42"
+    assert kwargs["graph_id"] == "kg_audit"
+    assert kwargs["status"] == "completed"
+    assert kwargs["surface"] == "mcp"
+
+  @pytest.mark.asyncio
+  async def test_domain_failure_is_audited_as_failed(self) -> None:
+    def _boom(session, body: _Request, created_by: str) -> _Response:  # type: ignore[no-untyped-def]
+      raise DemoNotFoundError("nope")
+
+    tool = _RegistrarMCPTool(
+      client=_client(user_id="usr_42"),
+      spec=_spec(command=_boom),
+      registrar=_registrar_stub(),
+    )
+    with (
+      patch(
+        "robosystems.middleware.mcp.tools.registrar.require_graph_extension_mcp",
+        return_value=MagicMock(),
+      ),
+      patch("robosystems.middleware.mcp.tools.registrar.log_operation_audit") as audit,
+    ):
+      result = await tool.execute({"id": "x", "value": 3})
+
+    assert "error" in result
+    assert audit.call_args.kwargs["status"] == "failed"
+
+  @pytest.mark.asyncio
+  async def test_identical_concurrent_call_is_refused_and_released_after(
+    self, _inflight_cache: _InflightCache
+  ) -> None:
+    import asyncio
+    import threading
+
+    gate = threading.Event()
+    calls = 0
+
+    def _slow(session, body: _Request, created_by: str) -> _Response:  # type: ignore[no-untyped-def]
+      nonlocal calls
+      calls += 1
+      gate.wait(timeout=5)
+      return _Response(id=body.id, echoed=body.value)
+
+    tool = _RegistrarMCPTool(
+      client=_client(user_id="usr_42"),
+      spec=_spec(command=_slow),
+      registrar=_registrar_stub(),
+    )
+    with patch(
+      "robosystems.middleware.mcp.tools.registrar.require_graph_extension_mcp",
+      return_value=MagicMock(),
+    ):
+      first = asyncio.ensure_future(tool.execute({"id": "x", "value": 3}))
+      while calls == 0:
+        await asyncio.sleep(0.005)
+      # Same arguments while the first is running → refused, not executed.
+      dup = await tool.execute({"id": "x", "value": 3})
+      # Different arguments are a different call and run.
+      gate.set()
+      other = await tool.execute({"id": "y", "value": 4})
+      result = await first
+      # Once released, the identical call is a deliberate repeat and runs.
+      again = await tool.execute({"id": "x", "value": 3})
+
+    assert dup["error"] == "in_progress"
+    assert result == {"id": "x", "echoed": 3}
+    assert other == {"id": "y", "echoed": 4}
+    assert again == {"id": "x", "echoed": 3}
+    assert calls == 3
+    assert _inflight_cache.held == {}
+
+
 class TestRegistrarToolExecute:
   @pytest.mark.asyncio
   async def test_happy_path_returns_model_dump(self) -> None:

--- a/tests/middleware/mcp/test_registrar.py
+++ b/tests/middleware/mcp/test_registrar.py
@@ -383,6 +383,32 @@ class TestRegistrarToolExecute:
     assert result == {"id": "x", "echoed": 3}
 
   @pytest.mark.asyncio
+  async def test_command_runs_in_a_worker_thread(self) -> None:
+    """The MCP server shares the API's single event loop. The command is sync
+    database work and must leave the loop free while it runs."""
+    import threading
+
+    seen: dict[str, Any] = {}
+
+    def _recording_command(session, body: _Request, created_by: str) -> _Response:  # type: ignore[no-untyped-def]
+      seen["thread"] = threading.current_thread()
+      return _Response(id=body.id, echoed=body.value)
+
+    tool = _RegistrarMCPTool(
+      client=_client(user_id="usr_42"),
+      spec=_spec(command=_recording_command),
+      registrar=_registrar_stub(),
+    )
+    with patch(
+      "robosystems.middleware.mcp.tools.registrar.require_graph_extension_mcp",
+      return_value=MagicMock(),
+    ):
+      result = await tool.execute({"id": "x", "value": 3})
+
+    assert result == {"id": "x", "echoed": 3}
+    assert seen["thread"] is not threading.main_thread()
+
+  @pytest.mark.asyncio
   async def test_mark_stale_reason_marks_graph_after_success(self) -> None:
     tool = _RegistrarMCPTool(
       client=_client(graph_id="kg_stale", user_id="usr_42"),

--- a/tests/middleware/mcp/tools/test_event_block_tools.py
+++ b/tests/middleware/mcp/tools/test_event_block_tools.py
@@ -125,3 +125,77 @@ class TestListEventBlocksReconcilingItemFilter:
     (event,) = result["events"]
     assert event["is_reconciling_item"] is True
     assert event["metadata"]["drift_payload"] == {"amount": 99}
+
+
+class TestDatabaseFaultsAreNotEchoedToTheModel:
+  """Hand-written tools used to return ``str(exc)`` for every failure. A DBAPI
+  error's string carries the SQL and its bound parameters; the registrar tools
+  already give a fixed message, and the hand-written tools now do the same."""
+
+  @pytest.mark.asyncio
+  async def test_schema_missing_is_not_initialized(self) -> None:
+    from sqlalchemy.exc import ProgrammingError
+
+    tool = ListEventBlocksTool(_client())
+    with _patched_session():
+      with patch(
+        f"{MODULE}.ops_list_event_blocks",
+        side_effect=ProgrammingError(
+          "SELECT * FROM events", {}, Exception('relation "events" does not exist')
+        ),
+      ):
+        result = await tool.execute({})
+    assert result == {
+      "error": "not_initialized",
+      "message": "Ledger not initialized. Connect a data source first.",
+    }
+
+  @pytest.mark.asyncio
+  async def test_other_database_error_is_a_fixed_message(self) -> None:
+    from sqlalchemy.exc import OperationalError
+
+    tool = ListEventBlocksTool(_client())
+    with _patched_session():
+      with patch(
+        f"{MODULE}.ops_list_event_blocks",
+        side_effect=OperationalError(
+          "SELECT secret_column FROM events WHERE x = %(x)s",
+          {"x": "sensitive"},
+          Exception("connection reset"),
+        ),
+      ):
+        result = await tool.execute({})
+    assert result["error"] == "command_failed"
+    assert "see server logs" in result["message"]
+    assert "secret_column" not in result["message"]
+    assert "sensitive" not in result["message"]
+
+  @pytest.mark.asyncio
+  async def test_domain_errors_keep_their_message(self) -> None:
+    tool = ListEventBlocksTool(_client())
+    with _patched_session():
+      with patch(
+        f"{MODULE}.ops_list_event_blocks",
+        side_effect=ValueError("event_category must be one of ..."),
+      ):
+        result = await tool.execute({})
+    assert result == {
+      "error": "command_failed",
+      "message": "event_category must be one of ...",
+    }
+
+  @pytest.mark.asyncio
+  async def test_runs_in_a_worker_thread(self) -> None:
+    import threading
+
+    seen: dict[str, object] = {}
+
+    def _record(*_a, **_k):
+      seen["thread"] = threading.current_thread()
+      return []
+
+    tool = ListEventBlocksTool(_client())
+    with _patched_session():
+      with patch(f"{MODULE}.ops_list_event_blocks", side_effect=_record):
+        await tool.execute({})
+    assert seen["thread"] is not threading.main_thread()

--- a/tests/middleware/mcp/tools/test_taxonomy_tools.py
+++ b/tests/middleware/mcp/tools/test_taxonomy_tools.py
@@ -265,3 +265,67 @@ class TestGetMappingSummaryTool:
 
     assert result["coverage_percent"] == 0.0
     assert result["mapped_count"] == 0
+
+
+class TestCreateMappingAssociationAttribution:
+  """`created_by` names the accountable user. The tool used to stamp the
+  literal `mapping-agent` even when the operator's caller was known."""
+
+  def _result(self):
+    r = MagicMock()
+    r.id = "assoc_1"
+    r.from_element_id = "elem_1"
+    r.to_element_id = "elem_2"
+    r.confidence = 0.9
+    return r
+
+  @pytest.mark.asyncio
+  async def test_stamps_the_acting_user_when_the_client_carries_one(self):
+    from robosystems.middleware.mcp.tools.taxonomy_tools import (
+      CreateMappingAssociationTool,
+    )
+
+    client = MagicMock()
+    client.graph_id = "kg01234567890abcdef"
+    client.user_id = "usr_caller"
+    tool = CreateMappingAssociationTool(client)
+    with (
+      _patch_session(),
+      patch(f"{MODULE}.create_mapping_association", return_value=self._result()) as cmd,
+      patch(f"{MODULE}.mark_graph_stale"),
+    ):
+      await tool.execute(
+        {
+          "mapping_id": "map_1",
+          "from_element_id": "elem_1",
+          "to_element_id": "elem_2",
+          "confidence": 0.9,
+        }
+      )
+    assert cmd.call_args.kwargs["created_by"] == "usr_caller"
+    # The suggester is still the operator.
+    assert cmd.call_args.args[1].suggested_by == "mapping-agent"
+
+  @pytest.mark.asyncio
+  async def test_falls_back_to_the_operator_tag_without_a_user(self):
+    from robosystems.middleware.mcp.tools.taxonomy_tools import (
+      CreateMappingAssociationTool,
+    )
+
+    client = MagicMock(spec=["graph_id"])
+    client.graph_id = "kg01234567890abcdef"
+    tool = CreateMappingAssociationTool(client)
+    with (
+      _patch_session(),
+      patch(f"{MODULE}.create_mapping_association", return_value=self._result()) as cmd,
+      patch(f"{MODULE}.mark_graph_stale"),
+    ):
+      await tool.execute(
+        {
+          "mapping_id": "map_1",
+          "from_element_id": "elem_1",
+          "to_element_id": "elem_2",
+          "confidence": 0.9,
+        }
+      )
+    assert cmd.call_args.kwargs["created_by"] == "mapping-agent"

--- a/tests/middleware/test_extension_gate.py
+++ b/tests/middleware/test_extension_gate.py
@@ -179,6 +179,19 @@ class TestRequireGraphExtension:
     assert exc_info.value.status_code == 403
     assert "not provisioned" in str(exc_info.value.detail)
 
+  def test_rejects_subgraph_ids_before_loading_metadata(self) -> None:
+    """A subgraph has no tenant schema. The route pattern admits
+    `{parent}_{name}` ids, so the dependency refuses them up front (403, the
+    GraphQL endpoint's answer) instead of letting the session factory reject
+    the id inside a handler as a 404 or a 500."""
+    dep = require_graph_extension("roboledger")
+    with patch(f"{MODULE}.Graph.get_by_id") as get_by_id:
+      with pytest.raises(HTTPException) as exc_info:
+        dep(graph_id=f"{GRAPH_ID}_dev", session=MagicMock())
+    assert exc_info.value.status_code == 403
+    assert "target the parent graph" in str(exc_info.value.detail)
+    get_by_id.assert_not_called()
+
   def test_rejects_entity_graph_without_extension(self) -> None:
     """Entity graph with empty schema_extensions → 403."""
     with pytest.raises(HTTPException) as exc_info:

--- a/tests/middleware/test_extensions.py
+++ b/tests/middleware/test_extensions.py
@@ -19,6 +19,7 @@ from robosystems.middleware import operations as middleware_module
 from robosystems.middleware.operations import (
   IDEMPOTENCY_TTL_SECONDS,
   IdempotencyCache,
+  IdempotencyInProgressError,
   IdempotencyKeyConflictError,
   OperationContext,
   OperationEnvelope,
@@ -248,8 +249,13 @@ class TestIdempotencyCache:
     async def _get(key: str) -> str | None:
       return store.get(key)
 
-    async def _set(key: str, value: str, ex: int | None = None) -> None:
+    async def _set(
+      key: str, value: str, ex: int | None = None, nx: bool = False
+    ) -> bool | None:
+      if nx and key in store:
+        return None
       store[key] = value
+      return True
 
     async def _delete(key: str) -> None:
       store.pop(key, None)
@@ -259,6 +265,46 @@ class TestIdempotencyCache:
     mock_client.delete = AsyncMock(side_effect=_delete)
 
     return IdempotencyCache(client=mock_client), mock_client, store
+
+  @pytest.mark.asyncio
+  async def test_reserve_claims_once_and_get_reports_in_progress(self) -> None:
+    cache, client, store = self._make_cache()
+    assert await cache.reserve("u", "g", "op", "k", "fp") is True
+    # SET NX with the short reservation TTL, not the 24h envelope TTL.
+    _, kwargs = client.set.call_args
+    assert kwargs["nx"] is True
+    assert kwargs["ex"] == middleware_module.IDEMPOTENCY_RESERVATION_TTL_SECONDS
+    # A second claim loses; a read with the same body says "in progress",
+    # a read with a different body is the usual conflict.
+    assert await cache.reserve("u", "g", "op", "k", "fp") is False
+    with pytest.raises(IdempotencyInProgressError):
+      await cache.get("u", "g", "op", "k", "fp")
+    with pytest.raises(IdempotencyKeyConflictError) as exc_info:
+      await cache.get("u", "g", "op", "k", "other")
+    assert not isinstance(exc_info.value, IdempotencyInProgressError)
+
+  @pytest.mark.asyncio
+  async def test_release_drops_only_a_pending_marker(self) -> None:
+    cache, _client, store = self._make_cache()
+    await cache.reserve("u", "g", "op", "k", "fp")
+    await cache.release("u", "g", "op", "k")
+    assert store == {}
+    # A completed envelope is never removed by release.
+    env = wrap_completed("op", {"ok": True})
+    await cache.put("u", "g", "op", "k", env, "fp")
+    await cache.release("u", "g", "op", "k")
+    assert len(store) == 1
+    assert (await cache.get("u", "g", "op", "k", "fp")) is not None
+
+  @pytest.mark.asyncio
+  async def test_put_replaces_the_reservation(self) -> None:
+    cache, _client, _store = self._make_cache()
+    await cache.reserve("u", "g", "op", "k", "fp")
+    env = wrap_completed("op", {"ok": True})
+    await cache.put("u", "g", "op", "k", env, "fp")
+    replay = await cache.get("u", "g", "op", "k", "fp")
+    assert replay is not None
+    assert replay.result == {"ok": True}
 
   @pytest.mark.asyncio
   async def test_miss_returns_none(self) -> None:
@@ -485,6 +531,8 @@ class _FakeIdempotencyCache:
 
   def __init__(self) -> None:
     self.store: dict[tuple[str, str, str, str], tuple[OperationEnvelope, str]] = {}
+    # Keys reserved by an in-flight run: key → body fingerprint.
+    self.pending: dict[tuple[str, str, str, str], str] = {}
 
   async def get(
     self,
@@ -494,13 +542,41 @@ class _FakeIdempotencyCache:
     idempotency_key: str,
     body_fingerprint: str,
   ) -> OperationEnvelope | None:
-    entry = self.store.get((user_id, graph_id, operation_name, idempotency_key))
+    k = (user_id, graph_id, operation_name, idempotency_key)
+    if k in self.pending:
+      if self.pending[k] != body_fingerprint:
+        raise IdempotencyKeyConflictError(operation_name)
+      raise IdempotencyInProgressError(operation_name)
+    entry = self.store.get(k)
     if entry is None:
       return None
     cached_envelope, cached_fingerprint = entry
     if cached_fingerprint != body_fingerprint:
       raise IdempotencyKeyConflictError(operation_name)
     return cached_envelope
+
+  async def reserve(
+    self,
+    user_id: str,
+    graph_id: str,
+    operation_name: str,
+    idempotency_key: str,
+    body_fingerprint: str,
+  ) -> bool:
+    k = (user_id, graph_id, operation_name, idempotency_key)
+    if k in self.pending or k in self.store:
+      return False
+    self.pending[k] = body_fingerprint
+    return True
+
+  async def release(
+    self,
+    user_id: str,
+    graph_id: str,
+    operation_name: str,
+    idempotency_key: str,
+  ) -> None:
+    self.pending.pop((user_id, graph_id, operation_name, idempotency_key), None)
 
   async def put(
     self,
@@ -512,10 +588,9 @@ class _FakeIdempotencyCache:
     body_fingerprint: str,
     ttl_seconds: int = IDEMPOTENCY_TTL_SECONDS,
   ) -> None:
-    self.store[(user_id, graph_id, operation_name, idempotency_key)] = (
-      envelope,
-      body_fingerprint,
-    )
+    k = (user_id, graph_id, operation_name, idempotency_key)
+    self.pending.pop(k, None)
+    self.store[k] = (envelope, body_fingerprint)
 
 
 def _make_ctx(**overrides: Any) -> OperationContext:
@@ -774,6 +849,90 @@ class TestExecuteOperationFailurePath:
     ):
       await execute_operation(ctx, _runner, idempotency_cache=cache)
 
+    assert cache.store == {}
+
+
+class TestExecuteOperationReservation:
+  """The cache had no in-flight state: two requests with the same key that
+  arrived inside the first one's run time both missed and both executed."""
+
+  @pytest.mark.asyncio
+  async def test_same_key_during_the_run_is_409_not_a_second_execution(
+    self,
+  ) -> None:
+    import asyncio
+
+    cache = _FakeIdempotencyCache()
+    ctx = _make_ctx(idempotency_key="k1", body_fingerprint="fp1")
+    calls = 0
+    release_runner = asyncio.Event()
+
+    def _slow_runner():
+      nonlocal calls
+      calls += 1
+      # Block the worker thread until the test lets the run finish.
+      asyncio.run_coroutine_threadsafe(release_runner.wait(), loop).result()
+      return {"n": calls}
+
+    loop = asyncio.get_running_loop()
+    with patch.object(middleware_module.logger, "info"):
+      first = asyncio.ensure_future(
+        execute_operation(ctx, _slow_runner, idempotency_cache=cache)
+      )
+      # Let the first request reach the runner and hold the reservation.
+      while calls == 0:
+        await asyncio.sleep(0.005)
+      with pytest.raises(IdempotencyInProgressError):
+        await execute_operation(ctx, _slow_runner, idempotency_cache=cache)
+      release_runner.set()
+      envelope = await first
+
+    assert calls == 1
+    assert envelope.result == {"n": 1}
+    # Once the first completes, the same key replays its envelope.
+    with patch.object(middleware_module.logger, "info"):
+      replay = await execute_operation(ctx, _slow_runner, idempotency_cache=cache)
+    assert replay.idempotent_replay is True
+    assert replay.result == {"n": 1}
+    assert calls == 1
+
+  @pytest.mark.asyncio
+  async def test_failed_run_releases_the_key_so_a_retry_executes(self) -> None:
+    cache = _FakeIdempotencyCache()
+    ctx = _make_ctx(idempotency_key="k2", body_fingerprint="fp2")
+    attempts = 0
+
+    def _flaky_runner():
+      nonlocal attempts
+      attempts += 1
+      if attempts == 1:
+        raise HTTPException(status_code=502, detail="upstream")
+      return {"attempt": attempts}
+
+    with (
+      patch.object(middleware_module.logger, "info"),
+      patch.object(middleware_module.logger, "error"),
+    ):
+      with pytest.raises(HTTPException):
+        await execute_operation(ctx, _flaky_runner, idempotency_cache=cache)
+      assert cache.pending == {}
+      envelope = await execute_operation(ctx, _flaky_runner, idempotency_cache=cache)
+    assert envelope.result == {"attempt": 2}
+
+  @pytest.mark.asyncio
+  async def test_failing_hook_releases_the_key(self) -> None:
+    cache = _FakeIdempotencyCache()
+    ctx = _make_ctx(idempotency_key="k3", body_fingerprint="fp3")
+
+    def _hook(_env):
+      raise RuntimeError("hook exploded")
+
+    with patch.object(middleware_module.logger, "info"):
+      with pytest.raises(RuntimeError):
+        await execute_operation(
+          ctx, lambda: {"ok": True}, idempotency_cache=cache, on_fresh_success=_hook
+        )
+    assert cache.pending == {}
     assert cache.store == {}
 
 

--- a/tests/middleware/test_extensions.py
+++ b/tests/middleware/test_extensions.py
@@ -935,6 +935,51 @@ class TestExecuteOperationReservation:
     assert cache.pending == {}
     assert cache.store == {}
 
+  @pytest.mark.asyncio
+  async def test_cancelled_request_still_records_and_releases(self) -> None:
+    """The runner's write commits in its worker thread whether or not the
+    client is still there. Before shielding, a disconnect mid-run skipped
+    both `except` arms: the envelope was never cached and the reservation
+    stayed pending for its whole TTL, so the client's retry got 409 for a
+    write that had already landed."""
+    import asyncio
+    import threading
+
+    cache = _FakeIdempotencyCache()
+    ctx = _make_ctx(idempotency_key="k4", body_fingerprint="fp4")
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def _slow_runner():
+      nonlocal calls
+      calls += 1
+      started.set()
+      release.wait(timeout=5)
+      return {"n": calls}
+
+    with patch.object(middleware_module.logger, "info"):
+      request = asyncio.ensure_future(
+        execute_operation(ctx, _slow_runner, idempotency_cache=cache)
+      )
+      while not started.is_set():
+        await asyncio.sleep(0.005)
+      request.cancel()
+      with pytest.raises(asyncio.CancelledError):
+        await request
+      # The client is gone; the work finishes anyway and is recorded.
+      release.set()
+      for _ in range(200):
+        if cache.store:
+          break
+        await asyncio.sleep(0.01)
+      assert cache.pending == {}
+      assert len(cache.store) == 1
+      # The retry replays instead of re-executing or being refused.
+      replay = await execute_operation(ctx, _slow_runner, idempotency_cache=cache)
+    assert replay.idempotent_replay is True
+    assert calls == 1
+
 
 class TestExecuteOperationIdempotency:
   @pytest.mark.asyncio

--- a/tests/middleware/test_extensions.py
+++ b/tests/middleware/test_extensions.py
@@ -589,6 +589,95 @@ class TestExecuteOperationHappyPath:
     assert audit["duration_ms"] >= 0
 
 
+class TestExecuteOperationRunsOffTheLoop:
+  """The API runs one uvicorn worker. A sync runner doing SQL or HTTP used
+  to execute inline on the event loop, freezing every other request —
+  including the ALB health check — for its whole duration."""
+
+  @pytest.mark.asyncio
+  async def test_sync_runner_does_not_block_the_event_loop(self) -> None:
+    import asyncio
+    import time
+
+    ctx = _make_ctx(operation_name="slow-op")
+    ticks: list[float] = []
+
+    async def _ticker() -> None:
+      for _ in range(3):
+        await asyncio.sleep(0.02)
+        ticks.append(time.monotonic())
+
+    def _blocking_runner():
+      time.sleep(0.25)
+      return {"slept": True}
+
+    with patch.object(middleware_module.logger, "info"):
+      ticker = asyncio.ensure_future(_ticker())
+      envelope = await execute_operation(ctx, _blocking_runner)
+      runner_returned_at = time.monotonic()
+      await ticker
+
+    assert envelope.result == {"slept": True}
+    # All three ticks landed while the runner was still sleeping — the loop
+    # kept turning. On the old inline path the ticker could not run until
+    # the runner returned, so every tick came after it.
+    assert len(ticks) == 3
+    assert all(t < runner_returned_at for t in ticks)
+
+  @pytest.mark.asyncio
+  async def test_sync_hook_runs_off_loop_and_async_hook_is_awaited(self) -> None:
+    import threading
+
+    ctx = _make_ctx(operation_name="hooked-op")
+    seen: dict[str, Any] = {}
+
+    def _sync_hook(envelope: OperationEnvelope) -> None:
+      seen["sync_thread"] = threading.current_thread()
+      seen["sync_env"] = envelope
+
+    async def _async_hook(envelope: OperationEnvelope) -> None:
+      seen["async_env"] = envelope
+
+    with patch.object(middleware_module.logger, "info"):
+      await execute_operation(ctx, lambda: {"a": 1}, on_fresh_success=_sync_hook)
+      await execute_operation(ctx, lambda: {"a": 2}, on_fresh_success=_async_hook)
+
+    assert seen["sync_thread"] is not threading.main_thread()
+    assert seen["sync_env"].result == {"a": 1}
+    assert seen["async_env"].result == {"a": 2}
+
+  @pytest.mark.asyncio
+  async def test_runner_sees_the_request_contextvars(self) -> None:
+    """The platform request-scoped session resolves through a ContextVar;
+    the worker thread must see the same context or the runner would get a
+    different Session than the dependencies that ran on the loop."""
+    import contextvars
+
+    marker: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+      "op_marker", default=None
+    )
+    ctx = _make_ctx(operation_name="ctx-op")
+    token = marker.set("from-request")
+    try:
+      with patch.object(middleware_module.logger, "info"):
+        envelope = await execute_operation(ctx, lambda: {"marker": marker.get()})
+    finally:
+      marker.reset(token)
+    assert envelope.result == {"marker": "from-request"}
+
+  @pytest.mark.asyncio
+  async def test_sync_runner_exception_still_propagates(self) -> None:
+    ctx = _make_ctx(operation_name="boom-op")
+
+    def _runner():
+      raise HTTPException(status_code=409, detail="locked")
+
+    with patch.object(middleware_module.logger, "info"):
+      with pytest.raises(HTTPException) as exc_info:
+        await execute_operation(ctx, _runner)
+    assert exc_info.value.status_code == 409
+
+
 class TestExecuteOperationFailurePath:
   @pytest.mark.asyncio
   async def test_http_exception_re_raised(self) -> None:

--- a/tests/operations/graph/test_deprovision_service.py
+++ b/tests/operations/graph/test_deprovision_service.py
@@ -316,12 +316,33 @@ class TestDeprovisionService:
   async def test_deprovision_already_deprovisioned(
     self, service, db_session, test_graph
   ):
-    """Returns early for already-deprovisioned graph."""
+    """An already-deprovisioned graph re-runs only the idempotent data-disposal
+    steps — a partial teardown used to leave a ghost tenant schema behind with
+    no way to retry — and touches nothing else."""
+    from unittest.mock import patch
+
     test_graph.transition_status(GraphStatus.DEPROVISIONED, db_session)
 
-    result = await service.deprovision_graph(test_graph.graph_id, db_session)
+    with (
+      patch(
+        "robosystems.db.extensions.drop_tenant_schema", return_value=True
+      ) as drop_schema,
+      patch.object(service, "_purge_search_index") as purge_search,
+      patch.object(service, "_purge_report_bundles") as purge_bundles,
+      patch.object(service, "_delete_database") as delete_db,
+      patch.object(service, "_deallocate_registry") as dealloc,
+    ):
+      result = await service.deprovision_graph(test_graph.graph_id, db_session)
 
     assert result.status == "already_deprovisioned"
+    assert result.extensions_schema_dropped is True
+    assert "residual data disposal re-run" in result.message
+    drop_schema.assert_called_once_with(test_graph.graph_id)
+    purge_search.assert_called_once()
+    purge_bundles.assert_called_once()
+    delete_db.assert_not_called()
+    dealloc.assert_not_called()
+    assert test_graph.status == GraphStatus.DEPROVISIONED.value
 
   @pytest.mark.asyncio
   async def test_deprovision_rejects_shared_repository(
@@ -826,3 +847,45 @@ class TestReportBundlePurge:
     db_session.refresh(test_graph)
     assert test_graph.status == GraphStatus.DEPROVISIONED.value
     assert test_graph.deleted_at is not None
+
+
+class TestOrphanTenantSchemas:
+  """A partial teardown, or a crash after the drop step failed, leaves a
+  tenant schema no graph owns; every per-tenant migration keeps touching it."""
+
+  def test_orphans_are_schemas_without_a_live_graph(self, db_session, test_graph):
+    from unittest.mock import patch
+
+    from robosystems.operations.graph.deprovision_service import (
+      find_orphan_tenant_schemas,
+    )
+
+    ghost = "kgdeadbeefdeadbeef01"
+    with patch(
+      "robosystems.db.extensions.list_tenant_schemas",
+      return_value=[test_graph.graph_id, ghost],
+    ):
+      assert find_orphan_tenant_schemas(db_session) == [ghost]
+
+      # A deprovisioned graph's schema is an orphan too.
+      test_graph.transition_status(GraphStatus.DEPROVISIONED, db_session)
+      db_session.flush()
+      assert find_orphan_tenant_schemas(db_session) == [test_graph.graph_id, ghost]
+
+  def test_purge_drops_each_orphan(self, db_session, test_graph):
+    from unittest.mock import patch
+
+    from robosystems.operations.graph.deprovision_service import (
+      purge_orphan_tenant_schemas,
+    )
+
+    ghost = "kgdeadbeefdeadbeef01"
+    with (
+      patch(
+        "robosystems.db.extensions.list_tenant_schemas",
+        return_value=[test_graph.graph_id, ghost],
+      ),
+      patch("robosystems.db.extensions.drop_tenant_schema", return_value=True) as drop,
+    ):
+      assert purge_orphan_tenant_schemas(db_session) == [ghost]
+    drop.assert_called_once_with(ghost)

--- a/tests/operations/operators/test_write_role_gate.py
+++ b/tests/operations/operators/test_write_role_gate.py
@@ -197,7 +197,7 @@ class TestToolSurfaceMatchesSpec:
         query="anything",
       )
 
-    tool_access.assert_called_once_with(GRAPH_ID, read_only=True)
+    tool_access.assert_called_once_with(GRAPH_ID, read_only=True, user_id=str(USER_ID))
 
   @pytest.mark.asyncio
   async def test_api_adapter_grants_writes_only_to_write_capable_specs(self) -> None:
@@ -221,7 +221,7 @@ class TestToolSurfaceMatchesSpec:
         query="anything",
       )
 
-    tool_access.assert_called_once_with(GRAPH_ID, read_only=False)
+    tool_access.assert_called_once_with(GRAPH_ID, read_only=False, user_id=str(USER_ID))
 
   @pytest.mark.asyncio
   async def test_http_tool_access_wires_read_only_into_the_tool_manager(self) -> None:
@@ -263,3 +263,12 @@ class TestToolSurfaceMatchesSpec:
       await HttpToolAccess(GRAPH_ID).initialize()
 
     assert tools_cls.call_args.kwargs["read_only"] is True
+
+
+class TestToolAccessCarriesTheActingUser:
+  def test_direct_tool_access_exposes_user_id_to_tools(self) -> None:
+    from robosystems.operations.operators.tool_access import DirectToolAccess
+
+    access = DirectToolAccess(GRAPH_ID, user_id="usr_worker")
+    assert access.user_id == "usr_worker"
+    assert DirectToolAccess(GRAPH_ID).user_id is None

--- a/tests/operations/operators/test_write_role_gate.py
+++ b/tests/operations/operators/test_write_role_gate.py
@@ -272,3 +272,72 @@ class TestToolAccessCarriesTheActingUser:
     access = DirectToolAccess(GRAPH_ID, user_id="usr_worker")
     assert access.user_id == "usr_worker"
     assert DirectToolAccess(GRAPH_ID).user_id is None
+
+
+class TestGraphScopeGate:
+  """The orchestrator checks `graph_scope` when it routes; the SSE, queued and
+  worker paths call the adapters directly and used to skip it."""
+
+  def _scoped_operator(self) -> MagicMock:
+    from robosystems.operations.operators.base import GraphScope
+
+    operator = MagicMock()
+    operator.spec = OperatorSpec(
+      name="Ledger-only Operator",
+      description="test",
+      capabilities=[OperatorCapability.CUSTOM],
+      graph_scope=GraphScope(schema_extension="roboledger"),
+    )
+    operator.run = AsyncMock(return_value=OperatorResult(content="ok"))
+    return operator
+
+  def test_refuses_a_graph_outside_the_scope(self) -> None:
+    from fastapi import HTTPException
+
+    from robosystems.operations.operators.base import enforce_operator_graph_scope
+
+    with patch(
+      "robosystems.middleware.mcp.tools.manager.resolve_schema_extensions",
+      return_value=["roboinvestor"],
+    ):
+      with pytest.raises(HTTPException) as exc_info:
+        enforce_operator_graph_scope(self._scoped_operator(), GRAPH_ID)
+    assert exc_info.value.status_code == 403
+
+  def test_passes_a_graph_inside_the_scope_and_unscoped_operators(self) -> None:
+    from robosystems.operations.operators.base import enforce_operator_graph_scope
+
+    with patch(
+      "robosystems.middleware.mcp.tools.manager.resolve_schema_extensions",
+      return_value=["roboledger"],
+    ) as resolve:
+      enforce_operator_graph_scope(self._scoped_operator(), GRAPH_ID)
+      resolve.assert_called_once_with(GRAPH_ID)
+      resolve.reset_mock()
+      enforce_operator_graph_scope(_operator(read_only=False), GRAPH_ID)
+      resolve.assert_not_called()
+
+  @pytest.mark.asyncio
+  async def test_api_adapter_applies_the_scope_gate(self) -> None:
+    from fastapi import HTTPException
+
+    from robosystems.operations.operators.adapters import api
+
+    user = MagicMock()
+    user.id = USER_ID
+    with (
+      patch.object(api, "enforce_operator_write_role"),
+      patch.object(api, "enforce_operator_credits"),
+      patch(
+        "robosystems.middleware.mcp.tools.manager.resolve_schema_extensions",
+        return_value=[],
+      ),
+    ):
+      with pytest.raises(HTTPException) as exc_info:
+        await api.run_operator_api(
+          operator=self._scoped_operator(),
+          graph_id=GRAPH_ID,
+          user=user,
+          query="anything",
+        )
+    assert exc_info.value.status_code == 403

--- a/tests/operations/roboledger/commands/test_fiscal_calendar.py
+++ b/tests/operations/roboledger/commands/test_fiscal_calendar.py
@@ -290,7 +290,7 @@ class TestBackfillPlanHistory:
     stamped_windows=frozenset(),
     close_side_effect=None,
   ):
-    """Run the backfill with the reopen/close commands patched out.
+    """Run the backfill with the restamp/close commands patched out.
 
     ``stamped_windows`` holds YYYY-MM months that already have canonical
     sets (the idempotency skip).
@@ -309,10 +309,13 @@ class TestBackfillPlanHistory:
       "error": 0,
       "skipped": 0,
     }
+    # A closed month goes through `_restamp_closed_period` (reopen + re-close
+    # as one fenced transaction); an open/`closing` month through
+    # `close_period`. Both stand in here with the same result/side effect.
     close_mock = MagicMock(return_value=close_result, side_effect=close_side_effect)
-    reopen_mock = MagicMock()
+    restamp_mock = MagicMock(return_value=close_result, side_effect=close_side_effect)
     with (
-      patch(f"{_MOD}.reopen_period", reopen_mock),
+      patch(f"{_MOD}._restamp_closed_period", restamp_mock),
       patch(f"{_MOD}.close_period", close_mock),
       patch(f"{_MOD}.qb_sync_state", return_value=(False, None)),
       patch(f"{_MOD}.build_fiscal_calendar_response", return_value=_fc_response()),
@@ -331,7 +334,7 @@ class TestBackfillPlanHistory:
         service=service,
         close_service=MagicMock(),
       )
-    return response, reopen_mock, close_mock
+    return response, restamp_mock, close_mock
 
   def test_nothing_closed_raises(self):
     with pytest.raises(BackfillPreconditionError) as exc_info:
@@ -373,7 +376,7 @@ class TestBackfillPlanHistory:
 
   def test_already_stamped_months_untouched(self):
     session = self._session(draft_counts=[0, 0], fp_statuses=["closed", "closed"])
-    response, reopen_mock, close_mock = self._run(
+    response, restamp_mock, close_mock = self._run(
       session,
       self._service(),
       stamped_windows={"2025-11", "2025-12"},
@@ -382,15 +385,15 @@ class TestBackfillPlanHistory:
     assert attempted == ["2026-01", "2026-02"]
     assert all(o.status == "stamped" for o in response.processed)
     assert response.remaining_periods == []
-    assert reopen_mock.call_count == 2
-    assert close_mock.call_count == 2
+    assert restamp_mock.call_count == 2
+    close_mock.assert_not_called()
 
   def test_restamp_re_derives_already_stamped_months(self):
     """restamp=true widens the walk to every month in range — the
     healing pass after an engine improvement changes what a stamp
     produces (e.g. the two-period CF derivation)."""
     session = self._session(draft_counts=[0] * 4, fp_statuses=["closed"] * 4)
-    response, reopen_mock, close_mock = self._run(
+    response, restamp_mock, close_mock = self._run(
       session,
       self._service(),
       body=BackfillPlanHistoryRequest(restamp=True),
@@ -399,12 +402,12 @@ class TestBackfillPlanHistory:
     attempted = [outcome.period for outcome in response.processed]
     assert attempted == ["2025-11", "2025-12", "2026-01", "2026-02"]
     assert all(o.status == "stamped" for o in response.processed)
-    assert reopen_mock.call_count == 4
-    assert close_mock.call_count == 4
+    assert restamp_mock.call_count == 4
+    close_mock.assert_not_called()
 
   def test_chunking_respects_max_periods(self):
     session = self._session(draft_counts=[0, 0], fp_statuses=["closed", "closed"])
-    response, _, close_mock = self._run(
+    response, restamp_mock, _ = self._run(
       session,
       self._service(),
       body=BackfillPlanHistoryRequest(max_periods=2),
@@ -412,14 +415,14 @@ class TestBackfillPlanHistory:
     attempted = [outcome.period for outcome in response.processed]
     assert attempted == ["2025-11", "2025-12"]
     assert response.remaining_periods == ["2026-01", "2026-02"]
-    assert close_mock.call_count == 2
+    assert restamp_mock.call_count == 2
 
   def test_draft_months_skipped_never_posted(self):
     session = self._session(
       draft_counts=[2, 0, 0, 0],
       fp_statuses=["closed", "closed", "closed"],
     )
-    response, _, close_mock = self._run(session, self._service())
+    response, restamp_mock, _ = self._run(session, self._service())
     assert response.processed[0].period == "2025-11"
     assert response.processed[0].status == "skipped_drafts"
     assert [o.period for o in response.processed if o.status == "stamped"] == [
@@ -427,7 +430,7 @@ class TestBackfillPlanHistory:
       "2026-01",
       "2026-02",
     ]
-    assert close_mock.call_count == 3
+    assert restamp_mock.call_count == 3
     assert response.remaining_periods == []
 
   def test_failure_halts_and_reports_remaining(self):
@@ -448,13 +451,13 @@ class TestBackfillPlanHistory:
       draft_counts=[0],
       fp_statuses=["closing"],
     )
-    response, reopen_mock, close_mock = self._run(
+    response, restamp_mock, close_mock = self._run(
       session,
       self._service(),
       body=BackfillPlanHistoryRequest(max_periods=1),
     )
     assert response.processed[0].status == "stamped"
-    reopen_mock.assert_not_called()
+    restamp_mock.assert_not_called()
     close_mock.assert_called_once()
 
   def test_stamp_outcome_fields_ride_through(self):
@@ -472,3 +475,54 @@ class TestBackfillPlanHistory:
       "error": 0,
       "skipped": 0,
     }
+
+
+class TestRestampClosedPeriod:
+  """The backfill's reopen + re-close is one transaction under one fence: a
+  failing re-close leaves nothing of the reopen behind."""
+
+  def _run(self, close_side_effect=None, session=None):
+    from robosystems.operations.roboledger.commands.fiscal_calendar import (
+      _restamp_closed_period,
+    )
+
+    session = session if session is not None else MagicMock()
+    close_service = MagicMock()
+    if close_side_effect is not None:
+      close_service.close.side_effect = close_side_effect
+    else:
+      close_service.close.return_value = _close_result()
+    with (
+      patch(f"{_MOD}._reopen_under_fence") as reopen_body,
+      patch(f"{_MOD}.qb_sync_state", return_value=(False, None)),
+      patch(f"{_MOD}.build_fiscal_calendar_response", return_value=_fc_response()),
+      patch(f"{_MOD}.exclusive_period_fence") as fence,
+    ):
+      result = _restamp_closed_period(
+        session,
+        MagicMock(),
+        GRAPH_ID,
+        "2026-01",
+        actor_id="usr_1",
+        note=None,
+        service=MagicMock(),
+        close_service=close_service,
+        actor_type="user",
+        allow_stale_sync=False,
+        allow_stranded_obligations=False,
+      )
+    return result, session, reopen_body, close_service, fence
+
+  def test_reopen_and_close_share_one_fence_and_one_commit(self):
+    result, session, reopen_body, close_service, fence = self._run()
+    fence.assert_called_once()
+    reopen_body.assert_called_once()
+    close_service.close.assert_called_once()
+    session.commit.assert_called_once()
+    assert result.period == "2026-01"
+
+  def test_a_failing_reclose_commits_nothing(self):
+    session = MagicMock()
+    with pytest.raises(UnbalancedLedgerError):
+      self._run(close_side_effect=UnbalancedLedgerError(100, 90), session=session)
+    session.commit.assert_not_called()

--- a/tests/operations/roboledger/commands/test_insert_race_translation.py
+++ b/tests/operations/roboledger/commands/test_insert_race_translation.py
@@ -1,0 +1,97 @@
+"""Select-then-insert commands translate the unique-key race into the same
+typed error their pre-check raises — never a raw IntegrityError 500."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+pytestmark = pytest.mark.unit
+
+
+def _integrity_error(constraint: str) -> IntegrityError:
+  return IntegrityError("INSERT", {}, Exception(f'violates "{constraint}"'))
+
+
+class TestPublishListMembers:
+  def test_racing_duplicate_member_is_already_present(self) -> None:
+    from robosystems.models.api.extensions.publish_lists import AddMembersRequest
+    from robosystems.operations.roboledger.commands.publish_lists import (
+      MembersAlreadyPresentError,
+      add_publish_list_members,
+    )
+
+    publish_list = MagicMock()
+    publish_list.created_by = "usr_owner"
+    session = MagicMock()
+    # list lookup, then the existing-members check (empty)
+    session.execute.return_value.scalar_one_or_none.return_value = publish_list
+    session.execute.return_value.scalars.return_value.all.return_value = []
+    session.flush.side_effect = _integrity_error("uq_publish_list_members")
+
+    graph = MagicMock()
+    graph.graph_id = "kg_target"
+    graph.schema_extensions = ["roboledger"]
+    platform = MagicMock()
+    platform.__enter__.return_value.execute.return_value.scalars.return_value.all.return_value = [
+      graph
+    ]
+    from unittest.mock import patch
+
+    with patch("robosystems.db.platform.SessionFactory", return_value=platform):
+      with pytest.raises(MembersAlreadyPresentError):
+        add_publish_list_members(
+          session,
+          "pl_1",
+          "kg_current",
+          AddMembersRequest(target_graph_ids=["kg_target"]),
+          added_by="usr_owner",
+        )
+
+
+class TestEventCreation:
+  def test_racing_duplicate_external_id_is_duplicate_event(self) -> None:
+    from robosystems.operations.event_block.commands import (
+      DuplicateEventError,
+      _flush_new_event,
+    )
+
+    session = MagicMock()
+    session.flush.side_effect = IntegrityError(
+      "INSERT",
+      {},
+      Exception('duplicate key value violates "idx_events_source_external_id"'),
+    )
+    body = MagicMock()
+    body.source = "quickbooks"
+    body.external_id = "JournalEntry_42"
+    with pytest.raises(DuplicateEventError):
+      _flush_new_event(session, MagicMock(), body)
+
+  def test_other_integrity_errors_still_surface(self) -> None:
+    from robosystems.operations.event_block.commands import _flush_new_event
+
+    session = MagicMock()
+    session.flush.side_effect = _integrity_error("events_agent_id_fkey")
+    body = MagicMock()
+    body.external_id = "x"
+    with pytest.raises(IntegrityError):
+      _flush_new_event(session, MagicMock(), body)
+
+
+class TestFiscalCalendarCreate:
+  def test_racing_second_initialize_is_already_initialized(self) -> None:
+    from robosystems.operations.roboledger.fiscal_calendar.service import (
+      CalendarAlreadyInitializedError,
+      FiscalCalendarService,
+    )
+
+    service = FiscalCalendarService()
+    session = MagicMock()
+    session.flush.side_effect = _integrity_error("uq_fiscal_calendar_graph")
+    with pytest.MonkeyPatch.context() as mp:
+      mp.setattr(service, "get", lambda _s, _g: None)
+      with pytest.raises(CalendarAlreadyInitializedError):
+        service.get_or_create(session, "kg_x")

--- a/tests/operations/roboledger/commands/test_insert_race_translation.py
+++ b/tests/operations/roboledger/commands/test_insert_race_translation.py
@@ -12,7 +12,11 @@ pytestmark = pytest.mark.unit
 
 
 def _integrity_error(constraint: str) -> IntegrityError:
-  return IntegrityError("INSERT", {}, Exception(f'violates "{constraint}"'))
+  return IntegrityError(
+    "INSERT",
+    {},
+    Exception(f'duplicate key value violates unique constraint "{constraint}"'),
+  )
 
 
 class TestPublishListMembers:
@@ -29,7 +33,7 @@ class TestPublishListMembers:
     # list lookup, then the existing-members check (empty)
     session.execute.return_value.scalar_one_or_none.return_value = publish_list
     session.execute.return_value.scalars.return_value.all.return_value = []
-    session.flush.side_effect = _integrity_error("uq_publish_list_members")
+    session.flush.side_effect = _integrity_error("uq_publish_list_members_pair")
 
     graph = MagicMock()
     graph.graph_id = "kg_target"
@@ -62,7 +66,9 @@ class TestEventCreation:
     session.flush.side_effect = IntegrityError(
       "INSERT",
       {},
-      Exception('duplicate key value violates "idx_events_source_external_id"'),
+      Exception(
+        'duplicate key value violates unique index "idx_events_source_external"'
+      ),
     )
     body = MagicMock()
     body.source = "quickbooks"
@@ -95,3 +101,63 @@ class TestFiscalCalendarCreate:
       mp.setattr(service, "get", lambda _s, _g: None)
       with pytest.raises(CalendarAlreadyInitializedError):
         service.get_or_create(session, "kg_x")
+
+
+class TestViolatedConstraint:
+  def test_reads_the_driver_diagnostic_first(self) -> None:
+    from robosystems.db.integrity import violated_constraint, violates
+
+    orig = MagicMock()
+    orig.diag.constraint_name = "uq_publish_list_members_pair"
+    exc = IntegrityError("INSERT", {}, orig)
+    assert violated_constraint(exc) == "uq_publish_list_members_pair"
+    assert violates(exc, "uq_publish_list_members_pair")
+    assert not violates(exc, "something_else")
+
+  def test_falls_back_to_the_quoted_name_in_the_message(self) -> None:
+    from robosystems.db.integrity import violated_constraint
+
+    exc = IntegrityError(
+      "INSERT",
+      {},
+      Exception('duplicate key value violates unique constraint "uq_x_y"'),
+    )
+    assert violated_constraint(exc) == "uq_x_y"
+    exc = IntegrityError("INSERT", {}, Exception("something unrelated"))
+    assert violated_constraint(exc) is None
+
+  def test_an_unrelated_constraint_is_not_reported_as_a_duplicate(self) -> None:
+    """The one thing the pre-check translation must not do: call a foreign-key
+    or CHECK failure a benign conflict."""
+    from robosystems.models.api.extensions.publish_lists import AddMembersRequest
+    from robosystems.operations.roboledger.commands.publish_lists import (
+      add_publish_list_members,
+    )
+
+    publish_list = MagicMock()
+    publish_list.created_by = "usr_owner"
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.return_value = publish_list
+    session.execute.return_value.scalars.return_value.all.return_value = []
+    session.flush.side_effect = _integrity_error(
+      "publish_list_members_publish_list_id_fkey"
+    )
+
+    graph = MagicMock()
+    graph.graph_id = "kg_target"
+    graph.schema_extensions = ["roboledger"]
+    platform = MagicMock()
+    platform.__enter__.return_value.execute.return_value.scalars.return_value.all.return_value = [
+      graph
+    ]
+    from unittest.mock import patch
+
+    with patch("robosystems.db.platform.SessionFactory", return_value=platform):
+      with pytest.raises(IntegrityError):
+        add_publish_list_members(
+          session,
+          "pl_1",
+          "kg_current",
+          AddMembersRequest(target_graph_ids=["kg_target"]),
+          added_by="usr_owner",
+        )

--- a/tests/operations/roboledger/commands/test_publish_lists.py
+++ b/tests/operations/roboledger/commands/test_publish_lists.py
@@ -1,0 +1,86 @@
+"""Publish-list membership is the owner's to change.
+
+`update_publish_list` / `delete_publish_list` already refused a non-owner; the
+member add/remove commands did not, so any graph member could redirect where
+another user's next share is delivered.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from robosystems.models.api.extensions.publish_lists import AddMembersRequest
+from robosystems.operations.roboledger.commands.publish_lists import (
+  PublishListNotAuthorizedError,
+  PublishListNotFoundError,
+  add_publish_list_members,
+  remove_publish_list_member,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _session_returning(row):
+  session = MagicMock()
+  session.execute.return_value.scalar_one_or_none.return_value = row
+  return session
+
+
+def _list(owner: str = "usr_owner"):
+  row = MagicMock()
+  row.id = "pl_1"
+  row.created_by = owner
+  return row
+
+
+class TestAddMembersOwnership:
+  def test_non_owner_is_refused_before_any_platform_lookup(self) -> None:
+    session = _session_returning(_list("usr_owner"))
+    with pytest.raises(PublishListNotAuthorizedError):
+      add_publish_list_members(
+        session,
+        "pl_1",
+        "kg_current",
+        AddMembersRequest(target_graph_ids=["kg_target"]),
+        added_by="usr_other",
+      )
+    session.add.assert_not_called()
+
+  def test_missing_list_is_not_found(self) -> None:
+    session = _session_returning(None)
+    with pytest.raises(PublishListNotFoundError):
+      add_publish_list_members(
+        session,
+        "pl_1",
+        "kg_current",
+        AddMembersRequest(target_graph_ids=["kg_target"]),
+        added_by="usr_owner",
+      )
+
+
+class TestRemoveMemberOwnership:
+  def test_non_owner_is_refused(self) -> None:
+    session = _session_returning(_list("usr_owner"))
+    with pytest.raises(PublishListNotAuthorizedError):
+      remove_publish_list_member(session, "pl_1", "m_1", acting_user_id="usr_other")
+    session.delete.assert_not_called()
+
+  def test_owner_removes_the_member(self) -> None:
+    publish_list = _list("usr_owner")
+    member = MagicMock()
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.side_effect = [publish_list, member]
+    assert (
+      remove_publish_list_member(session, "pl_1", "m_1", acting_user_id="usr_owner")
+      is True
+    )
+    session.delete.assert_called_once_with(member)
+
+  def test_missing_list_returns_false(self) -> None:
+    session = _session_returning(None)
+    assert (
+      remove_publish_list_member(session, "pl_x", "m_1", acting_user_id="usr_owner")
+      is False
+    )

--- a/tests/operations/roboledger/commands/test_reports.py
+++ b/tests/operations/roboledger/commands/test_reports.py
@@ -700,10 +700,12 @@ class _FakeReport:
     *,
     created_by: str = "usr_test",
     filing_status: str = "draft",
+    source_graph_id: str | None = None,
   ) -> None:
     self.id = report_id
     self.created_by = created_by
     self.filing_status = filing_status
+    self.source_graph_id = source_graph_id
 
 
 def _session_with_report(report: _FakeReport | None) -> MagicMock:
@@ -725,6 +727,19 @@ def test_regenerate_report_raises_not_authorized_when_owner_mismatch() -> None:
   body = MagicMock()
   with pytest.raises(NotAuthorizedError):
     regenerate_report(session, "kg_demo", "rpt_01", body, "usr_other")
+
+
+def test_regenerate_report_refuses_a_shared_in_copy_even_for_its_sender() -> None:
+  """A copy shared in from another graph carries the sender's user id in
+  `created_by`; a sender who is also a member here could otherwise regenerate
+  the copy from this graph's ledger and replace their own snapshot."""
+  report = _FakeReport(
+    "rpt_copy", created_by="usr_sender", filing_status="draft", source_graph_id="kg_src"
+  )
+  session = _session_with_report(report)
+  with pytest.raises(NotAuthorizedError) as exc:
+    regenerate_report(session, "kg_demo", "rpt_copy", MagicMock(), "usr_sender")
+  assert "shared in" in str(exc.value)
 
 
 def test_regenerate_report_raises_on_filed_report() -> None:

--- a/tests/operations/roboledger/commands/test_reports_filing.py
+++ b/tests/operations/roboledger/commands/test_reports_filing.py
@@ -27,6 +27,7 @@ def _make_report_def(
   """A MagicMock that mimics a Report ORM row well enough for these tests."""
   r = MagicMock()
   r.id = "rpt_01"
+  r.created_by = "user_01"
   r.name = "Q1 2026 Statements"
   r.taxonomy_id = "tax_usgaap_reporting"
   r.generation_status = "complete"
@@ -164,7 +165,9 @@ def test_transition_draft_to_under_review() -> None:
   session.get.return_value = _make_report_def(filing_status="draft")
 
   with _patch_response_helpers():
-    result = transition_filing_status(session, "rpt_01", "under_review")
+    result = transition_filing_status(
+      session, "rpt_01", "under_review", acting_user_id="user_01"
+    )
 
   assert result.filing_status == "under_review"
 
@@ -174,7 +177,9 @@ def test_transition_under_review_back_to_draft() -> None:
   session.get.return_value = _make_report_def(filing_status="under_review")
 
   with _patch_response_helpers():
-    result = transition_filing_status(session, "rpt_01", "draft")
+    result = transition_filing_status(
+      session, "rpt_01", "draft", acting_user_id="user_01"
+    )
 
   assert result.filing_status == "draft"
 
@@ -188,7 +193,9 @@ def test_transition_filed_to_archived() -> None:
   )
 
   with _patch_response_helpers():
-    result = transition_filing_status(session, "rpt_01", "archived")
+    result = transition_filing_status(
+      session, "rpt_01", "archived", acting_user_id="user_01"
+    )
 
   assert result.filing_status == "archived"
 
@@ -199,7 +206,7 @@ def test_transition_rejects_filing_via_generic_path() -> None:
   session.get.return_value = _make_report_def(filing_status="under_review")
 
   with pytest.raises(InvalidFilingTransitionError):
-    transition_filing_status(session, "rpt_01", "filed")
+    transition_filing_status(session, "rpt_01", "filed", acting_user_id="user_01")
 
 
 def test_transition_rejects_archive_from_draft() -> None:
@@ -208,7 +215,7 @@ def test_transition_rejects_archive_from_draft() -> None:
   session.get.return_value = _make_report_def(filing_status="draft")
 
   with pytest.raises(InvalidFilingTransitionError):
-    transition_filing_status(session, "rpt_01", "archived")
+    transition_filing_status(session, "rpt_01", "archived", acting_user_id="user_01")
 
 
 def test_transition_raises_when_report_missing() -> None:
@@ -216,10 +223,43 @@ def test_transition_raises_when_report_missing() -> None:
   session.get.return_value = None
 
   with pytest.raises(ReportNotFoundError):
-    transition_filing_status(session, "rpt_missing", "under_review")
+    transition_filing_status(
+      session, "rpt_missing", "under_review", acting_user_id="user_01"
+    )
 
 
 # ─── delete_report — filing-status immutability guard ───────────────────────
+
+
+def test_file_report_requires_the_author() -> None:
+  report = _make_report_def(filing_status="draft")
+  session = MagicMock()
+  session.get.return_value = report
+  with pytest.raises(NotAuthorizedError):
+    file_report(session, "rpt_01", filed_by="user_other")
+  assert report.filing_status == "draft"
+
+
+def test_file_report_refuses_a_shared_in_copy() -> None:
+  """A recipient filing a copy shared in from another graph would lock a
+  snapshot it did not author — and its own delete then refuses it as filed."""
+  report = _make_report_def(filing_status="draft")
+  report.source_graph_id = "kg_sender"
+  session = MagicMock()
+  session.get.return_value = report
+  with pytest.raises(NotAuthorizedError):
+    file_report(session, "rpt_01", filed_by="user_01")
+
+
+def test_transition_requires_the_author() -> None:
+  report = _make_report_def(filing_status="draft")
+  session = MagicMock()
+  session.get.return_value = report
+  with pytest.raises(NotAuthorizedError):
+    transition_filing_status(
+      session, "rpt_01", "under_review", acting_user_id="user_other"
+    )
+  assert report.filing_status == "draft"
 
 
 def test_delete_report_blocks_filed_status() -> None:

--- a/tests/operations/roboledger/commands/test_share_controls_db.py
+++ b/tests/operations/roboledger/commands/test_share_controls_db.py
@@ -191,6 +191,8 @@ def _clean_tenants(two_tenants):
       session.execute(text("DELETE FROM reports"))
       session.execute(text("DELETE FROM blocked_source_graphs"))
       session.execute(text("DELETE FROM report_shares"))
+      session.execute(text("DELETE FROM publish_list_members"))
+      session.execute(text("DELETE FROM publish_lists"))
       # Elements and structures before taxonomies: both carry a real FK to
       # `taxonomies.id`.
       session.execute(text("DELETE FROM elements"))
@@ -851,3 +853,165 @@ def test_revoke_survives_a_recipient_whose_schema_was_dropped() -> None:
   # And with no active share left, the sender can delete their own report.
   with extensions_session(SOURCE_GRAPH) as session:
     assert delete_report(session, _REPORT_SNAPSHOT["id"], acting_user_id=_SENDER)
+
+
+# ── share_report holds the source report for the whole share ─────────────────
+
+
+def _seed_publishable_report() -> str:
+  """A published report in the source schema, with a fact set and a publish
+  list pointing at the target. Returns the publish list id."""
+  from robosystems.models.api.fact_provenance import PivotProvenance
+  from robosystems.models.extensions.roboledger.fact import Fact
+  from robosystems.models.extensions.roboledger.publish_list import (
+    PublishList,
+    PublishListMember,
+  )
+  from robosystems.operations.roboledger.fact_set import create_fact_set
+
+  _seed_taxonomy(SOURCE_GRAPH, _STRUCTURE_TAXONOMY, "reporting_standard")
+  _seed_taxonomy(TARGET_GRAPH, _STRUCTURE_TAXONOMY, "reporting_standard")
+  _seed_structure(SOURCE_GRAPH, _LIBRARY_STRUCTURE_ID, "balance_sheet")
+  _seed_structure(TARGET_GRAPH, _LIBRARY_STRUCTURE_ID, "balance_sheet")
+  with extensions_session(SOURCE_GRAPH) as session:
+    session.add(
+      Report(
+        id=_REPORT_SNAPSHOT["id"],
+        name=_REPORT_SNAPSHOT["name"],
+        taxonomy_id=_REPORT_SNAPSHOT["taxonomy_id"],
+        period_type="quarterly",
+        period_start=_REPORT_SNAPSHOT["period_start"],
+        period_end=_REPORT_SNAPSHOT["period_end"],
+        comparative=False,
+        generation_status="published",
+        filing_status="draft",
+        created_by=_SENDER,
+      )
+    )
+    create_fact_set(
+      session,
+      id="fs_src_0001",
+      report_id=_REPORT_SNAPSHOT["id"],
+      structure_id=_LIBRARY_STRUCTURE_ID,
+      factset_type="report",
+      period_start=_REPORT_SNAPSHOT["period_start"],
+      period_end=_REPORT_SNAPSHOT["period_end"],
+      entity_id=_ENTITY_ID,
+      provenance=PivotProvenance(mapping_id="map_1", period="2026-01-01/2026-03-31"),
+      created_by=_SENDER,
+    )
+    session.flush()
+    session.add(
+      Fact(
+        id="fact_src_0001",
+        fact_set_id="fs_src_0001",
+        element_id="rs-gaap:Revenues",
+        value=100,
+        fact_type="Numeric",
+        value_type="inline",
+        period_start=_REPORT_SNAPSHOT["period_start"],
+        period_end=_REPORT_SNAPSHOT["period_end"],
+        period_type="duration",
+        unit="USD",
+        entity_id=_ENTITY_ID,
+      )
+    )
+    session.add(PublishList(id="plist_0001", name="Investors", created_by=_SENDER))
+    session.flush()
+    session.add(
+      PublishListMember(
+        id="plm_0001",
+        publish_list_id="plist_0001",
+        target_graph_id=TARGET_GRAPH,
+        added_by=_SENDER,
+      )
+    )
+  return "plist_0001"
+
+
+def test_share_report_records_the_share_in_the_same_transaction() -> None:
+  from robosystems.models.api.extensions.reports import ShareReportRequest
+  from robosystems.operations.roboledger.commands.reports import share_report
+
+  list_id = _seed_publishable_report()
+  with (
+    _patch_platform_graph_lookup(),
+    patch(
+      "robosystems.operations.roboledger.commands.reports._load_publication_artifacts",
+      return_value={},
+    ),
+  ):
+    response = share_report(
+      SOURCE_GRAPH,
+      _REPORT_SNAPSHOT["id"],
+      ShareReportRequest(publish_list_id=list_id),
+      acting_user_id=_SENDER,
+    )
+
+  assert [r.status for r in response.results] == ["shared"]
+  with extensions_session(SOURCE_GRAPH) as session:
+    shares = session.execute(text("SELECT target_graph_id FROM report_shares")).all()
+  assert [row[0] for row in shares] == [TARGET_GRAPH]
+  assert _counts(TARGET_GRAPH)[0] == 1
+
+
+def test_a_delete_cannot_slip_between_the_snapshot_and_the_share_rows() -> None:
+  """Before the report was locked for the share, `delete_report` could run
+  between the snapshot read and the `ReportShare` insert: it saw no active
+  shares, removed the source, and the recipient kept a copy nobody could
+  revoke. Now the delete waits on the row and gives up with a retryable error."""
+  import threading
+
+  from robosystems.models.api.extensions.reports import ShareReportRequest
+  from robosystems.operations.locking import RowLockedError
+  from robosystems.operations.roboledger.commands import reports as reports_module
+  from robosystems.operations.roboledger.commands.reports import share_report
+
+  list_id = _seed_publishable_report()
+  real_share_to_target = reports_module._share_to_target
+  copying = threading.Event()
+  release = threading.Event()
+
+  def _paused_share_to_target(**kwargs):
+    copying.set()
+    release.wait(timeout=10)
+    return real_share_to_target(**kwargs)
+
+  outcome: dict[str, object] = {}
+
+  def _run_share():
+    with (
+      _patch_platform_graph_lookup(),
+      patch(
+        "robosystems.operations.roboledger.commands.reports._load_publication_artifacts",
+        return_value={},
+      ),
+      patch(
+        "robosystems.operations.roboledger.commands.reports._share_to_target",
+        side_effect=_paused_share_to_target,
+      ),
+    ):
+      outcome["response"] = share_report(
+        SOURCE_GRAPH,
+        _REPORT_SNAPSHOT["id"],
+        ShareReportRequest(publish_list_id=list_id),
+        acting_user_id=_SENDER,
+      )
+
+  worker = threading.Thread(target=_run_share)
+  worker.start()
+  try:
+    assert copying.wait(timeout=10), "share never reached the copy step"
+    with extensions_session(SOURCE_GRAPH) as session:
+      with pytest.raises(RowLockedError, match=_REPORT_SNAPSHOT["id"]):
+        delete_report(session, _REPORT_SNAPSHOT["id"], acting_user_id=_SENDER)
+  finally:
+    release.set()
+    worker.join(timeout=30)
+
+  response = outcome["response"]
+  assert [r.status for r in response.results] == ["shared"]  # type: ignore[attr-defined]
+  # After the share commits, the delete is refused for the honest reason.
+  with extensions_session(SOURCE_GRAPH) as session:
+    with pytest.raises(ReportHasActiveSharesError):
+      delete_report(session, _REPORT_SNAPSHOT["id"], acting_user_id=_SENDER)

--- a/tests/operations/roboledger/commands/test_state_transition_locks_db.py
+++ b/tests/operations/roboledger/commands/test_state_transition_locks_db.py
@@ -535,3 +535,47 @@ class TestCalendarPointerLock:
         setter, GRAPH, "2026-01", actor_id="usr_op"
       )
       assert calendar.close_target_period == "2026-01"
+
+
+class TestFenceLeavesTheConnectionClean:
+  """A fence that fails to acquire must not hand a connection back to the pool
+  still carrying its 3s `lock_timeout` — the next borrower would inherit it."""
+
+  def test_lock_timeout_is_reset_when_acquisition_times_out(self, tenant):
+    from sqlalchemy import text as sql_text
+
+    from robosystems.db.extensions import get_extensions_engine
+    from robosystems.operations.locking import (
+      exclusive_period_fence,
+      period_fence_ident,
+    )
+
+    engine = get_extensions_engine()
+    period = "2031-01"
+    holder = engine.connect()
+    try:
+      holder.execute(
+        sql_text("SELECT pg_advisory_lock(872401, hashtext(:ident))"),
+        {"ident": period_fence_ident(GRAPH, period)},
+      )
+      with pytest.raises(RowLockedError):
+        with exclusive_period_fence(GRAPH, period, detail="held"):
+          pass
+    finally:
+      holder.execute(
+        sql_text("SELECT pg_advisory_unlock(872401, hashtext(:ident))"),
+        {"ident": period_fence_ident(GRAPH, period)},
+      )
+      holder.commit()
+      holder.close()
+
+    # Drain the pool's idle connections and check what each carries.
+    seen = []
+    conns = [engine.connect() for _ in range(engine.pool.size() + 1)]
+    try:
+      for conn in conns:
+        seen.append(conn.execute(sql_text("SHOW lock_timeout")).scalar_one())
+    finally:
+      for conn in conns:
+        conn.close()
+    assert all(value == "0" for value in seen), seen

--- a/tests/operations/roboledger/commands/test_state_transition_locks_db.py
+++ b/tests/operations/roboledger/commands/test_state_transition_locks_db.py
@@ -475,7 +475,9 @@ class TestFileReportLock:
       )
       with extensions_session(GRAPH) as other:
         with pytest.raises(RowLockedError, match=self.REPORT_ID):
-          transition_filing_status(other, self.REPORT_ID, "under_review")
+          transition_filing_status(
+            other, self.REPORT_ID, "under_review", acting_user_id="usr_seed"
+          )
 
   def test_a_locked_report_cannot_be_deleted(self, tenant):
     from robosystems.operations.roboledger.commands.reports import delete_report

--- a/tests/routers/admin/test_graphs.py
+++ b/tests/routers/admin/test_graphs.py
@@ -133,7 +133,8 @@ class TestDeprovisionGraph:
   def test_deprovision_already_deprovisioned(
     self, client, db_session, test_graph, mock_admin_auth
   ):
-    """Test 409 when graph is already deprovisioned."""
+    """An already-deprovisioned graph is a 200: the call re-runs the idempotent
+    data-disposal steps so a partial teardown can be finished from the CLI."""
     # First deprovision it
     test_graph.transition_status(GraphStatus.DEPROVISIONED, db_session)
 
@@ -142,8 +143,10 @@ class TestDeprovisionGraph:
       headers={"Authorization": "Bearer test-admin-key"},
     )
 
-    assert response.status_code == 409
-    assert "already deprovisioned" in response.json()["detail"].lower()
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "already_deprovisioned"
+    assert "already deprovisioned" in body["message"].lower()
 
   def test_deprovision_rejects_shared_repository(
     self, client, db_session, test_graph, mock_admin_auth

--- a/tests/routers/extensions/roboinvestor/test_operations.py
+++ b/tests/routers/extensions/roboinvestor/test_operations.py
@@ -98,6 +98,12 @@ def _make_user() -> MagicMock:
 
 
 class _FakeCache:
+  async def reserve(self, *args, **kwargs):
+    return True
+
+  async def release(self, *args, **kwargs):
+    return None
+
   def __init__(self) -> None:
     self.store: dict = {}
 

--- a/tests/routers/extensions/roboledger/test_information_block_ops.py
+++ b/tests/routers/extensions/roboledger/test_information_block_ops.py
@@ -95,6 +95,12 @@ def _schedule_payload() -> dict:
 
 
 class _FakeCache:
+  async def reserve(self, *args, **kwargs):
+    return True
+
+  async def release(self, *args, **kwargs):
+    return None
+
   def __init__(self) -> None:
     self.store: dict = {}
 

--- a/tests/routers/extensions/roboledger/test_operations.py
+++ b/tests/routers/extensions/roboledger/test_operations.py
@@ -266,7 +266,9 @@ class TestUpdateEntityOp:
 
     with patch(
       "robosystems.routers.extensions.roboledger.operations.extensions_session",
-      side_effect=ProgrammingError("stmt", {}, Exception("schema missing")),
+      side_effect=ProgrammingError(
+        "stmt", {}, Exception('relation "entities" does not exist')
+      ),
     ):
       with pytest.raises(HTTPException) as exc:
         await update_entity_op(
@@ -279,6 +281,50 @@ class TestUpdateEntityOp:
 
     assert exc.value.status_code == 404
     assert "not initialized" in exc.value.detail
+
+  @pytest.mark.asyncio
+  async def test_other_programming_error_is_not_a_404(self) -> None:
+    """Only a missing tenant schema means "not initialized". A different
+    database fault used to be swallowed into the same friendly 404 by the
+    hand-written handlers; the shared guard lets it surface."""
+    from sqlalchemy.exc import ProgrammingError
+
+    body = UpdateEntityRequest(name="New Name")
+
+    with patch(
+      "robosystems.routers.extensions.roboledger.operations.extensions_session",
+      side_effect=ProgrammingError(
+        "stmt", {}, Exception('column "nope" does not exist')
+      ),
+    ):
+      with pytest.raises(ProgrammingError):
+        await update_entity_op(
+          body=body,
+          graph_id=GRAPH_ID,
+          user=_make_user(),
+          idempotency_key=None,
+          cache=_FakeCache(),
+        )
+
+  @pytest.mark.asyncio
+  async def test_unmapped_value_error_is_422_with_its_message(self) -> None:
+    body = UpdateEntityRequest(name="New Name")
+
+    with patch(
+      "robosystems.routers.extensions.roboledger.operations.update_parent_entity",
+      side_effect=ValueError("ticker must be uppercase"),
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await update_entity_op(
+          body=body,
+          graph_id=GRAPH_ID,
+          user=_make_user(),
+          idempotency_key=None,
+          cache=_FakeCache(),
+        )
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "ticker must be uppercase"
 
   @pytest.mark.asyncio
   async def test_idempotency_key_cached_replay(self) -> None:

--- a/tests/routers/extensions/roboledger/test_operations.py
+++ b/tests/routers/extensions/roboledger/test_operations.py
@@ -104,6 +104,12 @@ def _make_entity_response() -> LedgerEntityResponse:
 
 
 class _FakeCache:
+  async def reserve(self, *args, **kwargs):
+    return True
+
+  async def release(self, *args, **kwargs):
+    return None
+
   """In-memory idempotency cache matching the real signature.
 
   Mirrors `IdempotencyCache.get/put` so route-handler tests can

--- a/tests/routers/extensions/roboledger/test_reads.py
+++ b/tests/routers/extensions/roboledger/test_reads.py
@@ -37,6 +37,12 @@ def _make_user(user_id: str = "usr_test"):
 
 
 class _FakeCache:
+  async def reserve(self, *args, **kwargs):
+    return True
+
+  async def release(self, *args, **kwargs):
+    return None
+
   async def get(self, *a, **kw):
     return None
 

--- a/tests/routers/extensions/roboledger/test_views.py
+++ b/tests/routers/extensions/roboledger/test_views.py
@@ -83,6 +83,12 @@ def _make_facts(count: int = 5):
 class _FakeCache:
   """Minimal idempotency cache stub that stores nothing."""
 
+  async def reserve(self, *args, **kwargs):
+    return True
+
+  async def release(self, *args, **kwargs):
+    return None
+
   async def get(self, *args, **kwargs):
     return None
 

--- a/tests/routers/extensions/test_graph_staleness_coverage.py
+++ b/tests/routers/extensions/test_graph_staleness_coverage.py
@@ -111,7 +111,7 @@ _STALE_IN_CALLEE = {
   # Async: enqueues the mapping operator, whose writes all land through this
   # direct MCP tool. The registrar-published tools inherit the mark from
   # their `OperationSpec`; this one is hand-written and marks for itself.
-  "auto-map-elements": "robosystems.middleware.mcp.tools.taxonomy_tools.CreateMappingAssociationTool.execute",
+  "auto-map-elements": "robosystems.middleware.mcp.tools.taxonomy_tools.CreateMappingAssociationTool._execute_sync",
 }
 
 # Same bar as `_EXEMPT`: name the table written and why the graph never

--- a/tests/routers/graphs/test_delete_graph_op.py
+++ b/tests/routers/graphs/test_delete_graph_op.py
@@ -22,6 +22,12 @@ from robosystems.routers.graphs.operations import delete_graph_op
 class _FakeCache:
   """In-memory idempotency cache matching the real signature."""
 
+  async def reserve(self, *args, **kwargs):
+    return True
+
+  async def release(self, *args, **kwargs):
+    return None
+
   def __init__(self) -> None:
     self.store: dict = {}
 

--- a/tests/routers/graphs/test_ops_shared_repo_gates.py
+++ b/tests/routers/graphs/test_ops_shared_repo_gates.py
@@ -30,6 +30,12 @@ from robosystems.routers.graphs.operations import (
 class _FakeCache:
   """In-memory idempotency cache matching the real signature."""
 
+  async def reserve(self, *args, **kwargs):
+    return True
+
+  async def release(self, *args, **kwargs):
+    return None
+
   def __init__(self) -> None:
     self.store: dict = {}
 

--- a/tests/routers/graphs/test_update_graph_metadata_op.py
+++ b/tests/routers/graphs/test_update_graph_metadata_op.py
@@ -25,6 +25,12 @@ _CMD = "robosystems.operations.graph.commands.metadata.update_graph_metadata_cmd
 class _FakeCache:
   """In-memory idempotency cache matching the real signature."""
 
+  async def reserve(self, *args, **kwargs):
+    return True
+
+  async def release(self, *args, **kwargs):
+    return None
+
   def __init__(self) -> None:
     self.store: dict = {}
 

--- a/tests/taxonomy/test_canonical_concepts_migration_shape.py
+++ b/tests/taxonomy/test_canonical_concepts_migration_shape.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 import importlib.util as _util
 from pathlib import Path
 
+import pytest
 from sqlalchemy import CheckConstraint
 
 from robosystems.db import extensions as extensions_db
-from robosystems.models.extensions import Structure
+from robosystems.models.extensions import Association, Element, Structure, Taxonomy
 from robosystems.taxonomy.writer import _ELEMENT_COLS
 
 _MIGRATION_PATH = (
@@ -94,4 +95,42 @@ class TestMetricTypeInStructureCheck:
     )
     assert any("associations" in s and "'has-part'" in s for s in statements), (
       "check_association_type widener must admit association_type='has-part'"
+    )
+
+
+class TestModelChecksMatchTheWidener:
+  """The model CHECKs and the provisioning widener now derive from the same
+  vocabulary tuples; a `create_all` tenant and a widened tenant carry
+  identical constraints. Guards the single-sourcing itself."""
+
+  @pytest.mark.parametrize(
+    ("model", "check_name", "column"),
+    [
+      (Structure, "check_block_type", "block_type"),
+      (Element, "check_element_source", "source"),
+      (Association, "check_association_type", "association_type"),
+      (Taxonomy, "check_taxonomy_type", "taxonomy_type"),
+    ],
+  )
+  def test_widener_installs_exactly_the_model_check(
+    self, model, check_name: str, column: str
+  ) -> None:
+    [check] = [
+      c
+      for c in model.__table__.constraints
+      if isinstance(c, CheckConstraint) and c.name == check_name
+    ]
+    model_clause = str(check.sqltext)
+
+    statements: list[str] = []
+
+    class FakeConn:
+      def execute(self, statement):
+        statements.append(str(statement))
+
+    extensions_db._widen_library_checks(FakeConn(), "kg0123456789abcdef")
+    [installed] = [s for s in statements if f"ADD CONSTRAINT {check_name}" in s]
+    assert model_clause in installed, (
+      f"{check_name}: the model CHECK and the widener disagree — edit the "
+      f"{column} vocabulary tuple on the model, not either CHECK"
     )

--- a/tests/taxonomy/test_forecast_migration_shape.py
+++ b/tests/taxonomy/test_forecast_migration_shape.py
@@ -96,23 +96,26 @@ class TestFreshPathParity:
 
   def test_provisioning_widens_match(self) -> None:
     """Fresh tenant schemas get their CHECKs from _widen_library_checks,
-    not from the migration chain — it must carry both new values."""
-    import inspect
-
+    not from the migration chain — it must carry both new values. The
+    widener now derives from the model vocabularies, so check what it emits."""
     from robosystems.db import extensions as extensions_db
 
-    source = inspect.getsource(extensions_db._widen_library_checks)
-    assert "'forecast'" in source
-    assert "'rs-driver'" in source
+    statements: list[str] = []
+
+    class FakeConn:
+      def execute(self, statement):
+        statements.append(str(statement))
+
+    extensions_db._widen_library_checks(FakeConn(), "kg0123456789abcdef")
+    assert any("'forecast'" in s for s in statements)
+    assert any("'rs-driver'" in s for s in statements)
 
   def test_models_match(self) -> None:
-    import inspect
+    from robosystems.models.extensions.element import ELEMENT_SOURCE_VALUES
+    from robosystems.models.extensions.structure import BLOCK_TYPE_VALUES
 
-    from robosystems.models.extensions import element as element_module
-    from robosystems.models.extensions import structure as structure_module
-
-    assert "'forecast'" in inspect.getsource(structure_module)
-    assert "'rs-driver'" in inspect.getsource(element_module)
+    assert "forecast" in BLOCK_TYPE_VALUES
+    assert "rs-driver" in ELEMENT_SOURCE_VALUES
 
   def test_manifest_lists_rs_driver_at_ordinal_15(self) -> None:
     manifest_path = (


### PR DESCRIPTION
## Summary

Follow-on to #1209: the queued tiers B and C of the same OLTP write-path review, folded into one PR so the whole set rides the next patch release together (design notes: `specs/extensions/oltp-write-path-hardening.md` §4, `specs/ledger/ledger-write-guards.md` §4 — the two rows that need a design decision or a dedupe migration stay open there).

### Runners off the event loop; one error policy (`c06b9f79`)
- **Every REST operation runner, sync `on_fresh_success` hook, and MCP tool body now runs in a worker thread** (`run_off_loop`, limiter sized to the extensions pool). The API runs one uvicorn worker; sync database and network work executed inline on the loop, so a close posting to QuickBooks or a bounded lock wait froze every other request — including the ALB health check.
- **The 22 hand-written roboledger handlers share the registrar's error policy** via `guard_command_runner` (schema-missing → 404, other database faults logged and surfaced, unmapped `ValueError` → 422 with its message) instead of each mapping every `ProgrammingError`/`ValueError` to the not-initialized 404. Hand-written MCP tools answer database faults with a fixed message rather than echoing the driver string.
- **Subgraph ids are refused up front (403)** by the extension dependency, matching the GraphQL endpoint, instead of failing inside a handler as 404 or 500 depending on which one caught it. Extensions engine singleton built under a lock.

### Idempotency in flight; attribution (`c9238c3b`)
- **Idempotency keys are reserved before the run** (`SET NX` pending marker). A duplicate that lands while the first request is still executing gets 409 ("still in progress") instead of executing alongside it; a failed run releases the claim so the retry executes. MCP calls, which carry no key, refuse an identical concurrent call the same way.
- **MCP tool calls emit the same audit line as their REST twin** (`surface=mcp`); MCP write-role denials emit the `AuthorizationDenied` audit; writes made through operators and in-process tools are stamped with the acting user (`DirectToolAccess`/`HttpToolAccess` carry `user_id`) rather than a fixed tag, the graph's first member, or `mcp:{graph_id}`.

### Ledger ownership, share consistency, teardown (`94dc91a5`)
- **Report lifecycle writes share one actor rule**: the author, never a copy shared in from another graph — file and status transitions were unchecked, and regenerate accepted a shared-in copy from its sender. Publish-list membership is the list owner's to change; a recipient only needs an extensions tenant (the rule `share-report` already applied).
- **`share-report` keeps the source report row-locked from snapshot to share rows in one transaction**, so a concurrent delete/regenerate waits (409 on the bounded wait) instead of leaving recipients with copies the sender can no longer revoke; a recipient's block that lands mid-copy still wins.
- **Backfill re-stamps a closed month as one fenced transaction** (reopen + re-close), so a failing re-close leaves the month closed rather than open with its statements retracted.
- **Deprovisioning** stamps `deleted_at` before it drops anything (the schema provisioner refuses such a graph, closing the in-flight-sync window), re-runs the idempotent disposal steps on an already-deprovisioned graph (admin returns 200 with what was still there), and gains an orphan-schema sweep (`GET/POST /admin/v1/graphs/orphan-schemas`, `admin graphs orphan-schemas [--drop]`). The extensions alembic env commits per migration under a `lock_timeout` with retry.

### Tier-C hygiene (`287dea3f`)
- Unique-key races surface as the typed conflict the pre-check raises (calendar init, block, publish-list members, mapping association, entity-taxonomy link, CoA auto-link, scenario dimension, event external id); JSON read-modify-write updates lock the row; `create_element` under a savepoint; portfolio dispose-before-add.
- Verification results swept at every report fact-set deletion; a deleted report's stored artifacts removed after commit; S3 client failure after commit no longer 500s.
- Engine `idle_in_transaction_session_timeout` (5 min; no `statement_timeout`), fence `RESET lock_timeout`, operator adapters enforce `graph_scope`, model CHECK vocabularies single-sourced with the provisioning widener (guard test), `qb_response_at` tz-aware.
- **Migration 0033 (extensions)**: `idx_events_qb_external_id` for tenants provisioned by `create_all` after 0014 (skips tenants that hold the 0014-named index); the index is on the `Event` model now.

## Behavior notes
- Hand-written roboledger ops: unmapped `ProgrammingError` → 500 (was 404), unmapped `ValueError` → 422 with message (was 404); subgraph ids → 403 (was 404/500).
- `Idempotency-Key` reuse while the first request runs → 409 (was a second execution). MCP: `{"error": "in_progress"}` for an identical concurrent call.
- `file-report` / `transition-filing-status` / `regenerate-report`: 403 for a non-author or a shared-in copy. `add-publish-list-members` / `remove-publish-list-member`: 403 for a non-owner; targets may be roboinvestor tenants. `share-report`: 409 on a held report.
- Admin `POST /admin/v1/graphs/{id}/deprovision` on an already-deprovisioned graph: 200 with `status=already_deprovisioned` (was 409).
- Extensions DB: run `just migrate-up extensions` (0033) with the patch.

## Test plan
- New tests: off-loop runner/hook/contextvars; idempotency reservation (concurrent same-key 409, failed run releases, hook failure releases, cache primitives); MCP registrar worker thread, audit line, in-flight refusal; hand-written tool DB-fault messages; subgraph guard; report ownership (regenerate/file/transition, shared-in copies); publish-list ownership; real-Postgres `share_report` (share rows in the same transaction; a delete during the copy step gets `RowLockedError`); restamp-as-one-transaction; deprovision re-run + orphan sweep + provisioner refusing an in-flight teardown; engine idle timeout; race translations; model-CHECK/widener parity; operator graph-scope gate; created_by attribution.
- Full unit suite: 13,146 passed. `just test-code` clean. Local stack: restarted on the branch, provisioned a skeleton roboledger graph, ran `initialize` / `create-agent` (replay + conflict) / subgraph guard end-to-end; 0033 applied and rolled back locally.
