### PR TITLE
fix(security): multi-tenancy tier B — lifecycle, role, and read-only parity across surfaces

### DIFF
--- a/robosystems/graphql/context.py
+++ b/robosystems/graphql/context.py
@@ -46,6 +46,7 @@ from robosystems.middleware.auth.dependencies import (
   get_current_user,
 )
 from robosystems.middleware.auth.utils import validate_api_key_with_graph
+from robosystems.middleware.billing.enforcement import require_graph_access
 from robosystems.middleware.extensions import load_graph_metadata
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
 from robosystems.middleware.graph.utils.subgraph import is_subgraph
@@ -166,6 +167,10 @@ async def get_context(
       meta = load_graph_metadata(graph_id, db)
       schema_extensions = meta.schema_extensions
       graph_type = meta.graph_type
+      # Lifecycle/subscription gate (reads): a suspended or expired graph is
+      # not readable through GraphQL any more than through /query. Same
+      # gate the REST reads run; raises 403/404 like the rest of the getter.
+      require_graph_access(graph_id, db, require_write=False)
 
   return {
     "request": request,

--- a/robosystems/middleware/auth/dependencies.py
+++ b/robosystems/middleware/auth/dependencies.py
@@ -565,19 +565,28 @@ async def get_current_user_with_graph_or_url_token(
 
 
 def require_graph_write_role(user_id: str, graph_id: str) -> None:
-  """Assert the user holds a write role (member/admin) on the graph.
+  """Assert the user may write to the graph right now.
 
-  ``viewer`` is read-only; bare graph *membership* (which
-  ``get_current_user_with_graph`` proves) is not sufficient to mutate a graph.
-  This is the single write-role authorization check the command surfaces share
-  — REST command ops (the extensions registrar, content-ops) call it before
-  dispatching, and the MCP surface enforces the same via
-  ``validate_mcp_access(..., "write")``. Raises 403 for a read-only role.
+  Two checks, one gate:
+
+  1. Role — ``viewer`` is read-only; bare graph *membership* (which
+     ``get_current_user_with_graph`` proves) is not sufficient to mutate a
+     graph. Raises 403 for a read-only role.
+  2. Lifecycle — the graph must be writable: not suspended, deleted or
+     deprovisioned, and (billing on) not in a canceled grace period or a tier
+     upgrade. This is ``require_graph_access(require_write=True)``.
+
+  It is the single write gate the command surfaces share — the extensions
+  registrar, content-ops, the lifecycle ops, connections and write-capable
+  operators call it before dispatching, and the MCP surface enforces the same
+  pair via ``validate_mcp_access(..., "write")`` — so a state that blocks
+  writes on one surface blocks them on all of them.
 
   Opens a short-lived platform session — ``GraphUser`` lives in the platform
   DB, not the per-graph OLTP DB.
   """
   from robosystems.database import SessionFactory
+  from robosystems.middleware.billing.enforcement import require_graph_access
   from robosystems.models.core import GraphUser
 
   session = SessionFactory()
@@ -596,6 +605,7 @@ def require_graph_write_role(user_id: str, graph_id: str) -> None:
         status_code=status.HTTP_403_FORBIDDEN,
         detail=f"Write access denied to graph {graph_id}; your role is read-only.",
       )
+    require_graph_access(graph_id, session, require_write=True)
   finally:
     session.close()
 

--- a/robosystems/middleware/billing/enforcement.py
+++ b/robosystems/middleware/billing/enforcement.py
@@ -122,24 +122,19 @@ def check_graph_subscription_active(
   return (True, None)
 
 
-def require_graph_access(
-  graph_id: str, session: Session, require_write: bool = False
-) -> Graph:
-  """Validate graph is accessible for the requested operation type.
+def _assert_graph_live(graph: Graph | None) -> Graph:
+  """Layer 1 of ``require_graph_access``: the graph exists and is not gone.
 
-  Checks two layers:
-  1. Graph status (suspended -> 403, deprovisioned -> 404)
-  2. Subscription status (grace period: reads OK, writes blocked)
+  ``deleted_at`` counts as gone — teardown stamps it before the tenant schema
+  and database are dropped and flips ``status`` only at the end, so a graph
+  caught mid-teardown (or stranded there) must answer 404, not serve.
   """
-  graph = Graph.get_by_id(graph_id, session, include_deprovisioned=True)
-
-  if not graph:
+  if graph is None or graph.deleted_at is not None:
     raise HTTPException(
       status_code=status.HTTP_404_NOT_FOUND,
       detail="Graph not found.",
     )
 
-  # Layer 1: Graph lifecycle status
   graph_status = graph.status or GraphStatus.ACTIVE.value
 
   if graph_status == GraphStatus.DEPROVISIONED.value:
@@ -153,16 +148,44 @@ def require_graph_access(
       status_code=status.HTTP_403_FORBIDDEN,
       detail="Subscription has ended. Resubscribe to access this graph.",
     )
+  return graph
+
+
+def require_graph_access(
+  graph_id: str, session: Session, require_write: bool = False
+) -> Graph:
+  """Validate graph is accessible for the requested operation type.
+
+  Checks two layers:
+  1. Graph lifecycle (deleted/deprovisioned -> 404, suspended -> 403)
+  2. Subscription status (grace period: reads OK, writes blocked)
+
+  A subgraph carries no subscription of its own and lives on its parent's
+  infrastructure, so it is held to its parent's lifecycle *and* billed
+  through the parent: both rows must be live, and the subscription lookup
+  (and its cache entry) is keyed on the parent graph. Returns the row for
+  ``graph_id`` itself.
+  """
+  graph = _assert_graph_live(
+    Graph.get_by_id(graph_id, session, include_deprovisioned=True)
+  )
+
+  billing_graph = graph
+  if graph.is_subgraph and graph.parent_graph_id:
+    billing_graph = _assert_graph_live(
+      Graph.get_by_id(graph.parent_graph_id, session, include_deprovisioned=True)
+    )
+  billing_graph_id = str(billing_graph.graph_id)
 
   # Layer 2: Subscription check (only when billing is enabled)
   if not env.BILLING_ENABLED:
     return graph
 
   # Skip subscription check for shared repositories
-  if graph.is_repository:
+  if billing_graph.is_repository:
     return graph
 
-  cached = _get_cached_subscription(graph_id)
+  cached = _get_cached_subscription(billing_graph_id)
   if cached == "active":
     return graph
   elif cached == "upgrading":
@@ -192,12 +215,12 @@ def require_graph_access(
 
   # Cache miss — query DB
   subscription = BillingSubscription.get_by_resource(
-    resource_type="graph", resource_id=graph_id, session=session
+    resource_type="graph", resource_id=billing_graph_id, session=session
   )
 
   if not subscription:
-    logger.warning(f"No subscription found for graph {graph_id}")
-    _cache_subscription(graph_id, "no_subscription")
+    logger.warning(f"No subscription found for graph {billing_graph_id}")
+    _cache_subscription(billing_graph_id, "no_subscription")
     raise HTTPException(
       status_code=status.HTTP_403_FORBIDDEN,
       detail="No active subscription for this graph.",
@@ -205,7 +228,7 @@ def require_graph_access(
 
   if subscription.status == "upgrading":
     # Tier migration in progress: reads OK, writes blocked
-    _cache_subscription(graph_id, "upgrading")
+    _cache_subscription(billing_graph_id, "upgrading")
     if require_write:
       raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
@@ -223,7 +246,7 @@ def require_graph_access(
 
     if ends_at and ends_at > now:
       # Grace period: reads OK, writes blocked
-      _cache_subscription(graph_id, "canceled_grace")
+      _cache_subscription(billing_graph_id, "canceled_grace")
       if require_write:
         raise HTTPException(
           status_code=status.HTTP_403_FORBIDDEN,
@@ -232,7 +255,7 @@ def require_graph_access(
       return graph
 
     # Past grace period
-    _cache_subscription(graph_id, "canceled_expired")
+    _cache_subscription(billing_graph_id, "canceled_expired")
     raise HTTPException(
       status_code=status.HTTP_403_FORBIDDEN,
       detail="Subscription has ended. Resubscribe to access this graph.",
@@ -240,7 +263,7 @@ def require_graph_access(
 
   # Only explicitly active subscriptions get full access
   if subscription.status == SubscriptionStatus.ACTIVE.value:
-    _cache_subscription(graph_id, "active")
+    _cache_subscription(billing_graph_id, "active")
     return graph
 
   # All other statuses (past_due, unpaid, paused, pending, etc.) are blocked

--- a/robosystems/middleware/extensions.py
+++ b/robosystems/middleware/extensions.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm import Session
 from robosystems.database import get_db_session
 from robosystems.logger import logger
 from robosystems.middleware.auth.dependencies import require_graph_write_role
+from robosystems.middleware.billing.enforcement import require_graph_access
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
 from robosystems.middleware.graph.utils.subgraph import is_subgraph
 from robosystems.middleware.operations import (
@@ -283,6 +284,11 @@ def require_graph_extension(extension: str) -> Callable[..., GraphExtensionConte
         status_code=403,
         detail=f"{extension} is not provisioned for this graph",
       )
+    # Lifecycle/subscription gate at read strength — every extensions route
+    # (reads, views, commands) passes through here, so a suspended or expired
+    # graph is closed on the whole surface. Commands additionally run the
+    # write-strength check inside `require_graph_write_role`.
+    require_graph_access(graph_id, session, require_write=False)
     return meta
 
   return _dep

--- a/robosystems/middleware/mcp/tools/cypher_tool.py
+++ b/robosystems/middleware/mcp/tools/cypher_tool.py
@@ -187,34 +187,49 @@ RETURN DISTINCT labels(a)[0] AS from_type, type(r) AS rel_type, labels(b)[0] AS 
     Raises:
         ValueError: If query contains write, bulk, admin, or schema-DDL operations
     """
-    # Route every category through the central security analyzer — the same
-    # predicates the StatementKernel (REST /query/cypher) composes — so this
-    # tool-layer guard can't diverge. It also protects the Operator path, which
-    # invokes this tool directly, bypassing the HTTP handler and kernel.
-    from robosystems.security.cypher_analyzer import (
-      is_admin_operation,
-      is_bulk_operation,
-      is_schema_ddl,
-      is_write_operation,
+    assert_read_only_cypher(query)
+
+
+def assert_read_only_cypher(query: str) -> None:
+  """Refuse anything but a read for the read-graph-cypher tool.
+
+  Module-level so every path that executes on the tool's behalf runs the
+  same predicate: `CypherTool.execute_query` (direct and streaming), the
+  Operator path (which calls the tool directly, bypassing the HTTP handler
+  and kernel), and the queued strategies in the MCP routers, which submit
+  the raw statement to the query queue without ever constructing the tool.
+
+  Raises:
+      ValueError: If the query contains write, bulk, admin, or schema-DDL
+          operations.
+  """
+  # Route every category through the central security analyzer — the same
+  # predicates the StatementKernel (REST /query/cypher) composes — so this
+  # tool-layer guard can't diverge.
+  from robosystems.security.cypher_analyzer import (
+    is_admin_operation,
+    is_bulk_operation,
+    is_schema_ddl,
+    is_write_operation,
+  )
+
+  if is_bulk_operation(query):
+    logger.warning("Blocked bulk operation (COPY/LOAD/IMPORT) in read-graph-cypher")
+    raise ValueError("Only read-only queries are allowed")
+
+  if is_admin_operation(query):
+    logger.warning(
+      "Blocked administrative operation (EXPORT/INSTALL/ATTACH/USE) in "
+      "read-graph-cypher"
     )
+    raise ValueError("Only read-only queries are allowed")
 
-    if is_bulk_operation(query):
-      logger.warning("Blocked bulk operation (COPY/LOAD/IMPORT) in read-graph-cypher")
-      raise ValueError("Only read-only queries are allowed")
+  if is_schema_ddl(query):
+    logger.warning("Blocked schema DDL in read-graph-cypher")
+    raise ValueError("Only read-only queries are allowed")
 
-    if is_admin_operation(query):
-      logger.warning(
-        "Blocked administrative operation (EXPORT/INSTALL/ATTACH/USE) in "
-        "read-graph-cypher"
-      )
-      raise ValueError("Only read-only queries are allowed")
-
-    if is_schema_ddl(query):
-      logger.warning("Blocked schema DDL in read-graph-cypher")
-      raise ValueError("Only read-only queries are allowed")
-
-    if is_write_operation(query):
-      logger.warning(
-        "Blocked write operation (CREATE/MERGE/SET/DELETE) in read-graph-cypher"
-      )
-      raise ValueError("Only read-only queries are allowed")
+  if is_write_operation(query):
+    logger.warning(
+      "Blocked write operation (CREATE/MERGE/SET/DELETE) in read-graph-cypher"
+    )
+    raise ValueError("Only read-only queries are allowed")

--- a/robosystems/middleware/mcp/tools/graph_tools.py
+++ b/robosystems/middleware/mcp/tools/graph_tools.py
@@ -243,6 +243,12 @@ class CreateSubgraphTool:
         detail = str(gate_error.detail)
         if gate_error.status_code == 409:
           return {"error": "name_taken", "message": detail}
+        if gate_error.status_code == 400:
+          # A malformed name is caught by validate_subgraph_name() above, so
+          # this is unreachable for real input today; keep the mapping
+          # exhaustive so a 400 from any gate helper codes as invalid_name
+          # rather than defaulting into the subgraph_not_allowed bucket.
+          return {"error": "invalid_name", "message": detail}
         lowered = detail.lower()
         is_role_denial = "admin access" in lowered or "access denied" in lowered
         return {

--- a/robosystems/middleware/mcp/tools/graph_tools.py
+++ b/robosystems/middleware/mcp/tools/graph_tools.py
@@ -174,7 +174,6 @@ class CreateSubgraphTool:
     }
 
   async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
-    from robosystems.models.core.graph import Graph
     from robosystems.operations.graph.subgraph_service import SubgraphService
 
     name = arguments.get("name") or ""
@@ -208,11 +207,49 @@ class CreateSubgraphTool:
 
     session, close = _open_platform_session()
     try:
-      parent = session.query(Graph).filter(Graph.graph_id == parent_graph_id).first()
-      if not parent:
+      # Mirror the REST gates (`routers/graphs/subgraphs/main.py::create_subgraph`)
+      # by running the same helpers: the feature flag, admin role + lifecycle/
+      # subscription state on the parent, tier support, active parent, quota
+      # and name uniqueness. A gate that exists on one of two entry points to
+      # the same service is not a gate.
+      from fastapi import HTTPException
+
+      from robosystems.config import env
+      from robosystems.routers.graphs.subgraphs.utils import (
+        check_subgraph_quota,
+        validate_subgraph_name_unique,
+        verify_parent_graph_access,
+        verify_parent_graph_active,
+        verify_subgraph_tier_support,
+      )
+
+      if not env.SUBGRAPH_CREATION_ENABLED:
         return {
-          "error": "parent_not_found",
-          "message": f"Parent graph {parent_graph_id} not found.",
+          "error": "subgraph_creation_disabled",
+          "message": "Subgraph creation is currently disabled.",
+        }
+      try:
+        parent = verify_parent_graph_access(parent_graph_id, user, session, "admin")
+        verify_subgraph_tier_support(parent)
+        verify_parent_graph_active(parent)
+        _count, _max, existing = check_subgraph_quota(parent, session)
+        validate_subgraph_name_unique(name, existing, parent_graph_id)
+      except HTTPException as gate_error:
+        if gate_error.status_code == 404:
+          return {
+            "error": "parent_not_found",
+            "message": f"Parent graph {parent_graph_id} not found.",
+          }
+        detail = str(gate_error.detail)
+        if gate_error.status_code == 409:
+          return {"error": "name_taken", "message": detail}
+        lowered = detail.lower()
+        is_role_denial = "admin access" in lowered or "access denied" in lowered
+        return {
+          "error": "insufficient_permissions"
+          if is_role_denial
+          else "subgraph_not_allowed",
+          "message": detail,
         }
 
       service = SubgraphService()
@@ -235,8 +272,6 @@ class CreateSubgraphTool:
       # stdio bridge you created then switched in-session, but a remote
       # connector is URL-anchored, so the caller needs the address and the
       # (already-satisfied) credential answer handed to them, not inferred.
-      from robosystems.config import env
-
       subgraph_id = result.get("graph_id")
       return {
         "subgraph_id": subgraph_id,

--- a/robosystems/models/core/graph/graph_user.py
+++ b/robosystems/models/core/graph/graph_user.py
@@ -190,30 +190,52 @@ class GraphUser(Model):
     Org OWNER/ADMIN hold implicit graph admin on graphs their org owns (paying
     for a graph carries the right to manage it), so the effective role is the
     stronger of the explicit row and that implicit grant.
+
+    Nobody holds a role on a graph that is gone. A missing, deprovisioned, or
+    ``deleted_at``-stamped graph (teardown stamps first and flips status last)
+    resolves to no role for everyone — including org OWNER/ADMIN, whose
+    implicit grant would otherwise outlive the graph via ``Graph.org_id`` —
+    so every surface that authorizes through this resolver (REST, GraphQL,
+    MCP, the extensions registrar) denies in one place. A subgraph row that
+    exists is held to the same standard as its parent.
     """
     from robosystems.middleware.graph.types import parse_graph_id
+    from robosystems.models.core.graph.graph import Graph, GraphStatus
 
     parent_id, _ = parse_graph_id(graph_id)
 
+    graph_ids = {parent_id, graph_id}
+    rows = (
+      session.query(Graph.graph_id, Graph.org_id, Graph.status, Graph.deleted_at)
+      .filter(Graph.graph_id.in_(graph_ids))
+      .all()
+    )
+    by_id = {r.graph_id: r for r in rows}
+    parent_row = by_id.get(parent_id)
+    if parent_row is None:
+      return None, False
+    for row in by_id.values():
+      if row.status == GraphStatus.DEPROVISIONED.value or row.deleted_at is not None:
+        return None, False
+
     explicit_role: GraphRole | None = None
-    row = (
+    membership = (
       session.query(cls)
       .filter(cls.user_id == user_id, cls.graph_id == parent_id)
       .first()
     )
-    if row is not None:
+    if membership is not None:
       try:
-        explicit_role = GraphRole.coerce(row.role)
+        explicit_role = GraphRole.coerce(membership.role)
       except ValueError:
         explicit_role = GraphRole.VIEWER
 
     if explicit_role == GraphRole.ADMIN:
       return GraphRole.ADMIN, False
 
-    from robosystems.models.core.graph.graph import Graph
     from robosystems.models.core.org.org_user import OrgRole, OrgUser
 
-    org_id = session.query(Graph.org_id).filter(Graph.graph_id == parent_id).scalar()
+    org_id = parent_row.org_id
     if org_id is not None:
       org_user = OrgUser.get_by_org_and_user(org_id, user_id, session)
       if org_user is not None and org_user.role in (OrgRole.OWNER, OrgRole.ADMIN):

--- a/robosystems/operations/connection_service.py
+++ b/robosystems/operations/connection_service.py
@@ -110,8 +110,13 @@ class ConnectionService:
 
     Pass `graph_id` (the URL scope the caller already authorized) whenever it
     is known: `connection_id` is caller-supplied, so without the scope check a
-    guessed id reaches another graph's connection. `SYSTEM_USER_ID` bypasses
-    the ownership check.
+    guessed id reaches another graph's connection.
+
+    Connections are graph assets that record their creator, not the
+    creator's property: with `graph_id` given, the graph scope is the
+    authorization and every member of the graph resolves the same
+    connection (role is enforced by the caller). Without a graph scope the
+    legacy creator check applies; `SYSTEM_USER_ID` bypasses it.
     """
     session = db_session or SessionFactory()
     session_created = db_session is None
@@ -122,11 +127,11 @@ class ConnectionService:
         logger.warning("Connection not found: %s", connection_id)
         return None
 
-      if graph_id and conn.graph_id != graph_id:
-        logger.warning("Connection %s not in requested graph scope", connection_id)
-        return None
-
-      if user_id and user_id != SYSTEM_USER_ID and conn.user_id != user_id:
+      if graph_id:
+        if conn.graph_id != graph_id:
+          logger.warning("Connection %s not in requested graph scope", connection_id)
+          return None
+      elif user_id and user_id != SYSTEM_USER_ID and conn.user_id != user_id:
         logger.warning("User not authorized for connection %s", connection_id)
         return None
 
@@ -164,15 +169,18 @@ class ConnectionService:
   ) -> list[dict[str, Any]]:
     """List connections, without decrypting credentials.
 
-    `graph_id` takes precedence over `entity_id`; `SYSTEM_USER_ID` sees every
-    user's connections. Each dict carries `has_credentials` and `is_expired`.
+    `graph_id` takes precedence over `entity_id`. A graph scope lists the
+    graph's connections for every member (they are graph assets — see
+    `get_connection`); only the legacy scope-less call filters by creator, and
+    `SYSTEM_USER_ID` sees every user's connections. Each dict carries
+    `has_credentials` and `is_expired`.
     """
     session = db_session or SessionFactory()
     session_created = db_session is None
 
     try:
       target_graph_id = graph_id or entity_id
-      filter_user_id = None if user_id == SYSTEM_USER_ID else user_id
+      filter_user_id = None if (graph_id or user_id == SYSTEM_USER_ID) else user_id
 
       connections = Connection.list_filtered(
         session=session,
@@ -475,10 +483,12 @@ class ConnectionService:
     Graph-scoped on purpose: the connection must belong to `graph_id` (the
     URL scope the caller already authorized) — this prevents flipping
     another graph's connection into write-back via a guessed connection_id.
+    Any write-role member of the graph may set the policy, not only the
+    member who created the connection (the router enforces the role).
     Returns the updated connection dict, or None when the connection is
-    missing, belongs to a different graph, or isn't owned by the user.
-    Raises ValueError for an unsupported policy value (the model validates);
-    valid values are 'native' and 'qb_authoritative'.
+    missing or belongs to a different graph. Raises ValueError for an
+    unsupported policy value (the model validates); valid values are
+    'native' and 'qb_authoritative'.
     """
     session = db_session or SessionFactory()
     session_created = db_session is None
@@ -492,9 +502,6 @@ class ConnectionService:
         logger.warning(
           "Connection %s does not belong to graph %s", connection_id, graph_id
         )
-        return None
-      if user_id and user_id != SYSTEM_USER_ID and conn.user_id != user_id:
-        logger.warning("User not authorized for connection %s", connection_id)
         return None
 
       conn.set_write_policy(session, write_policy)

--- a/robosystems/operations/graph/deprovision_service.py
+++ b/robosystems/operations/graph/deprovision_service.py
@@ -592,7 +592,23 @@ class GraphDeprovisionService:
         .filter(GraphUser.graph_id == graph_id)
         .all()
       ]
-      self._invalidate_member_access(graph_id, member_ids)
+      # Org OWNER/ADMIN hold implicit graph admin without a GraphUser row, so
+      # their cached decisions have to be dropped by name as well.
+      from ...models.core.graph.graph import Graph
+      from ...models.core.org.org_user import OrgRole, OrgUser
+
+      org_id = session.query(Graph.org_id).filter(Graph.graph_id == graph_id).scalar()
+      if org_id is not None:
+        member_ids += [
+          row[0]
+          for row in session.query(OrgUser.user_id)
+          .filter(
+            OrgUser.org_id == org_id,
+            OrgUser.role.in_([OrgRole.OWNER, OrgRole.ADMIN]),
+          )
+          .all()
+        ]
+      self._invalidate_member_access(graph_id, list(dict.fromkeys(member_ids)))
 
       session.query(GraphUser).filter(GraphUser.graph_id == graph_id).delete(
         synchronize_session=False

--- a/robosystems/routers/extensions/roboledger/views.py
+++ b/robosystems/routers/extensions/roboledger/views.py
@@ -24,9 +24,12 @@ import time
 import uuid
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Path
+from sqlalchemy.orm import Session
 
 from robosystems.config.shared_repositories import is_shared_repository_or_subgraph
+from robosystems.database import get_db_session
 from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+from robosystems.middleware.billing.enforcement import require_graph_access
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
 from robosystems.middleware.operations import (
   IdempotencyCache,
@@ -73,6 +76,29 @@ _OP_TAG = "Extensions: RoboLedger"
 _RATE_LIMIT = Depends(subscription_aware_rate_limit_dependency)
 
 
+def _require_readable_graph(
+  graph_id: str = Path(..., pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN),
+  _user: User = Depends(get_current_user_with_graph),
+  session: Session = Depends(get_db_session),
+) -> None:
+  """Lifecycle/subscription gate (read strength) for the analytical views.
+
+  The views read LadybugDB directly rather than the extensions OLTP, so they
+  do not pass through `require_graph_extension`; this is the same
+  `require_graph_access` check that dependency and `/query` run, so a
+  suspended or expired graph is closed here too. Shared repositories pass —
+  their access is per-user, checked by `get_current_user_with_graph`.
+
+  Depends on the auth dependency so it can only run for an authenticated
+  member (route-level dependencies otherwise resolve before the handler's
+  own, and graph state must not be observable before authentication).
+  """
+  require_graph_access(graph_id, session, require_write=False)
+
+
+_READABLE_GRAPH = Depends(_require_readable_graph)
+
+
 @router.post(
   "/build-fact-grid",
   response_model=OperationEnvelope[ViewResponse],
@@ -80,7 +106,7 @@ _RATE_LIMIT = Depends(subscription_aware_rate_limit_dependency)
   summary="Build Fact Grid",
   description="Queries LadybugDB `Fact` nodes by element qnames or canonical concepts, with filters for periods, entities, form, and fiscal context. Returns deduplicated facts plus the aspects they span — arranging them into a table is the consumer's job, since collapsing cells safely requires the full aspect signature. Works on both roboledger tenant graphs (post-materialization) and the SEC shared repository.",
   tags=[_OP_TAG],
-  dependencies=[_RATE_LIMIT],
+  dependencies=[_RATE_LIMIT, _READABLE_GRAPH],
   responses={**OPERATION_ERROR_RESPONSES},
 )
 @endpoint_metrics_decorator(
@@ -190,7 +216,7 @@ async def build_fact_grid_op(
     "graphs, provide `report_id` explicitly."
   ),
   tags=[_OP_TAG],
-  dependencies=[_RATE_LIMIT],
+  dependencies=[_RATE_LIMIT, _READABLE_GRAPH],
   responses={**OPERATION_ERROR_RESPONSES},
 )
 @endpoint_metrics_decorator(

--- a/robosystems/routers/graphs/connections/management.py
+++ b/robosystems/routers/graphs/connections/management.py
@@ -62,6 +62,10 @@ async def create_connection(
   db: Session = Depends(get_db_session),
   _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
 ) -> ConnectionResponse:
+  # Registering a source is a write to the graph (it seeds sync, the fiscal
+  # calendar and the mapping operator); membership alone is not enough.
+  require_graph_write_role(str(current_user.id), graph_id)
+
   # Initialize robustness components
   components = create_robustness_components()
 

--- a/robosystems/routers/graphs/connections/oauth.py
+++ b/robosystems/routers/graphs/connections/oauth.py
@@ -9,7 +9,10 @@ from sqlalchemy.orm import Session
 
 from robosystems.database import get_db_session
 from robosystems.logger import logger
-from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+from robosystems.middleware.auth.dependencies import (
+  get_current_user_with_graph,
+  require_graph_write_role,
+)
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
 from robosystems.middleware.rate_limits import subscription_aware_rate_limit_dependency
 from robosystems.models.api.common import (
@@ -47,6 +50,10 @@ async def init_oauth(
   db: Session = Depends(get_db_session),
   _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
 ) -> OAuthInitResponse:
+  # Completing OAuth stores credentials and starts a full-rebuild sync —
+  # a write to the graph, so the write role is required from the start.
+  require_graph_write_role(str(current_user.id), graph_id)
+
   try:
     # Get connection to verify it exists and get provider
     connection = await ConnectionService.get_connection(
@@ -117,6 +124,10 @@ async def oauth_callback(
   db: Session = Depends(get_db_session),
   _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
 ):
+  # The callback stores tokens, revives soft-deleted connections and kicks
+  # off the initial sync: a write to the graph.
+  require_graph_write_role(str(current_user.id), graph_id)
+
   try:
     # Handle OAuth errors
     if request.error:
@@ -236,8 +247,19 @@ async def oauth_callback(
         target_connection_id, tokens, provider_data, db, user_id=str(current_user.id)
       )
 
+      if connection is None:
+        # Tokens are stored on the revived row already; the sync below
+        # needs the connection dict, so this is a hard stop, not a
+        # crash — surfacing an actionable error beats an AttributeError
+        # after the credential write.
+        raise create_error_response(
+          status_code=status.HTTP_404_NOT_FOUND,
+          detail="Connection not found",
+          code=ErrorCode.NOT_FOUND,
+        )
+
       # Update connection metadata
-      metadata = (connection or {}).get("metadata") or {}
+      metadata = connection.get("metadata") or {}
       metadata.update(
         {
           "status": "connected",

--- a/robosystems/routers/graphs/connections/sync.py
+++ b/robosystems/routers/graphs/connections/sync.py
@@ -7,7 +7,10 @@ from sqlalchemy.orm import Session
 
 from robosystems.database import get_db_session
 from robosystems.logger import logger
-from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+from robosystems.middleware.auth.dependencies import (
+  get_current_user_with_graph,
+  require_graph_write_role,
+)
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
 from robosystems.middleware.operations import (
   IdempotencyCache,
@@ -76,6 +79,12 @@ async def sync_connection(
 ) -> OperationEnvelope:
   op_name = "sync-connection"
   user_id = str(current_user.id)
+
+  # A sync rewrites the graph's captured events (full_rebuild wipes and
+  # reloads them); membership alone is not enough. Same gate the MCP
+  # `sync-connection` tool clears through its write classification.
+  require_graph_write_role(user_id, graph_id)
+
   body_fp = fingerprint_body(request)
 
   replay = await check_idempotency(

--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -753,6 +753,20 @@ async def call_mcp_tool(
           query: str = tool_call.arguments.get("query", "")  # type: ignore[assignment]
           parameters = tool_call.arguments.get("parameters", {})
 
+          # The queue executes the raw statement without constructing the
+          # tool, so the read-only guard `CypherTool` applies on the direct
+          # path has to run here — a read tool must not become a write path
+          # for a write-role caller by picking a queue strategy.
+          from robosystems.middleware.mcp.tools.cypher_tool import (
+            assert_read_only_cypher,
+          )
+
+          try:
+            assert_read_only_cypher(query)
+          except ValueError as exc:
+            await handler.close()
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+
           queue_manager = get_query_queue()
           queue_id = await queue_manager.submit_query(
             cypher=query,

--- a/robosystems/routers/graphs/mcp/handlers.py
+++ b/robosystems/routers/graphs/mcp/handlers.py
@@ -63,7 +63,11 @@ async def validate_mcp_access(
   """Validate user access for MCP operations, raising 403 on denial.
 
   Shared repositories resolve through repository access (subgraphs resolve to
-  their parent); other graphs check per-graph membership.
+  their parent); other graphs check per-graph membership and role, then the
+  graph's lifecycle/subscription state (``require_graph_access``) — the same
+  pair the REST command surfaces enforce through ``require_graph_write_role``
+  — so a suspended, mid-teardown or grace-period graph is no more writable
+  through an MCP tool than through an operation endpoint.
   """
   # Check shared repositories (including subgraphs like "sec_historical")
   from robosystems.config.shared_repositories import is_shared_repository_or_subgraph
@@ -102,6 +106,12 @@ async def validate_mcp_access(
         )
     elif not GraphUser.user_has_access(current_user.id, graph_id, db):
       raise HTTPException(status_code=403, detail=f"Access denied to graph {graph_id}")
+
+    from robosystems.middleware.billing.enforcement import require_graph_access
+
+    require_graph_access(
+      graph_id, db, require_write=operation_type in ("write", "admin")
+    )
 
 
 class MCPHandler:

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -160,6 +160,10 @@ def _rpc_error(
   )
 
 
+class _ReadOnlyViolation(Exception):
+  """A read-graph-cypher statement refused by the read-only guard."""
+
+
 def _tool_error_payload(msg_id: Any, text: str) -> dict[str, Any]:
   """A tool-execution failure as a complete JSON-RPC response payload.
 
@@ -537,6 +541,7 @@ async def _stream_queued_call(
   stops consuming queue capacity.
   """
   from robosystems.middleware.graph.query_queue import get_query_queue
+  from robosystems.middleware.mcp.tools.cypher_tool import assert_read_only_cypher
 
   queue_manager = get_query_queue()
   query: str = tool_call.arguments.get("query", "")  # type: ignore[assignment]
@@ -550,6 +555,12 @@ async def _stream_queued_call(
   outcome = "client_disconnected"
   try:
     try:
+      # Same read-only guard the tool applies on the direct path; the queue
+      # runs the raw statement, so it must be refused before submission.
+      try:
+        assert_read_only_cypher(query)
+      except ValueError as exc:
+        raise _ReadOnlyViolation(str(exc)) from exc
       queue_id = await queue_manager.submit_query(
         cypher=query,
         parameters=parameters,  # type: ignore[arg-type]
@@ -626,6 +637,12 @@ async def _stream_queued_call(
             break
 
           await asyncio.sleep(_QUEUE_POLL_SECONDS)
+    except _ReadOnlyViolation as exc:
+      # A denied statement is a policy answer, not a backend failure: no
+      # breaker hit, and the model sees why so it can rephrase.
+      query_settled = True
+      outcome = "denied"
+      payload = _tool_error_payload(msg_id, f"Error: {exc}")
     except TimeoutError:
       outcome = "bridge_timeout"
       # Deliberate: the bridge ceiling exhausting counts against the breaker.

--- a/robosystems/routers/graphs/operator/execute.py
+++ b/robosystems/routers/graphs/operator/execute.py
@@ -66,15 +66,22 @@ router = APIRouter()
 async def _enforce_shared_repository_agent_limits(
   graph_id: str, current_user: User, db: Session
 ) -> None:
-  """Apply shared-repository access + per-plan agent volume limits.
+  """Apply the graph lifecycle gate, then shared-repository agent limits.
 
   Repository plans advertise agent_calls_per_* limits; until this hook,
   nothing ever checked them (query/mcp/search had their equivalents, the
-  operator surface did not), so the advertised numbers were unenforced.
+  operator surface did not), so the advertised numbers were unenforced. The
+  lifecycle gate is the same one: a suspended or expired graph refused the
+  operator on no surface until this ran here.
   """
+  from robosystems.middleware.billing.enforcement import require_graph_access
   from robosystems.routers.graphs.query.execute import (
     _check_shared_repository_limits,
   )
+
+  # Lifecycle/subscription gate (read strength — write-capable operators run
+  # the write-strength check through `enforce_operator_write_role`).
+  require_graph_access(graph_id, db, require_write=False)
 
   await _check_shared_repository_limits(
     graph_id, current_user, db, endpoint="agent", operation="agent"

--- a/tests/graphql/extensions/test_context.py
+++ b/tests/graphql/extensions/test_context.py
@@ -42,6 +42,15 @@ def _entity_meta(
   )
 
 
+@pytest.fixture(autouse=True)
+def _bypass_lifecycle_gate():
+  """`get_context` runs the graph lifecycle/subscription gate after the access
+  check and metadata load; these tests use synthetic graph ids, so bypass it
+  by default. `TestGetContextLifecycleGate` covers the wiring."""
+  with patch(f"{MODULE}.require_graph_access", return_value=None):
+    yield
+
+
 def _make_request(headers: dict[str, str] | None = None) -> MagicMock:
   """Build a stub Request with controllable headers."""
   request = MagicMock()
@@ -405,3 +414,72 @@ class TestSubgraphGuard:
 
     assert ctx["graph_id"] == "sec"
     mock_check.assert_called_once_with(user, "sec")
+
+
+@pytest.mark.asyncio
+class TestGetContextLifecycleGate:
+  """A suspended, mid-teardown or expired graph is not readable through
+  GraphQL: the same `require_graph_access` gate `/query` runs, at read
+  strength, after the access check and only for real graphs (the `library`
+  sentinel has no Graph row)."""
+
+  async def test_gate_runs_after_access_check_at_read_strength(self):
+    request = _make_request(headers={})
+    user = MagicMock()
+    user.id = "usr_test"
+    db = MagicMock()
+    order: list[str] = []
+
+    with (
+      patch(f"{MODULE}.get_current_user", new_callable=AsyncMock, return_value=user),
+      patch(
+        f"{MODULE}.check_graph_access",
+        side_effect=lambda *_a, **_k: order.append("access"),
+      ),
+      patch(f"{MODULE}.load_graph_metadata", return_value=_entity_meta()),
+      patch(
+        f"{MODULE}.require_graph_access",
+        side_effect=lambda *_a, **_k: order.append("lifecycle"),
+      ) as gate,
+    ):
+      await get_context(request=request, api_key="rfs_valid", graph_id=GRAPH_ID, db=db)
+
+    assert order == ["access", "lifecycle"]
+    gate.assert_called_once_with(GRAPH_ID, db, require_write=False)
+
+  async def test_closed_graph_is_refused(self):
+    request = _make_request(headers={})
+    user = MagicMock()
+    user.id = "usr_test"
+
+    with (
+      patch(f"{MODULE}.get_current_user", new_callable=AsyncMock, return_value=user),
+      patch(f"{MODULE}.check_graph_access"),
+      patch(f"{MODULE}.load_graph_metadata", return_value=_entity_meta()),
+      patch(
+        f"{MODULE}.require_graph_access",
+        side_effect=HTTPException(status_code=403, detail="Subscription has ended."),
+      ),
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await get_context(
+          request=request, api_key="rfs_valid", graph_id=GRAPH_ID, db=MagicMock()
+        )
+    assert exc.value.status_code == 403
+
+  async def test_library_sentinel_skips_the_gate(self):
+    request = _make_request(headers={})
+    user = MagicMock()
+    user.id = "usr_test"
+
+    with (
+      patch(f"{MODULE}.get_current_user", new_callable=AsyncMock, return_value=user),
+      patch(f"{MODULE}.check_graph_access"),
+      patch(f"{MODULE}.require_graph_access") as gate,
+    ):
+      ctx = await get_context(
+        request=request, api_key="rfs_valid", graph_id="library", db=MagicMock()
+      )
+
+    assert ctx["graph_type"] == "library"
+    gate.assert_not_called()

--- a/tests/middleware/auth/test_dependencies.py
+++ b/tests/middleware/auth/test_dependencies.py
@@ -1375,9 +1375,58 @@ class TestRequireGraphWriteRole:
         "robosystems.models.core.GraphUser.user_has_write_access",
         return_value=True,
       ),
+      patch(
+        "robosystems.middleware.billing.enforcement.require_graph_access"
+      ) as mock_access,
     ):
-      # member/admin -> no raise
+      # member/admin on a writable graph -> no raise
       require_graph_write_role("user_1", "kg0123456789abcdef")
+    # The lifecycle half of the gate runs as a *write* check on the same
+    # short-lived session the role check used.
+    mock_access.assert_called_once()
+    args, kwargs = mock_access.call_args
+    assert args[0] == "kg0123456789abcdef"
+    assert kwargs.get("require_write") is True
+
+  def test_write_role_blocked_by_graph_lifecycle(self):
+    """A write role is not enough: a graph that is not writable (suspended,
+    mid-teardown, canceled grace period, tier upgrade) refuses the write from
+    the same gate, so no command surface has to remember the second check."""
+    with (
+      patch("robosystems.database.SessionFactory", return_value=Mock()),
+      patch(
+        "robosystems.models.core.GraphUser.user_has_write_access",
+        return_value=True,
+      ),
+      patch(
+        "robosystems.middleware.billing.enforcement.require_graph_access",
+        side_effect=HTTPException(
+          status_code=status.HTTP_403_FORBIDDEN,
+          detail="Subscription canceled. Write operations disabled.",
+        ),
+      ),
+    ):
+      with pytest.raises(HTTPException) as exc:
+        require_graph_write_role("user_1", "kg0123456789abcdef")
+      assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+      assert "Write operations disabled" in exc.value.detail
+
+  def test_role_is_checked_before_lifecycle(self):
+    """A viewer is refused on role alone; the lifecycle lookup never runs, so
+    the denial is attributed (audited) to the role and not the graph state."""
+    with (
+      patch("robosystems.database.SessionFactory", return_value=Mock()),
+      patch(
+        "robosystems.models.core.GraphUser.user_has_write_access",
+        return_value=False,
+      ),
+      patch(
+        "robosystems.middleware.billing.enforcement.require_graph_access"
+      ) as mock_access,
+    ):
+      with pytest.raises(HTTPException):
+        require_graph_write_role("user_1", "kg0123456789abcdef")
+      mock_access.assert_not_called()
 
 
 class TestApiKeyIdentityStash:

--- a/tests/middleware/auth/test_utils.py
+++ b/tests/middleware/auth/test_utils.py
@@ -493,19 +493,22 @@ class TestGraphScopedKeys:
     mock_api_key_class.get_by_key.return_value = mock_key_record
     return mock_key_record
 
-  @patch("robosystems.models.core.GraphUser")
   @patch("robosystems.database.SessionFactory")
   @patch("robosystems.middleware.auth.utils.api_key_cache")
   @patch("robosystems.middleware.auth.utils.UserAPIKey")
   def test_scoped_key_valid_on_its_graph_db(
-    self, mock_api_key_class, mock_cache, mock_session_factory, mock_graph_user
+    self, mock_api_key_class, mock_cache, mock_session_factory
   ):
     """A scoped key authenticates its own graph through the DB path."""
     mock_cache.get_cached_api_key_validation.return_value = None
     mock_cache.get_cached_graph_access.return_value = None
     self._db_setup(mock_api_key_class, mock_session_factory, "kg123")
 
-    with patch("robosystems.models.core.GraphUser.user_has_access", return_value=True):
+    # utils binds `GraphUser` at import (`from ...models.core import GraphUser`),
+    # so the access decision must be patched on the name utils actually calls.
+    with patch(
+      "robosystems.middleware.auth.utils.GraphUser.user_has_access", return_value=True
+    ):
       result = validate_api_key_with_graph(
         "rfsc" + "a" * 64, "kg123", require_scoped=True
       )

--- a/tests/middleware/billing/test_enforcement.py
+++ b/tests/middleware/billing/test_enforcement.py
@@ -469,6 +469,9 @@ class TestRequireGraphAccessBillingDisabled:
     graph = Mock()
     graph.status = "active"
     graph.is_repository = False
+    graph.deleted_at = None
+    graph.is_subgraph = False
+    graph.parent_graph_id = None
     return graph
 
   @patch("robosystems.middleware.billing.enforcement.env")
@@ -527,6 +530,9 @@ class TestRequireGraphAccessGracePeriod:
     graph = Mock()
     graph.status = "active"
     graph.is_repository = False
+    graph.deleted_at = None
+    graph.is_subgraph = False
+    graph.parent_graph_id = None
     return graph
 
   def _canceled_subscription(self, ends_at):
@@ -606,3 +612,112 @@ class TestRequireGraphAccessGracePeriod:
     graph = require_graph_access("kg_gracetest4", mock_session)
 
     assert graph is mock_graph_class.get_by_id.return_value
+
+
+class TestRequireGraphAccessLifecycle:
+  """Lifecycle layer of require_graph_access: gone graphs and subgraphs.
+
+  ``deleted_at`` is stamped first in teardown and ``status`` flipped last, so
+  the stamp alone must read as gone. Subgraphs carry no subscription and no
+  infrastructure of their own: they are held to the parent's lifecycle and
+  billed through the parent.
+  """
+
+  @pytest.fixture
+  def mock_session(self):
+    return Mock()
+
+  @pytest.fixture(autouse=True)
+  def clear_subscription_cache(self):
+    from robosystems.middleware.billing import enforcement
+
+    enforcement._subscription_cache.clear()
+    yield
+    enforcement._subscription_cache.clear()
+
+  @staticmethod
+  def _graph(graph_id, *, status="active", deleted_at=None, parent=None):
+    graph = Mock()
+    graph.graph_id = graph_id
+    graph.status = status
+    graph.is_repository = False
+    graph.deleted_at = deleted_at
+    graph.is_subgraph = parent is not None
+    graph.parent_graph_id = parent
+    return graph
+
+  @patch("robosystems.middleware.billing.enforcement.env")
+  @patch("robosystems.middleware.billing.enforcement.Graph")
+  def test_deleted_at_stamp_is_gone(self, mock_graph_class, mock_env, mock_session):
+    mock_env.BILLING_ENABLED = False
+    mock_graph_class.get_by_id.return_value = self._graph(
+      "kg_stranded", status="suspended", deleted_at=datetime.now(UTC)
+    )
+
+    with pytest.raises(HTTPException) as exc:
+      require_graph_access("kg_stranded", mock_session)
+    assert exc.value.status_code == 404
+
+  @patch("robosystems.middleware.billing.enforcement.env")
+  @patch("robosystems.middleware.billing.enforcement.BillingSubscription")
+  @patch("robosystems.middleware.billing.enforcement.Graph")
+  def test_subgraph_billed_through_parent(
+    self, mock_graph_class, mock_subscription_class, mock_env, mock_session
+  ):
+    """The subscription lookup and its cache entry key on the parent, and the
+    subgraph's own row is what is returned."""
+    mock_env.BILLING_ENABLED = True
+    parent = self._graph("kg_parent")
+    child = self._graph("kg_parent_dev", parent="kg_parent")
+    mock_graph_class.get_by_id.side_effect = lambda gid, *_a, **_k: {
+      "kg_parent": parent,
+      "kg_parent_dev": child,
+    }[gid]
+    active = Mock()
+    active.status = SubscriptionStatus.ACTIVE.value
+    mock_subscription_class.get_by_resource.return_value = active
+
+    graph = require_graph_access("kg_parent_dev", mock_session, require_write=True)
+
+    assert graph is child
+    mock_subscription_class.get_by_resource.assert_called_once_with(
+      resource_type="graph", resource_id="kg_parent", session=mock_session
+    )
+    from robosystems.middleware.billing import enforcement
+
+    assert "kg_parent" in enforcement._subscription_cache
+    assert "kg_parent_dev" not in enforcement._subscription_cache
+
+  @patch("robosystems.middleware.billing.enforcement.env")
+  @patch("robosystems.middleware.billing.enforcement.Graph")
+  def test_subgraph_of_suspended_parent_is_suspended(
+    self, mock_graph_class, mock_env, mock_session
+  ):
+    mock_env.BILLING_ENABLED = False
+    parent = self._graph("kg_parent", status="suspended")
+    child = self._graph("kg_parent_dev", parent="kg_parent")
+    mock_graph_class.get_by_id.side_effect = lambda gid, *_a, **_k: {
+      "kg_parent": parent,
+      "kg_parent_dev": child,
+    }[gid]
+
+    with pytest.raises(HTTPException) as exc:
+      require_graph_access("kg_parent_dev", mock_session)
+    assert exc.value.status_code == 403
+
+  @patch("robosystems.middleware.billing.enforcement.env")
+  @patch("robosystems.middleware.billing.enforcement.Graph")
+  def test_subgraph_of_deleted_parent_is_gone(
+    self, mock_graph_class, mock_env, mock_session
+  ):
+    mock_env.BILLING_ENABLED = False
+    parent = self._graph("kg_parent", deleted_at=datetime.now(UTC))
+    child = self._graph("kg_parent_dev", parent="kg_parent")
+    mock_graph_class.get_by_id.side_effect = lambda gid, *_a, **_k: {
+      "kg_parent": parent,
+      "kg_parent_dev": child,
+    }[gid]
+
+    with pytest.raises(HTTPException) as exc:
+      require_graph_access("kg_parent_dev", mock_session)
+    assert exc.value.status_code == 404

--- a/tests/middleware/mcp/tools/test_graph_tools.py
+++ b/tests/middleware/mcp/tools/test_graph_tools.py
@@ -205,6 +205,28 @@ class TestCreateSubgraphExecute:
     mock_svc_class.assert_not_called()
 
   @pytest.mark.asyncio
+  async def test_malformed_name_from_gate_codes_as_invalid_name(
+    self, mock_db: MagicMock
+  ) -> None:
+    """A 400 from a gate helper (e.g. the REST name validator) codes as
+    invalid_name, not the subgraph_not_allowed default. Unreachable for real
+    input — validate_subgraph_name() catches a bad name before the gates — but
+    the mapping is kept exhaustive so the error code can't drift."""
+    from fastapi import HTTPException
+
+    parent = MagicMock()
+    with self._gates(parent):
+      with patch(
+        f"{self.UTILS}.validate_subgraph_name_unique",
+        side_effect=HTTPException(
+          status_code=400,
+          detail="Subgraph name must be alphanumeric and 1-20 characters",
+        ),
+      ):
+        result = await CreateSubgraphTool(_client()).execute({"name": "dev"})
+    assert result["error"] == "invalid_name"
+
+  @pytest.mark.asyncio
   async def test_name_collision_reported(self, mock_db: MagicMock) -> None:
     from fastapi import HTTPException
 

--- a/tests/middleware/mcp/tools/test_graph_tools.py
+++ b/tests/middleware/mcp/tools/test_graph_tools.py
@@ -60,6 +60,29 @@ def _session_cm(mock_session: MagicMock):
   return cm
 
 
+def _live_graph_row(graph_id: str = GRAPH_ID) -> MagicMock:
+  """A `Graph` projection row as `GraphUser.get_effective_role` reads it —
+  the resolver first checks the graph is live (exists, not deprovisioned, no
+  `deleted_at`) before consulting the membership row."""
+  row = MagicMock()
+  row.graph_id = graph_id
+  row.org_id = None
+  row.status = "active"
+  row.deleted_at = None
+  return row
+
+
+def _script_admin_role(mock_db: MagicMock, role: str = "admin") -> None:
+  """Script the two queries `get_effective_role` runs against the fake
+  session: a live Graph row (`.all()`), then the caller's GraphUser row
+  (`.first()`)."""
+  membership = MagicMock()
+  membership.role = role
+  chain = mock_db.query.return_value.filter.return_value
+  chain.all.return_value = [_live_graph_row()]
+  chain.first.return_value = membership
+
+
 @pytest.fixture
 def mock_db():
   """Patch `_open_platform_session` to return a fake session."""
@@ -101,22 +124,113 @@ class TestCreateSubgraphExecute:
     result = await tool.execute({"name": "dev"})
     assert result["error"] == "authentication_required"
 
+  # The tool mirrors the REST create-subgraph gates by calling the same
+  # helpers from routers/graphs/subgraphs/utils.py; these tests patch those
+  # helpers at their source module (the tool imports them lazily).
+  UTILS = "robosystems.routers.graphs.subgraphs.utils"
+
+  def _gates(self, parent: MagicMock):
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+    stack.enter_context(
+      patch(f"{self.UTILS}.verify_parent_graph_access", return_value=parent)
+    )
+    stack.enter_context(patch(f"{self.UTILS}.verify_subgraph_tier_support"))
+    stack.enter_context(patch(f"{self.UTILS}.verify_parent_graph_active"))
+    stack.enter_context(
+      patch(f"{self.UTILS}.check_subgraph_quota", return_value=(0, 3, []))
+    )
+    stack.enter_context(patch(f"{self.UTILS}.validate_subgraph_name_unique"))
+    return stack
+
   @pytest.mark.asyncio
   async def test_parent_not_found(self, mock_db: MagicMock) -> None:
-    mock_db.query.return_value.filter.return_value.first.return_value = None
-    result = await CreateSubgraphTool(_client()).execute({"name": "dev"})
+    from fastapi import HTTPException
+
+    with patch(
+      f"{self.UTILS}.verify_parent_graph_access",
+      side_effect=HTTPException(status_code=404, detail="Graph not found."),
+    ):
+      result = await CreateSubgraphTool(_client()).execute({"name": "dev"})
     assert result["error"] == "parent_not_found"
+
+  @pytest.mark.asyncio
+  async def test_feature_flag_off_returns_disabled(self, mock_db: MagicMock) -> None:
+    from robosystems.config import env as env_module
+
+    with patch.object(env_module, "SUBGRAPH_CREATION_ENABLED", False):
+      result = await CreateSubgraphTool(_client()).execute({"name": "dev"})
+    assert result["error"] == "subgraph_creation_disabled"
+
+  @pytest.mark.asyncio
+  async def test_member_without_admin_rejected(self, mock_db: MagicMock) -> None:
+    """REST requires admin on the parent (`verify_parent_graph_access(...,
+    "admin")`); the tool asks the same helper for the same role, so a member
+    who is not admin gets the REST answer over MCP too."""
+    from fastapi import HTTPException
+
+    with patch(
+      f"{self.UTILS}.verify_parent_graph_access",
+      side_effect=HTTPException(
+        status_code=403,
+        detail="Admin access to parent graph required for this operation",
+      ),
+    ) as gate:
+      result = await CreateSubgraphTool(_client()).execute({"name": "dev"})
+    assert result["error"] == "insufficient_permissions"
+    assert gate.call_args.args[3] == "admin"
+
+  @pytest.mark.asyncio
+  async def test_lifecycle_and_tier_gates_are_mirrored(
+    self, mock_db: MagicMock
+  ) -> None:
+    from fastapi import HTTPException
+
+    parent = MagicMock()
+    with (
+      patch(f"{self.UTILS}.verify_parent_graph_access", return_value=parent),
+      patch(
+        f"{self.UTILS}.verify_subgraph_tier_support",
+        side_effect=HTTPException(
+          status_code=403, detail="Subgraphs are not available for this tier."
+        ),
+      ),
+      patch(
+        "robosystems.operations.graph.subgraph_service.SubgraphService"
+      ) as mock_svc_class,
+    ):
+      result = await CreateSubgraphTool(_client()).execute({"name": "dev"})
+    assert result["error"] == "subgraph_not_allowed"
+    mock_svc_class.assert_not_called()
+
+  @pytest.mark.asyncio
+  async def test_name_collision_reported(self, mock_db: MagicMock) -> None:
+    from fastapi import HTTPException
+
+    parent = MagicMock()
+    with self._gates(parent):
+      with patch(
+        f"{self.UTILS}.validate_subgraph_name_unique",
+        side_effect=HTTPException(
+          status_code=409, detail="Subgraph name 'dev' already exists."
+        ),
+      ):
+        result = await CreateSubgraphTool(_client()).execute({"name": "dev"})
+    assert result["error"] == "name_taken"
 
   @pytest.mark.asyncio
   async def test_happy_path_delegates_to_subgraph_service(
     self, mock_db: MagicMock
   ) -> None:
     parent = MagicMock()
-    mock_db.query.return_value.filter.return_value.first.return_value = parent
 
-    with patch(
-      "robosystems.operations.graph.subgraph_service.SubgraphService"
-    ) as mock_svc_class:
+    with (
+      self._gates(parent),
+      patch(
+        "robosystems.operations.graph.subgraph_service.SubgraphService"
+      ) as mock_svc_class,
+    ):
       mock_svc = AsyncMock()
       mock_svc.create_subgraph.return_value = {
         "graph_id": f"{GRAPH_ID}_dev",
@@ -205,15 +319,19 @@ class TestDeleteSubgraphExecute:
   async def test_happy_path(self, mock_db: MagicMock) -> None:
     subgraph = MagicMock()
     subgraph.is_subgraph = True
-    admin = MagicMock()
-    admin.role = "admin"
     filter_chain = MagicMock()
-    filter_chain.first.side_effect = [subgraph, admin]
+    filter_chain.first.side_effect = [subgraph]
     mock_db.query.return_value.filter.return_value = filter_chain
 
-    with patch(
-      "robosystems.operations.graph.subgraph_service.SubgraphService"
-    ) as mock_svc_class:
+    with (
+      patch(
+        "robosystems.models.core.graph.graph_user.GraphUser.user_has_admin_access",
+        return_value=True,
+      ),
+      patch(
+        "robosystems.operations.graph.subgraph_service.SubgraphService"
+      ) as mock_svc_class,
+    ):
       mock_svc = AsyncMock()
       mock_svc_class.return_value = mock_svc
 
@@ -350,9 +468,7 @@ class TestCreateBackupExecute:
   async def test_non_admin_rejected(self, mock_db: MagicMock) -> None:
     from robosystems.config import env as env_module
 
-    non_admin = MagicMock()
-    non_admin.role = "member"
-    mock_db.query.return_value.filter.return_value.first.return_value = non_admin
+    _script_admin_role(mock_db, role="member")
 
     with patch.object(env_module, "BACKUP_CREATION_ENABLED", True):
       result = await CreateBackupTool(_client()).execute({})
@@ -363,9 +479,7 @@ class TestCreateBackupExecute:
   async def test_happy_path_enqueues_dagster_job(self, mock_db: MagicMock) -> None:
     from robosystems.config import env as env_module
 
-    admin = MagicMock()
-    admin.role = "admin"
-    mock_db.query.return_value.filter.return_value.first.return_value = admin
+    _script_admin_role(mock_db)
 
     graph = MagicMock()
     graph.graph_tier = "ladybug-standard"
@@ -411,9 +525,7 @@ class TestCreateBackupExecute:
     """
     from robosystems.config import env as env_module
 
-    admin = MagicMock()
-    admin.role = "admin"
-    mock_db.query.return_value.filter.return_value.first.return_value = admin
+    _script_admin_role(mock_db)
 
     graph = MagicMock()
     graph.graph_tier = "ladybug-standard"
@@ -440,9 +552,7 @@ class TestCreateBackupExecute:
     """A negative limit means unlimited, not "zero allowed"."""
     from robosystems.config import env as env_module
 
-    admin = MagicMock()
-    admin.role = "admin"
-    mock_db.query.return_value.filter.return_value.first.return_value = admin
+    _script_admin_role(mock_db)
 
     graph = MagicMock()
     graph.graph_tier = "ladybug-xlarge"

--- a/tests/middleware/test_extension_gate.py
+++ b/tests/middleware/test_extension_gate.py
@@ -116,10 +116,17 @@ class TestLoadGraphMetadata:
 
 class TestRequireGraphExtension:
   def _call_dep(self, extension: str, graph: MagicMock | None) -> GraphExtensionContext:
-    """Invoke the inner dependency with mocks for session + graph loader."""
+    """Invoke the inner dependency with mocks for session + graph loader.
+
+    The lifecycle/subscription gate the dependency runs last is bypassed here
+    (it has its own tests in tests/middleware/billing/test_enforcement.py);
+    `TestRequireGraphExtensionLifecycle` covers the wiring."""
     session = MagicMock()
     dep = require_graph_extension(extension)
-    with patch(f"{MODULE}.Graph.get_by_id", return_value=graph):
+    with (
+      patch(f"{MODULE}.Graph.get_by_id", return_value=graph),
+      patch(f"{MODULE}.require_graph_access", return_value=None),
+    ):
       return dep(graph_id=GRAPH_ID, session=session)
 
   def test_passes_on_entity_graph_with_extension(self) -> None:
@@ -225,9 +232,57 @@ class TestRequireGraphExtension:
     investor_dep = require_graph_extension("roboinvestor")
 
     graph_ledger_only = _graph(graph_type="entity", schema_extensions=["roboledger"])
-    with patch(f"{MODULE}.Graph.get_by_id", return_value=graph_ledger_only):
+    with (
+      patch(f"{MODULE}.Graph.get_by_id", return_value=graph_ledger_only),
+      patch(f"{MODULE}.require_graph_access", return_value=None),
+    ):
       # Ledger passes
       ledger_dep(graph_id=GRAPH_ID, session=MagicMock())
       # Investor rejects on the same graph
       with pytest.raises(HTTPException):
         investor_dep(graph_id=GRAPH_ID, session=MagicMock())
+
+
+class TestRequireGraphExtensionLifecycle:
+  """Every extensions route (reads, views, commands) passes through this
+  dependency, so a suspended or expired graph is closed on the whole surface
+  from one place — after the provisioning checks, at read strength."""
+
+  def test_gate_runs_after_provisioning_checks(self) -> None:
+    session = MagicMock()
+    dep = require_graph_extension("roboledger")
+    graph = _graph(graph_type="entity", schema_extensions=["roboledger"])
+    with (
+      patch(f"{MODULE}.Graph.get_by_id", return_value=graph),
+      patch(f"{MODULE}.require_graph_access", return_value=None) as gate,
+    ):
+      dep(graph_id=GRAPH_ID, session=session)
+    gate.assert_called_once_with(GRAPH_ID, session, require_write=False)
+
+  def test_unprovisioned_graph_never_reaches_the_gate(self) -> None:
+    session = MagicMock()
+    dep = require_graph_extension("roboinvestor")
+    graph = _graph(graph_type="entity", schema_extensions=["roboledger"])
+    with (
+      patch(f"{MODULE}.Graph.get_by_id", return_value=graph),
+      patch(f"{MODULE}.require_graph_access", return_value=None) as gate,
+    ):
+      with pytest.raises(HTTPException) as exc_info:
+        dep(graph_id=GRAPH_ID, session=session)
+    assert exc_info.value.status_code == 403
+    gate.assert_not_called()
+
+  def test_closed_graph_is_refused(self) -> None:
+    session = MagicMock()
+    dep = require_graph_extension("roboledger")
+    graph = _graph(graph_type="entity", schema_extensions=["roboledger"])
+    with (
+      patch(f"{MODULE}.Graph.get_by_id", return_value=graph),
+      patch(
+        f"{MODULE}.require_graph_access",
+        side_effect=HTTPException(status_code=403, detail="Subscription has ended."),
+      ),
+    ):
+      with pytest.raises(HTTPException) as exc_info:
+        dep(graph_id=GRAPH_ID, session=session)
+    assert exc_info.value.status_code == 403

--- a/tests/models/core/graph/test_graph_role_access.py
+++ b/tests/models/core/graph/test_graph_role_access.py
@@ -176,3 +176,91 @@ class TestOrphanedGraphRecovery:
 
     assert not GraphUser.user_has_access(creator.id, graph.graph_id, test_db)
     assert GraphUser.user_has_admin_access(test_user.id, graph.graph_id, test_db)
+
+
+class TestGoneGraphsGrantNoRole:
+  """Nobody holds a role on a graph that is gone.
+
+  Teardown stamps ``deleted_at`` first and flips ``status`` last; org
+  OWNER/ADMIN hold implicit admin through ``Graph.org_id`` with no GraphUser
+  row to delete. Both paths used to outlive the graph — the resolver is the
+  one place every surface authorizes through, so it denies here.
+  """
+
+  def test_deprovisioned_graph_denies_explicit_admin(
+    self, test_db, test_user, test_org
+  ):
+    from robosystems.models.core import GraphStatus
+
+    graph = _create_org_graph(test_db, test_org.id)
+    grantee = _create_user(test_db, test_user.password_hash)
+    GraphUser.create(
+      user_id=grantee.id, graph_id=graph.graph_id, role=GraphRole.ADMIN, session=test_db
+    )
+    assert GraphUser.user_has_admin_access(grantee.id, graph.graph_id, test_db)
+
+    graph.status = GraphStatus.DEPROVISIONED.value
+    test_db.commit()
+
+    role, _ = GraphUser.get_effective_role(grantee.id, graph.graph_id, test_db)
+    assert role is None
+    assert not GraphUser.user_has_access(grantee.id, graph.graph_id, test_db)
+
+  def test_deleted_at_stamp_denies_org_owner(self, test_db, test_user, test_org):
+    """The implicit grant does not survive the soft-delete stamp — even while
+    ``status`` still reads suspended/active mid-teardown."""
+    from datetime import UTC, datetime
+
+    graph = _create_org_graph(test_db, test_org.id)
+    assert GraphUser.user_has_admin_access(test_user.id, graph.graph_id, test_db)
+
+    graph.deleted_at = datetime.now(UTC)
+    test_db.commit()
+
+    role, implicit = GraphUser.get_effective_role(test_user.id, graph.graph_id, test_db)
+    assert role is None
+    assert implicit is False
+    assert not GraphUser.user_has_admin_access(test_user.id, graph.graph_id, test_db)
+
+  def test_subgraph_of_gone_parent_denies(self, test_db, test_user, test_org):
+    from robosystems.models.core import GraphStatus
+
+    graph = _create_org_graph(test_db, test_org.id)
+    subgraph_id = f"{graph.graph_id}_dev"
+    assert GraphUser.user_has_admin_access(test_user.id, subgraph_id, test_db)
+
+    graph.status = GraphStatus.DEPROVISIONED.value
+    test_db.commit()
+
+    assert not GraphUser.user_has_access(test_user.id, subgraph_id, test_db)
+
+  def test_gone_subgraph_row_denies_while_parent_lives(
+    self, test_db, test_user, test_org
+  ):
+    """A subgraph row that exists is held to the same standard as its parent."""
+    from robosystems.models.core import GraphStatus
+
+    graph = _create_org_graph(test_db, test_org.id)
+    subgraph = Graph.create(
+      graph_id=f"{graph.graph_id}_dev",
+      org_id=test_org.id,
+      graph_name="dev",
+      graph_type="generic",
+      session=test_db,
+      is_subgraph=True,
+      parent_graph_id=graph.graph_id,
+      subgraph_index=1,
+      subgraph_name="dev",
+    )
+    assert GraphUser.user_has_admin_access(test_user.id, subgraph.graph_id, test_db)
+
+    subgraph.status = GraphStatus.DEPROVISIONED.value
+    test_db.commit()
+
+    assert not GraphUser.user_has_access(test_user.id, subgraph.graph_id, test_db)
+    # The parent itself is untouched.
+    assert GraphUser.user_has_admin_access(test_user.id, graph.graph_id, test_db)
+
+  def test_missing_graph_row_denies(self, test_db, test_user):
+    role, _ = GraphUser.get_effective_role(test_user.id, _kg_id(), test_db)
+    assert role is None

--- a/tests/operations/graph/test_deprovision_service.py
+++ b/tests/operations/graph/test_deprovision_service.py
@@ -599,6 +599,21 @@ class TestDeprovisionService:
       session=db_session,
     )
 
+    # An org ADMIN with no GraphUser row: implicit graph admin through the
+    # org, so no membership row is deleted for them — their cached decision
+    # has to be dropped by name.
+    org_admin = User(
+      id=f"org_admin_{uuid.uuid4().hex[:8]}",
+      email=f"admin+{uuid.uuid4().hex[:8]}@example.com",
+      name="Org Admin",
+      password_hash="hash",
+    )
+    db_session.add(org_admin)
+    db_session.commit()
+    OrgUser.create(
+      org_id=test_graph.org_id, user_id=org_admin.id, role="ADMIN", session=db_session
+    )
+
     connection = Connection.create(
       graph_id=test_graph.graph_id,
       user_id=test_user.id,
@@ -646,6 +661,11 @@ class TestDeprovisionService:
       # cannot carry a request onto the half-dropped graph.
       cache.invalidate_user_jwt_graph_access.assert_any_call(
         test_user.id, test_graph.graph_id
+      )
+      # ...and so do the org OWNER/ADMIN's, who hold implicit admin with no
+      # row of their own to delete.
+      cache.invalidate_user_jwt_graph_access.assert_any_call(
+        org_admin.id, test_graph.graph_id
       )
       cache.invalidate_user_graph_access.assert_called_once_with(
         "*", test_graph.graph_id

--- a/tests/operations/test_connection_service.py
+++ b/tests/operations/test_connection_service.py
@@ -221,6 +221,30 @@ class TestGetConnection:
 
   @pytest.mark.asyncio
   @pytest.mark.unit
+  async def test_graph_scope_supersedes_creator(self):
+    """With the (authorized) graph scope given, a connection created by a
+    colleague resolves — connections belong to the graph, not the creator."""
+    mock_session = MagicMock()
+    mock_conn = _make_mock_connection(graph_id="kg_test", user_id="usr_other")
+
+    with (
+      patch(f"{MODULE}.Connection") as MockConn,
+      patch(f"{MODULE}.ConnectionCredentials") as MockCreds,
+    ):
+      MockConn.get_by_id.return_value = mock_conn
+      MockCreds.get_by_connection_id.return_value = None
+      result = await ConnectionService.get_connection(
+        connection_id="conn_test123",
+        user_id="usr_123",
+        graph_id="kg_test",
+        db_session=mock_session,
+      )
+
+    assert result is not None
+    assert result["connection_id"] == "conn_test123"
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
   async def test_system_user_bypasses_access_check(self):
     mock_session = MagicMock()
     mock_conn = _make_mock_connection(user_id="usr_other")
@@ -338,6 +362,49 @@ class TestListConnections:
 
     call_kwargs = MockConn.list_filtered.call_args.kwargs
     assert call_kwargs["user_id"] is None
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_graph_scope_lists_every_members_connections(self):
+    """A graph-scoped list is not filtered by creator: every member sees the
+    graph's connections (the duplicate check on create relies on this too —
+    'one per provider per graph' was silently 'per creator per graph')."""
+    mock_session = MagicMock()
+
+    with (
+      patch(f"{MODULE}.Connection") as MockConn,
+      patch(f"{MODULE}.ConnectionCredentials"),
+    ):
+      MockConn.list_filtered.return_value = []
+
+      await ConnectionService.list_connections(
+        graph_id="kg_test",
+        user_id="usr_123",
+        db_session=mock_session,
+      )
+
+    call_kwargs = MockConn.list_filtered.call_args.kwargs
+    assert call_kwargs["graph_id"] == "kg_test"
+    assert call_kwargs["user_id"] is None
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_scopeless_list_still_filters_by_creator(self):
+    mock_session = MagicMock()
+
+    with (
+      patch(f"{MODULE}.Connection") as MockConn,
+      patch(f"{MODULE}.ConnectionCredentials"),
+    ):
+      MockConn.list_filtered.return_value = []
+
+      await ConnectionService.list_connections(
+        user_id="usr_123",
+        db_session=mock_session,
+      )
+
+    call_kwargs = MockConn.list_filtered.call_args.kwargs
+    assert call_kwargs["user_id"] == "usr_123"
 
   @pytest.mark.asyncio
   @pytest.mark.unit
@@ -1082,7 +1149,10 @@ class TestSetWritePolicy:
 
   @pytest.mark.asyncio
   @pytest.mark.unit
-  async def test_wrong_user_returns_none(self):
+  async def test_other_member_of_graph_may_set_policy(self):
+    """A connection is a graph asset: any write-role member of the graph sets
+    its policy, not only the member who created it (co-admins were 404ing on
+    each other's connections while delete was already graph-scoped)."""
     mock_session = MagicMock()
     mock_conn = _make_mock_connection(graph_id="kg_test", user_id="usr_other")
 
@@ -1096,8 +1166,8 @@ class TestSetWritePolicy:
         db_session=mock_session,
       )
 
-    assert result is None
-    mock_conn.set_write_policy.assert_not_called()
+    assert result is not None
+    mock_conn.set_write_policy.assert_called_once_with(mock_session, "native")
 
   @pytest.mark.asyncio
   @pytest.mark.unit

--- a/tests/routers/graphs/connections/test_management.py
+++ b/tests/routers/graphs/connections/test_management.py
@@ -119,6 +119,14 @@ def _make_robustness_components():
 class TestCreateConnection:
   """Tests for the create_connection endpoint."""
 
+  @pytest.fixture(autouse=True)
+  def _bypass_write_role(self):
+    """These tests use synthetic users with no GraphUser row, so the write-role
+    + lifecycle gate would 403 before reaching handler logic. The deny path is
+    covered in tests/routers/graphs/test_write_role_gates.py; bypass it here."""
+    with patch(f"{MANAGEMENT_MODULE}.require_graph_write_role"):
+      yield
+
   @pytest.mark.unit
   @pytest.mark.asyncio
   async def test_create_connection_success_quickbooks(self):

--- a/tests/routers/graphs/connections/test_oauth.py
+++ b/tests/routers/graphs/connections/test_oauth.py
@@ -85,6 +85,14 @@ def _make_oauth_callback_request(
 class TestInitOAuth:
   """Tests for the init_oauth endpoint."""
 
+  @pytest.fixture(autouse=True)
+  def _bypass_write_role(self):
+    """These tests use synthetic users with no GraphUser row, so the write-role
+    + lifecycle gate would 403 before reaching handler logic. The deny path is
+    covered in tests/routers/graphs/test_write_role_gates.py; bypass it here."""
+    with patch(f"{OAUTH_MODULE}.require_graph_write_role"):
+      yield
+
   @pytest.mark.unit
   @pytest.mark.asyncio
   async def test_init_oauth_success_quickbooks(self):
@@ -300,6 +308,14 @@ class TestInitOAuth:
 class TestOAuthCallback:
   """Tests for the oauth_callback endpoint."""
 
+  @pytest.fixture(autouse=True)
+  def _bypass_write_role(self):
+    """These tests use synthetic users with no GraphUser row, so the write-role
+    + lifecycle gate would 403 before reaching handler logic. The deny path is
+    covered in tests/routers/graphs/test_write_role_gates.py; bypass it here."""
+    with patch(f"{OAUTH_MODULE}.require_graph_write_role"):
+      yield
+
   @pytest.mark.unit
   @pytest.mark.asyncio
   async def test_oauth_callback_success_quickbooks(self):
@@ -480,6 +496,81 @@ class TestOAuthCallback:
     assert (
       mock_oauth_handler.store_tokens.call_args.args[0] == "conn_prior_soft_deleted"
     )
+
+  @pytest.mark.unit
+  @pytest.mark.asyncio
+  async def test_oauth_callback_revived_lookup_miss_is_404_not_crash(self):
+    """If the revived connection cannot be re-read after the prior row was
+    restored (it is stored, tokens are written), the callback answers a 404
+    rather than an AttributeError on `None.get(...)`."""
+    mock_user = _make_mock_user()
+    mock_db = MagicMock()
+    request = _make_oauth_callback_request()
+    connection_dict = _make_connection_dict(provider="quickbooks")
+
+    state_data = {
+      "user_id": USER_ID,
+      "connection_id": CONNECTION_ID,
+      "redirect_uri": "http://localhost:3001/connections/qb-callback",
+    }
+    tokens = {"access_token": "access_abc", "refresh_token": "refresh_xyz"}
+
+    prior_conn = MagicMock()
+    prior_conn.id = "conn_prior_soft_deleted"
+    pending_conn = MagicMock()
+    pending_conn.id = CONNECTION_ID
+
+    mock_oauth_handler = MagicMock()
+    mock_oauth_handler.exchange_code_for_tokens = AsyncMock(return_value=tokens)
+    mock_oauth_provider = MagicMock()
+    mock_oauth_provider.extract_provider_data = MagicMock(
+      return_value={"realm_id": "9341452700148642"}
+    )
+    mock_provider_registry = MagicMock()
+    mock_provider_registry.sync_connection = AsyncMock()
+
+    with (
+      patch(
+        "robosystems.operations.providers.oauth_handler.OAuthState.validate",
+        return_value=state_data,
+      ),
+      patch(
+        f"{OAUTH_MODULE}.ConnectionService.get_connection",
+        new_callable=AsyncMock,
+        side_effect=[connection_dict, None],
+      ),
+      patch(f"{OAUTH_MODULE}.ConnectionService.update", new_callable=AsyncMock),
+      patch(
+        "robosystems.models.core.connection.connection.Connection."
+        "find_soft_deleted_for_realm",
+        return_value=prior_conn,
+      ),
+      patch(
+        "robosystems.models.core.connection.connection.Connection.get_by_id",
+        return_value=pending_conn,
+      ),
+      patch(
+        "robosystems.operations.providers.quickbooks_provider.quickbooks_oauth_handler",
+        mock_oauth_handler,
+      ),
+      patch(
+        "robosystems.operations.providers.quickbooks_provider.quickbooks_oauth_provider",
+        mock_oauth_provider,
+      ),
+      patch(f"{OAUTH_MODULE}.provider_registry", mock_provider_registry),
+    ):
+      with pytest.raises(HTTPException) as exc_info:
+        await oauth_callback(
+          provider="quickbooks",
+          graph_id=GRAPH_ID,
+          request=request,
+          current_user=mock_user,
+          db=mock_db,
+          _rate_limit=None,
+        )
+
+    assert exc_info.value.status_code == 404
+    mock_provider_registry.sync_connection.assert_not_called()
 
   @pytest.mark.unit
   @pytest.mark.asyncio

--- a/tests/routers/graphs/connections/test_sync.py
+++ b/tests/routers/graphs/connections/test_sync.py
@@ -103,6 +103,14 @@ class TestSyncConnection:
   """Tests for the sync_connection endpoint."""
 
   @pytest.fixture(autouse=True)
+  def _bypass_write_role(self):
+    """These tests use synthetic users with no GraphUser row, so the write-role
+    + lifecycle gate would 403 before reaching handler logic. The deny path is
+    covered in tests/routers/graphs/test_write_role_gates.py; bypass it here."""
+    with patch(f"{SYNC_MODULE}.require_graph_write_role"):
+      yield
+
+  @pytest.fixture(autouse=True)
   def _bypass_sync_lock(self):
     """The sync endpoint acquires a `DistributedLock` against the real
     Valkey LOCKS database. Unit tests run sequentially against shared

--- a/tests/routers/graphs/mcp/test_mcp_execute.py
+++ b/tests/routers/graphs/mcp/test_mcp_execute.py
@@ -358,6 +358,7 @@ class TestCallMcpToolValidation:
         "robosystems.routers.graphs.mcp.execute.get_graph_repository", new=AsyncMock()
       ),
       patch("robosystems.models.core.GraphUser.user_has_access", return_value=True),
+      patch("robosystems.middleware.billing.enforcement.require_graph_access"),
       patch("robosystems.routers.graphs.mcp.execute.MCPHandler") as handler_cls,
       patch(
         "robosystems.routers.graphs.mcp.execute.create_operation_response",
@@ -382,6 +383,72 @@ class TestCallMcpToolValidation:
     assert body["operation_id"] == "op-xyz"
     assert body["monitor_url"] == "/v1/operations/op-xyz/stream"
     queue.submit_query.assert_awaited_once()
+
+  @pytest.mark.asyncio
+  async def test_queue_path_refuses_write_statement_before_submission(self):
+    """`read-graph-cypher` stays a read tool on the queue strategies.
+
+    The queue executes the raw statement without constructing `CypherTool`,
+    so a write-role caller who lands on a queue strategy would otherwise get
+    a write through a read tool. The read-only guard runs before
+    `submit_query`; a violation is a 403, not an enqueued write.
+
+    On a subgraph deliberately: the statement kernel's write policy already
+    refuses direct writes on *main* graphs, so a main-graph id would pass
+    this test without the guard. Subgraphs accept direct writes from a
+    write-role caller — that is where the read tool leaked.
+    """
+    from robosystems.routers.graphs.mcp.execute import call_mcp_tool
+
+    mock_request = Mock()
+    mock_request.headers = {
+      "user-agent": "python-httpx/0.27",
+      "accept": "application/json",
+    }
+    user = _make_mock_user()
+    tool_call = _make_mock_tool_call(
+      "read-graph-cypher", {"query": "MATCH (n) DETACH DELETE n"}
+    )
+
+    queue = Mock()
+    queue.get_stats = Mock(return_value={"queue_size": 20, "running_queries": 10})
+    queue.submit_query = AsyncMock(return_value="queue-abc")
+
+    with (
+      patch("robosystems.routers.graphs.mcp.execute.record_operation_metric"),
+      patch("robosystems.routers.graphs.mcp.execute.circuit_breaker"),
+      patch("robosystems.routers.graphs.mcp.execute.log_shared_query_start"),
+      patch("robosystems.routers.graphs.mcp.execute.record_shared_query_outcome"),
+      patch(
+        "robosystems.routers.graphs.mcp.execute.get_query_queue", return_value=queue
+      ),
+      patch(
+        "robosystems.routers.graphs.mcp.execute.get_graph_repository", new=AsyncMock()
+      ),
+      # A write-role caller: the statement kernel classifies the DELETE as a
+      # write and the role check passes — the read-only guard is what refuses.
+      patch(
+        "robosystems.models.core.GraphUser.user_has_write_access", return_value=True
+      ),
+      patch("robosystems.middleware.billing.enforcement.require_graph_access"),
+      patch("robosystems.routers.graphs.mcp.execute.MCPHandler") as handler_cls,
+    ):
+      handler_cls.return_value.close = AsyncMock()
+
+      with pytest.raises(HTTPException) as exc:
+        await call_mcp_tool(
+          full_request=mock_request,
+          graph_id="kg01234567890abcdef_dev",
+          tool_call=tool_call,
+          format=None,
+          test_mode=False,
+          current_user=user,
+          _rate_limit=None,
+        )
+
+    assert exc.value.status_code == 403
+    assert "Only read-only queries are allowed" in str(exc.value.detail)
+    queue.submit_query.assert_not_awaited()
 
   def test_non_cypher_tool_not_in_cypher_tool_list(self):
     """Test that non-cypher tools are not in the cypher validation tool list.

--- a/tests/routers/graphs/mcp/test_mcp_handlers.py
+++ b/tests/routers/graphs/mcp/test_mcp_handlers.py
@@ -76,10 +76,41 @@ class TestValidateMcpAccess:
         "robosystems.models.core.GraphUser.user_has_access",
         return_value=True,
       ),
+      patch(
+        "robosystems.middleware.billing.enforcement.require_graph_access"
+      ) as mock_access,
     ):
       await validate_mcp_access(
         "kg01234567890abcdef", _make_mock_user(), Mock(), "read"
       )
+    # Membership proven → the lifecycle/subscription gate runs at read strength.
+    mock_access.assert_called_once()
+    assert mock_access.call_args.kwargs["require_write"] is False
+
+  @pytest.mark.asyncio
+  async def test_user_graph_read_blocked_by_lifecycle(self):
+    """A member of a suspended / expired graph is refused even for reads —
+    the same answer `/query` gives, so MCP is not the surface that still
+    serves a graph the platform has closed."""
+    with (
+      patch(
+        "robosystems.config.shared_repositories.is_shared_repository_or_subgraph",
+        return_value=False,
+      ),
+      patch(
+        "robosystems.models.core.GraphUser.user_has_access",
+        return_value=True,
+      ),
+      patch(
+        "robosystems.middleware.billing.enforcement.require_graph_access",
+        side_effect=HTTPException(status_code=403, detail="Subscription has ended."),
+      ),
+    ):
+      with pytest.raises(HTTPException) as exc_info:
+        await validate_mcp_access(
+          "kg01234567890abcdef", _make_mock_user(), Mock(), "read"
+        )
+      assert exc_info.value.status_code == 403
 
   @pytest.mark.asyncio
   async def test_user_graph_access_denied(self):
@@ -112,11 +143,41 @@ class TestValidateMcpAccess:
         "robosystems.models.core.GraphUser.user_has_write_access",
         return_value=True,
       ) as mock_write,
+      patch(
+        "robosystems.middleware.billing.enforcement.require_graph_access"
+      ) as mock_access,
     ):
       await validate_mcp_access(
         "kg01234567890abcdef", _make_mock_user(), Mock(), "write"
       )
       mock_write.assert_called_once()
+    # Write tools run the lifecycle gate at write strength: a canceled grace
+    # period or a tier upgrade blocks the MCP write like the REST write.
+    assert mock_access.call_args.kwargs["require_write"] is True
+
+  @pytest.mark.asyncio
+  async def test_user_graph_write_blocked_by_lifecycle(self):
+    with (
+      patch(
+        "robosystems.config.shared_repositories.is_shared_repository_or_subgraph",
+        return_value=False,
+      ),
+      patch(
+        "robosystems.models.core.GraphUser.user_has_write_access",
+        return_value=True,
+      ),
+      patch(
+        "robosystems.middleware.billing.enforcement.require_graph_access",
+        side_effect=HTTPException(
+          status_code=403, detail="Graph tier upgrade in progress."
+        ),
+      ),
+    ):
+      with pytest.raises(HTTPException) as exc_info:
+        await validate_mcp_access(
+          "kg01234567890abcdef", _make_mock_user(), Mock(), "write"
+        )
+      assert exc_info.value.status_code == 403
 
   @pytest.mark.asyncio
   async def test_user_graph_write_denied_for_readonly_role(self):

--- a/tests/routers/graphs/mcp/test_mcp_remote.py
+++ b/tests/routers/graphs/mcp/test_mcp_remote.py
@@ -622,6 +622,39 @@ class TestStreamQueuedCall:
     assert final["result"]["isError"] is True
     assert "syntax error" in final["result"]["content"][0]["text"]
 
+  async def test_write_statement_is_refused_before_submission(self):
+    """`read-graph-cypher` is a read tool on every strategy: the queue path
+    runs the raw statement, so the same read-only guard the tool applies on
+    the direct path must refuse a write here — before anything is enqueued,
+    with the reason surfaced to the model and no breaker hit."""
+    manager = _make_queue_manager([{"status": "completed"}])
+    tool_call = _make_tool_call()
+    tool_call.arguments = {"query": "MATCH (n) DETACH DELETE n", "parameters": {}}
+    breaker = Mock()
+    with (
+      patch.object(remote, "circuit_breaker", breaker),
+      patch.object(remote, "_get_user_priority", Mock(return_value=5)),
+      patch.object(remote, "_QUEUE_POLL_SECONDS", 0),
+      patch(
+        "robosystems.middleware.graph.query_queue.get_query_queue",
+        return_value=manager,
+      ),
+    ):
+      events = [
+        event
+        async for event in remote._stream_queued_call(
+          "kg123", tool_call, _make_user(), 8, None
+        )
+      ]
+
+    final = json.loads(events[-1]["data"])
+    assert final["id"] == 8
+    assert final["result"]["isError"] is True
+    assert "read-only" in final["result"]["content"][0]["text"]
+    manager.submit_query.assert_not_awaited()
+    manager.cancel_query.assert_not_awaited()
+    breaker.record_failure.assert_not_called()
+
   async def test_disconnect_cancels_queued_query(self):
     manager = _make_queue_manager(
       [{"status": "pending", "queue_position": 1}, {"status": "pending"}] * 50

--- a/tests/routers/graphs/test_credits.py
+++ b/tests/routers/graphs/test_credits.py
@@ -142,24 +142,31 @@ class TestGetGraphAccess:
       assert exc_info.value.status_code == 400
 
   def test_user_graph_access_validation_fail_safety(self):
-    """Test safety check when user_has_access returns True but no GraphUser found."""
+    """No effective role → 403, even on a live graph.
+
+    `get_graph_access` resolves the caller's role via
+    `GraphUser.get_effective_role`; when that returns None (no membership row
+    and no implicit org grant) the request is denied. The graph itself is
+    live here, so the denial is the role decision, not the lifecycle gate.
+    """
     identity = _make_mock_identity(is_shared_repository=False, is_user_graph=True)
+
+    live_graph = Mock()
+    live_graph.graph_id = "kg01234567890abcdef"
+    live_graph.org_id = None  # no org → no implicit admin
+    live_graph.status = "active"
+    live_graph.deleted_at = None
 
     mock_db = Mock()
     mock_query = Mock()
     mock_query.filter.return_value = mock_query
-    mock_query.first.return_value = None
+    mock_query.all.return_value = [live_graph]  # liveness query
+    mock_query.first.return_value = None  # no membership row
     mock_db.query.return_value = mock_query
 
-    with (
-      patch(
-        "robosystems.middleware.graph.utils.MultiTenantUtils.get_graph_identity",
-        return_value=identity,
-      ),
-      patch(
-        "robosystems.models.core.graph.graph_user.GraphUser.user_has_access",
-        return_value=True,
-      ),
+    with patch(
+      "robosystems.middleware.graph.utils.MultiTenantUtils.get_graph_identity",
+      return_value=identity,
     ):
       with pytest.raises(HTTPException) as exc_info:
         get_graph_access(

--- a/tests/routers/graphs/test_delete_graph_op.py
+++ b/tests/routers/graphs/test_delete_graph_op.py
@@ -100,8 +100,20 @@ class TestDeleteGraphRunner:
   """
 
   def _setup_admin_membership(self, db: MagicMock, role: str = "admin") -> MagicMock:
-    """Wire `db.query(GraphUser).filter(...).first()` to return a membership
-    with the given role (None means no membership)."""
+    """Wire the two queries `get_effective_role` runs against `db`:
+
+    - the graph-liveness query (`.all()`) returns one live Graph row, so the
+      resolver gets past the "graph is gone" guard; and
+    - the membership query (`.first()`) returns a GraphUser with the given
+      role (None means no membership).
+    """
+    live_graph = MagicMock()
+    live_graph.graph_id = "kg_x"
+    live_graph.org_id = "org_1"
+    live_graph.status = "active"
+    live_graph.deleted_at = None
+    db.query.return_value.filter.return_value.all.return_value = [live_graph]
+
     membership = None
     if role is not None:
       membership = MagicMock()

--- a/tests/routers/graphs/test_disabled_providers.py
+++ b/tests/routers/graphs/test_disabled_providers.py
@@ -192,6 +192,29 @@ class TestDisabledProviderHandling:
         session=test_db,
       )
 
+    # An active subscription: creating/syncing a connection is a write, and
+    # the write gate now enforces the graph's lifecycle/subscription state
+    # (billing is on under pytest.ini). Without this the write gate would 403
+    # on "no subscription" before the provider-enabled check under test.
+    from robosystems.models.core import OrgUser
+    from robosystems.models.core.billing import BillingSubscription
+
+    if (
+      BillingSubscription.get_by_resource("graph", VALID_TEST_GRAPH_ID, test_db) is None
+    ):
+      org_users = OrgUser.get_user_orgs(test_user.id, test_db)
+      org_id = org_users[0].org_id if org_users else test_org.id
+      sub = BillingSubscription.create_subscription(
+        org_id=org_id,
+        resource_type="graph",
+        resource_id=VALID_TEST_GRAPH_ID,
+        plan_name="ladybug-standard",
+        base_price_cents=9900,
+        session=test_db,
+      )
+      sub.status = "active"
+      test_db.commit()
+
     # Create an API key for the test user
     _, plain_key = UserAPIKey.create(
       user_id=test_user.id, name="Test API Key", session=test_db

--- a/tests/routers/graphs/test_file_upload.py
+++ b/tests/routers/graphs/test_file_upload.py
@@ -11,6 +11,21 @@ from tests.conftest import VALID_TEST_GRAPH_ID
 
 @pytest.mark.unit
 class TestUploadRouterAutoTableCreation:
+  @pytest.fixture(autouse=True)
+  def _bypass_graph_access_gate(self):
+    """`create_file_upload_cmd` opens with the lifecycle/subscription gate
+    `require_graph_access(require_write=True)`; these tests drive it with a
+    bare Mock session, so stub the gate to a live generic graph. Its own
+    behavior is covered in tests/middleware/billing/test_enforcement.py and
+    tests/operations/graph/commands/test_create_file_upload_size_gate.py."""
+    graph = Mock()
+    graph.graph_type = "generic"
+    with patch(
+      "robosystems.middleware.billing.enforcement.require_graph_access",
+      return_value=graph,
+    ):
+      yield
+
   @pytest.mark.asyncio
   async def test_auto_creates_node_table_for_pascal_case_name(self):
     graph_id = VALID_TEST_GRAPH_ID

--- a/tests/routers/graphs/test_mcp_execution.py
+++ b/tests/routers/graphs/test_mcp_execution.py
@@ -333,16 +333,16 @@ class TestMCPAccessControl:
 
   @pytest.mark.asyncio
   async def test_mcp_access_validation_user_graph(
-    self, db_session: Session, test_user: User, test_user_graph
+    self, db_session: Session, test_user: User, test_graph_with_credits
   ):
     """Test MCP access validation for user graphs."""
     from robosystems.routers.graphs.mcp.handlers import validate_mcp_access
 
-    # User should have access to their own graph
+    # User should have access to their own (subscribed) graph
     # validate_mcp_access doesn't return a boolean, it raises HTTPException on failure
     try:
       await validate_mcp_access(
-        graph_id=test_user_graph.graph_id,
+        graph_id=test_graph_with_credits["graph"].graph_id,
         current_user=test_user,
         db=db_session,
         operation_type="read",

--- a/tests/routers/graphs/test_mcp_handlers.py
+++ b/tests/routers/graphs/test_mcp_handlers.py
@@ -242,19 +242,68 @@ class TestMCPAccessValidation:
 
   @pytest.mark.asyncio
   async def test_validate_mcp_access_entity_graph(
-    self, db_session, test_user, test_user_graph
+    self, db_session, test_user, test_graph_with_credits
   ):
     """Test access validation for entity graphs."""
-    # User has access to their own graph - should not raise
+    graph_id = test_graph_with_credits["graph"].graph_id
+    # User has access to their own (subscribed, active) graph - should not raise
     try:
       await validate_mcp_access(
-        graph_id=test_user_graph.graph_id, current_user=test_user, db=db_session
+        graph_id=graph_id, current_user=test_user, db=db_session
       )
       # If no exception, access was granted
       assert True
     except HTTPException:
       # Access was denied
       raise AssertionError("User should have access to their own graph")
+
+  @pytest.mark.asyncio
+  async def test_validate_mcp_access_requires_subscription(
+    self, db_session, test_user, test_user_graph
+  ):
+    """Membership on a graph with no live subscription is refused (billing
+    on): MCP applies the same lifecycle/subscription gate as `/query`."""
+    with pytest.raises(HTTPException) as exc_info:
+      await validate_mcp_access(
+        graph_id=test_user_graph.graph_id, current_user=test_user, db=db_session
+      )
+    assert exc_info.value.status_code == 403
+    assert "subscription" in str(exc_info.value.detail).lower()
+
+  @pytest.mark.asyncio
+  async def test_validate_mcp_access_suspended_graph(
+    self, db_session, test_user, test_graph_with_credits
+  ):
+    """A suspended graph is closed on the MCP surface too."""
+    from robosystems.models.core import GraphStatus
+
+    graph = test_graph_with_credits["graph"]
+    graph.status = GraphStatus.SUSPENDED.value
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as exc_info:
+      await validate_mcp_access(
+        graph_id=graph.graph_id, current_user=test_user, db=db_session
+      )
+    assert exc_info.value.status_code == 403
+
+  @pytest.mark.asyncio
+  async def test_validate_mcp_access_deleted_graph(
+    self, db_session, test_user, test_graph_with_credits
+  ):
+    """A graph mid-teardown (deleted_at stamped, status not yet flipped) is
+    gone for its admin as well — the role resolver denies it outright."""
+    from datetime import UTC, datetime
+
+    graph = test_graph_with_credits["graph"]
+    graph.deleted_at = datetime.now(UTC)
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as exc_info:
+      await validate_mcp_access(
+        graph_id=graph.graph_id, current_user=test_user, db=db_session
+      )
+    assert exc_info.value.status_code == 403
 
   @pytest.mark.asyncio
   async def test_validate_mcp_access_no_permission(self, db_session, test_user):
@@ -314,42 +363,17 @@ class TestMCPAccessValidation:
 
   @pytest.mark.asyncio
   async def test_validate_mcp_access_write_level(
-    self, db_session, test_user, test_user_graph
+    self, db_session, test_user, test_graph_with_credits
   ):
     """Test that write-level access allows MCP tools."""
-    # Update user_graph to have write access
-    test_user_graph.access_level = "write"
-    db_session.commit()
-
+    graph_id = test_graph_with_credits["graph"].graph_id
     try:
       await validate_mcp_access(
-        graph_id=test_user_graph.graph_id, current_user=test_user, db=db_session
+        graph_id=graph_id, current_user=test_user, db=db_session, operation_type="write"
       )
       assert True
     except HTTPException:
       raise AssertionError("User should have write access")
-
-  @pytest.mark.asyncio
-  async def test_validate_mcp_access_inactive_graph(
-    self, db_session, test_user, test_user_graph
-  ):
-    """Test that inactive graphs still allow access if user has permissions."""
-    # Make graph inactive
-    test_user_graph.is_active = False
-    db_session.commit()
-
-    # The current implementation doesn't check is_active in validate_mcp_access
-    # It only checks if the user has access to the graph
-    # This test documents the current behavior
-    try:
-      await validate_mcp_access(
-        graph_id=test_user_graph.graph_id, current_user=test_user, db=db_session
-      )
-      # Current implementation doesn't check is_active, so access is granted
-      assert True
-    except HTTPException:
-      # If this starts failing, it means the implementation now checks is_active
-      raise AssertionError("Implementation changed - now checks is_active field")
 
 
 class TestMCPErrorSanitization:

--- a/tests/routers/graphs/test_operator.py
+++ b/tests/routers/graphs/test_operator.py
@@ -7,6 +7,20 @@ from robosystems.models.api.graphs.operator import OperatorMessage
 from tests.conftest import VALID_TEST_GRAPH_ID
 
 
+@pytest.fixture(autouse=True)
+def _bypass_graph_lifecycle_gate():
+  """The operator router runs `require_graph_access` (lifecycle/subscription)
+  before dispatch; these tests use synthetic graph ids with no Graph row, so
+  the gate would 404 before reaching the handler logic under test. Its own
+  behavior is covered in tests/middleware/billing/test_enforcement.py and the
+  wiring in test_operator_router.py::TestOperatorLifecycleGate."""
+  with patch(
+    "robosystems.middleware.billing.enforcement.require_graph_access",
+    return_value=None,
+  ):
+    yield
+
+
 @pytest.fixture
 def mock_anthropic_response():
   """Mock response from Anthropic API"""

--- a/tests/routers/graphs/test_operator_router.py
+++ b/tests/routers/graphs/test_operator_router.py
@@ -15,6 +15,20 @@ from robosystems.operations.operators.base import OperatorMode
 from tests.conftest import VALID_TEST_GRAPH_ID
 
 
+@pytest.fixture(autouse=True)
+def _bypass_graph_lifecycle_gate():
+  """The operator router runs `require_graph_access` (lifecycle/subscription)
+  before dispatch; these tests use synthetic graph ids with no Graph row, so
+  the gate would 404 before reaching the handler logic under test. Its own
+  behavior is covered in tests/middleware/billing/test_enforcement.py and the
+  wiring in TestOperatorLifecycleGate."""
+  with patch(
+    "robosystems.middleware.billing.enforcement.require_graph_access",
+    return_value=None,
+  ):
+    yield
+
+
 @pytest.fixture
 def mock_user():
   """Create a mock authenticated user."""
@@ -433,6 +447,45 @@ class TestOperatorEndpoints:
     components = openapi["components"]["schemas"]
     assert "OperatorRequest" in components
     assert "OperatorResponse" in components
+
+
+class TestOperatorLifecycleGate:
+  """The operator surface runs the graph lifecycle/subscription gate.
+
+  A suspended, mid-teardown or expired graph accepted operator runs on no
+  other surface's say-so — the gate lives in the shared pre-dispatch helper
+  so every operator entry point (sync, SSE, queued) inherits it.
+  """
+
+  @pytest.mark.asyncio
+  async def test_lifecycle_gate_runs_before_repository_limits(self):
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from fastapi import HTTPException
+
+    from robosystems.routers.graphs.operator.execute import (
+      _enforce_shared_repository_agent_limits,
+    )
+
+    user = MagicMock()
+    db = MagicMock()
+
+    with (
+      patch(
+        "robosystems.middleware.billing.enforcement.require_graph_access",
+        side_effect=HTTPException(status_code=403, detail="Subscription has ended."),
+      ) as gate,
+      patch(
+        "robosystems.routers.graphs.query.execute._check_shared_repository_limits",
+        new=AsyncMock(),
+      ) as mock_check,
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await _enforce_shared_repository_agent_limits("kg0123456789abcdef", user, db)
+
+    assert exc.value.status_code == 403
+    gate.assert_called_once_with("kg0123456789abcdef", db, require_write=False)
+    mock_check.assert_not_awaited()
 
 
 class TestOperatorSharedRepositoryLimits:

--- a/tests/routers/graphs/test_operator_subgraph_integration.py
+++ b/tests/routers/graphs/test_operator_subgraph_integration.py
@@ -10,6 +10,20 @@ from robosystems.models.api.graphs.operator import OperatorMessage
 from robosystems.models.core import Graph, GraphCredits, User
 
 
+@pytest.fixture(autouse=True)
+def _bypass_graph_lifecycle_gate():
+  """The operator router runs `require_graph_access` (lifecycle/subscription)
+  before dispatch; these tests use synthetic graph ids with no Graph row, so
+  the gate would 404 before reaching the handler logic under test. Its own
+  behavior is covered in tests/middleware/billing/test_enforcement.py and the
+  wiring in test_operator_router.py::TestOperatorLifecycleGate."""
+  with patch(
+    "robosystems.middleware.billing.enforcement.require_graph_access",
+    return_value=None,
+  ):
+    yield
+
+
 @pytest.fixture
 def parent_graph_with_credits(db_session: Session) -> tuple[Graph, GraphCredits, User]:
   import uuid

--- a/tests/routers/graphs/test_write_role_gates.py
+++ b/tests/routers/graphs/test_write_role_gates.py
@@ -17,6 +17,8 @@ from fastapi import HTTPException
 
 OPS = "robosystems.routers.graphs.operations"
 MGMT = "robosystems.routers.graphs.connections.management"
+OAUTH = "robosystems.routers.graphs.connections.oauth"
+SYNC = "robosystems.routers.graphs.connections.sync"
 
 
 def _deny_gate() -> MagicMock:
@@ -85,6 +87,110 @@ class TestLifecycleWriteRoleGates:
         )
     assert exc.value.status_code == 403
     gate.assert_called_once_with("usr_1", "kg123")
+
+
+@pytest.mark.unit
+class TestConnectionWriteRoleGates:
+  """Connections are a write surface end to end: creating one seeds sync, the
+  fiscal calendar and the mapping operator; completing OAuth stores credentials
+  and starts a full-rebuild sync; a sync rewrites captured events. All four
+  entry points authenticate on membership only, so each must run the shared
+  write gate before any work — a viewer must not reach the provider registry,
+  the OAuth handler or the sync kernel."""
+
+  def test_create_connection_denies_viewer(self):
+    from robosystems.routers.graphs.connections.management import create_connection
+
+    gate = _deny_gate()
+    with (
+      patch(f"{MGMT}.require_graph_write_role", gate),
+      patch(f"{MGMT}.create_robustness_components") as components,
+    ):
+      with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+          create_connection(
+            graph_id="kg123",
+            request=MagicMock(provider="quickbooks"),
+            current_user=SimpleNamespace(id="usr_1"),
+            db=MagicMock(),
+            _rate_limit=None,
+          )
+        )
+    assert exc.value.status_code == 403
+    gate.assert_called_once_with("usr_1", "kg123")
+    components.assert_not_called()
+
+  def test_init_oauth_denies_viewer(self):
+    from robosystems.routers.graphs.connections.oauth import init_oauth
+
+    gate = _deny_gate()
+    with (
+      patch(f"{OAUTH}.require_graph_write_role", gate),
+      patch(f"{OAUTH}.ConnectionService") as service,
+    ):
+      with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+          init_oauth(
+            graph_id="kg123",
+            request=MagicMock(connection_id="conn_1"),
+            current_user=SimpleNamespace(id="usr_1"),
+            db=MagicMock(),
+            _rate_limit=None,
+          )
+        )
+    assert exc.value.status_code == 403
+    gate.assert_called_once_with("usr_1", "kg123")
+    service.get_connection.assert_not_called()
+
+  def test_oauth_callback_denies_viewer(self):
+    from robosystems.routers.graphs.connections.oauth import oauth_callback
+
+    gate = _deny_gate()
+    with (
+      patch(f"{OAUTH}.require_graph_write_role", gate),
+      patch(f"{OAUTH}.ConnectionService") as service,
+    ):
+      with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+          oauth_callback(
+            provider="quickbooks",
+            graph_id="kg123",
+            request=MagicMock(error=None),
+            current_user=SimpleNamespace(id="usr_1"),
+            db=MagicMock(),
+            _rate_limit=None,
+          )
+        )
+    assert exc.value.status_code == 403
+    gate.assert_called_once_with("usr_1", "kg123")
+    service.get_connection.assert_not_called()
+
+  def test_sync_connection_denies_viewer(self):
+    from robosystems.routers.graphs.connections.sync import sync_connection
+
+    gate = _deny_gate()
+    with (
+      patch(f"{SYNC}.require_graph_write_role", gate),
+      patch(f"{SYNC}.dispatch_connection_sync") as dispatch,
+      patch(f"{SYNC}.check_idempotency") as idem,
+    ):
+      with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+          sync_connection(
+            graph_id="kg123",
+            connection_id="conn_1",
+            request=MagicMock(),
+            current_user=SimpleNamespace(id="usr_1"),
+            db=MagicMock(),
+            _rate_limit=None,
+            idempotency_key=None,
+            cache=MagicMock(),
+          )
+        )
+    assert exc.value.status_code == 403
+    gate.assert_called_once_with("usr_1", "kg123")
+    dispatch.assert_not_called()
+    idem.assert_not_called()
 
 
 @pytest.mark.unit

--- a/tests/security/isolation/test_landing.py
+++ b/tests/security/isolation/test_landing.py
@@ -1,0 +1,100 @@
+"""Landing axis — an authorized write lands where it should, and nowhere else.
+
+The horizontal and vertical axes prove denial: a non-owner is turned away.
+They cannot see an *authorized* request doing the wrong thing — the class
+the tenant-schema fall-through belonged to, where an owner's write was
+accepted and landed in a schema every tenant shares. This axis proves the
+landing: the owner writes through the extensions command surface, reads the
+row back through GraphQL on the same graph, and the same owner's *other*
+graph does not see it. That last leg is the sharp one — same principal, same
+authorization, different tenant schema — so it isolates the schema binding
+from the access control.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+import pytest
+
+from ._http import Client
+from ._oracle import Verdict
+from ._report import Finding, Report
+
+pytestmark = [
+  pytest.mark.isolation,
+  pytest.mark.security,
+  pytest.mark.integration,
+]
+
+_AGENTS_QUERY = {"query": "{ agents(isActive: true) { name } }"}
+
+
+def _agent_names(response) -> list[str]:
+  if response.status_code // 100 != 2:
+    return []
+  data = (response.json() or {}).get("data") or {}
+  return [a.get("name", "") for a in (data.get("agents") or [])]
+
+
+def test_owner_write_lands_only_in_its_own_graph(
+  tenants, client: Client, report: Report
+) -> None:
+  nonce = f"IsoHarness Landing {secrets.token_hex(4)}"
+  op = f"/extensions/roboledger/{tenants.graph_a}/operations/create-agent"
+  w = client.post(
+    op,
+    principal=tenants.tenant_a,
+    json={"agent_type": "vendor", "name": nonce},
+  )
+  if w.status_code in (403, 404) and "roboledger" in w.text.lower():
+    pytest.skip(f"roboledger not provisioned on the target graph: {w.text[:120]}")
+  assert w.status_code // 100 == 2, (
+    f"positive control failed: owner write refused ({w.status_code}) {w.text[:200]}"
+  )
+
+  # Read it back on the graph it was written to.
+  own = client.post(
+    f"/extensions/{tenants.graph_a}/graphql",
+    principal=tenants.tenant_a,
+    json=_AGENTS_QUERY,
+  )
+  own_names = _agent_names(own)
+  assert nonce in own_names, (
+    f"write accepted but not readable on its own graph ({own.status_code}): "
+    f"{own.text[:200]}"
+  )
+
+  # The same owner's other graph — same authorization, different tenant
+  # schema — must not see it. If graph_a2 could not be provisioned, fall back
+  # to tenant B's graph as B (weaker: also covered by the horizontal axis).
+  if tenants.graph_a2:
+    other_graph, other_principal, label = tenants.graph_a2, tenants.tenant_a, "A→A2"
+  else:
+    other_graph, other_principal, label = tenants.graph_b, tenants.tenant_b, "B"
+  other = client.post(
+    f"/extensions/{other_graph}/graphql",
+    principal=other_principal,
+    json=_AGENTS_QUERY,
+  )
+  other_names = _agent_names(other)
+  leaked = nonce in other_names
+  report.add(
+    Finding(
+      "landing",
+      "graphql-readback",
+      "POST",
+      f"/extensions/{other_graph}/graphql",
+      label,
+      other_graph,
+      Verdict.LEAK if leaked else Verdict.PASS,
+      other.status_code,
+      "row written to graph_a visible from another graph"
+      if leaked
+      else "row confined to the graph it was written to",
+    )
+  )
+  assert not leaked, (
+    f"LANDING LEAK: a row written to {tenants.graph_a} is visible from "
+    f"{other_graph} — the write did not land in the tenant's own schema"
+  )

--- a/tests/security/isolation/test_vertical.py
+++ b/tests/security/isolation/test_vertical.py
@@ -21,6 +21,8 @@ and these tests run; otherwise `tenants.roles` is empty and they skip.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from ._http import Client
@@ -101,4 +103,163 @@ def test_org_admin_has_implicit_graph_admin(tenants, client: Client) -> None:
   m = client.get(f"/v1/graphs/{tenants.graph_a}/members", principal=admin)
   assert m.status_code // 100 == 2, (
     f"org admin denied on org graph — derived privilege broken: {m.status_code}"
+  )
+
+
+# ── Connections — a write surface end to end ────────────────────────────────
+# Registering a source seeds sync, the fiscal calendar and the mapping
+# operator; completing OAuth stores credentials and starts a full-rebuild
+# sync; a sync rewrites captured events. All of it authenticates on graph
+# membership, so each entry point must run the write-role gate itself.
+# Bogus connection ids are deliberate: the gate must answer 403 *before* the
+# lookup — a 404 here would mean a viewer got as far as resolving the row.
+
+
+def test_viewer_cannot_create_connection(tenants, client: Client) -> None:
+  viewer = _role(tenants, "viewer")
+  w = client.post(
+    f"/v1/graphs/{tenants.graph_a}/connections",
+    principal=viewer,
+    json={"provider": "sec", "sec_config": {"cik": "0000320193"}},
+  )
+  assert w.status_code in (401, 403), (
+    f"VIEWER CREATED A CONNECTION (escalation): {w.status_code}"
+  )
+
+
+def test_viewer_cannot_sync_connection(tenants, client: Client) -> None:
+  viewer = _role(tenants, "viewer")
+  w = client.post(
+    f"/v1/graphs/{tenants.graph_a}/connections/conn_isoprobe/sync",
+    principal=viewer,
+    json={"full_rebuild": True},
+  )
+  assert w.status_code in (401, 403), (
+    f"VIEWER REACHED SYNC (escalation or gate after lookup): {w.status_code}"
+  )
+
+
+def test_viewer_cannot_init_oauth(tenants, client: Client) -> None:
+  viewer = _role(tenants, "viewer")
+  w = client.post(
+    f"/v1/graphs/{tenants.graph_a}/connections/oauth/init",
+    principal=viewer,
+    json={
+      "connection_id": "conn_isoprobe",
+      "redirect_uri": "http://localhost/callback",
+    },
+  )
+  assert w.status_code in (401, 403), (
+    f"VIEWER REACHED OAUTH INIT (escalation or gate after lookup): {w.status_code}"
+  )
+
+
+# ── Cypher classifier verbs ─────────────────────────────────────────────────
+# Statements that are neither reads nor CREATE/MERGE/SET/DELETE writes but
+# still mutate or steer the database: transaction control (a BEGIN left open
+# on a pooled connection poisons the next borrower), CHECKPOINT (admin), and
+# COMMENT ON (schema DDL). A viewer's read-only role must refuse all of them
+# through the same classifier that refuses a CREATE.
+
+_CLASSIFIER_VERBS = [
+  "BEGIN TRANSACTION",
+  "BEGIN TRANSACTION READ ONLY",
+  "COMMIT",
+  "ROLLBACK",
+  "CHECKPOINT",
+  "COMMENT ON TABLE Entity IS 'iso-harness'",
+  "MATCH (n) RETURN count(n) AS c; CHECKPOINT",
+]
+
+
+@pytest.mark.parametrize("statement", _CLASSIFIER_VERBS)
+def test_viewer_cannot_use_classifier_verbs(
+  tenants, client: Client, statement: str
+) -> None:
+  viewer = _role(tenants, "viewer")
+  w = client.post(
+    f"/v1/graphs/{tenants.graph_a}/query/cypher",
+    principal=viewer,
+    json={"query": statement, "parameters": {}},
+  )
+  assert w.status_code in (401, 403), (
+    f"VIEWER RAN {statement.split()[0]} (classifier gap): {w.status_code} "
+    f"{w.text[:200]}"
+  )
+
+
+# ── MCP tool-level admin gates ──────────────────────────────────────────────
+# The REST lifecycle ops require admin; the MCP tools for the same actions
+# must too. A member passes the transport's write classification (member ≥
+# write), so the denial has to come from the tool itself. Tool errors travel
+# as a 200 with the error inside the result text, so the probe reads the body.
+
+
+def _mcp_tool_result(response) -> dict:
+  """Decode the tool's own JSON result out of an MCP call-tool response."""
+  if response.status_code // 100 != 2:
+    return {"_http_status": response.status_code}
+  try:
+    body = response.json()
+    result = body.get("result", body)
+    text = result.get("text") if isinstance(result, dict) else None
+    return json.loads(text) if isinstance(text, str) else {"_raw": result}
+  except (ValueError, AttributeError):
+    return {"_raw": response.text[:200]}
+
+
+def test_member_cannot_create_subgraph_via_mcp(tenants, client: Client) -> None:
+  member = _role(tenants, "member")
+  r = client.post(
+    f"/v1/graphs/{tenants.graph_a}/mcp/call-tool",
+    principal=member,
+    json={"name": "create-subgraph", "arguments": {"name": "isomcp"}},
+  )
+  if r.status_code in (401, 403):
+    return  # denied at the transport — fine
+  result = _mcp_tool_result(r)
+  if result.get("error") == "subgraph_creation_disabled":
+    pytest.skip("SUBGRAPH_CREATION_ENABLED is off in the target; gate not observable")
+  assert result.get("error") == "insufficient_permissions", (
+    f"MEMBER CREATED A SUBGRAPH OVER MCP (escalation vs REST admin gate): {result}"
+  )
+
+
+def test_member_cannot_create_backup_via_mcp(tenants, client: Client) -> None:
+  member = _role(tenants, "member")
+  r = client.post(
+    f"/v1/graphs/{tenants.graph_a}/mcp/call-tool",
+    principal=member,
+    json={"name": "create-backup", "arguments": {}},
+  )
+  if r.status_code in (401, 403):
+    return
+  result = _mcp_tool_result(r)
+  if result.get("error") == "backup_disabled":
+    pytest.skip("BACKUP_CREATION_ENABLED is off in the target; gate not observable")
+  assert result.get("error") == "insufficient_permissions", (
+    f"MEMBER CREATED A BACKUP OVER MCP (escalation vs REST admin gate): {result}"
+  )
+
+
+# ── Pre-authentication ──────────────────────────────────────────────────────
+# An anonymous or invalid-key request against a graph must be a 401/403 and
+# nothing else: not a 404 (existence oracle), not a 429 keyed to the graph
+# (which would mean the graph's rate-limit bucket is charged before the caller
+# proved they may use it — a drain of the tenant's quota by an outsider).
+
+
+def test_anonymous_request_is_refused_without_touching_the_graph(
+  tenants, client: Client
+) -> None:
+  path = f"/v1/graphs/{tenants.graph_a}/query/cypher"
+  for _ in range(5):
+    r = client.post(path, json=_CYPHER)  # no credentials at all
+    assert r.status_code in (401, 403), f"anonymous → {r.status_code}"
+    r = client.post(path, api_key="rfs_isoharness_invalid_key", json=_CYPHER)
+    assert r.status_code in (401, 403), f"invalid key → {r.status_code}"
+  # The owner is unaffected by the anonymous burst.
+  ok = client.post(path, principal=tenants.tenant_a, json=_CYPHER)
+  assert ok.status_code // 100 == 2, (
+    f"owner degraded after anonymous burst: {ok.status_code}"
   )


### PR DESCRIPTION
## Multi-tenancy resilience — tier B (parity + robustness)

Follow-up to #1211 (tier A). Closes the same-tenant parity and platform-robustness rows from the 2026-08-18 resilience review: surfaces that authorized correctly but did not all enforce the same *state* — graph lifecycle/subscription, write role, and read-only classification — across REST, GraphQL, and MCP.

### What changed

- **One lifecycle gate on every surface.** The write half of the lifecycle/subscription check is folded into the single write-role gate the command surfaces already share, so a state that blocks writes on one surface blocks them on all. The read half is applied at each read surface's own entry (MCP access, GraphQL context, extensions dependency, analytical views, operators). `require_graph_access` treats a soft-delete stamp as gone before status flips, and gates a subgraph through its parent.
- **The role resolver refuses a graph that is gone.** `GraphUser.get_effective_role` returns no role on a missing/deprovisioned/soft-deleted graph — including for the org-owner implicit grant, which has no membership row to invalidate. Deprovision drops those implicit holders' cached decisions by name.
- **Connections require a write role.** Create, OAuth init/callback, and sync authenticated on membership only; each now runs the write-role gate. Connection reads and policy writes are graph-scoped rather than creator-scoped, so co-admins reach a colleague's connection.
- **MCP parity.** `create-subgraph` over MCP runs the same feature-flag/admin/lifecycle/tier/quota gates as REST; `read-graph-cypher` stays read-only under the queued execution strategies.

### Tests

- Unit + integration coverage for every gate above, each with a red-then-green check against the pre-fix behavior.
- Isolation harness gains an **owner-side landing axis** (a write lands only in its own tenant schema, verified by reading it back through GraphQL on the writing graph and confirming its absence from another graph the same owner controls) plus **vertical probes** for connections, cypher classifier verbs, and MCP admin tools. Local run: 65 probes, 0 leaks.

No migration. Detailed mechanics and the review that scoped this are in the private vault (`specs/security/multitenancy-resilience-review.md` §2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
