### PR TITLE
fix(platform): multi-tenancy tier B — runtime robustness (limiter, sessions, teardown, DSN)

### DIFF
--- a/robosystems/dagster/jobs/graph_lifecycle.py
+++ b/robosystems/dagster/jobs/graph_lifecycle.py
@@ -108,6 +108,16 @@ def deprovision_suspended_graphs(
         error_msg = f"Failed to deprovision {graph_id}: {e}"
         errors.append(error_msg)
         context.log.error(error_msg)
+        # A DBAPI error leaves this shared session in a failed transaction
+        # (e.g. a delete in _clean_pg_records). Without a rollback the NEXT
+        # graph's first statement raises PendingRollbackError and the whole
+        # run cascades — one poison graph took down every graph after it.
+        # Reset so each graph is independent; the failed one is left stranded
+        # (deleted_at set, status not deprovisioned) for the sensor to retry.
+        try:
+          session.rollback()
+        except Exception:
+          context.log.warning(f"Session rollback after {graph_id} failure failed")
 
   context.log.info(
     f"Deprovisioned {deprovisioned_count}/{len(config.graph_ids)} graphs"

--- a/robosystems/dagster/sensors/graph_lifecycle.py
+++ b/robosystems/dagster/sensors/graph_lifecycle.py
@@ -161,12 +161,43 @@ def suspended_graph_deprovisioning_sensor(context: SensorEvaluationContext):
       .all()
     )
 
-    if not ready_subs:
+    graph_ids = [sub.resource_id for sub in ready_subs if sub.resource_id]
+
+    # Re-select graphs stranded mid-teardown: deleted_at was stamped (teardown
+    # started) but status never reached DEPROVISIONED — a run killed part-way
+    # (a Dagster daemon restart on deploy; teardown includes a full backup), a
+    # DBAPI error that failed the run, or a database-delete failure that
+    # deliberately left the registry intact (deprovision_service). The query
+    # above excludes them (deleted_at IS NULL), so nothing would ever retry
+    # them and their .lbug / registry entry / tenant rows would sit forever.
+    # Gate on deleted_at being older than a threshold so a normal in-flight
+    # teardown (minutes) is not double-run; a teardown "leaving" for over an
+    # hour is genuinely stuck. deprovision_graph is idempotent on re-run.
+    stranded_cutoff = now - timedelta(hours=1)
+    stranded = (
+      db.query(Graph.graph_id)
+      .filter(
+        Graph.deleted_at.isnot(None),
+        Graph.deleted_at < stranded_cutoff,
+        Graph.status != GraphStatus.DEPROVISIONED.value,
+        Graph.is_repository.is_(False),
+      )
+      .all()
+    )
+    stranded_ids = [row[0] for row in stranded if row[0]]
+    if stranded_ids:
+      context.log.info(
+        f"Found {len(stranded_ids)} graphs stranded mid-teardown to retry"
+      )
+    # Dedup: a stranded graph could also match ready_subs.
+    graph_ids = list(dict.fromkeys(graph_ids + stranded_ids))
+
+    if not graph_ids:
       return
 
-    graph_ids = [sub.resource_id for sub in ready_subs if sub.resource_id]
     context.log.info(
-      f"Found {len(graph_ids)} suspended graphs ready for deprovisioning"
+      f"Found {len(graph_ids)} graphs ready for deprovisioning "
+      f"({len(stranded_ids)} stranded)"
     )
 
     yield RunRequest(

--- a/robosystems/db/platform.py
+++ b/robosystems/db/platform.py
@@ -118,14 +118,23 @@ from contextlib import contextmanager  # noqa: E402
 
 @contextmanager
 def platform_session():
-  """Context-manager wrapper around the FastAPI dependency-style generator.
+  """Independent platform-DB session for code OUTSIDE FastAPI's dependency
+  machinery — GraphQL resolvers, MCP tools, runner threads, scripts, Dagster
+  jobs.
 
-  `get_db_session()` is implemented as a generator so it can serve as a
-  FastAPI dependency. Code that runs OUTSIDE FastAPI's dependency
-  machinery — GraphQL resolvers, MCP tools, scripts, Dagster jobs —
-  shouldn't have to drive the generator protocol manually. Wrap the
-  same machinery in a normal `with` block so callers get standard
-  context-manager semantics.
+  It opens a fresh ``SessionFactory()`` session, NOT the request-scoped
+  registry, and that distinction is load-bearing. The scoped ``session`` is
+  keyed by the request (``_session_scope``: request contextvar → task →
+  thread), and a runner thread spawned by a request inherits the request's
+  contextvars — so a scoped session opened *inside* a request, or inside a
+  worker thread it started, resolves to the endpoint's own Session. Were this
+  context manager to drive ``get_db_session()`` (the scoped path), its
+  ``finally`` close would then tear down the endpoint's session mid-flight:
+  objects expunged, pending ``add()``s silently discarded, the next use
+  auto-beginning a fresh empty transaction. An independent session has its own
+  lifecycle and cannot reach across into the request's. The scoped registry
+  stays for FastAPI ``Depends`` (``get_db_session`` / ``get_async_db_session``)
+  only.
 
   Usage:
 
@@ -137,12 +146,11 @@ def platform_session():
   This replaces ad-hoc `gen = get_db_session(); next(gen); ...; gen.close()`
   patterns that used to live in the GraphQL resolvers and MCP tools.
   """
-  gen = get_db_session()
-  db = next(gen)
+  db = SessionFactory()
   try:
     yield db
   finally:
-    gen.close()
+    db.close()
 
 
 async def get_async_db_session():

--- a/robosystems/graph_api/core/duckdb/manager.py
+++ b/robosystems/graph_api/core/duckdb/manager.py
@@ -846,10 +846,16 @@ class DuckDBTableManager:
     except HTTPException:
       raise
     except Exception as e:
-      logger.error(f"Write failed for graph {request.graph_id}: {e}")
+      from robosystems.security.error_handling import redact_connection_secrets
+
+      # postgres_scan() statements carry the extensions DSN; a failure can echo
+      # the statement, so scrub the credential before it goes to the log or the
+      # 400 detail returned to the caller.
+      safe = redact_connection_secrets(str(e))
+      logger.error(f"Write failed for graph {request.graph_id}: {safe}")
       raise HTTPException(
         status_code=status.HTTP_400_BAD_REQUEST,
-        detail=f"Query failed: {e!s}",
+        detail=f"Query failed: {safe}",
       )
 
   def query_table_streaming(self, request: TableQueryRequest, chunk_size: int = 1000):

--- a/robosystems/middleware/mcp/tools/_gate.py
+++ b/robosystems/middleware/mcp/tools/_gate.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from robosystems.database import get_db_session
 from robosystems.middleware.extensions import (
   GraphExtensionContext,
   load_graph_metadata,
@@ -56,15 +55,15 @@ def _load_with_short_lived_session(graph_id: str) -> GraphExtensionContext:
   gate opens its own. The session lifetime is one lookup — no concurrency
   concerns, no long-held connections.
   """
-  db_gen = get_db_session()
-  session: Session = next(db_gen)
+  # Independent session — the scoped session would be the request's own
+  # (this runs inside a request), and closing it here would close it mid-flight.
+  from robosystems.database import SessionFactory
+
+  session: Session = SessionFactory()
   try:
     return load_graph_metadata(graph_id, session)
   finally:
-    try:
-      next(db_gen)
-    except StopIteration:
-      pass
+    session.close()
 
 
 def require_graph_extension_mcp(

--- a/robosystems/middleware/mcp/tools/graph_tools.py
+++ b/robosystems/middleware/mcp/tools/graph_tools.py
@@ -52,21 +52,21 @@ from robosystems.logger import logger
 
 
 def _open_platform_session():
-  """Open a short-lived platform-DB session.
+  """Open a short-lived, INDEPENDENT platform-DB session.
 
-  MCP tools don't receive a FastAPI-injected session, so each helper
-  opens its own generator-backed session and closes it on exit.
+  MCP tools don't receive a FastAPI-injected session. This opens its own
+  ``SessionFactory()`` session rather than the request-scoped registry: an MCP
+  tool body runs inside a request and inside a runner thread that inherited the
+  request's contextvars, so the scoped session would resolve to the endpoint's
+  own Session and closing it here would tear it down mid-request. Returns
+  ``(session, close)``.
   """
-  from robosystems.database import get_db_session
+  from robosystems.database import SessionFactory
 
-  gen = get_db_session()
-  session = next(gen)
+  session = SessionFactory()
 
   def close():
-    try:
-      next(gen)
-    except StopIteration:
-      pass
+    session.close()
 
   return session, close
 

--- a/robosystems/middleware/mcp/tools/graphql_tool.py
+++ b/robosystems/middleware/mcp/tools/graphql_tool.py
@@ -396,15 +396,12 @@ class GraphqlQueryTool(BaseTool):
     if not user_id:
       return None
 
-    from robosystems.database import get_db_session
+    from robosystems.database import SessionFactory
     from robosystems.models.core import User
 
-    db_gen = get_db_session()
-    db = next(db_gen)
+    # Independent session (see platform_session docs).
+    db = SessionFactory()
     try:
       return db.get(User, user_id)
     finally:
-      try:
-        next(db_gen)
-      except StopIteration:
-        pass
+      db.close()

--- a/robosystems/middleware/mcp/tools/manager.py
+++ b/robosystems/middleware/mcp/tools/manager.py
@@ -120,20 +120,17 @@ def resolve_schema_extensions(graph_id: str) -> list[str]:
 
   # User graph: query PostgreSQL
   try:
-    from robosystems.database import get_db_session
+    from robosystems.database import SessionFactory
     from robosystems.models.core import Graph
 
-    db_gen = get_db_session()
-    db = next(db_gen)
+    # Independent session (see platform_session docs).
+    db = SessionFactory()
     try:
       graph = Graph.get_by_id(graph_id, db)
       if graph and graph.schema_extensions:
         return list(graph.schema_extensions)
     finally:
-      try:
-        next(db_gen)
-      except StopIteration:
-        pass
+      db.close()
   except Exception:
     logger.warning(f"Could not resolve schema extensions for {graph_id}")
 
@@ -539,18 +536,16 @@ class GraphMCPTools:
     if self._cached_meta is not None:
       return self._cached_meta
     try:
-      from robosystems.database import get_db_session
+      # Independent session (see platform_session docs): the scoped session
+      # would resolve to the request's own and closing it here would close it.
+      from robosystems.database import SessionFactory
       from robosystems.middleware.extensions import load_graph_metadata
 
-      db_gen = get_db_session()
-      session = next(db_gen)
+      session = SessionFactory()
       try:
         self._cached_meta = load_graph_metadata(self.client.graph_id, session)
       finally:
-        try:
-          next(db_gen)
-        except StopIteration:
-          pass
+        session.close()
     except Exception:
       logger.debug(
         "Graph metadata preload failed for %s; registrar tools will fall back to per-call load",

--- a/robosystems/middleware/operations.py
+++ b/robosystems/middleware/operations.py
@@ -686,10 +686,26 @@ async def run_off_loop(func: Callable[..., Any], *args: Any) -> Any:
   QuickBooks or a bounded lock wait sits on a busy row: the API runs one
   uvicorn worker, and before this every operation's SQL and HTTP ran inline
   on the loop.
+
+  The worker-thread run is **shielded** from native asyncio cancellation.
+  ``anyio.to_thread.run_sync`` shields only anyio-flavoured cancellation;
+  ``asyncio.wait_for`` / ``asyncio.timeout`` / ``Task.cancel()`` — which the
+  MCP transports and the worker's operator budget use — raise straight
+  through it, and anyio then releases the ``CapacityLimiter`` token while the
+  thread (and its still-open DB connection) runs on to completion. That
+  uncouples the limiter from the real thread count: under timeouts the pool
+  overflows into ``pool_timeout`` failures, and a "timed out" write still
+  commits later. Shielding ties the token's lifetime to the thread's, not the
+  caller's — a timeout means *abandoned, still running*, and the limiter keeps
+  bounding runner threads. (A Python thread cannot be cancelled anyway, so
+  this only makes the accounting honest.) Matches ``execute_operation``'s use
+  of ``asyncio.shield``.
   """
   if inspect.iscoroutinefunction(func):
     return await func(*args)
-  result = await anyio.to_thread.run_sync(func, *args, limiter=_get_runner_limiter())
+  result = await asyncio.shield(
+    anyio.to_thread.run_sync(func, *args, limiter=_get_runner_limiter())
+  )
   if inspect.isawaitable(result):
     result = await result
   return result

--- a/robosystems/middleware/operations.py
+++ b/robosystems/middleware/operations.py
@@ -703,9 +703,19 @@ async def run_off_loop(func: Callable[..., Any], *args: Any) -> Any:
   """
   if inspect.iscoroutinefunction(func):
     return await func(*args)
-  result = await asyncio.shield(
+  work = asyncio.ensure_future(
     anyio.to_thread.run_sync(func, *args, limiter=_get_runner_limiter())
   )
+  try:
+    result = await asyncio.shield(work)
+  except asyncio.CancelledError:
+    # The worker thread keeps running to completion (a Python thread cannot be
+    # cancelled), and nothing awaits `work` any more — retrieve its outcome
+    # when it lands so a late failure reaches the structured logger rather than
+    # surfacing as an "exception was never retrieved" stderr traceback from a
+    # task nobody holds. Same handling as `execute_operation`.
+    work.add_done_callback(_log_abandoned_outcome)
+    raise
   if inspect.isawaitable(result):
     result = await result
   return result

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
   from robosystems.graph_api.client.client import GraphClient
 
 from robosystems.logger import logger
+from robosystems.security.error_handling import redact_connection_secrets
 
 # Association types the graph renderer needs. Anything omitted here exists in
 # OLTP but is invisible to the graph — dropping `mapping`, for instance, empties
@@ -1389,7 +1390,9 @@ class ExtensionsMaterializer:
     except Exception as e:
       logger.error(f"Failed to get graph client for {graph_id}: {e}")
       result.status = "error"
-      result.errors.append(f"Graph client initialization failed: {e!s}")
+      result.errors.append(
+        redact_connection_secrets(f"Graph client initialization failed: {e!s}")
+      )
       result.duration_ms = (time.time() - start_time) * 1000
       return result
 
@@ -1417,7 +1420,7 @@ class ExtensionsMaterializer:
     except Exception as e:
       logger.error(f"Ledger materialization failed for {graph_id}: {e}", exc_info=True)
       result.status = "error"
-      result.errors.append(str(e))
+      result.errors.append(redact_connection_secrets(str(e)))
     finally:
       await end_destructive_op(busy_instance_id, OP_KIND_EXTENSIONS_MATERIALIZE)
 
@@ -1670,7 +1673,10 @@ class ExtensionsMaterializer:
         await client.execute_write(graph_id, sql.strip(), timeout=120.0)
         result.tables_staged.append(table_name)
       except Exception as e:
-        error_msg = f"Failed to stage {table_name}: {e!s}"
+        # The staging SQL carries the extensions DSN; a DuckDB error can echo
+        # it, so scrub the credential before it reaches the log or the
+        # tenant-visible result.
+        error_msg = redact_connection_secrets(f"Failed to stage {table_name}: {e!s}")
         logger.warning(error_msg)
         if table_name in RELATIONSHIP_TABLES and "DIMENSION" in table_name:
           logger.info(f"Skipping {table_name} (no dimension data)")
@@ -1712,7 +1718,9 @@ class ExtensionsMaterializer:
         result.tables_materialized.append(table_name)
         logger.info(f"Materialized {rows} rows for {table_name}")
       except Exception as e:
-        error_msg = f"Failed to materialize {table_name}: {e!s}"
+        error_msg = redact_connection_secrets(
+          f"Failed to materialize {table_name}: {e!s}"
+        )
         logger.error(error_msg)
         result.errors.append(error_msg)
         if table_name in node_tables:

--- a/robosystems/operations/graph/deprovision_service.py
+++ b/robosystems/operations/graph/deprovision_service.py
@@ -263,6 +263,41 @@ class GraphDeprovisionService:
   ) -> None:
     """Create a final backup before teardown, and register it for retrieval."""
     try:
+      from ...models.core.graph.graph_backup import (
+        BackupStatus,
+        BackupType,
+        GraphBackup,
+      )
+
+      # Idempotency for the stranded-graph retry: the sensor re-selects a graph
+      # whose database delete keeps failing every cycle, and a fresh full S3
+      # dump on each pass buys nothing. If THIS teardown already produced a
+      # completed final backup — one created since `deleted_at` was stamped at
+      # step 0 (an older backup would be a nightly/on-demand one, not the final
+      # snapshot) — reuse it and skip the re-dump.
+      if graph.deleted_at is not None:
+        deleted_at = graph.deleted_at
+        if deleted_at.tzinfo is None:
+          deleted_at = deleted_at.replace(tzinfo=UTC)
+        for prior in GraphBackup.get_by_graph_id(
+          graph.graph_id,
+          session=session,
+          backup_type=BackupType.FULL.value,
+          status=BackupStatus.COMPLETED.value,
+        ):
+          created = prior.created_at
+          if created is not None and created.tzinfo is None:
+            created = created.replace(tzinfo=UTC)
+          if created is not None and created >= deleted_at:
+            result.backup_created = True
+            result.backup_path = prior.s3_key
+            logger.info(
+              f"Final backup from this teardown already exists for "
+              f"{graph.graph_id}; skipping re-dump on retry",
+              extra={"graph_id": graph.graph_id},
+            )
+            return
+
       from .engine.backup_manager import (
         BackupFormat,
         BackupJob,

--- a/robosystems/operations/graph/deprovision_service.py
+++ b/robosystems/operations/graph/deprovision_service.py
@@ -206,6 +206,25 @@ class GraphDeprovisionService:
     # graph can finish what a partial teardown left behind.
     self._dispose_residual_data(graph_id, result)
 
+    # If the graph database itself could not be deleted, the `.lbug` is still
+    # on the instance. Freeing the registry slot now would strand it: the
+    # instance/volume would read as empty to the allocator while carrying the
+    # departed tenant's file, poisoning the next tenant that lands there (see
+    # `graph_api` on-disk vs registry counting). So leave the registry entry
+    # and the status alone — deleted_at is already stamped, so the graph is
+    # closed to callers, and the teardown sensor re-selects a stranded graph
+    # (deleted_at set, status not yet deprovisioned) to retry the whole
+    # sequence. Every step above is idempotent on re-run.
+    if not result.database_deleted:
+      result.status = "partial"
+      logger.warning(
+        f"Graph {graph_id} database delete failed; leaving registry, PG records "
+        "and status intact for the teardown sensor to retry (avoids stranding "
+        "the .lbug on a freed instance)",
+        extra={"graph_id": graph_id, "errors": result.errors},
+      )
+      return result
+
     # --- 4. Deallocate DynamoDB registry ---
     await self._deallocate_registry(graph_id, result)
 

--- a/robosystems/operations/graph/graph_creation_service.py
+++ b/robosystems/operations/graph/graph_creation_service.py
@@ -622,6 +622,33 @@ class GraphCreationService:
           return
 
       if location:
+        # Pre-persist failure (no Graph row above): `_create_database` may
+        # already have written the `.lbug` to the instance, and there is no
+        # Graph row to drive teardown. Delete the file BEFORE releasing the
+        # allocation — a freed registry slot whose `.lbug` is still on disk
+        # poisons that instance, because the graph_api counts on-disk
+        # databases against `max_databases` (=1 on every tier) while the
+        # allocator counts registry rows, so the instance reports full to
+        # `create_database` (507) yet empty to `_find_best_instance`, which
+        # keeps re-picking it. Best-effort: if the delete fails the daily
+        # reclaim reconciliation is the backstop.
+        try:
+          from robosystems.graph_api.client.factory import get_graph_client
+
+          cleanup_client = await get_graph_client(
+            graph_id=graph_id, operation_type="write"
+          )
+          try:
+            await cleanup_client.delete_database(graph_id)
+            logger.info(f"Deleted orphaned database file for {graph_id} on cleanup")
+          finally:
+            await cleanup_client.close()
+        except Exception as e:
+          logger.warning(
+            f"Cleanup database delete failed for {graph_id} "
+            f"(reclaim reconciliation will catch it): {e}"
+          )
+
         manager = LadybugAllocationManager(environment=env.ENVIRONMENT)
         await manager.deallocate_database(graph_id)
         logger.info(f"Deallocated {graph_id}")

--- a/robosystems/operations/graph/subgraph_service.py
+++ b/robosystems/operations/graph/subgraph_service.py
@@ -77,10 +77,12 @@ class SubgraphService:
       )
 
     from ...config.graph_tier import GraphTierConfig
-    from ...database import get_db_session
+    from ...database import SessionFactory
     from ...models.core.graph import Graph
 
-    db = next(get_db_session())
+    # Independent session (see platform_session docs): the scoped session
+    # would be the caller's request session and close() would tear it down.
+    db = SessionFactory()
     try:
       parent_graph = db.query(Graph).filter(Graph.graph_id == parent_graph_id).first()
       if not parent_graph:
@@ -117,10 +119,11 @@ class SubgraphService:
 
     try:
       from robosystems.config import env
-      from robosystems.database import get_db_session
+      from robosystems.database import SessionFactory
       from robosystems.models.core.graph import Graph
 
-      session = next(get_db_session())
+      # Independent session (see platform_session docs).
+      session = SessionFactory()
       parent_graph_record = (
         session.query(Graph).filter(Graph.graph_id == parent_graph_id).first()
       )
@@ -277,7 +280,7 @@ class SubgraphService:
     databases no registry knows about. A failed ``fork_parent`` does *not*
     unwind the subgraph; it is reported in the returned ``fork_status``.
     """
-    from ...database import get_db_session
+    from ...database import SessionFactory
     from ...models.core.graph import Graph
 
     subgraph_id = construct_subgraph_id(parent_graph.graph_id, name)
@@ -313,7 +316,8 @@ class SubgraphService:
       logger.error(f"Failed to create LadybugDB database for subgraph: {e}")
       raise
 
-    db = next(get_db_session())
+    # Independent session (see platform_session docs).
+    db = SessionFactory()
     try:
       existing_subgraphs = (
         db.query(Graph)

--- a/robosystems/routers/admin/graphs.py
+++ b/robosystems/routers/admin/graphs.py
@@ -413,6 +413,13 @@ async def deprovision_graph(
       status=(
         "already_deprovisioned"
         if result.status == "already_deprovisioned"
+        # A database-delete failure leaves the graph stranded (not flipped to
+        # DEPROVISIONED) for the teardown sensor to retry — reporting
+        # "deprovisioned" would misdescribe a graph that is still live. A
+        # "partial" whose database WAS deleted (e.g. a registry-dealloc lag) is
+        # genuinely deprovisioned.
+        else "partial"
+        if not result.database_deleted
         else "deprovisioned"
       ),
       database_deleted=result.database_deleted,

--- a/robosystems/security/error_handling.py
+++ b/robosystems/security/error_handling.py
@@ -6,6 +6,7 @@ a status code derived from the error's classification, so an error never
 reveals database, path, or configuration internals.
 """
 
+import re
 from typing import Any, NoReturn
 
 from fastapi import HTTPException, status
@@ -248,6 +249,27 @@ def is_safe_to_expose(detail_message: str) -> bool:
   ]
 
   return not any(pattern in detail_lower for pattern in sensitive_patterns)
+
+
+_CONNSTR_PASSWORD_RE = re.compile(r"password=\S+")
+_URL_CRED_RE = re.compile(r"(postgres(?:ql)?://[^:/@\s]+:)[^@\s]+@")
+
+
+def redact_connection_secrets(text: str) -> str:
+  """Redact database credentials from an error string, keeping the rest.
+
+  The extensions materializer interpolates a libpq connstr (``password=…``)
+  into the ``postgres_scan()`` SQL it ships to the graph_api; a DuckDB error
+  that echoes the failing statement would otherwise carry the RDS master
+  credential into a tenant-visible operation result (``result.errors``) and the
+  logs. This scrubs the secret and leaves the diagnostic text intact — unlike
+  :func:`sanitize_error_detail`, which would blank the whole message.
+  """
+  if not text:
+    return text
+  text = _CONNSTR_PASSWORD_RE.sub("password=***", text)
+  text = _URL_CRED_RE.sub(r"\1***@", text)
+  return text
 
 
 def sanitize_error_detail(detail_message: str) -> str:

--- a/tests/dagster/test_graph_jobs.py
+++ b/tests/dagster/test_graph_jobs.py
@@ -171,3 +171,49 @@ class TestRestoreBackupOpFailsClosed:
 
     with pytest.raises(Failure, match="Safety backup failed"):
       self._run(backup_raises=True)
+
+
+class TestDeprovisionSuspendedGraphsSessionIsolation:
+  """One graph's DBAPI failure must not poison the shared session for the
+  graphs after it. The op rolls the session back per-failure so each graph is
+  independent; the failed one is left stranded for the sensor to retry."""
+
+  @pytest.mark.unit
+  def test_a_failed_graph_rolls_back_and_the_next_graph_still_runs(self):
+    from dagster import build_op_context
+
+    from robosystems.dagster.jobs.graph_lifecycle import (
+      DeprovisionGraphsConfig,
+      deprovision_suspended_graphs,
+    )
+
+    session = MagicMock()
+    db = MagicMock()
+    db.get_session.return_value.__enter__ = lambda *_: session
+    db.get_session.return_value.__exit__ = lambda *_: False
+
+    ok = MagicMock()
+    ok.status = "success"
+    ok.errors = []
+
+    async def _deprovision(graph_id, _sess, create_backup=True):
+      if graph_id == "kg_poison":
+        raise RuntimeError("PG delete blew up mid-transaction")
+      return ok
+
+    with patch(
+      "robosystems.operations.graph.deprovision_service.GraphDeprovisionService"
+    ) as svc_cls:
+      svc_cls.return_value.deprovision_graph = _deprovision
+
+      result = deprovision_suspended_graphs(
+        build_op_context(),
+        db,
+        DeprovisionGraphsConfig(graph_ids=["kg_poison", "kg_ok"]),
+      )
+
+    # The poison graph failed → the session was reset before the next graph,
+    # and the next graph was still deprovisioned.
+    session.rollback.assert_called_once()
+    assert result["deprovisioned_count"] == 1
+    assert any("kg_poison" in e for e in result["errors"])

--- a/tests/dagster/test_graph_lifecycle.py
+++ b/tests/dagster/test_graph_lifecycle.py
@@ -44,6 +44,48 @@ class TestSuspendedGraphDeprovisioningSensor:
 
       assert len(runs) == 0
 
+  def test_re_selects_graphs_stranded_mid_teardown(self):
+    """A graph whose teardown started (deleted_at set) but never reached
+    DEPROVISIONED is excluded by the retention query (deleted_at IS NULL); the
+    sensor's second query re-selects it so it is retried rather than stranded
+    forever with its .lbug / registry entry / tenant rows intact."""
+    with patch("robosystems.database.session") as mock_db:
+      mock_session = MagicMock()
+      mock_db.return_value = mock_session
+      # No subscription-driven graphs...
+      mock_session.query.return_value.join.return_value.filter.return_value.all.return_value = []
+      # ...but one stranded graph (query(Graph.graph_id).filter(...).all()).
+      mock_session.query.return_value.filter.return_value.all.return_value = [
+        ("kg_stranded",)
+      ]
+
+      context = build_sensor_context()
+      runs = list(suspended_graph_deprovisioning_sensor(context))
+
+      assert len(runs) == 1
+      config = runs[0].run_config["ops"]["deprovision_suspended_graphs"]["config"]
+      assert config["graph_ids"] == ["kg_stranded"]
+
+  def test_dedups_a_graph_that_is_both_ready_and_stranded(self):
+    mock_sub = MagicMock()
+    mock_sub.resource_id = "kg_both"
+    with patch("robosystems.database.session") as mock_db:
+      mock_session = MagicMock()
+      mock_db.return_value = mock_session
+      mock_session.query.return_value.join.return_value.filter.return_value.all.return_value = [
+        mock_sub
+      ]
+      mock_session.query.return_value.filter.return_value.all.return_value = [
+        ("kg_both",)
+      ]
+
+      context = build_sensor_context()
+      runs = list(suspended_graph_deprovisioning_sensor(context))
+
+      assert len(runs) == 1
+      config = runs[0].run_config["ops"]["deprovision_suspended_graphs"]["config"]
+      assert config["graph_ids"] == ["kg_both"]
+
   def test_session_cleanup(self):
     """Database session is always cleaned up."""
     with patch("robosystems.database.session") as mock_db:

--- a/tests/db/test_platform_session.py
+++ b/tests/db/test_platform_session.py
@@ -1,0 +1,42 @@
+"""`platform_session()` must be independent of the request-scoped session.
+
+Regression for the tier-B robustness review §2.5: `platform_session()` used to
+drive `get_db_session()`, which returns the request-scoped Session (keyed by
+the request contextvar → task → thread). Opened *inside* a request — a GraphQL
+resolver, an MCP tool, a runner thread that inherited the request's
+contextvars — it resolved to the endpoint's own Session, and its `finally`
+close tore that session down mid-flight (objects expunged, pending adds
+silently discarded). It now opens an independent SessionFactory() session.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robosystems.db import platform as P
+
+
+@pytest.mark.unit
+def test_platform_session_does_not_touch_the_request_scoped_session():
+  token = P.activate_request_scope()
+  try:
+    # The endpoint's session for this request scope.
+    request_session = P.session()
+
+    with P.platform_session() as nested:
+      # It must be a distinct Session, not the request's own.
+      assert nested is not request_session
+
+    # After the nested session closes, the request's session must be untouched
+    # — the same object, still registered in the scoped registry (pre-fix,
+    # platform_session's finally called session.remove(), dropping it).
+    assert P.session() is request_session
+  finally:
+    P.session.remove()
+    P.deactivate_request_scope(token)
+
+
+@pytest.mark.unit
+def test_two_platform_sessions_are_distinct():
+  with P.platform_session() as a, P.platform_session() as b:
+    assert a is not b

--- a/tests/graph_api/test_subgraph_fork.py
+++ b/tests/graph_api/test_subgraph_fork.py
@@ -106,7 +106,7 @@ async def test_create_subgraph_with_fork():
 
   with patch.object(service, "create_subgraph_database") as mock_create_db:
     with patch.object(service, "fork_parent_data") as mock_fork:
-      with patch("robosystems.database.get_db_session") as mock_get_db:
+      with patch("robosystems.database.SessionFactory") as mock_factory:
         # Setup mocks
         mock_create_db.return_value = {"status": "created", "instance_id": "i-12345"}
 
@@ -116,8 +116,10 @@ async def test_create_subgraph_with_fork():
           "row_count": 1000,
         }
 
+        # create_subgraph opens its own independent session (SessionFactory,
+        # not the request-scoped get_db_session) to persist the subgraph row.
         mock_db = Mock()
-        mock_get_db.return_value = iter([mock_db])
+        mock_factory.return_value = mock_db
         mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
         mock_db.commit = Mock()
         mock_db.refresh = Mock()

--- a/tests/middleware/mcp/test_gate.py
+++ b/tests/middleware/mcp/test_gate.py
@@ -187,24 +187,39 @@ class TestMCPExtensionGateError:
 
 
 class TestLoadWithShortLivedSession:
-  """The helper opens a platform-DB session via a generator, runs one
-  lookup, and closes the session. Generator-based DB helpers are easy
-  to leak if the finally/close path isn't wired right."""
+  """The helper opens an INDEPENDENT platform-DB session (SessionFactory,
+  never the request-scoped registry — it runs inside a request), runs one
+  lookup, and closes it. §2.5: driving the scoped session here would close
+  the endpoint's own session mid-request."""
 
-  def test_generator_is_exhausted_on_success(self) -> None:
+  def test_independent_session_is_opened_and_closed(self) -> None:
     from robosystems.middleware.mcp.tools import _gate
 
     mock_session = MagicMock()
 
-    def _gen():
-      yield mock_session
-      # Second `next()` raises StopIteration, simulating normal close
-
     with (
-      patch.object(_gate, "get_db_session", _gen),
+      patch(
+        "robosystems.database.SessionFactory", return_value=mock_session
+      ) as factory,
       patch.object(_gate, "load_graph_metadata", return_value=_entity_meta()) as loader,
     ):
       result = _gate._load_with_short_lived_session("kg01ABC")
 
+    factory.assert_called_once_with()
     loader.assert_called_once_with("kg01ABC", mock_session)
+    mock_session.close.assert_called_once_with()
     assert "roboledger" in result.schema_extensions
+
+  def test_session_is_closed_even_when_the_lookup_raises(self) -> None:
+    from robosystems.middleware.mcp.tools import _gate
+
+    mock_session = MagicMock()
+
+    with (
+      patch("robosystems.database.SessionFactory", return_value=mock_session),
+      patch.object(_gate, "load_graph_metadata", side_effect=RuntimeError("boom")),
+    ):
+      with pytest.raises(RuntimeError):
+        _gate._load_with_short_lived_session("kg01ABC")
+
+    mock_session.close.assert_called_once_with()

--- a/tests/middleware/test_run_off_loop.py
+++ b/tests/middleware/test_run_off_loop.py
@@ -72,6 +72,35 @@ async def test_timeout_holds_the_runner_token_until_the_thread_completes(
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_late_failure_after_timeout_is_logged_not_lost(fresh_limiter):
+  """A worker that raises *after* the caller timed out must reach the logger,
+  not surface as an unretrieved-exception stderr traceback from an orphan task
+  (parity with execute_operation's abandoned-outcome handling)."""
+  from unittest.mock import patch
+
+  release = threading.Event()
+
+  def slow_then_fail():
+    release.wait(5.0)
+    raise RuntimeError("late boom")
+
+  with patch.object(operations.logger, "warning") as mock_warning:
+    with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+      await asyncio.wait_for(operations.run_off_loop(slow_then_fail), 0.2)
+
+    release.set()
+    for _ in range(500):
+      if mock_warning.called:
+        break
+      await asyncio.sleep(0.01)
+
+  assert mock_warning.called, "a post-cancellation worker failure was not logged"
+  logged = " ".join(str(a) for a in mock_warning.call_args.args)
+  assert "late boom" in logged or "RuntimeError" in logged
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_normal_completion_releases_the_token(fresh_limiter):
   limiter = fresh_limiter
 

--- a/tests/middleware/test_run_off_loop.py
+++ b/tests/middleware/test_run_off_loop.py
@@ -1,0 +1,91 @@
+"""`run_off_loop` must keep the runner limiter honest under native timeouts.
+
+Regression for the tier-B robustness review §2.4: anyio's `to_thread.run_sync`
+shields only anyio cancellation, so `asyncio.wait_for` / `asyncio.timeout`
+raise straight through it and anyio releases the `CapacityLimiter` token while
+the worker thread — and its DB connection — is still running. That uncouples
+the limiter from the real thread count; under timeouts the extensions pool
+overflows. The fix shields the thread run, tying the token to the thread's
+lifetime, not the caller's.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import anyio
+import pytest
+
+from robosystems.middleware import operations
+
+
+@pytest.fixture
+def fresh_limiter():
+  """Isolate the module-global runner limiter for the test."""
+  prev = operations._runner_limiter
+  operations._runner_limiter = anyio.CapacityLimiter(5)
+  try:
+    yield operations._runner_limiter
+  finally:
+    operations._runner_limiter = prev
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_timeout_holds_the_runner_token_until_the_thread_completes(
+  fresh_limiter,
+):
+  limiter = fresh_limiter
+  started = threading.Event()
+  release = threading.Event()
+
+  def slow_work():
+    started.set()
+    # Hold the worker thread open past the caller's timeout.
+    release.wait(5.0)
+    return "committed-late"
+
+  assert limiter.borrowed_tokens == 0
+
+  # The caller times out while the thread is still running.
+  with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+    await asyncio.wait_for(operations.run_off_loop(slow_work), 0.2)
+
+  # The thread is still live, so the token must NOT have been released — this
+  # is the assertion that fails against the pre-fix code (token drops to 0 at
+  # the timeout while the thread runs on).
+  assert started.is_set()
+  assert limiter.borrowed_tokens == 1, (
+    "runner token released while the worker thread was still running — "
+    "the limiter no longer bounds the real thread count"
+  )
+
+  # Let the thread finish; the token is released on thread completion.
+  release.set()
+  for _ in range(500):
+    if limiter.borrowed_tokens == 0:
+      break
+    await asyncio.sleep(0.01)
+  assert limiter.borrowed_tokens == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_normal_completion_releases_the_token(fresh_limiter):
+  limiter = fresh_limiter
+
+  def quick_work():
+    return 42
+
+  assert await operations.run_off_loop(quick_work) == 42
+  assert limiter.borrowed_tokens == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_coroutine_func_is_awaited_directly(fresh_limiter):
+  async def coro_work():
+    return "async"
+
+  assert await operations.run_off_loop(coro_work) == "async"

--- a/tests/operations/graph/test_deprovision_service.py
+++ b/tests/operations/graph/test_deprovision_service.py
@@ -431,10 +431,18 @@ class TestDeprovisionService:
       assert test_graph.status == GraphStatus.DEPROVISIONED.value
 
   @pytest.mark.asyncio
-  async def test_deprovision_database_deletion_failure_continues(
+  async def test_deprovision_database_deletion_failure_leaves_graph_for_retry(
     self, service, db_session, test_graph
   ):
-    """Database deletion failure does not block deprovisioning."""
+    """A database-delete failure must NOT free the registry or flip the status.
+
+    The `.lbug` is still on the instance; freeing the registry slot would
+    strand it (the allocator reads the instance as empty while the graph_api
+    counts the on-disk file against max_databases). So the registry entry and
+    the status are left intact — deleted_at is already stamped, so the graph is
+    closed to callers — and the teardown sensor re-selects the stranded graph
+    to retry the whole sequence.
+    """
     with (
       patch(
         "robosystems.graph_api.client.factory.get_graph_client",
@@ -457,10 +465,17 @@ class TestDeprovisionService:
 
       assert result.status == "partial"
       assert result.database_deleted is False
+      assert result.registry_deallocated is False
       assert any("Database deletion failed" in e for e in result.errors)
 
+      # Registry was NOT freed, so the .lbug is not stranded on an "empty"
+      # instance.
+      mock_alloc.deallocate_database.assert_not_called()
+
+      # Status left un-deprovisioned, deleted_at still set → sensor retries it.
       db_session.refresh(test_graph)
-      assert test_graph.status == GraphStatus.DEPROVISIONED.value
+      assert test_graph.status != GraphStatus.DEPROVISIONED.value
+      assert test_graph.deleted_at is not None
 
   @pytest.mark.asyncio
   async def test_deprovision_registry_deallocation_failure_continues(

--- a/tests/operations/graph/test_deprovision_service.py
+++ b/tests/operations/graph/test_deprovision_service.py
@@ -167,6 +167,96 @@ class TestDeprovisionService:
       assert test_graph.deleted_at is not None
 
   @pytest.mark.asyncio
+  async def test_final_backup_is_skipped_when_this_teardown_already_made_one(
+    self, service, db_session, test_graph
+  ):
+    """On a stranded-graph retry the sensor re-selects the same graph every
+    cycle; the final backup must not be re-dumped each time. A completed FULL
+    backup created since deleted_at (this teardown's own) is reused."""
+    from datetime import UTC, datetime, timedelta
+
+    from robosystems.models.core.graph.graph_backup import (
+      BackupStatus,
+      BackupType,
+      GraphBackup,
+    )
+    from robosystems.operations.graph.deprovision_service import DeprovisionResult
+
+    test_graph.deleted_at = datetime.now(UTC) - timedelta(minutes=10)
+    db_session.commit()
+
+    prior = GraphBackup.create(
+      graph_id=test_graph.graph_id,
+      database_name=test_graph.graph_id,
+      backup_type=BackupType.FULL.value,
+      s3_bucket="test-bucket",
+      s3_key="backups/prior-final.lbug.zip",
+      session=db_session,
+    )
+    prior.status = BackupStatus.COMPLETED.value
+    prior.created_at = datetime.now(UTC) - timedelta(minutes=5)  # after deleted_at
+    db_session.commit()
+
+    result = DeprovisionResult(graph_id=test_graph.graph_id, status="success")
+
+    with patch(
+      "robosystems.operations.graph.engine.backup_manager.BackupManager"
+    ) as mock_backup_cls:
+      mock_backup = AsyncMock()
+      mock_backup_cls.return_value = mock_backup
+
+      await service._create_final_backup(test_graph, db_session, result)
+
+    # No fresh S3 dump; the existing final backup is reused.
+    mock_backup.create_backup.assert_not_called()
+    assert result.backup_created is True
+    assert result.backup_path == "backups/prior-final.lbug.zip"
+
+  @pytest.mark.asyncio
+  async def test_final_backup_ignores_a_backup_older_than_this_teardown(
+    self, service, db_session, test_graph
+  ):
+    """A nightly/on-demand backup from before deleted_at is NOT the final
+    snapshot — the first teardown still takes a fresh dump."""
+    from datetime import UTC, datetime, timedelta
+
+    from robosystems.models.core.graph.graph_backup import (
+      BackupStatus,
+      BackupType,
+      GraphBackup,
+    )
+    from robosystems.operations.graph.deprovision_service import DeprovisionResult
+
+    test_graph.deleted_at = datetime.now(UTC)
+    db_session.commit()
+
+    nightly = GraphBackup.create(
+      graph_id=test_graph.graph_id,
+      database_name=test_graph.graph_id,
+      backup_type=BackupType.FULL.value,
+      s3_bucket="test-bucket",
+      s3_key="backups/nightly.lbug.zip",
+      session=db_session,
+    )
+    nightly.status = BackupStatus.COMPLETED.value
+    nightly.created_at = datetime.now(UTC) - timedelta(days=1)  # before deleted_at
+    db_session.commit()
+
+    result = DeprovisionResult(graph_id=test_graph.graph_id, status="success")
+
+    with patch(
+      "robosystems.operations.graph.engine.backup_manager.BackupManager"
+    ) as mock_backup_cls:
+      mock_backup = AsyncMock()
+      mock_backup.s3_adapter.bucket_name = "test-bucket"
+      mock_backup.create_backup.return_value = _final_backup_metadata()
+      mock_backup_cls.return_value = mock_backup
+
+      await service._create_final_backup(test_graph, db_session, result)
+
+    mock_backup.create_backup.assert_awaited_once()
+
+  @pytest.mark.asyncio
   async def test_final_backup_is_registered_for_retrieval(
     self, service, db_session, test_graph
   ):

--- a/tests/operations/graph/test_graph_creation_cleanup.py
+++ b/tests/operations/graph/test_graph_creation_cleanup.py
@@ -151,11 +151,54 @@ class TestCleanupBeforePersist:
   """A failure before the row is committed still has an allocation to release."""
 
   @pytest.mark.asyncio
-  async def test_cleanup_deallocates_when_no_row_exists(self, db_session):
+  async def test_cleanup_deletes_the_orphan_database_before_deallocating(
+    self, db_session
+  ):
+    """Pre-persist: `_create_database` may have written the `.lbug`, but there
+    is no Graph row to drive teardown. The file must be deleted BEFORE the
+    registry slot is freed — a freed slot whose `.lbug` is still on disk
+    poisons the instance (on-disk count vs registry count diverge)."""
     service = GraphCreationService()
+    order: list[str] = []
+
+    graph_client = AsyncMock()
+    graph_client.delete_database.side_effect = lambda gid: order.append("delete")
+
+    async def _get_client(**_kwargs):
+      return graph_client
 
     with (
       patch("robosystems.db.platform.platform_session", lambda: _yield(db_session)),
+      patch("robosystems.graph_api.client.factory.get_graph_client", _get_client),
+      patch(f"{SERVICE_MODULE}.LadybugAllocationManager") as alloc_cls,
+    ):
+      manager = AsyncMock()
+      manager.deallocate_database.side_effect = lambda gid: order.append("dealloc")
+      alloc_cls.return_value = manager
+
+      await service._cleanup("kg_neverpersisted", _location(), None)
+
+    graph_client.delete_database.assert_awaited_once_with("kg_neverpersisted")
+    manager.deallocate_database.assert_awaited_once_with("kg_neverpersisted")
+    assert order == ["delete", "dealloc"], "the .lbug must be deleted before dealloc"
+
+  @pytest.mark.asyncio
+  async def test_cleanup_still_deallocates_when_the_orphan_delete_fails(
+    self, db_session
+  ):
+    """A failed delete must not abort the deallocation — best-effort, with the
+    reclaim reconciliation as the backstop."""
+    service = GraphCreationService()
+
+    graph_client = AsyncMock()
+    graph_client.delete_database.side_effect = Exception("graph api down")
+
+    async def _get_client(**_kwargs):
+      return graph_client
+
+    with (
+      patch("robosystems.db.platform.platform_session", lambda: _yield(db_session)),
+      patch("robosystems.graph_api.client.factory.get_graph_client", _get_client),
       patch(f"{SERVICE_MODULE}.LadybugAllocationManager") as alloc_cls,
     ):
       manager = AsyncMock()

--- a/tests/routers/admin/test_graphs.py
+++ b/tests/routers/admin/test_graphs.py
@@ -164,10 +164,12 @@ class TestDeprovisionGraph:
     assert response.status_code == 403
     assert "shared repository" in response.json()["detail"].lower()
 
-  def test_deprovision_database_deletion_fails_gracefully(
+  def test_deprovision_database_deletion_leaves_graph_stranded_for_retry(
     self, client, db_session, test_graph, mock_admin_auth
   ):
-    """Test that DB deletion failure still succeeds with database_deleted=False."""
+    """A DB-delete failure must not report the graph as deprovisioned: the
+    graph is left stranded (status not flipped, registry not freed, deleted_at
+    set) for the teardown sensor to retry, and the response says so."""
     with (
       patch(
         "robosystems.graph_api.client.factory.get_graph_client",
@@ -192,13 +194,14 @@ class TestDeprovisionGraph:
       assert response.status_code == 200
       data = response.json()
       assert data["database_deleted"] is False
-      assert data["status"] == "deprovisioned"
+      # Honest status — the graph is NOT deprovisioned.
+      assert data["status"] == "partial"
       assert data["warnings"] is not None
       assert any("Database deletion failed" in w for w in data["warnings"])
-      assert "not found or already removed" in data["message"]
 
       db_session.refresh(test_graph)
-      assert test_graph.status == GraphStatus.DEPROVISIONED.value
+      assert test_graph.status != GraphStatus.DEPROVISIONED.value
+      assert test_graph.deleted_at is not None
 
   def test_deprovision_with_skip_backup(
     self, client, db_session, test_graph, mock_admin_auth

--- a/tests/security/test_redact_connection_secrets.py
+++ b/tests/security/test_redact_connection_secrets.py
@@ -1,0 +1,47 @@
+"""Credentials must never reach a tenant-visible error or the logs.
+
+Regression for the tier-B robustness review §2.8: the extensions materializer
+interpolates a libpq connstr (`password=...`) into every postgres_scan()
+statement; a DuckDB error that echoes the failing statement would otherwise
+carry the RDS master credential into `result.errors` and the graph_api logs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robosystems.security.error_handling import redact_connection_secrets
+
+
+@pytest.mark.unit
+@pytest.mark.security
+class TestRedactConnectionSecrets:
+  def test_redacts_libpq_password_keeps_diagnostics(self):
+    raw = (
+      "Failed to stage Entity: Parser Error near "
+      "postgres_scan('dbname=extensions user=postgres password=hunter2 "
+      "host=pg.internal port=5432', 'kg1a2b', 'entities')"
+    )
+    out = redact_connection_secrets(raw)
+    assert "hunter2" not in out
+    assert "password=***" in out
+    # The useful diagnostic text survives.
+    assert "Failed to stage Entity" in out
+    assert "dbname=extensions" in out
+
+  def test_redacts_url_form_credentials(self):
+    raw = "connect failed: postgresql://postgres:s3cr3t@rds.aws:5432/extensions"
+    out = redact_connection_secrets(raw)
+    assert "s3cr3t" not in out
+    assert "postgresql://postgres:***@rds.aws:5432/extensions" in out
+
+  def test_empty_and_secretless_text_pass_through(self):
+    assert redact_connection_secrets("") == ""
+    assert redact_connection_secrets("plain error, no creds") == "plain error, no creds"
+
+  def test_multiple_occurrences_all_redacted(self):
+    raw = "password=a failed; retry with password=b also failed"
+    out = redact_connection_secrets(raw)
+    assert "password=a" not in out
+    assert "password=b" not in out
+    assert out.count("password=***") == 2


### PR DESCRIPTION
## Multi-tenancy tier B — robustness

Third and final follow-up to the 2026-08-18 resilience review (after #1211 tier A, #1212 tier B parity). This closes the platform-robustness rows — concurrency, session lifetime, teardown/creation recovery, and error-surface hardening — that don't change the authorization model but make the multi-tenant plane hold under failure.

### What changed

- **§2.4 — the runner limiter stays honest under timeouts.** anyio's `to_thread.run_sync` shields only anyio cancellation, so `asyncio.wait_for`/`timeout` (the MCP transports and the worker's operator budget) raise straight through and release the `CapacityLimiter` token while the worker thread — and its DB connection — is still running. The token uncoupled from the real thread count means the extensions pool overflows under timeouts and a "timed out" write still commits later. The thread run is now shielded, tying the token's lifetime to the thread's, and a post-cancellation failure is logged through the structured logger.
- **§2.5 — non-dependency callers get an independent session.** `platform_session()` and the MCP/subgraph helpers drove the request-scoped session; opened inside a request (a resolver, an MCP tool, a runner thread that inherited the request contextvars) it resolved to the endpoint's own Session and closing it tore that session down mid-flight. They now open an independent `SessionFactory()` session; the scoped registry stays for FastAPI `Depends` only.
- **§2.6 (source) + §2.7 — teardown and creation-rollback stop stranding a database.** A failed creation before the metadata commit deletes the orphaned `.lbug` before releasing the allocation (a freed slot whose file is still on disk poisons the instance). A teardown whose DB-delete fails no longer frees the registry or flips the status — the graph is left stranded (`deleted_at` set) and the sensor re-selects it to retry (reusing its final backup rather than re-dumping). The deprovision job rolls its shared session back per failure so one graph's DBAPI error can't cascade to the rest of the run.
- **§2.8 — harden the materialization error surface.** Redact database credentials from extensions-materialization error text before it reaches an operation result or the logs (diagnostics preserved). Mechanism detail is in the vault.

### Tests
Every fix has unit coverage with a red-then-green check against the pre-fix behavior. Broad affected sweep green (~2,000+ tests across operations, MCP, dagster, extensions, graph_api, connections).

### Deferred (need a staging drill / soak, not just code)
- **§2.6c** — the instance-side parent-level reconciliation sweep. It is a *destructive* auto-delete; it needs a dry-run/observability soak before it deletes real databases. The source fixes above prevent the orphan at creation and teardown, so this is a backstop.
- **§2.10** — the tier-change drain (the `/admin/drain` route is absent); needs a staging drill before/with the fix.

No migration. Full mechanics and the review that scoped this are in the private vault (`specs/security/multitenancy-resilience-review.md` §2). **Sequence the deploy promptly after merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
