### PR TITLE
feat(volumes): make the per-tier volume IOPS/throughput floor authoritative on attach

### DIFF
--- a/bin/lambda/graph_volume_manager.py
+++ b/bin/lambda/graph_volume_manager.py
@@ -66,11 +66,49 @@ RETENTION_DAYS = int(os.environ.get("SNAPSHOT_RETENTION_DAYS", "7"))
 # never stolen out from under itself.
 STALE_CLAIM_SECONDS = int(os.environ.get("STALE_CLAIM_SECONDS", "900"))
 
-# Volume defaults (used as fallback when tier not found in tier_config)
+# Volume defaults (used as fallback when tier not found in TIER_VOLUME_SPEC)
 DEFAULT_SIZE = 50  # GB
 DEFAULT_TYPE = "gp3"
 DEFAULT_IOPS = 3000
 DEFAULT_THROUGHPUT = 125  # MB/s
+
+# Per-tier volume spec.
+#
+# `size` is the INITIAL size, not a cap: the volume monitor expands at 80% usage
+# every 15 minutes, and EBS volumes can grow but never shrink - so provisioning
+# small and growing on demand costs strictly less than provisioning for a ceiling
+# most graphs never reach. The product cap is enforced separately by
+# instance_storage_limit_gb in .github/configs/graph.yml (20/50/100 GB); these do
+# not need to match it, since expansion at 80% fires before the write-path cap
+# is reached. gp3's baseline performance is size-independent, so a smaller
+# volume carries no performance penalty.
+#
+# `iops` / `throughput` are the gp3 performance FLOOR for the tier. They are
+# applied at creation AND re-asserted on every attach by
+# reconcile_volume_performance: a data volume outlives many instances (the
+# shared master's is reattached on every nightly wake), so a creation-time
+# setting alone would leave every existing volume at whatever it was minted
+# with. The floor only ever raises a volume; it never lowers one.
+#
+# ladybug-shared runs the SEC nightly full rebuild, whose relationship-table
+# COPYs are bound by small random reads (endpoint hash-index probes + CSR
+# rewrites) into this volume. At the 3000-IOPS baseline the volume sat 78-93%
+# busy moving ~20 MB/s and the rebuild took 6.4h; at 12000 IOPS / 500 MB/s the
+# same tables ran ~2.4x faster (2026-08-19). The other tiers stay at baseline.
+TIER_VOLUME_SPEC: dict[str, dict[str, int]] = {
+  "ladybug-standard": {"size": 20, "iops": 3000, "throughput": 125},
+  "ladybug-large": {"size": 50, "iops": 3000, "throughput": 125},
+  "ladybug-xlarge": {"size": 50, "iops": 3000, "throughput": 125},
+  "ladybug-shared": {"size": 200, "iops": 12000, "throughput": 500},
+}
+
+
+def volume_spec_for_tier(tier: str) -> dict[str, int]:
+  return TIER_VOLUME_SPEC.get(
+    tier,
+    {"size": DEFAULT_SIZE, "iops": DEFAULT_IOPS, "throughput": DEFAULT_THROUGHPUT},
+  )
+
 
 # DynamoDB tables
 table = dynamodb.Table(TABLE_NAME)  # Volume registry
@@ -173,7 +211,7 @@ def handle_instance_launch(event: dict[str, Any]) -> dict[str, Any]:
       logger.info(f"Claimed existing SEC volume {volume_id} for shared repository")
       try:
         # Preserve the SEC database in the volume's database list
-        return attach_and_register_volume(volume_id, instance_id, ["sec"])
+        return attach_and_register_volume(volume_id, instance_id, ["sec"], tier=tier)
       except Exception:
         release_claim(volume_id, instance_id)
         raise
@@ -235,7 +273,9 @@ def handle_instance_launch(event: dict[str, Any]) -> dict[str, Any]:
           f"Claimed volume {volume_id} with databases: {volume.get('databases')} in AZ {az}"
         )
         try:
-          return attach_and_register_volume(volume_id, instance_id, volume_databases)
+          return attach_and_register_volume(
+            volume_id, instance_id, volume_databases, tier=tier
+          )
         except Exception:
           # Put it back so the next launch can use it; the instance still fails,
           # which is the pre-existing behaviour for a genuine attach failure.
@@ -538,10 +578,84 @@ def ordered_volume_candidates(
   return matching + with_data + empty
 
 
+def reconcile_volume_performance(volume_id: str, tier: str) -> dict[str, Any]:
+  """Raise an existing gp3 volume to its tier's IOPS/throughput floor.
+
+  A modify_volume on gp3 is online (the volume stays usable while EBS
+  optimizes it), so this runs on the attach path without blocking anything.
+  It only ever raises: a volume already at or above spec is left alone, and a
+  hand-raised volume is never clamped back down. Every failure is logged and
+  swallowed - the attach must never fail because a performance tweak could
+  not be applied; the next launch simply retries.
+  """
+  spec = volume_spec_for_tier(tier)
+  try:
+    volume = ec2.describe_volumes(VolumeIds=[volume_id])["Volumes"][0]
+  except (ClientError, IndexError, KeyError) as e:
+    logger.warning(f"Could not describe {volume_id} for performance reconcile: {e}")
+    return {"reconciled": False, "reason": "describe_failed"}
+
+  if volume.get("VolumeType") != DEFAULT_TYPE:
+    # Only gp3 provisions IOPS/throughput independently of size.
+    return {"reconciled": False, "reason": f"volume_type_{volume.get('VolumeType')}"}
+
+  current_iops = int(volume.get("Iops") or 0)
+  current_throughput = int(volume.get("Throughput") or 0)
+  target: dict[str, int] = {}
+  if current_iops < spec["iops"]:
+    target["Iops"] = spec["iops"]
+  if current_throughput < spec["throughput"]:
+    target["Throughput"] = spec["throughput"]
+  if not target:
+    return {"reconciled": False, "reason": "at_or_above_spec"}
+
+  try:
+    response = ec2.modify_volume(VolumeId=volume_id, **target)
+  except ClientError as e:
+    code = e.response.get("Error", {}).get("Code", "")
+    # IncorrectModificationState: another modification is still in flight
+    # (a size expansion from the volume monitor, or an earlier change inside
+    # EBS's six-hour cooldown). Nothing to do but try again next launch.
+    logger.warning(
+      f"Performance reconcile for {volume_id} ({tier}) deferred: {code or e}"
+    )
+    return {"reconciled": False, "reason": code or "modify_failed"}
+
+  state = response.get("VolumeModification", {}).get("ModificationState")
+  logger.info(
+    f"Raised {volume_id} ({tier}) to spec {target} from "
+    f"iops={current_iops} throughput={current_throughput} (state={state})"
+  )
+  try:
+    table.update_item(
+      Key={"volume_id": volume_id},
+      UpdateExpression=(
+        "SET iops = :iops, #throughput = :throughput, "
+        "last_performance_reconcile = :timestamp"
+      ),
+      # `throughput` is a DynamoDB reserved word.
+      ExpressionAttributeNames={"#throughput": "throughput"},
+      ExpressionAttributeValues={
+        ":iops": target.get("Iops", current_iops),
+        ":throughput": target.get("Throughput", current_throughput),
+        ":timestamp": datetime.now(UTC).isoformat(),
+      },
+    )
+  except ClientError as e:
+    logger.warning(f"Could not record performance reconcile for {volume_id}: {e}")
+
+  return {"reconciled": True, "modification_state": state, **target}
+
+
 def attach_and_register_volume(
-  volume_id: str, instance_id: str, databases: Any
+  volume_id: str, instance_id: str, databases: Any, tier: str | None = None
 ) -> dict[str, Any]:
-  """Attach a volume to an instance and update registry"""
+  """Attach a volume to an instance and update registry.
+
+  When ``tier`` is given the volume is first raised to that tier's performance
+  floor (see reconcile_volume_performance) - this is the hook that lets an
+  existing, long-lived volume pick up a spec change without being recreated.
+  """
   device = "/dev/xvdf"
 
   # Wait for instance to be running
@@ -569,6 +683,9 @@ def attach_and_register_volume(
     logger.warning(
       f"Volume {volume_id} did not reach available in 2 min: {e}; will attempt attach"
     )
+
+  if tier:
+    reconcile_volume_performance(volume_id, tier)
 
   # Attach the volume with retry logic.
   # Retry both IncorrectState (instance not ready) and VolumeInUse (volume still
@@ -667,24 +784,8 @@ def attach_and_register_volume(
 def create_and_attach_volume(
   instance_id: str, tier: str, az: str, databases: list[str], node_type: str
 ) -> dict[str, Any]:
-  """Create a new volume and attach it to the instance"""
-  # Initial volume sizes. These are starting points, not caps: the volume
-  # monitor expands at 80% usage every 15 minutes, and EBS volumes can grow
-  # but never shrink - so provisioning small and growing on demand costs
-  # strictly less than provisioning for a ceiling most graphs never reach.
-  # The product cap is enforced separately by instance_storage_limit_gb in
-  # .github/configs/graph.yml (20/50/100 GB); these do not need to match it,
-  # since expansion at 80% fires before the write-path cap is reached.
-  # gp3's 3000 IOPS / 125 MBps baseline is size-independent, so a smaller
-  # volume carries no performance penalty.
-  tier_config = {
-    "ladybug-standard": {"size": 20, "iops": 3000},
-    "ladybug-large": {"size": 50, "iops": 3000},
-    "ladybug-xlarge": {"size": 50, "iops": 3000},
-    "ladybug-shared": {"size": 200, "iops": 3000},
-  }
-
-  config = tier_config.get(tier, {"size": DEFAULT_SIZE, "iops": DEFAULT_IOPS})
+  """Create a new volume to the tier's spec and attach it to the instance"""
+  config = volume_spec_for_tier(tier)
 
   # Determine volume name based on node type
   if node_type in ["shared_master", "shared_replica"]:
@@ -698,7 +799,7 @@ def create_and_attach_volume(
     Size=config["size"],
     VolumeType=DEFAULT_TYPE,
     Iops=config["iops"],
-    Throughput=DEFAULT_THROUGHPUT,
+    Throughput=config["throughput"],
     Encrypted=True,
     TagSpecifications=[
       {
@@ -734,6 +835,8 @@ def create_and_attach_volume(
       "databases": databases,
       "created_at": datetime.now(UTC).isoformat(),
       "node_type": node_type,
+      "iops": config["iops"],
+      "throughput": config["throughput"],
     }
   )
 

--- a/tests/lambda/test_graph_volume_manager.py
+++ b/tests/lambda/test_graph_volume_manager.py
@@ -931,3 +931,156 @@ def test_sync_registry_still_corrects_genuine_mismatches(gvm):
   item = _registry_item(volume_id)
   assert item["status"] == "available"
   assert item["instance_id"] == "unattached"
+
+
+# ---------------------------------------------------------------------------
+# Volume performance spec: created to spec, and existing volumes raised to the
+# tier floor on every attach (a volume outlives many instances, so a creation-
+# time setting alone would never reach the long-lived shared master volume).
+# ---------------------------------------------------------------------------
+
+
+def _volume_perf(volume_id: str) -> tuple[int, int]:
+  ec2 = boto3.client("ec2", region_name="us-east-1")
+  vol = ec2.describe_volumes(VolumeIds=[volume_id])["Volumes"][0]
+  return vol["Iops"], vol["Throughput"]
+
+
+def _create_test_volume_with_perf(iops: int, throughput: int) -> str:
+  ec2 = boto3.client("ec2", region_name="us-east-1")
+  resp = ec2.create_volume(
+    AvailabilityZone="us-east-1c",
+    Size=200,
+    VolumeType="gp3",
+    Iops=iops,
+    Throughput=throughput,
+    Encrypted=True,
+  )
+  return resp["VolumeId"]
+
+
+def test_reconcile_raises_shared_volume_to_tier_floor(gvm):
+  volume_id = _create_test_volume_with_perf(3000, 125)
+  _seed_sec_volume(volume_id)
+
+  result = gvm.reconcile_volume_performance(volume_id, "ladybug-shared")
+
+  spec = gvm.TIER_VOLUME_SPEC["ladybug-shared"]
+  assert result["reconciled"] is True
+  assert _volume_perf(volume_id) == (spec["iops"], spec["throughput"])
+  item = _registry_item(volume_id)
+  assert int(item["iops"]) == spec["iops"]
+  assert int(item["throughput"]) == spec["throughput"]
+  assert "last_performance_reconcile" in item
+
+
+def test_reconcile_never_lowers_a_volume_above_spec(gvm):
+  """The spec is a floor: a hand-raised volume must not be clamped down."""
+  volume_id = _create_test_volume_with_perf(16000, 1000)
+  _seed_sec_volume(volume_id)
+
+  result = gvm.reconcile_volume_performance(volume_id, "ladybug-shared")
+
+  assert result == {"reconciled": False, "reason": "at_or_above_spec"}
+  assert _volume_perf(volume_id) == (16000, 1000)
+
+
+def test_reconcile_is_a_noop_for_baseline_tiers(gvm):
+  volume_id = _create_test_volume_with_perf(3000, 125)
+  _seed_registry("test-volume-registry", volume_id, ["kg_a"], tier="ladybug-standard")
+
+  result = gvm.reconcile_volume_performance(volume_id, "ladybug-standard")
+
+  assert result["reason"] == "at_or_above_spec"
+  assert _volume_perf(volume_id) == (3000, 125)
+
+
+def test_reconcile_defers_when_a_modification_is_in_flight(gvm):
+  """EBS refuses overlapping modifications (a size expansion, or the six-hour
+  cooldown after an earlier change). The reconcile must log and step aside,
+  never raise into the attach path."""
+  volume_id = _create_test_volume_with_perf(3000, 125)
+  _seed_sec_volume(volume_id)
+  err = ClientError(
+    {"Error": {"Code": "IncorrectModificationState", "Message": "in progress"}},
+    "ModifyVolume",
+  )
+
+  with patch.object(gvm.ec2, "modify_volume", side_effect=err):
+    result = gvm.reconcile_volume_performance(volume_id, "ladybug-shared")
+
+  assert result == {"reconciled": False, "reason": "IncorrectModificationState"}
+  assert _volume_perf(volume_id) == (3000, 125)
+
+
+def test_shared_master_launch_raises_existing_sec_volume_on_attach(gvm):
+  """The real target: the persistent SEC volume, minted at baseline long ago,
+  is raised to the current floor when the master next wakes and reattaches."""
+  instance_id = _create_test_instance()
+  volume_id = _create_test_volume_with_perf(3000, 125)
+  _seed_sec_volume(volume_id)
+
+  result = gvm.handle_instance_launch(
+    {"instance_id": instance_id, "node_type": "shared_master", "tier": "ladybug-shared"}
+  )
+
+  spec = gvm.TIER_VOLUME_SPEC["ladybug-shared"]
+  assert result["statusCode"] == 200
+  assert result["volume_id"] == volume_id
+  assert _volume_perf(volume_id) == (spec["iops"], spec["throughput"])
+  assert _registry_item(volume_id)["status"] == "attached"
+
+
+def test_shared_master_launch_still_attaches_when_reconcile_is_deferred(gvm):
+  instance_id = _create_test_instance()
+  volume_id = _create_test_volume_with_perf(3000, 125)
+  _seed_sec_volume(volume_id)
+  err = ClientError(
+    {"Error": {"Code": "IncorrectModificationState", "Message": "in progress"}},
+    "ModifyVolume",
+  )
+
+  with patch.object(gvm.ec2, "modify_volume", side_effect=err):
+    result = gvm.handle_instance_launch(
+      {
+        "instance_id": instance_id,
+        "node_type": "shared_master",
+        "tier": "ladybug-shared",
+      }
+    )
+
+  assert result["statusCode"] == 200
+  assert result["volume_id"] == volume_id
+  assert _registry_item(volume_id)["status"] == "attached"
+  assert _volume_perf(volume_id) == (3000, 125)
+
+
+def test_new_shared_volume_is_created_to_spec(gvm):
+  instance_id = _create_test_instance()
+
+  result = gvm.handle_instance_launch(
+    {"instance_id": instance_id, "node_type": "shared_master", "tier": "ladybug-shared"}
+  )
+
+  spec = gvm.TIER_VOLUME_SPEC["ladybug-shared"]
+  assert result["statusCode"] == 200
+  assert _volume_perf(result["volume_id"]) == (spec["iops"], spec["throughput"])
+  item = _registry_item(result["volume_id"])
+  assert int(item["iops"]) == spec["iops"]
+  assert int(item["throughput"]) == spec["throughput"]
+
+
+def test_new_writer_volume_stays_at_baseline(gvm):
+  instance_id = _create_test_instance()
+
+  result = gvm.handle_instance_launch(
+    {
+      "instance_id": instance_id,
+      "node_type": "writer",
+      "tier": "ladybug-standard",
+      "databases": ["kg_new"],
+    }
+  )
+
+  assert result["statusCode"] == 200
+  assert _volume_perf(result["volume_id"]) == (3000, 125)


### PR DESCRIPTION
## Summary
- The graph data volume is created by the volume-manager Lambda from a hardcoded tier config that is consulted only at `create_volume` time — a stack update never reaches an existing volume, and the shared master's volume is persistent and reattached on every nightly wake. Until now a spec change could only take effect by hand or by recreating the volume.
- Lifts the tier config to a module-level `TIER_VOLUME_SPEC` (size + iops + throughput), creates new volumes to it, and adds `reconcile_volume_performance`, called on the attach path: raises an existing gp3 volume to the tier's floor via the same in-place `modify_volume` mechanism `expand_volume` already uses. It only ever raises (a hand-raised volume is never clamped down), never blocks the attach, and logs-and-defers when EBS has a modification in flight (size expansion / 6h cooldown). The registry item records `iops` / `throughput` / `last_performance_reconcile`.
- `ladybug-shared` moves to **12000 IOPS / 500 MB/s** (~+$60/mo). The SEC nightly full rebuild's relationship-table COPYs were bound by small random reads on the 3000-IOPS baseline (data volume 78–93 % busy at ~20 MB/s, iowait 42–53 %, 6.4h rebuild). This was applied by hand to the prod volume on 2026-08-19 as an A/B: the same tables ran ~2.4× faster (Association node 29→10 min, STRUCTURE_HAS_ASSOCIATION 81→34 min, ASSOCIATION_HAS_FROM_ELEMENT 65→27 min). This PR makes that config-owned so a recreated volume can't silently regress. Writer tiers stay at baseline.

## Test plan
- [x] `uv run pytest tests/lambda/test_graph_volume_manager.py` — 39 passed (8 new: raise-to-floor, never-lower, baseline no-op, deferred-on-in-flight-modification, launch raises existing SEC volume, launch still attaches when deferred, new shared volume created to spec, writer volume stays at baseline)
- [x] ruff / format / basedpyright clean
- [ ] After deploy: on the next master wake, the Lambda log shows either `Raised vol-… (ladybug-shared) …` or nothing (volume already at spec from the manual change) and the registry item carries `iops=12000`, `throughput=500`