### PR TITLE
fix: multi-tenancy hardening — tenant binding, connection scoping, query classification, limiter keying

### DIFF
--- a/robosystems/db/extensions.py
+++ b/robosystems/db/extensions.py
@@ -190,6 +190,9 @@ def _bind_statement(search_path: str, tenant_schema: str | None) -> str:
   set_local = f"SET LOCAL search_path TO {search_path}"
   if tenant_schema is None:
     return set_local
+  # Validated here as well as by the caller: this is the interpolation, and
+  # the guarantee should not depend on statement order in `extensions_session`.
+  tenant_schema = _sanitize_schema(tenant_schema)
   return (
     "DO $$ BEGIN "
     f"IF to_regnamespace('{tenant_schema}') IS NULL THEN "

--- a/robosystems/db/extensions.py
+++ b/robosystems/db/extensions.py
@@ -38,6 +38,17 @@ IDLE_IN_TRANSACTION_TIMEOUT_MS = 5 * 60 * 1000
 # all sentinel call sites share one string and renames don't drift.
 LIBRARY_GRAPH_ID = "library"
 
+# The schema extensions that give a graph an OLTP tenant schema. A graph
+# carrying any of these must have its schema provisioned at creation — an
+# extensions-flagged graph with no schema is not "empty", it is a session
+# whose bind is refused (see `_bind_statement`).
+TENANT_SCHEMA_EXTENSIONS: tuple[str, ...] = ("roboledger", "roboinvestor")
+
+
+def needs_tenant_schema(schema_extensions) -> bool:
+  """Whether a graph with these schema extensions gets a tenant schema."""
+  return any(ext in TENANT_SCHEMA_EXTENSIONS for ext in (schema_extensions or ()))
+
 
 def get_extensions_database_url() -> str:
   """Get extensions database URL with SSL for staging/prod."""
@@ -161,7 +172,37 @@ def _search_path_for(graph_id: str) -> str:
   return f"{_sanitize_schema(graph_id)}, public"
 
 
-def bind_search_path(session: Session, search_path: str) -> None:
+def _bind_statement(search_path: str, tenant_schema: str | None) -> str:
+  """The SQL that binds one transaction to ``search_path``.
+
+  For a tenant, the bind is guarded: PostgreSQL accepts a ``search_path``
+  whose first entry does not exist and silently skips it, and ``public``
+  holds a live copy of every tenant table (it is the template new tenants
+  are copied from). A session bound to a schema that was never provisioned,
+  or that teardown has already dropped, would therefore run every
+  unqualified statement against the shared template tables — no error, no
+  audit trail, one tenant's rows landing where every tenant's session can
+  read them. So the schema is required to exist, in the same round trip as
+  the ``SET LOCAL``, and its absence raises ``invalid_schema_name``
+  (``3F000``): the same failure a genuinely missing schema produces, which
+  the surfaces already translate to "not initialized" (404).
+  """
+  set_local = f"SET LOCAL search_path TO {search_path}"
+  if tenant_schema is None:
+    return set_local
+  return (
+    "DO $$ BEGIN "
+    f"IF to_regnamespace('{tenant_schema}') IS NULL THEN "
+    f"RAISE EXCEPTION 'tenant schema \"{tenant_schema}\" does not exist' "
+    "USING ERRCODE = '3F000'; "
+    "END IF; END $$; "
+    f"{set_local}"
+  )
+
+
+def bind_search_path(
+  session: Session, search_path: str, *, tenant_schema: str | None = None
+) -> None:
   """Bind ``session`` to ``search_path`` for every transaction it opens.
 
   ``SET search_path`` is connection state, and a ``Session`` does not keep
@@ -177,8 +218,13 @@ def bind_search_path(session: Session, search_path: str) -> None:
   gone at commit or rollback, never left on a pooled connection for the
   next borrower to inherit. Nested (savepoint) transactions inherit the
   outer transaction's setting and are skipped.
+
+  When ``tenant_schema`` is given the bind is fail-closed: it refuses to
+  begin a transaction on a schema that does not exist — see
+  :func:`_bind_statement` for why falling through to ``public`` is the
+  failure being prevented.
   """
-  stmt = text(f"SET LOCAL search_path TO {search_path}")
+  stmt = text(_bind_statement(search_path, tenant_schema))
 
   @event.listens_for(session, "after_begin")
   def _stamp(_session: Session, transaction: SessionTransaction, connection) -> None:
@@ -195,6 +241,9 @@ def extensions_session(graph_id: str):
   resolve in the graph_id schema and shared tables resolve from public. The
   binding holds for the life of the session, across any commit inside it —
   see :func:`bind_search_path` for why that is not the same as one ``SET``.
+  The bind is fail-closed: a graph whose schema does not exist (never
+  provisioned, or already torn down) raises ``invalid_schema_name`` on the
+  session's first statement instead of falling through to ``public``.
 
   Special case: `graph_id="library"` routes to the taxonomy library
   (read-only; library content currently lives in the `public` schema,
@@ -216,8 +265,9 @@ def extensions_session(graph_id: str):
       A SQLAlchemy Session scoped to the tenant schema (or library).
   """
   search_path = _search_path_for(graph_id)
+  tenant_schema = None if graph_id == LIBRARY_GRAPH_ID else graph_id
   session: Session = _get_session_factory()()
-  bind_search_path(session, search_path)
+  bind_search_path(session, search_path, tenant_schema=tenant_schema)
   try:
     yield session
     session.commit()
@@ -488,12 +538,13 @@ def list_tenant_schemas() -> list[str]:
 def tenant_schema_exists(graph_id: str) -> bool:
   """Whether ``graph_id`` still has a tenant schema in the extensions DB.
 
-  Cross-graph paths need this because ``extensions_session`` cannot tell
-  them: ``SET search_path`` to a schema that does not exist is legal in
-  PostgreSQL and only fails later, on the first query, as an ordinary
-  ``ProgrammingError`` indistinguishable from a genuine schema fault. Code
-  that must distinguish "the recipient was deprovisioned" from "something is
-  broken" has to ask up front — see ``_delete_shared_copy``.
+  ``extensions_session`` refuses to bind to a missing schema (see
+  ``_bind_statement``), so a session on a deprovisioned graph fails on its
+  first statement with ``invalid_schema_name``. Cross-graph paths that must
+  distinguish "the recipient was deprovisioned" from "something is broken"
+  before opening a session at all — and report it as a per-target outcome
+  rather than an error — ask up front with this; see ``_delete_shared_copy``
+  and ``_share_to_target``.
 
   Returns ``False`` when no extension domain is enabled or when ``graph_id``
   is not a tenant-schema id (subgraphs share their parent's schema).

--- a/robosystems/graph_api/core/ladybug/pool.py
+++ b/robosystems/graph_api/core/ladybug/pool.py
@@ -128,7 +128,22 @@ class LadybugConnectionPool:
       return self._create_new_connection(database_name, read_only)
 
   def _release_connection(self, database_name: str, connection_info: ConnectionInfo):
-    """Mark a connection as done with. Connections stay in the pool for reuse."""
+    """Mark a connection as done with. Connections stay in the pool for reuse.
+
+    A manual transaction left open on the connection would be inherited by
+    the next borrower — a read-only one refuses their writes, a write one
+    holds locks against everyone else on the database. The query validators
+    refuse `BEGIN` before it reaches the engine; this is the backstop for
+    anything that gets past them. The engine raises when there is nothing to
+    roll back, so that (the common case) is silent.
+    """
+    try:
+      connection_info.connection.execute("ROLLBACK")
+      logger.warning(
+        f"Rolled back a transaction left open on a pooled connection for {database_name}"
+      )
+    except Exception:
+      pass
     logger.debug(f"Released connection for {database_name}")
 
   def invalidate_connection(self, database_name: str):

--- a/robosystems/middleware/auth/dependencies.py
+++ b/robosystems/middleware/auth/dependencies.py
@@ -209,6 +209,17 @@ def _stash_api_key_identity(
     request.state.auth_method = auth_method
 
 
+def _publish_graph_authorization(request: Request, graph_id: str) -> None:
+  """Record that the caller was authorized on ``graph_id`` for this request.
+
+  Read by the subscription-aware rate limiter: a graph's own budget may only
+  be charged by a caller authorized on that graph, and this attribute is the
+  cheap, in-request evidence. It is set after the access check passes and
+  never before.
+  """
+  request.state.auth_graph_id = graph_id
+
+
 def verify_jwt_claims(
   token: str, device_fingerprint: dict[str, Any] | None = None
 ) -> tuple[str, int] | None:
@@ -413,6 +424,7 @@ async def get_current_user_with_graph(
             user_agent=user_agent,
             auth_method="jwt_token",
           )
+          _publish_graph_authorization(request, graph_id)
           return user
         else:
           SecurityAuditLogger.log_authorization_denied(
@@ -451,6 +463,7 @@ async def get_current_user_with_graph(
         user_agent=user_agent,
         auth_method="api_key",
       )
+      _publish_graph_authorization(request, graph_id)
       return user
     else:
       SecurityAuditLogger.log_security_event(

--- a/robosystems/middleware/rate_limits/rate_limiting.py
+++ b/robosystems/middleware/rate_limits/rate_limiting.py
@@ -56,15 +56,61 @@ def _verify_jwt_for_rate_limiting(token: str) -> str | None:
     return None
 
 
+def _api_key_digest(api_key: str) -> str:
+  import hashlib
+
+  return hashlib.sha256(api_key.encode()).hexdigest()
+
+
+def _api_key_is_cached_valid(api_key_hash: str) -> bool:
+  from robosystems.middleware.auth.cache import api_key_cache
+
+  try:
+    return api_key_cache.get_cached_api_key_validation(api_key_hash) is not None
+  except Exception:
+    return False
+
+
+def _caller_is_authorized_on_graph(
+  request: Request, user_id: str, graph_id: str, parent_graph_id: str
+) -> bool:
+  """Whether the identified caller is known to be authorized on the graph.
+
+  A graph's budget belongs to its members; charging it from a request that
+  merely names the graph in its URL would let anyone drain a tenant's
+  throughput without credentials. Evidence, cheapest first: the graph auth
+  dependency already ran and published its decision on ``request.state``;
+  otherwise the auth cache holds a positive decision for this principal on
+  the graph (or its parent) from an earlier request. Absent both, the
+  request is not graph-keyed — it falls back to the caller's own budget.
+  """
+  if getattr(request.state, "auth_graph_id", None) in (graph_id, parent_graph_id):
+    return True
+
+  from robosystems.middleware.auth.cache import api_key_cache
+
+  try:
+    if user_id.startswith("apikey_"):
+      digest = user_id[len("apikey_") :]
+      lookup = lambda g: api_key_cache.get_cached_graph_access(digest, g)  # noqa: E731
+    else:
+      lookup = lambda g: api_key_cache.get_cached_jwt_graph_access(user_id, g)  # noqa: E731
+    return any(lookup(g) is True for g in dict.fromkeys((graph_id, parent_graph_id)))
+  except Exception:
+    return False
+
+
 def get_user_identifier(request: Request) -> str:
   """Get user identifier for rate limiting based on authentication."""
+  # A key is an identity only once it is known to be valid (see
+  # `get_user_from_request`); an unverified header falls through to the
+  # published principal or the IP bucket, so junk keys cannot each mint a
+  # budget of their own.
   api_key = request.headers.get("X-API-Key")
   if api_key:
-    # Hash the API key for privacy
-    import hashlib
-
-    api_key_hash = hashlib.sha256(api_key.encode()).hexdigest()
-    return f"apikey:{api_key_hash}"
+    api_key_hash = _api_key_digest(api_key)
+    if _api_key_is_cached_valid(api_key_hash):
+      return f"apikey:{api_key_hash}"
 
   auth_header = request.headers.get("Authorization")
   if auth_header and auth_header.startswith("Bearer "):
@@ -271,15 +317,17 @@ def get_user_from_request(request: Request) -> str | None:
     if user_id:
       return user_id
 
-  # Check for API key authentication - we'll need to look up the user
+  # API key: an identity only once the key is known to be valid. The auth
+  # cache is keyed by the same digest and is populated by every successful
+  # validation, so this is one cache read and no re-validation. A header
+  # that is not cached-valid mints no identity — otherwise any string in
+  # the header would be "a user" with a fresh budget of its own, and the
+  # limiter would be trivially bypassed by rotating garbage keys.
   api_key = request.headers.get("X-API-Key")
   if api_key:
-    # For now, we'll use API key hashing for anonymity
-    # In production, you'd want to look up the user associated with the API key
-    import hashlib
-
-    api_key_hash = hashlib.sha256(api_key.encode()).hexdigest()
-    return f"apikey_{api_key_hash}"
+    api_key_hash = _api_key_digest(api_key)
+    if _api_key_is_cached_valid(api_key_hash):
+      return f"apikey_{api_key_hash}"
 
   # Principal published by the auth dependencies for credentials that carry
   # no reparseable header — the MCP connector's URL-carried key today, opaque
@@ -624,9 +672,14 @@ def subscription_aware_rate_limit_dependency(request: Request):
   #   3. The category hits the tenant's own instance. Shared-infrastructure
   #      categories stay user-keyed and tier-flat, or a customer could multiply
   #      their load on OpenSearch or the extensions RDS by creating graphs.
+  #   4. The caller is authorized on the graph. The bucket is the tenant's
+  #      budget; only a member may draw from it. When the auth dependency
+  #      has not run yet (router-level mounting) and no cached decision
+  #      exists, the request stays on the caller's own budget.
   graph_id = extract_graph_id(request.url.path) if user_id else None
   if (
     graph_id
+    and user_id
     and not is_shared_repository_or_subgraph(graph_id)
     and category in RateLimitConfig.DEDICATED_RESOURCE_CATEGORIES
   ):
@@ -636,8 +689,9 @@ def subscription_aware_rate_limit_dependency(request: Request):
     # budgets against one machine. Resolving the parent also spares the
     # resolver a per-subgraph cache entry and database row dependency.
     parent_graph_id, _subgraph_name = parse_graph_id(graph_id)
-    subscription_tier = resolve_graph_tier(parent_graph_id)
-    identifier = f"graph_sub:{parent_graph_id}"
+    if _caller_is_authorized_on_graph(request, user_id, graph_id, parent_graph_id):
+      subscription_tier = resolve_graph_tier(parent_graph_id)
+      identifier = f"graph_sub:{parent_graph_id}"
 
   limit_config = get_subscription_rate_limit(subscription_tier, category)
   if not limit_config:

--- a/robosystems/models/core/graph/graph.py
+++ b/robosystems/models/core/graph/graph.py
@@ -361,10 +361,20 @@ class Graph(Model):
   def get_by_id(
     cls, graph_id: str, session: Session, include_deprovisioned: bool = False
   ) -> Optional["Graph"]:
-    """Get a graph by its ID, skipping deprovisioned graphs by default."""
+    """Get a graph by its ID, skipping deprovisioned graphs by default.
+
+    A graph whose ``deleted_at`` is stamped is gone too: teardown stamps it
+    first and flips ``status`` last, and in between the tenant schema and
+    database are being dropped. Serving such a graph would bind sessions to a
+    schema that no longer exists — so the soft-delete stamp, not just the
+    terminal status, is what "deprovisioned" means to every reader that does
+    not opt in.
+    """
     query = session.query(cls).filter(cls.graph_id == graph_id)
     if not include_deprovisioned:
-      query = query.filter(cls.status != GraphStatus.DEPROVISIONED.value)
+      query = query.filter(
+        cls.status != GraphStatus.DEPROVISIONED.value, cls.deleted_at.is_(None)
+      )
     return query.first()
 
   @classmethod

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -182,6 +182,37 @@ def _flush_new_event(
     raise
 
 
+class ConnectionNotOnGraphError(ValueError):
+  """A ``connection_id`` that is not one of this graph's connections.
+
+  Connection ids are platform-wide, so an id alone says nothing about which
+  tenant owns it. Every place an event names a connection — the routing
+  ``metadata.connection_id`` at capture, a patch to it, the override on
+  execute — must resolve to a connection registered on the *calling* graph,
+  or the publish would post into (and refresh the tokens of) another
+  tenant's source-of-truth system.
+  """
+
+
+def _require_connection_on_graph(connection_id: str, graph_id: str) -> None:
+  from robosystems.database import SessionFactory as _PlatformSessionFactory
+  from robosystems.models.core.connection.connection import Connection
+
+  with _PlatformSessionFactory() as platform_session:
+    connection = Connection.get_by_id(connection_id, platform_session)
+    if connection is None or str(connection.graph_id) != str(graph_id):
+      raise ConnectionNotOnGraphError(
+        f"Connection {connection_id!r} is not registered on this graph."
+      )
+
+
+def _validate_routed_connection(metadata: dict | None, graph_id: str) -> None:
+  """Validate ``metadata.connection_id`` when an event carries one."""
+  connection_id = (metadata or {}).get("connection_id")
+  if connection_id:
+    _require_connection_on_graph(str(connection_id), graph_id)
+
+
 def _validate_event_source(source: str, graph_id: str) -> None:
   """A source is valid iff it's platform-emitted or registered on the graph.
 
@@ -279,6 +310,7 @@ def create_event_block(
   rolls back.
   """
   _validate_event_source(body.source, graph_id)
+  _validate_routed_connection(body.metadata, graph_id)
   _assert_not_duplicate(session, body)
 
   if body.apply_handlers:
@@ -404,6 +436,8 @@ def update_event_block(
   session: Session,
   body: UpdateEventBlockRequest,
   created_by: str,
+  *,
+  graph_id: str,
 ) -> EventBlockEnvelope:
   """Apply a status transition and/or field corrections to an event block.
 
@@ -526,6 +560,7 @@ def update_event_block(
     event.effective_at = body.effective_at
 
   if body.metadata_patch:
+    _validate_routed_connection(body.metadata_patch, graph_id)
     merged = dict(event.metadata_ or {})
     merged.update(body.metadata_patch)
     event.metadata_ = merged
@@ -743,6 +778,7 @@ def execute_event_block(
   body: ExecuteEventBlockRequest,
   created_by: str,
   *,
+  graph_id: str,
   acquire_period_fence: bool = True,
 ) -> ExecuteEventBlockResponse:
   """Publish an event to its connection's source-of-truth system.
@@ -881,6 +917,12 @@ def execute_event_block(
         status=str(event.status),
         qb_external_id=None,
         qb_error=None,
+      )
+    # The id came from the request or from client-editable metadata; only a
+    # connection registered on *this* graph may be published to.
+    if str(connection.graph_id) != str(graph_id):
+      raise ConnectionNotOnGraphError(
+        f"Connection {connection_id!r} is not registered on this graph."
       )
 
     if connection.write_policy == "native":

--- a/robosystems/operations/graph/deprovision_service.py
+++ b/robosystems/operations/graph/deprovision_service.py
@@ -544,6 +544,14 @@ class GraphDeprovisionService:
       result.errors.append(error_msg)
       logger.warning(error_msg, extra={"graph_id": graph_id})
 
+  @staticmethod
+  def _invalidate_member_access(graph_id: str, member_ids: list[str]) -> None:
+    from ...middleware.auth.cache import api_key_cache
+
+    for user_id in member_ids:
+      api_key_cache.invalidate_user_jwt_graph_access(user_id, graph_id)
+    api_key_cache.invalidate_user_graph_access("*", graph_id)
+
   def _clean_pg_records(
     self, graph_id: str, session: Session, result: DeprovisionResult
   ) -> None:
@@ -572,6 +580,19 @@ class GraphDeprovisionService:
       session.query(GraphCredits).filter(GraphCredits.graph_id == graph_id).delete(
         synchronize_session=False
       )
+
+      # Drop the members' cached access decisions with their rows: a warm
+      # positive entry would otherwise let a member's request past the auth
+      # dependency for up to the cache TTL, onto a graph whose schema and
+      # database are being dropped underneath it. Best-effort — the cache
+      # helpers log and swallow their own failures.
+      member_ids = [
+        row[0]
+        for row in session.query(GraphUser.user_id)
+        .filter(GraphUser.graph_id == graph_id)
+        .all()
+      ]
+      self._invalidate_member_access(graph_id, member_ids)
 
       session.query(GraphUser).filter(GraphUser.graph_id == graph_id).delete(
         synchronize_session=False

--- a/robosystems/operations/graph/graph_creation_service.py
+++ b/robosystems/operations/graph/graph_creation_service.py
@@ -149,10 +149,26 @@ class GraphCreationService:
         graph_id, org_id, location, config, schema_ddl, schema_info
       )
 
+      # The tenant schema is provisioned whenever the graph carries an
+      # extension that has one — independent of whether an entity is created
+      # up front. An extensions-flagged graph with no schema passes the
+      # extension gate and then has nowhere to land (db/extensions.py,
+      # `_bind_statement`), so "empty entity graph" means an empty *schema*,
+      # not a missing one.
+      from robosystems.db.extensions import (
+        needs_tenant_schema,
+        provision_tenant_schema,
+      )
+
       entity_dict = None
-      if config.graph_type == "entity" and config.create_entity and config.entity_data:
-        self._emit(config, "Provisioning entity...", 85)
-        entity_dict = await self._provision_entity(graph_id, config)
+      if not config.has_custom_schema and needs_tenant_schema(config.schema_extensions):
+        self._emit(config, "Provisioning tenant schema...", 82)
+        provision_tenant_schema(graph_id)
+        if (
+          config.graph_type == "entity" and config.create_entity and config.entity_data
+        ):
+          self._emit(config, "Provisioning entity...", 85)
+          entity_dict = await self._provision_entity(graph_id, config)
 
       self._emit(config, "Creating credit pool...", 92)
       self._create_credits(graph_id, config)
@@ -429,11 +445,12 @@ class GraphCreationService:
     graph_id: str,
     config: GraphCreationConfig,
   ) -> dict[str, Any]:
-    """Provision extensions OLTP tenant schema and create entity node.
+    """Create the entity row in the (already provisioned) tenant schema.
 
-    Only called for entity graphs with create_entity=True.
+    Only called for entity graphs with create_entity=True; the schema itself
+    is provisioned by the pipeline for every extensions-flagged graph.
     """
-    from robosystems.db.extensions import extensions_session, provision_tenant_schema
+    from robosystems.db.extensions import extensions_session
     from robosystems.models.api import EntityCreate
     from robosystems.models.extensions.entity import Entity as LedgerEntity
 
@@ -447,8 +464,6 @@ class GraphCreationService:
     # on the entity, not the graph, so one graph can hold entities of
     # different legal forms.
     reporting_style_id = resolve_reporting_style_id(config.entity_data)
-
-    provision_tenant_schema(graph_id)
 
     entity_identifier = f"entity_{graph_id}"
     entity_uri = entity_data.uri or f"https://robosystems.ai/entities#{graph_id}"

--- a/robosystems/operations/roboledger/commands/publish_lists.py
+++ b/robosystems/operations/roboledger/commands/publish_lists.py
@@ -162,7 +162,9 @@ def add_publish_list_members(
   applies to a recipient), prevents self-add, and rejects duplicates.
   """
   from robosystems.db.platform import SessionFactory
+  from robosystems.middleware.graph.utils.subgraph import is_subgraph
   from robosystems.models.core import Graph
+  from robosystems.models.core.graph import GraphStatus
   from robosystems.operations.roboledger.commands.reports import (
     _RECEIVING_EXTENSIONS,
   )
@@ -176,14 +178,20 @@ def add_publish_list_members(
     raise PublishListNotAuthorizedError("Not authorized to modify this publish list.")
 
   with SessionFactory() as platform_session:
+    # Live graphs only: a deprovisioned or mid-teardown recipient has no
+    # schema for a share to land in, and a subgraph never has one of its own.
     graphs = (
       platform_session.execute(
-        select(Graph).where(Graph.graph_id.in_(body.target_graph_ids))
+        select(Graph).where(
+          Graph.graph_id.in_(body.target_graph_ids),
+          Graph.status != GraphStatus.DEPROVISIONED.value,
+          Graph.deleted_at.is_(None),
+        )
       )
       .scalars()
       .all()
     )
-    found_ids = {str(g.graph_id) for g in graphs}
+    found_ids = {str(g.graph_id) for g in graphs if not is_subgraph(g.graph_id)}
 
     missing = set(body.target_graph_ids) - found_ids
     if missing:

--- a/robosystems/operations/roboledger/commands/reports.py
+++ b/robosystems/operations/roboledger/commands/reports.py
@@ -1375,14 +1375,23 @@ def _share_to_target(
   publication_artifacts: dict[str, str] | None = None,
 ) -> ShareResultItem:
   """Copy report definition + FactSets + facts to a target tenant schema."""
-  from robosystems.db.extensions import extensions_session
+  from robosystems.db.extensions import extensions_session, tenant_schema_exists
   from robosystems.db.platform import SessionFactory
   from robosystems.models.core import Graph
+  from robosystems.models.core.graph import GraphStatus
 
   try:
     with SessionFactory() as platform_session:
+      # A deprovisioned (or mid-teardown) recipient reads as absent: its
+      # schema is gone or going, and teardown never prunes it from senders'
+      # publish lists, so a re-share to the list would otherwise be attempted
+      # against a schema that does not exist.
       target_graph = platform_session.execute(
-        select(Graph).where(Graph.graph_id == target_graph_id)
+        select(Graph).where(
+          Graph.graph_id == target_graph_id,
+          Graph.status != GraphStatus.DEPROVISIONED.value,
+          Graph.deleted_at.is_(None),
+        )
       ).scalar_one_or_none()
 
       if not target_graph:
@@ -1415,6 +1424,17 @@ def _share_to_target(
       target_graph_id=target_graph_id,
       status="error",
       error="Failed to validate target graph.",
+    )
+
+  # The row can outlive the schema (a torn-down recipient, or one that never
+  # provisioned). The session bind refuses a missing schema, so this only
+  # decides the *message*: a per-target outcome the sender can act on rather
+  # than a generic failure — the same courtesy `_delete_shared_copy` extends.
+  if not tenant_schema_exists(target_graph_id):
+    return ShareResultItem(
+      target_graph_id=target_graph_id,
+      status="error",
+      error="Target graph has no extensions tenant schema.",
     )
 
   try:

--- a/robosystems/operations/roboledger/fiscal_calendar/close_service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_service.py
@@ -590,6 +590,7 @@ class PeriodCloseService:
               connection_id=qb_connection_id,
             ),
             created_by=actor_id,
+            graph_id=graph_id,
             acquire_period_fence=False,
           )
         if result.status == "pending":

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -1600,6 +1600,9 @@ update_event_block_op = _registrar.register(
       JournalEntryNotPostedError: 422,
       ValueError: 422,
     },
+    # A `metadata_patch.connection_id` must name one of this graph's
+    # connections; the tenant session alone doesn't carry the graph id.
+    requires_graph_id=True,
     mark_stale_reason="event_block_updated",
   )
 )
@@ -1646,6 +1649,9 @@ execute_event_block_op = _registrar.register(
       ClosedPeriodError: 422,
       ValueError: 422,
     },
+    # The connection published to must be one of this graph's; the override
+    # in the body and the routing id in event metadata are both caller-set.
+    requires_graph_id=True,
     mark_stale_reason="event_published",
   )
 )

--- a/robosystems/security/cypher_analyzer.py
+++ b/robosystems/security/cypher_analyzer.py
@@ -174,6 +174,12 @@ class CypherSecurityAnalyzer:
     # no parentheses, so the procedure pattern above never sees it.
     self.call_assignment_pattern = re.compile(r"\bCALL\s+([\w.]+)\s*=", re.IGNORECASE)
 
+    # Statement-leading transaction control / checkpoint — see
+    # `_find_admin_operations`.
+    self.transaction_control_pattern = re.compile(
+      r"(?:^|;)\s*(BEGIN|COMMIT|ROLLBACK|CHECKPOINT)\b", re.IGNORECASE
+    )
+
     # Comments, string literals, and backtick identifiers are masked by the
     # single-pass scanner in `_clean_query` (not by regex) so an in-string
     # comment marker can't hide a trailing write keyword.
@@ -517,6 +523,16 @@ class CypherSecurityAnalyzer:
     if re.search(r"\bDETACH\s+DATABASE\b", query, re.IGNORECASE):
       found_operations.add("DETACH_DATABASE")
 
+    # Transaction control and CHECKPOINT. Every request runs in its own
+    # auto-transaction; a manual BEGIN leaves a transaction open on a pooled
+    # engine connection that the next borrower inherits — a read-only one
+    # refuses their writes, a write one holds locks against ingestion and
+    # every other tenant of a shared database — and CHECKPOINT is an
+    # engine-level maintenance verb. Matched at statement start (or after a
+    # `;`) so a property named `begin` or `commit` in a read is untouched.
+    if self.transaction_control_pattern.search(query):
+      found_operations.add("TRANSACTION_CONTROL")
+
     return found_operations
 
   def _find_system_calls(self, query: str) -> set[str]:
@@ -569,6 +585,13 @@ class CypherSecurityAnalyzer:
     # Check for RENAME TABLE
     if re.search(r"\bRENAME\s+TABLE\b", query, re.IGNORECASE):
       found_operations.add("RENAME_TABLE")
+
+    # COMMENT ON is a catalog write: it changes what `CALL show_tables()`
+    # returns to every reader of the database, and the write keyword set
+    # never sees it (`comment` is far too common a property name to match
+    # bare). The two-word form is unambiguous.
+    if re.search(r"\bCOMMENT\s+ON\b", query, re.IGNORECASE):
+      found_operations.add("COMMENT_ON")
 
     return found_operations
 

--- a/tests/db/test_extensions_isolation.py
+++ b/tests/db/test_extensions_isolation.py
@@ -38,10 +38,14 @@ import robosystems.db.extensions as ext
 from robosystems.db.extensions import LIBRARY_GRAPH_ID, extensions_session
 
 # Two distinct, well-formed tenant graph_ids (kg + 16+ hex) standing in for two
-# graphs under the same org — the multi-graph-per-org case. ``SET search_path``
-# to a schema that does not exist is legal, so no schema is created here.
+# graphs under the same org — the multi-graph-per-org case. The bind is
+# fail-closed (a missing schema raises rather than falling through to
+# ``public``), so the ``tenants`` fixture creates these two — empty is enough:
+# these tests only ever ask the connection who it is.
 GRAPH_A = "kg00000000000000aa"
 GRAPH_B = "kg00000000000000bb"
+# Never created: the graph a session must refuse to bind to.
+GRAPH_UNPROVISIONED = "kg00000000000000de"
 
 _WHOAMI = text("select pg_backend_pid(), current_setting('search_path')")
 
@@ -64,6 +68,19 @@ def engine():
   eng.dispose()
 
 
+@pytest.fixture()
+def tenants(engine):
+  """Provision (empty) tenant schemas for GRAPH_A / GRAPH_B; drop after."""
+  with engine.begin() as conn:
+    for schema in (GRAPH_A, GRAPH_B):
+      conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
+    conn.execute(text(f'DROP SCHEMA IF EXISTS "{GRAPH_UNPROVISIONED}" CASCADE'))
+  yield
+  with engine.begin() as conn:
+    for schema in (GRAPH_A, GRAPH_B, GRAPH_UNPROVISIONED):
+      conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+
+
 def _poison_pool(engine, *stamps: str) -> None:
   """Leave idle pooled connections bound to *other* schemas — the state a
   raw connection, or a pre-fix session, would leave behind."""
@@ -83,7 +100,7 @@ def _idle_search_paths(engine) -> list[str]:
   return paths
 
 
-def test_binding_survives_a_mid_flow_commit(engine):
+def test_binding_survives_a_mid_flow_commit(engine, tenants):
   """The one that matters: commit inside the session, keep going, still on
   the same tenant — even when the pool hands back a connection another
   tenant last used."""
@@ -96,7 +113,7 @@ def test_binding_survives_a_mid_flow_commit(engine):
   assert after[1] == f"{GRAPH_A}, public", after
 
 
-def test_binding_survives_a_rollback(engine):
+def test_binding_survives_a_rollback(engine, tenants):
   _poison_pool(engine, GRAPH_B, "kg00000000000000cc")
   with extensions_session(GRAPH_A) as session:
     session.execute(_WHOAMI)
@@ -104,7 +121,7 @@ def test_binding_survives_a_rollback(engine):
     assert session.execute(_WHOAMI).one()[1] == f"{GRAPH_A}, public"
 
 
-def test_binding_holds_inside_a_savepoint(engine):
+def test_binding_holds_inside_a_savepoint(engine, tenants):
   """Handlers dispatch inside ``begin_nested()``; the binding is the outer
   transaction's and a savepoint neither loses nor re-stamps it."""
   with extensions_session(GRAPH_A) as session:
@@ -113,7 +130,7 @@ def test_binding_holds_inside_a_savepoint(engine):
     assert session.execute(_WHOAMI).one()[1] == f"{GRAPH_A}, public"
 
 
-def test_nothing_is_left_on_the_pooled_connection(engine):
+def test_nothing_is_left_on_the_pooled_connection(engine, tenants):
   """``SET LOCAL`` ends with the transaction: after the session, no idle
   connection carries the tenant — commit or rollback."""
   with extensions_session(GRAPH_A) as session:
@@ -127,12 +144,46 @@ def test_nothing_is_left_on_the_pooled_connection(engine):
   assert not leaked, leaked
 
 
-def test_distinct_graphs_get_distinct_search_paths(engine):
+def test_distinct_graphs_get_distinct_search_paths(engine, tenants):
   """Two graphs under one org never share a scope, in either order."""
   with extensions_session(GRAPH_A) as session:
     assert session.execute(_WHOAMI).one()[1] == f"{GRAPH_A}, public"
   with extensions_session(GRAPH_B) as session:
     assert session.execute(_WHOAMI).one()[1] == f"{GRAPH_B}, public"
+
+
+def test_refuses_to_bind_a_schema_that_does_not_exist(engine, tenants):
+  """The other silent landing. PostgreSQL skips a missing ``search_path``
+  entry, and ``public`` holds a copy of every tenant table, so a session on
+  a never-provisioned (or already-dropped) graph would run every unqualified
+  statement against the shared template — no error. The bind must refuse,
+  on the first statement, with the same code a genuinely missing schema
+  produces, so the surfaces' "not initialized" translation applies."""
+  from sqlalchemy.exc import ProgrammingError
+
+  from robosystems.middleware.extensions import is_schema_missing
+
+  with pytest.raises(ProgrammingError) as excinfo:
+    with extensions_session(GRAPH_UNPROVISIONED) as session:
+      session.execute(text("select current_schema()"))
+  assert getattr(excinfo.value.orig, "pgcode", None) == "3F000"
+  assert is_schema_missing(excinfo.value)
+  assert GRAPH_UNPROVISIONED in str(excinfo.value)
+
+
+def test_refuses_the_next_transaction_after_the_schema_is_dropped(engine, tenants):
+  """Teardown drops the schema while a member's session may still be open:
+  the transaction that began before the drop is the tenant's; the next one
+  must not land on ``public``."""
+  from sqlalchemy.exc import ProgrammingError
+
+  with pytest.raises(ProgrammingError):
+    with extensions_session(GRAPH_B) as session:
+      assert session.execute(_WHOAMI).one()[1] == f"{GRAPH_B}, public"
+      session.commit()
+      with engine.begin() as conn:
+        conn.execute(text(f'DROP SCHEMA "{GRAPH_B}" CASCADE'))
+      session.execute(_WHOAMI)
 
 
 def test_library_sentinel_binds_public_only(engine):
@@ -191,9 +242,20 @@ def test_commits_and_closes_on_success():
   ):
     with extensions_session(GRAPH_A) as yielded:
       assert yielded is session
-  bind.assert_called_once_with(session, f"{GRAPH_A}, public")
+  bind.assert_called_once_with(session, f"{GRAPH_A}, public", tenant_schema=GRAPH_A)
   session.commit.assert_called_once()
   session.close.assert_called_once()
+
+
+def test_bind_statement_guards_tenants_and_not_the_library():
+  """The guard is part of the bind — same round trip, no second query a
+  caller could forget — and the library sentinel binds ``public`` unguarded."""
+  tenant = ext._bind_statement(f"{GRAPH_A}, public", GRAPH_A)
+  assert tenant.startswith("DO $$")
+  assert f"to_regnamespace('{GRAPH_A}') IS NULL" in tenant
+  assert "ERRCODE = '3F000'" in tenant
+  assert tenant.endswith(f"SET LOCAL search_path TO {GRAPH_A}, public")
+  assert ext._bind_statement("public", None) == "SET LOCAL search_path TO public"
 
 
 def test_no_bypass_of_the_scoped_session_factory():

--- a/tests/db/test_extensions_isolation.py
+++ b/tests/db/test_extensions_isolation.py
@@ -256,6 +256,9 @@ def test_bind_statement_guards_tenants_and_not_the_library():
   assert "ERRCODE = '3F000'" in tenant
   assert tenant.endswith(f"SET LOCAL search_path TO {GRAPH_A}, public")
   assert ext._bind_statement("public", None) == "SET LOCAL search_path TO public"
+  # The interpolation validates its own input, independent of the caller.
+  with pytest.raises(ValueError):
+    ext._bind_statement("kg00000000000000aa, public", "kg00000000000000aa') --")
 
 
 def test_no_bypass_of_the_scoped_session_factory():

--- a/tests/graph_api/core/ladybug/test_pool.py
+++ b/tests/graph_api/core/ladybug/test_pool.py
@@ -142,6 +142,21 @@ class TestLadybugConnectionPoolAcquireRelease:
     # Should not raise
     pool._release_connection("testdb", mock_info)
 
+  def test_release_rolls_back_a_transaction_left_open(self):
+    """The backstop behind the validators: a manual transaction that reached
+    the engine must not be handed to the next borrower of the connection.
+    The engine raises when nothing is open, and that is swallowed."""
+    pool = _make_pool(self.temp_dir)
+    mock_info = MagicMock()
+    pool._release_connection("testdb", mock_info)
+    mock_info.connection.execute.assert_called_once_with("ROLLBACK")
+
+    quiet = MagicMock()
+    quiet.connection.execute.side_effect = RuntimeError(
+      "No active transaction for ROLLBACK."
+    )
+    pool._release_connection("testdb", quiet)  # must not raise
+
 
 @pytest.mark.unit
 class TestLadybugConnectionPoolValidity:

--- a/tests/middleware/rate_limits/test_graph_tier_resolver.py
+++ b/tests/middleware/rate_limits/test_graph_tier_resolver.py
@@ -6,6 +6,7 @@ with ten graphs shared one budget. These cover the resolution that replaced it,
 weighted toward the failure modes — resolution must never fail *open*.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -203,6 +204,8 @@ class TestSharedRepositoryIsolation:
         ):
           for gid in ("kg1aaa", "kg1bbb"):
             request.url.path = f"/v1/graphs/{gid}/query/cypher"
+            # The graph auth dependency ran and authorized this caller.
+            request.state.auth_graph_id = gid
             subscription_aware_rate_limit_dependency(request)
 
     assert seen == [
@@ -245,6 +248,7 @@ class TestSharedRepositoryIsolation:
         ) as mock_resolve:
           for gid in (parent, f"{parent}_dev"):
             request.url.path = f"/v1/graphs/{gid}/query/cypher"
+            request.state.auth_graph_id = gid
             subscription_aware_rate_limit_dependency(request)
 
     assert seen == [f"graph_sub:{parent}:graph_query"] * 2, seen
@@ -295,3 +299,123 @@ class TestTierDifferentiation:
       ("kuzu-standard", 1.0),
     ):
       assert GraphTierConfig.get_api_rate_multiplier(tier) == expected
+
+
+class TestGraphBucketsAreMembersOnly:
+  """A graph's budget is charged only by a caller authorized on it. The URL
+  alone is not authorization: wherever the limiter runs ahead of the graph
+  auth dependency, an anonymous or unrelated caller could otherwise drain a
+  tenant's read/write budget with requests that all go on to 401."""
+
+  @staticmethod
+  def _request(path: str, headers: dict | None = None):
+    request = MagicMock()
+    request.method = "POST"
+    request.client.host = "1.2.3.4"
+    request.state = SimpleNamespace()  # nothing published: auth has not run
+    request.headers = headers or {}
+    request.url.path = path
+    return request
+
+  @staticmethod
+  def _limit(request, seen):
+    from robosystems.middleware.rate_limits.rate_limiting import (
+      subscription_aware_rate_limit_dependency,
+    )
+
+    def record(identifier, limit, window):
+      seen.append(identifier)
+      return (True, 100)
+
+    with patch(
+      "robosystems.middleware.rate_limits.rate_limiting.rate_limit_cache.check_rate_limit",
+      side_effect=record,
+    ):
+      with patch(
+        "robosystems.middleware.rate_limits.graph_tier_resolver.resolve_graph_tier",
+        return_value="ladybug-standard",
+      ):
+        subscription_aware_rate_limit_dependency(request)
+
+  def test_an_unverified_api_key_is_not_an_identity(self):
+    """Any string in X-API-Key used to mint a fresh per-key budget. Now a key
+    the auth cache has never validated is anonymous, and anonymous requests
+    share the IP bucket."""
+    from robosystems.middleware.rate_limits.rate_limiting import get_user_from_request
+
+    request = self._request(
+      "/v1/graphs/kg1victim/memory/remember", {"X-API-Key": "junk"}
+    )
+    with patch(
+      "robosystems.middleware.auth.cache.api_key_cache.get_cached_api_key_validation",
+      return_value=None,
+    ):
+      assert get_user_from_request(request) is None
+    with patch(
+      "robosystems.middleware.auth.cache.api_key_cache.get_cached_api_key_validation",
+      return_value={"user_id": "u1"},
+    ):
+      assert get_user_from_request(request).startswith("apikey_")
+
+  def test_anonymous_requests_never_charge_the_graph_bucket(self):
+    seen: list = []
+    request = self._request(
+      "/v1/graphs/kg1victim/memory/remember", {"X-API-Key": "junk"}
+    )
+    with patch(
+      "robosystems.middleware.auth.cache.api_key_cache.get_cached_api_key_validation",
+      return_value=None,
+    ):
+      self._limit(request, seen)
+    assert seen and all(i.startswith("anon_sub:") for i in seen), seen
+
+  def test_an_identified_but_unauthorized_caller_stays_on_their_own_budget(self):
+    seen: list = []
+    request = self._request("/v1/graphs/kg1victim/documents")
+    with (
+      patch(
+        "robosystems.middleware.rate_limits.rate_limiting.get_user_from_request",
+        return_value="user_attacker",
+      ),
+      patch(
+        "robosystems.middleware.auth.cache.api_key_cache.get_cached_jwt_graph_access",
+        return_value=None,
+      ),
+    ):
+      self._limit(request, seen)
+    assert seen == ["user_sub:user_attacker:graph_write"], seen
+
+  def test_a_cached_positive_decision_is_enough_when_auth_has_not_run_yet(self):
+    """Router-level mounting runs the limiter first; a member's earlier
+    request left a positive decision in the auth cache, so the graph
+    bucket applies without a second authorization round-trip."""
+    seen: list = []
+    request = self._request("/v1/graphs/kg1mine/documents")
+    with (
+      patch(
+        "robosystems.middleware.rate_limits.rate_limiting.get_user_from_request",
+        return_value="user_member",
+      ),
+      patch(
+        "robosystems.middleware.auth.cache.api_key_cache.get_cached_jwt_graph_access",
+        return_value=True,
+      ),
+    ):
+      self._limit(request, seen)
+    assert seen == ["graph_sub:kg1mine:graph_write"], seen
+
+  def test_a_negative_cached_decision_does_not_unlock_the_graph_bucket(self):
+    seen: list = []
+    request = self._request("/v1/graphs/kg1victim/documents")
+    with (
+      patch(
+        "robosystems.middleware.rate_limits.rate_limiting.get_user_from_request",
+        return_value="apikey_" + "0" * 64,
+      ),
+      patch(
+        "robosystems.middleware.auth.cache.api_key_cache.get_cached_graph_access",
+        return_value=False,
+      ),
+    ):
+      self._limit(request, seen)
+    assert seen and seen[0].startswith("user_sub:apikey_"), seen

--- a/tests/middleware/rate_limits/test_rate_limiting.py
+++ b/tests/middleware/rate_limits/test_rate_limiting.py
@@ -70,8 +70,17 @@ class TestGetUserIdentifier:
 
   def test_api_key_returns_hashed(self):
     request = _make_request(headers={"X-API-Key": "test-key"})
-    result = get_user_identifier(request)
+    with patch(f"{MODULE}._api_key_is_cached_valid", return_value=True):
+      result = get_user_identifier(request)
     assert result.startswith("apikey:")
+
+  def test_an_unverified_api_key_falls_through_to_ip(self):
+    """A header the auth cache has never validated is not an identity —
+    otherwise every junk key would be a fresh, un-limited caller."""
+    request = _make_request(headers={"X-API-Key": "junk"})
+    with patch(f"{MODULE}._api_key_is_cached_valid", return_value=False):
+      result = get_user_identifier(request)
+    assert result.startswith("ip:")
 
   def test_jwt_bearer_returns_user_id(self):
     request = _make_request(headers={"Authorization": "Bearer valid_token"})
@@ -185,9 +194,15 @@ class TestGetUserFromRequest:
 
   def test_api_key_returns_hashed(self):
     request = _make_request(headers={"X-API-Key": "test-key"})
-    result = get_user_from_request(request)
+    with patch(f"{MODULE}._api_key_is_cached_valid", return_value=True):
+      result = get_user_from_request(request)
     assert result is not None
     assert result.startswith("apikey_")
+
+  def test_an_unverified_api_key_is_anonymous(self):
+    request = _make_request(headers={"X-API-Key": "junk"})
+    with patch(f"{MODULE}._api_key_is_cached_valid", return_value=False):
+      assert get_user_from_request(request) is None
 
 
 @pytest.mark.unit
@@ -576,10 +591,23 @@ class TestPublishedPrincipalIdentity:
     assert get_user_from_request(request) == "user-42"
 
   def test_header_credentials_still_take_precedence(self):
+    """A validated header key names the caller more precisely (per key,
+    not per user) than the published principal, so it wins."""
     request = _make_request(headers={"X-API-Key": "rfs" + "a" * 64})
     request.state = self._State("user-42")
-    assert get_user_identifier(request).startswith("apikey:")
-    assert "user-42" not in get_user_identifier(request)
+    with patch(f"{MODULE}._api_key_is_cached_valid", return_value=True):
+      assert get_user_identifier(request).startswith("apikey:")
+      assert "user-42" not in get_user_identifier(request)
+
+  def test_an_unvalidated_header_yields_to_the_published_principal(self):
+    """The published principal is set only after successful validation, so
+    it is the better evidence when the header itself is not cached-valid
+    (a URL-carried key the auth dependency validated by another path)."""
+    request = _make_request(headers={"X-API-Key": "rfs" + "a" * 64})
+    request.state = self._State("user-42")
+    with patch(f"{MODULE}._api_key_is_cached_valid", return_value=False):
+      assert get_user_identifier(request) == "apikey:user:user-42"
+      assert get_user_from_request(request) == "user-42"
 
   def test_absent_principal_falls_back_to_ip(self):
     request = _make_request(host="10.0.0.9")

--- a/tests/middleware/rate_limits/test_subscription_rate_limiting.py
+++ b/tests/middleware/rate_limits/test_subscription_rate_limiting.py
@@ -241,6 +241,9 @@ class TestSubscriptionAwareRateLimiting:
     # Setup mocks - authenticated users get standard tier
     mock_get_user.return_value = "user_456"  # Authenticated user
     mock_check_rate_limit.return_value = (True, 5000)  # Allowed with 5000 remaining
+    # The graph auth dependency authorized this caller on the graph; the graph
+    # bucket is a member's budget and is charged only with that evidence.
+    mock_request.state.auth_graph_id = "kg1a2b3c"
 
     # Call the dependency
     subscription_aware_rate_limit_dependency(mock_request)

--- a/tests/models/core/graph/test_graph_model.py
+++ b/tests/models/core/graph/test_graph_model.py
@@ -408,6 +408,28 @@ class TestGraphModel:
     not_found = Graph.get_by_id("nonexistent", db_session)
     assert not_found is None
 
+  def test_get_by_id_treats_a_soft_deleted_graph_as_gone(self, test_org, db_session):
+    """Teardown stamps `deleted_at` first and flips `status` last; between
+    the two the schema is being dropped, so readers must not see the graph.
+    Only callers that opt in (`include_deprovisioned=True`) still can."""
+    from datetime import UTC, datetime
+
+    graph = Graph.create(
+      graph_id="kg_mid_teardown",
+      graph_name="Mid Teardown",
+      graph_type="entity",
+      org_id=test_org.id,
+      session=db_session,
+    )
+    graph.deleted_at = datetime.now(UTC)
+    db_session.commit()
+
+    assert Graph.get_by_id("kg_mid_teardown", db_session) is None
+    opted_in = Graph.get_by_id(
+      "kg_mid_teardown", db_session, include_deprovisioned=True
+    )
+    assert opted_in is not None and opted_in.status != "deprovisioned"
+
   def test_get_by_extension(self, test_org, db_session):
     """Test getting graphs by schema extension."""
     # Clean up any existing graphs to ensure test isolation

--- a/tests/operations/event_block/test_commands_source_validation.py
+++ b/tests/operations/event_block/test_commands_source_validation.py
@@ -151,3 +151,102 @@ class TestCreateEventBlockSourceGate:
 
     assert envelope.source == "salesforce"
     assert envelope.status == "captured"
+
+
+class TestRoutedConnectionMustBeOnTheGraph:
+  """`metadata.connection_id` is what `execute-event-block` publishes to.
+  It is caller-set at capture and patchable afterwards, and connection ids
+  are platform-wide — so both write paths must join it to the calling graph,
+  or a later publish would post into another tenant's source-of-truth."""
+
+  @staticmethod
+  def _patch_get_by_id(connection):
+    session_factory = MagicMock()
+    session_factory.return_value.__enter__ = MagicMock(return_value=MagicMock())
+    session_factory.return_value.__exit__ = MagicMock(return_value=False)
+    return (
+      patch("robosystems.database.SessionFactory", session_factory),
+      patch(
+        "robosystems.models.core.connection.connection.Connection.get_by_id",
+        MagicMock(return_value=connection),
+      ),
+    )
+
+  def test_capture_refuses_a_connection_registered_on_another_graph(self) -> None:
+    from robosystems.operations.event_block.commands import (
+      ConnectionNotOnGraphError,
+      _validate_routed_connection,
+    )
+
+    foreign = SimpleNamespace(id="conn_victim", graph_id="kg000000000000ffff")
+    factory_p, lookup_p = self._patch_get_by_id(foreign)
+    with factory_p, lookup_p:
+      with pytest.raises(ConnectionNotOnGraphError):
+        _validate_routed_connection({"connection_id": "conn_victim"}, GRAPH_ID)
+
+  def test_capture_accepts_the_graphs_own_connection_and_none_at_all(self) -> None:
+    from robosystems.operations.event_block.commands import _validate_routed_connection
+
+    own = SimpleNamespace(id="conn_mine", graph_id=GRAPH_ID)
+    factory_p, lookup_p = self._patch_get_by_id(own)
+    with factory_p, lookup_p:
+      _validate_routed_connection({"connection_id": "conn_mine"}, GRAPH_ID)
+    # No routing id → nothing to join; no platform lookup at all.
+    factory_p2, lookup_p2 = self._patch_get_by_id(None)
+    with factory_p2, lookup_p2 as get_by_id:
+      _validate_routed_connection({"posting_date": "2026-05-19"}, GRAPH_ID)
+      _validate_routed_connection(None, GRAPH_ID)
+    get_by_id.assert_not_called()
+
+  def test_create_event_block_validates_before_persisting(self) -> None:
+    from robosystems.operations.event_block.commands import ConnectionNotOnGraphError
+
+    session = MagicMock()
+    foreign = SimpleNamespace(id="conn_victim", graph_id="kg000000000000ffff")
+    factory_p, lookup_p = self._patch_get_by_id(foreign)
+    body = CreateEventBlockRequest(
+      event_type="bank_transaction",
+      event_category="treasury",
+      source="manual",
+      occurred_at=datetime(2026, 7, 1, tzinfo=UTC),
+      metadata={"connection_id": "conn_victim"},
+      apply_handlers=False,
+    )
+    with factory_p, lookup_p:
+      with pytest.raises(ConnectionNotOnGraphError):
+        create_event_block(session, body, created_by="usr", graph_id=GRAPH_ID)
+    session.add.assert_not_called()
+
+  def test_metadata_patch_cannot_reroute_to_another_graphs_connection(self) -> None:
+    from robosystems.models.api.event_block import UpdateEventBlockRequest
+    from robosystems.operations.event_block.commands import (
+      ConnectionNotOnGraphError,
+      update_event_block,
+    )
+
+    event = MagicMock()
+    event.id = "evt_1"
+    event.status = "captured"
+    event.metadata_ = {"connection_id": "conn_mine"}
+    session = MagicMock()
+    session.get.return_value = event
+    # The locked read: `.filter(...).order_by(...).populate_existing()
+    # .with_for_update().all()` keyed by id afterwards.
+    locked_q = session.query.return_value.filter.return_value
+    locked_q.order_by.return_value = locked_q
+    locked_q.populate_existing.return_value = locked_q
+    locked_q.with_for_update.return_value = locked_q
+    locked_q.all.return_value = [event]
+    foreign = SimpleNamespace(id="conn_victim", graph_id="kg000000000000ffff")
+    factory_p, lookup_p = self._patch_get_by_id(foreign)
+    with factory_p, lookup_p:
+      with pytest.raises(ConnectionNotOnGraphError):
+        update_event_block(
+          session,
+          UpdateEventBlockRequest(
+            event_id="evt_1", metadata_patch={"connection_id": "conn_victim"}
+          ),
+          created_by="usr",
+          graph_id=GRAPH_ID,
+        )
+    assert event.metadata_ == {"connection_id": "conn_mine"}

--- a/tests/operations/event_block/test_commands_update.py
+++ b/tests/operations/event_block/test_commands_update.py
@@ -82,7 +82,9 @@ class TestSupersedeChain:
       transition_to="superseded",
       superseded_by_id="evt_b",
     )
-    envelope = update_event_block(session, body, created_by="usr_test")
+    envelope = update_event_block(
+      session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+    )
 
     assert predecessor.status == "superseded"
     assert predecessor.replaced_by_event_id == "evt_b"
@@ -97,7 +99,9 @@ class TestSupersedeChain:
 
     body = UpdateEventBlockRequest(event_id="evt_a", transition_to="superseded")
     with pytest.raises(InvalidEventTransitionError, match="superseded_by_id"):
-      update_event_block(session, body, created_by="usr_test")
+      update_event_block(
+        session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+      )
 
     assert predecessor.status == "classified"
     assert predecessor.replaced_by_event_id is None
@@ -114,7 +118,9 @@ class TestSupersedeChain:
       superseded_by_id="evt_a",
     )
     with pytest.raises(InvalidEventTransitionError, match="cannot supersede itself"):
-      update_event_block(session, body, created_by="usr_test")
+      update_event_block(
+        session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+      )
 
     assert predecessor.status == "classified"
     session.commit.assert_not_called()
@@ -130,7 +136,9 @@ class TestSupersedeChain:
       superseded_by_id="evt_missing",
     )
     with pytest.raises(EventNotFoundError, match="evt_missing"):
-      update_event_block(session, body, created_by="usr_test")
+      update_event_block(
+        session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+      )
 
     assert predecessor.status == "classified"
     assert predecessor.replaced_by_event_id is None
@@ -148,7 +156,9 @@ class TestSupersedeChain:
       superseded_by_id="evt_b",
     )
     with pytest.raises(InvalidEventTransitionError, match="terminal"):
-      update_event_block(session, body, created_by="usr_test")
+      update_event_block(
+        session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+      )
 
     assert predecessor.status == "fulfilled"
     assert predecessor.replaced_by_event_id is None
@@ -167,7 +177,9 @@ class TestSupersedeChain:
         transition_to="superseded",
         superseded_by_id="evt_b",
       )
-      update_event_block(session, body, created_by="usr_test")
+      update_event_block(
+        session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+      )
 
       assert predecessor.status == "superseded", f"failed from {source_status}"
       assert predecessor.replaced_by_event_id == "evt_b"
@@ -184,7 +196,9 @@ class TestDualityLateBinding:
       event_id="evt_payment",
       discharges_event_id="evt_invoice",
     )
-    envelope = update_event_block(session, body, created_by="usr_test")
+    envelope = update_event_block(
+      session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+    )
 
     assert payment.discharges_event_id == "evt_invoice"
     assert envelope.discharges_event_id == "evt_invoice"
@@ -198,7 +212,9 @@ class TestDualityLateBinding:
       event_id="evt_dep",
       obligated_by_event_id="evt_asset",
     )
-    envelope = update_event_block(session, body, created_by="usr_test")
+    envelope = update_event_block(
+      session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+    )
 
     assert schedule_entry.obligated_by_event_id == "evt_asset"
     assert envelope.obligated_by_event_id == "evt_asset"
@@ -242,7 +258,9 @@ class TestApproveFiresHandler:
       "robosystems.operations.event_block.commands.get_python_handler",
       return_value=fake_handler,
     ) as get_handler:
-      update_event_block(session, body, created_by="usr_test")
+      update_event_block(
+        session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+      )
 
     get_handler.assert_called_once_with("journal_entry_recorded")
     fake_handler.dispatch.assert_called_once_with(
@@ -280,7 +298,9 @@ class TestApproveFiresHandler:
         return_value=None,
       ),
     ):
-      update_event_block(session, body, created_by="usr_test")
+      update_event_block(
+        session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+      )
 
     fence.assert_called_once()
     assert order == ["fence", "row_lock"], order
@@ -309,7 +329,9 @@ class TestApproveFiresHandler:
         return_value=None,
       ),
     ):
-      update_event_block(session, body, created_by="usr_test")
+      update_event_block(
+        session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+      )
 
     fence.assert_called_once()
     assert fence.call_args.args[1:] == (date(2026, 3, 1), date(2026, 4, 30))
@@ -322,7 +344,9 @@ class TestApproveFiresHandler:
     with patch(
       "robosystems.operations.event_block.commands.assert_period_not_closed"
     ) as fence:
-      update_event_block(session, body, created_by="usr_test")
+      update_event_block(
+        session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+      )
 
     fence.assert_not_called()
     assert event.status == "voided"
@@ -339,7 +363,9 @@ class TestApproveFiresHandler:
       "robosystems.operations.event_block.commands.get_python_handler",
       return_value=fake_handler,
     ):
-      update_event_block(session, body, created_by="usr_test")
+      update_event_block(
+        session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+      )
 
     fake_handler.dispatch.assert_called_once()
 
@@ -355,7 +381,9 @@ class TestApproveFiresHandler:
       "robosystems.operations.event_block.commands.get_python_handler",
       return_value=fake_handler,
     ):
-      update_event_block(session, body, created_by="usr_test")
+      update_event_block(
+        session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+      )
 
     fake_handler.dispatch.assert_not_called()
     assert event.status == "fulfilled"
@@ -372,7 +400,9 @@ class TestApproveFiresHandler:
       "robosystems.operations.event_block.commands.get_python_handler",
       return_value=fake_handler,
     ):
-      update_event_block(session, body, created_by="usr_test")
+      update_event_block(
+        session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+      )
 
     fake_handler.dispatch.assert_not_called()
     assert event.status == "voided"
@@ -389,7 +419,9 @@ class TestApproveFiresHandler:
       "robosystems.operations.event_block.commands.get_python_handler",
       return_value=None,
     ):
-      update_event_block(session, body, created_by="usr_test")
+      update_event_block(
+        session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+      )
 
     assert event.status == "committed"
     session.commit.assert_called_once()
@@ -421,7 +453,9 @@ class TestApproveFiresHandler:
       return_value=fake_handler,
     ):
       with pytest.raises(HandlerMetadataValidationError) as exc:
-        update_event_block(session, body, created_by="usr_test")
+        update_event_block(
+          session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+        )
 
     assert "evt_qb_001" in str(exc.value)
     assert "journal_entry_recorded" in str(exc.value)
@@ -441,7 +475,9 @@ class TestTransitionRowLock:
     session = _session_with_events(event)
 
     body = UpdateEventBlockRequest(event_id="evt_a", description="corrected")
-    update_event_block(session, body, created_by="usr_test")
+    update_event_block(
+      session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+    )
 
     locked_q = session.query.return_value.filter.return_value
     locked_q.with_for_update.assert_called()
@@ -465,6 +501,7 @@ class TestTransitionRowLock:
         event_id="evt_a", transition_to="superseded", superseded_by_id="evt_b"
       ),
       created_by="usr_test",
+      graph_id="kg00000000000000aa",
     )
 
     locked_q = session.query.return_value.filter.return_value
@@ -490,7 +527,9 @@ class TestLockContention:
     session = _session_with_events(event)
 
     body = UpdateEventBlockRequest(event_id="evt_a", description="corrected")
-    update_event_block(session, body, created_by="usr_test")
+    update_event_block(
+      session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+    )
 
     statements = [str(c.args[0]) for c in session.execute.call_args_list if c.args]
     assert any("lock_timeout" in s for s in statements)
@@ -503,7 +542,9 @@ class TestLockContention:
 
     body = UpdateEventBlockRequest(event_id="evt_a", transition_to="committed")
     with pytest.raises(RowLockedError, match="evt_a"):
-      update_event_block(session, body, created_by="usr_test")
+      update_event_block(
+        session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+      )
 
     session.commit.assert_not_called()
 
@@ -520,7 +561,9 @@ class TestLockContention:
 
     body = UpdateEventBlockRequest(event_id="evt_a", transition_to="committed")
     with pytest.raises(RowLockedError, match="evt_a"):
-      update_event_block(session, body, created_by="usr_test")
+      update_event_block(
+        session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+      )
 
     session.commit.assert_not_called()
 
@@ -534,4 +577,6 @@ class TestLockContention:
 
     body = UpdateEventBlockRequest(event_id="evt_a", transition_to="committed")
     with pytest.raises(OperationalError):
-      update_event_block(session, body, created_by="usr_test")
+      update_event_block(
+        session, body, created_by="usr_test", graph_id="kg00000000000000aa"
+      )

--- a/tests/operations/event_block/test_execute.py
+++ b/tests/operations/event_block/test_execute.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 COMMANDS_MODULE = "robosystems.operations.event_block.commands"
+GRAPH_ID = "kg00000000000000aa"
 
 
 def _make_event(
@@ -75,6 +76,7 @@ class TestExecuteEventBlockNativeFastPath:
       session,
       ExecuteEventBlockRequest(event_id="evt_test_abc"),
       created_by="user_1",
+      graph_id=GRAPH_ID,
     )
 
     assert result.status == "classified"
@@ -91,6 +93,7 @@ class TestExecuteEventBlockNativeFastPath:
     session = _make_session(evt)
 
     mock_connection = MagicMock()
+    mock_connection.graph_id = GRAPH_ID
     mock_connection.write_policy = "native"
     mock_connection.provider = "quickbooks"
     mock_platform_session = MagicMock()
@@ -108,10 +111,59 @@ class TestExecuteEventBlockNativeFastPath:
         session,
         ExecuteEventBlockRequest(event_id="evt_test_abc"),
         created_by="user_1",
+        graph_id=GRAPH_ID,
       )
 
     assert result.status == "classified"
     assert result.qb_external_id is None
+    assert evt.status == "classified"
+
+  def test_a_connection_from_another_graph_is_refused_before_any_qb_client(self):
+    """The override and the routing id are both caller-controlled and
+    connection ids are platform-wide, so the publish must join the connection
+    to the calling graph — even for a native-policy connection, whose fast
+    path would otherwise report success for a graph it never belonged to."""
+    from robosystems.models.api.event_block import ExecuteEventBlockRequest
+    from robosystems.operations.event_block.commands import (
+      ConnectionNotOnGraphError,
+      execute_event_block,
+    )
+
+    evt = _make_event(metadata={"connection_id": "conn_victims"})
+    session = _make_session(evt)
+
+    other_graphs_connection = MagicMock()
+    other_graphs_connection.graph_id = "kg00000000000000bb"
+    other_graphs_connection.write_policy = "qb_authoritative"
+    other_graphs_connection.provider = "quickbooks"
+    other_graphs_connection.realm_id = "9341452700148642"
+    mock_platform_session = MagicMock()
+    mock_platform_session.__enter__ = MagicMock(return_value=mock_platform_session)
+    mock_platform_session.__exit__ = MagicMock(return_value=False)
+
+    with (
+      patch("robosystems.database.SessionFactory", return_value=mock_platform_session),
+      patch(
+        "robosystems.models.core.connection.connection.Connection.get_by_id",
+        return_value=other_graphs_connection,
+      ),
+      patch("robosystems.adapters.quickbooks.client.api.QBClient") as qb_client,
+      patch(
+        "robosystems.models.core.connection.connection_credentials.ConnectionCredentials.get_by_connection_id"
+      ) as creds,
+    ):
+      with pytest.raises(ConnectionNotOnGraphError):
+        execute_event_block(
+          session,
+          ExecuteEventBlockRequest(
+            event_id="evt_test_abc", connection_id="conn_victims"
+          ),
+          created_by="user_1",
+          graph_id=GRAPH_ID,
+        )
+
+    creds.assert_not_called()
+    qb_client.assert_not_called()
     assert evt.status == "classified"
 
   def test_event_not_found_raises(self):
@@ -128,6 +180,7 @@ class TestExecuteEventBlockNativeFastPath:
         session,
         ExecuteEventBlockRequest(event_id="evt_nonexistent"),
         created_by="user_1",
+        graph_id=GRAPH_ID,
       )
 
   def test_missing_connection_skips_write(self):
@@ -154,6 +207,7 @@ class TestExecuteEventBlockNativeFastPath:
         session,
         ExecuteEventBlockRequest(event_id="evt_test_abc"),
         created_by="user_1",
+        graph_id=GRAPH_ID,
       )
 
     assert result.status == "classified"
@@ -173,6 +227,7 @@ class TestExecuteEventBlockQBAuthoritativeAccept:
     session = _make_session(evt)
 
     mock_connection = MagicMock()
+    mock_connection.graph_id = GRAPH_ID
     mock_connection.write_policy = "qb_authoritative"
     mock_connection.provider = "quickbooks"
     mock_connection.realm_id = "9341452700148642"
@@ -214,6 +269,7 @@ class TestExecuteEventBlockQBAuthoritativeAccept:
         session,
         ExecuteEventBlockRequest(event_id="evt_test_abc"),
         created_by="user_1",
+        graph_id=GRAPH_ID,
       )
 
     assert result.status == "fulfilled"
@@ -262,7 +318,10 @@ class TestExecuteEventBlockQBAuthoritativeAccept:
     session = _make_session(evt)
 
     mock_connection = MagicMock(
-      write_policy="qb_authoritative", provider="quickbooks", realm_id="9341"
+      graph_id=GRAPH_ID,
+      write_policy="qb_authoritative",
+      provider="quickbooks",
+      realm_id="9341",
     )
     mock_cred = MagicMock()
     mock_cred.get_credentials.return_value = {"refresh_token": "r"}
@@ -290,6 +349,7 @@ class TestExecuteEventBlockQBAuthoritativeAccept:
         session,
         ExecuteEventBlockRequest(event_id="evt_test_abc"),
         created_by="user_1",
+        graph_id=GRAPH_ID,
       )
 
     # Response surfaces the primary (first) qb_txn_id.
@@ -336,7 +396,10 @@ class TestExecuteEventBlockQBReject:
     session = _make_session(evt)
 
     mock_connection = MagicMock(
-      write_policy="qb_authoritative", provider="quickbooks", realm_id="9341"
+      graph_id=GRAPH_ID,
+      write_policy="qb_authoritative",
+      provider="quickbooks",
+      realm_id="9341",
     )
     mock_cred = MagicMock()
     mock_cred.get_credentials.return_value = {"refresh_token": "r"}
@@ -371,6 +434,7 @@ class TestExecuteEventBlockQBReject:
         session,
         ExecuteEventBlockRequest(event_id="evt_test_abc"),
         created_by="user_1",
+        graph_id=GRAPH_ID,
       )
 
     assert result.status == "pending"
@@ -407,6 +471,7 @@ class TestExecuteEventBlockRefusesRetracted:
         session,
         ExecuteEventBlockRequest(event_id="evt_test_abc"),
         created_by="user_1",
+        graph_id=GRAPH_ID,
       )
 
     post.assert_not_called()
@@ -430,6 +495,7 @@ class TestExecuteEventBlockRefusesRetracted:
         session,
         ExecuteEventBlockRequest(event_id="evt_test_abc"),
         created_by="user_1",
+        graph_id=GRAPH_ID,
       )
 
     post.assert_not_called()
@@ -455,6 +521,7 @@ class TestExecuteEventBlockRefusesRetracted:
         session,
         ExecuteEventBlockRequest(event_id="evt_test_abc"),
         created_by="user_1",
+        graph_id=GRAPH_ID,
       )
 
     post.assert_not_called()
@@ -476,6 +543,7 @@ class TestExecuteEventBlockRefusesRetracted:
         session,
         ExecuteEventBlockRequest(event_id="evt_test_abc"),
         created_by="user_1",
+        graph_id=GRAPH_ID,
       )
 
     post.assert_not_called()

--- a/tests/operations/event_block/test_update_locking_db.py
+++ b/tests/operations/event_block/test_update_locking_db.py
@@ -150,6 +150,7 @@ def test_sync_batch_lock_blocks_an_approval(tenant):
           approval_session,
           UpdateEventBlockRequest(event_id=EVENT_ID, transition_to="committed"),
           created_by="usr_approver",
+          graph_id=GRAPH,
         )
     waited = time.monotonic() - started
 
@@ -210,6 +211,7 @@ def test_approval_that_waits_out_a_lock_sees_the_committed_row(tenant):
           approval_session,
           UpdateEventBlockRequest(event_id=EVENT_ID, transition_to="voided"),
           created_by="usr_approver",
+          graph_id=GRAPH,
         )
   finally:
     t.join(timeout=10)
@@ -347,6 +349,7 @@ class TestPublishLock:
               publish_session,
               ExecuteEventBlockRequest(event_id=EVENT_ID),
               created_by="usr_operator",
+              graph_id=GRAPH,
             )
       post.assert_not_called()
 
@@ -423,6 +426,7 @@ class TestSharedSessionRefresh:
         session,
         ExecuteEventBlockRequest(event_id=EVENT_ID),
         created_by="usr_operator",
+        graph_id=GRAPH,
       )
 
       assert event.description == "set by the close loop, not yet committed"

--- a/tests/operations/graph/test_deprovision_service.py
+++ b/tests/operations/graph/test_deprovision_service.py
@@ -628,6 +628,7 @@ class TestDeprovisionService:
       patch(
         "robosystems.middleware.graph.allocation_manager.LadybugAllocationManager"
       ) as mock_alloc_cls,
+      patch("robosystems.middleware.auth.cache.api_key_cache") as cache,
     ):
       mock_client = AsyncMock()
       mock_get_client.return_value = mock_client
@@ -640,6 +641,15 @@ class TestDeprovisionService:
       )
 
       assert result.records_cleaned is True
+
+      # Members' cached access decisions go with their rows, so a warm entry
+      # cannot carry a request onto the half-dropped graph.
+      cache.invalidate_user_jwt_graph_access.assert_any_call(
+        test_user.id, test_graph.graph_id
+      )
+      cache.invalidate_user_graph_access.assert_called_once_with(
+        "*", test_graph.graph_id
+      )
 
       # Records should be deleted
       remaining_users = (

--- a/tests/operations/graph/test_graph_creation_cleanup.py
+++ b/tests/operations/graph/test_graph_creation_cleanup.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -302,3 +302,90 @@ class TestCleanupIsBestEffort:
       ),
     ):
       await service._cleanup(persisted_graph.graph_id, _location(), None)
+
+
+class TestTenantSchemaProvisioning:
+  """An extensions-flagged graph must get its tenant schema at creation
+  whether or not an entity is created up front. `create_entity=false` used to
+  skip provisioning entirely, leaving a graph that passes the extension gate
+  with no schema for its sessions to land in.
+  """
+
+  def _pipeline(self, service, provision, provision_entity):
+    return (
+      patch.object(service, "_validate_org", return_value="org_test"),
+      patch.object(service, "_generate_graph_id", return_value="kg00000000000000ee"),
+      patch.object(
+        service, "_allocate", new_callable=AsyncMock, return_value=_location()
+      ),
+      patch.object(
+        service,
+        "_create_database",
+        new_callable=AsyncMock,
+        return_value=(AsyncMock(), None),
+      ),
+      patch.object(
+        service,
+        "_install_schema",
+        new_callable=AsyncMock,
+        return_value=("", {}),
+      ),
+      patch.object(service, "_persist_metadata"),
+      patch.object(service, "_create_credits"),
+      patch.object(service, "_provision_entity", provision_entity),
+      patch("robosystems.db.extensions.provision_tenant_schema", provision),
+    )
+
+  @pytest.mark.asyncio
+  async def test_extensions_graph_without_entity_still_gets_a_schema(self):
+    service = GraphCreationService()
+    provision = MagicMock()
+    provision_entity = AsyncMock()
+    config = GraphCreationConfig(
+      user_id="u1",
+      tier="ladybug-standard",
+      graph_name="Empty ledger",
+      graph_type="entity",
+      schema_extensions=["roboledger"],
+      create_entity=False,
+    )
+    with ExitStack() as stack:
+      for p in self._pipeline(service, provision, provision_entity):
+        stack.enter_context(p)
+      await service.create(config)
+
+    provision.assert_called_once_with("kg00000000000000ee")
+    provision_entity.assert_not_awaited()
+
+  @pytest.mark.asyncio
+  async def test_entity_graph_provisions_then_creates_the_entity(self):
+    service = GraphCreationService()
+    provision = MagicMock()
+    provision_entity = AsyncMock(return_value={"id": "entity_x"})
+    config = GraphCreationConfig(
+      user_id="u1",
+      tier="ladybug-standard",
+      graph_name="Ledger",
+      graph_type="entity",
+      schema_extensions=["roboledger"],
+      entity_data={"name": "Acme"},
+    )
+    with ExitStack() as stack:
+      for p in self._pipeline(service, provision, provision_entity):
+        stack.enter_context(p)
+      result = await service.create(config)
+
+    provision.assert_called_once_with("kg00000000000000ee")
+    provision_entity.assert_awaited_once()
+    assert result.entity == {"id": "entity_x"}
+
+  @pytest.mark.asyncio
+  async def test_generic_graph_gets_no_tenant_schema(self):
+    service = GraphCreationService()
+    provision = MagicMock()
+    with ExitStack() as stack:
+      for p in self._pipeline(service, provision, AsyncMock()):
+        stack.enter_context(p)
+      await service.create(_config())
+
+    provision.assert_not_called()

--- a/tests/operations/roboledger/commands/test_publish_lists.py
+++ b/tests/operations/roboledger/commands/test_publish_lists.py
@@ -35,6 +35,46 @@ def _list(owner: str = "usr_owner"):
   return row
 
 
+class TestAddMembersAdmitsOnlyLiveTenants:
+  """A recipient must be a live graph with a schema of its own: dead graphs
+  are filtered out of the platform lookup (so they read as not found), and a
+  subgraph id — which never has a schema — is dropped the same way."""
+
+  def _run(self, targets, platform_rows):
+    from unittest.mock import patch
+
+    from robosystems.operations.roboledger.commands.publish_lists import (
+      TargetGraphsNotFoundError,
+    )
+
+    session = _session_returning(_list("usr_owner"))
+    platform = MagicMock()
+    platform.__enter__.return_value.execute.return_value.scalars.return_value.all.return_value = platform_rows
+    with patch("robosystems.db.platform.SessionFactory", return_value=platform):
+      with pytest.raises(TargetGraphsNotFoundError):
+        add_publish_list_members(
+          session,
+          "pl_1",
+          "kg_current",
+          AddMembersRequest(target_graph_ids=targets),
+          added_by="usr_owner",
+        )
+    # The liveness filter is part of the query, not a Python check after it.
+    stmt = platform.__enter__.return_value.execute.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "deleted_at IS NULL" in compiled
+    assert "status !=" in compiled
+
+  def test_a_deprovisioned_recipient_reads_as_not_found(self) -> None:
+    self._run(["kg00000000000000aa"], platform_rows=[])
+
+  def test_a_subgraph_id_is_never_a_recipient(self) -> None:
+    sub = MagicMock()
+    sub.graph_id = "kg00000000000000aa_dev"
+    sub.schema_extensions = ["roboledger"]
+    self._run(["kg00000000000000aa_dev"], platform_rows=[sub])
+
+
 class TestAddMembersOwnership:
   def test_non_owner_is_refused_before_any_platform_lookup(self) -> None:
     session = _session_returning(_list("usr_owner"))

--- a/tests/operations/roboledger/commands/test_reports.py
+++ b/tests/operations/roboledger/commands/test_reports.py
@@ -493,6 +493,7 @@ def test_share_to_target_stamps_asserted_provenance() -> None:
 
   with (
     patch("robosystems.db.platform.SessionFactory", return_value=platform_cm),
+    patch("robosystems.db.extensions.tenant_schema_exists", return_value=True),
     patch("robosystems.db.extensions.extensions_session", return_value=ext_cm),
     patch.object(reports_mod, "create_fact_set", side_effect=_capture),
     patch.object(reports_mod, "_ensure_linked_entity"),
@@ -580,6 +581,7 @@ def test_share_to_target_carries_nonnumeric_columns() -> None:
 
   with (
     patch("robosystems.db.platform.SessionFactory", return_value=platform_cm),
+    patch("robosystems.db.extensions.tenant_schema_exists", return_value=True),
     patch("robosystems.db.extensions.extensions_session", return_value=ext_cm),
     patch.object(reports_mod, "create_fact_set", side_effect=_fs),
     patch.object(reports_mod, "_ensure_linked_entity"),
@@ -643,6 +645,7 @@ def test_share_carries_the_senders_holon_into_the_recipients_prefix() -> None:
 
   with (
     patch("robosystems.db.platform.SessionFactory", return_value=platform_cm),
+    patch("robosystems.db.extensions.tenant_schema_exists", return_value=True),
     patch("robosystems.db.extensions.extensions_session", return_value=ext_cm),
     patch.object(reports_mod, "S3Client", return_value=s3),
     patch.object(reports_mod, "_ensure_linked_entity"),

--- a/tests/operations/roboledger/commands/test_share_controls.py
+++ b/tests/operations/roboledger/commands/test_share_controls.py
@@ -331,12 +331,53 @@ def _patched_share(*, blocked: bool):
   extensions = MagicMock()
   extensions.return_value.__enter__.return_value = target_session
 
+  # The recipient's schema is checked up front so a dead target gets a
+  # per-target message rather than a bind failure; provisioned here.
+  ext_p = patch("robosystems.db.extensions.extensions_session", extensions)
+  exists_p = patch("robosystems.db.extensions.tenant_schema_exists", return_value=True)
+
+  class _Both:
+    def __enter__(self):
+      exists_p.__enter__()
+      return ext_p.__enter__()
+
+    def __exit__(self, *exc):
+      ext_p.__exit__(*exc)
+      exists_p.__exit__(*exc)
+
   return (
     patch("robosystems.db.platform.SessionFactory", return_value=platform),
-    patch("robosystems.db.extensions.extensions_session", extensions),
+    _Both(),
     patch(f"{_REPORTS_CMD}.is_source_blocked", return_value=blocked),
     target_session,
   )
+
+
+def test_share_to_a_deprovisioned_recipient_is_reported_not_attempted() -> None:
+  """Teardown never prunes a dead graph from senders' publish lists. The row
+  can still be there (soft-deleted) and the schema gone; the share must
+  bounce with a per-target message before any tenant session is opened."""
+  platform = MagicMock()
+  platform.__enter__.return_value.execute.return_value.scalar_one_or_none.return_value = _target_graph_row()
+  extensions = MagicMock()
+
+  with (
+    patch("robosystems.db.platform.SessionFactory", return_value=platform),
+    patch("robosystems.db.extensions.tenant_schema_exists", return_value=False),
+    patch("robosystems.db.extensions.extensions_session", extensions),
+  ):
+    result = _share_to_target(
+      source_graph_id=_SOURCE_GRAPH,
+      report_snapshot={"id": "rpt_source", "name": "Q1", "taxonomy_id": "tax_01"},
+      source_fact_sets=[],
+      source_facts=[],
+      target_graph_id=_TARGET_GRAPH,
+      shared_by="user_sender",
+    )
+
+  assert result.status == "error"
+  assert "no extensions tenant schema" in (result.error or "").lower()
+  extensions.assert_not_called()
 
 
 def test_share_to_a_blocking_recipient_returns_an_error_and_writes_nothing() -> None:

--- a/tests/security/test_cypher_analyzer.py
+++ b/tests/security/test_cypher_analyzer.py
@@ -98,6 +98,15 @@ class TestIsSchemaDD:
   def test_non_ddl_query(self, analyzer):
     assert analyzer.is_schema_ddl("MATCH (n:Person) RETURN n") is False
 
+  def test_comment_on_is_catalog_ddl(self, analyzer):
+    """`COMMENT ON` rewrites what every reader sees in `show_tables()`; the
+    write keyword set cannot carry a bare `comment` (too common a property),
+    so the two-word form is refused as DDL — on the read path too."""
+    assert analyzer.is_schema_ddl("COMMENT ON TABLE Entity IS 'tenant note'")
+    assert analyzer.is_schema_ddl("comment on table Entity is 'x'")
+    assert analyzer.is_write_operation("COMMENT ON TABLE Entity IS 'x'") is False
+    assert analyzer.is_schema_ddl("MATCH (n) RETURN n.comment") is False
+
   def test_module_level_function(self):
     assert is_schema_ddl("CREATE NODE TABLE Test(id STRING, PRIMARY KEY(id))")
 
@@ -135,6 +144,36 @@ class TestIsAdminOperation:
 
   def test_non_admin_query(self, analyzer):
     assert analyzer.is_admin_operation("MATCH (n) RETURN n") is False
+
+  @pytest.mark.parametrize(
+    "statement",
+    [
+      "BEGIN TRANSACTION",
+      "begin transaction read only",
+      "COMMIT",
+      "ROLLBACK",
+      "CHECKPOINT",
+      "  BEGIN TRANSACTION",
+      "MATCH (n) RETURN count(n); COMMIT",
+    ],
+  )
+  def test_transaction_control_is_refused_as_admin(self, analyzer, statement):
+    """A manual transaction outlives the request on a pooled engine
+    connection and the next borrower inherits it; CHECKPOINT is engine
+    maintenance. All are refused on every surface, like ATTACH."""
+    assert analyzer.is_admin_operation(statement)
+
+  @pytest.mark.parametrize(
+    "statement",
+    [
+      "MATCH (n) RETURN n.begin, n.commit, n.rollback",
+      "MATCH (p:Period) WHERE p.checkpoint > 1 RETURN p",
+      "// begin\nMATCH (n) RETURN n",
+      "MATCH (n) WHERE n.name = 'COMMIT' RETURN n",
+    ],
+  )
+  def test_transaction_words_inside_a_read_are_not_admin(self, analyzer, statement):
+    assert analyzer.is_admin_operation(statement) is False
 
   def test_module_level_function(self):
     assert is_admin_operation("EXPORT DATABASE 'test'")


### PR DESCRIPTION
## Summary

Tier A of the multi-tenancy resilience review that followed #1206 / #1210 (`local/RoboSystems/specs/security/multitenancy-resilience-review.md`, §1). Four independent hardenings, each with red-then-green tests; intended as the patch right behind v1.9.6.

- **Extensions tenant binding fails closed** — a session bound to a tenant schema that does not exist now refuses on its first statement (`invalid_schema_name`, which the surfaces already translate to "not initialized") instead of resolving unqualified names elsewhere. Every graph carrying an OLTP extension gets its schema at creation independent of `create_entity`; a soft-deleted graph reads as gone to every default lookup; teardown drops members' cached access with their rows; report shares and publish lists admit only live, provisioned recipients.
- **Event connections are joined to the calling graph** — `execute-event-block` (REST + MCP) refuses a connection not registered on the graph; the routing id is validated the same way at capture and through metadata patches.
- **Query classifier** — statement-leading `BEGIN`/`COMMIT`/`ROLLBACK`/`CHECKPOINT` are refused as administrative and `COMMENT ON` as schema DDL, at the kernel and again in the graph API; the engine connection pool rolls back anything left open before reuse.
- **Rate limiter keying** — a graph's budget is charged only by callers authorized on it; an API key is an identity to the limiter only once the auth cache has validated it (unverified callers share the anonymous IP bucket).

## Test plan

- [x] `tests/db/test_extensions_isolation.py` — fail-closed bind (real Postgres), including the schema-dropped-mid-session case
- [x] creation-service, deprovision, graph-model, share/publish-list tests for the admission doors
- [x] `tests/operations/event_block/*` — cross-graph connection refused before any QB client is built; capture + patch validation
- [x] `tests/security/test_cypher_analyzer.py`, `tests/graph_api/core/ladybug/test_pool.py`
- [x] `tests/middleware/rate_limits/*` — members-only graph buckets, unverified-key identity
- [x] Local stack: the classifier gate refuses the new verbs on `/query/cypher`; with `RATE_LIMIT_ENABLED=true`, junk-key requests land in `anon_sub:{ip}` and only the owner charges `graph_sub:{graph}`
- [x] `just test-code` clean; full `just test` (in progress at PR open — will confirm on CI)

No migration. No SDK contract change (no request/response shape changed; `execute-event-block` and `update-event-block` gain a server-side graph check only).
