### PR TITLE
fix(security): pre-onboarding hardening — OLTP statement ceiling, GraphQL off-loop, read-path audit, async op lifecycle

### DIFF
--- a/examples/_scenario/reset.py
+++ b/examples/_scenario/reset.py
@@ -51,7 +51,7 @@ def reset_demo_state(graph_id: str) -> None:
 
   assert_local_extensions_db()
 
-  with extensions_session(graph_id) as session:
+  with extensions_session(graph_id, statement_timeout_ms=None) as session:
     # 1-3. All entries + line items + transactions (tenant-generated;
     # the library itself never authors these). Dimension tables
     # FK back to their parent rows so wipe them first.

--- a/examples/roboinvestor_demo/_reset.py
+++ b/examples/roboinvestor_demo/_reset.py
@@ -40,7 +40,7 @@ def reset_investor_state(graph_id: str) -> None:
 
   assert_local_extensions_db()
 
-  with extensions_session(graph_id) as session:
+  with extensions_session(graph_id, statement_timeout_ms=None) as session:
     # Positions FK both portfolios and securities, so they go first.
     session.execute(text("DELETE FROM positions"))
     session.execute(text("DELETE FROM portfolios"))
@@ -105,7 +105,7 @@ def reset_issuer_share_state(graph_id: str) -> None:
 
   assert_local_extensions_db()
 
-  with extensions_session(graph_id) as session:
+  with extensions_session(graph_id, statement_timeout_ms=None) as session:
     session.execute(text("DELETE FROM report_shares"))
     session.execute(text("DELETE FROM publish_list_members"))
     session.execute(text("DELETE FROM publish_lists"))

--- a/examples/roboledger_demo/_reset.py
+++ b/examples/roboledger_demo/_reset.py
@@ -54,7 +54,7 @@ def reset_demo_state(graph_id: str) -> None:
 
   assert_local_extensions_db()
 
-  with extensions_session(graph_id) as session:
+  with extensions_session(graph_id, statement_timeout_ms=None) as session:
     # 1-3. All entries + line items + transactions (tenant-generated;
     # the library itself never authors these). Dimension tables
     # FK back to their parent rows so wipe them first.

--- a/robosystems/adapters/quickbooks/pipeline/load.py
+++ b/robosystems/adapters/quickbooks/pipeline/load.py
@@ -362,7 +362,7 @@ def _bootstrap_fiscal_calendar_if_needed(
 
   try:
     service = FiscalCalendarService()
-    with extensions_session(config.graph_id) as session:
+    with extensions_session(config.graph_id, statement_timeout_ms=None) as session:
       existing = service.get(session, config.graph_id)
       if existing is not None and existing.initialized_at is not None:
         # Self-heal: earlier bootstrap revisions seeded the calendar pointer
@@ -453,7 +453,7 @@ def _trigger_auto_map_if_needed(
 
   mapping_id: str | None = None
   try:
-    with extensions_session(config.graph_id) as session:
+    with extensions_session(config.graph_id, statement_timeout_ms=None) as session:
       structure = (
         session.query(Structure)
         .filter(

--- a/robosystems/config/constants.py
+++ b/robosystems/config/constants.py
@@ -39,6 +39,15 @@ PRESIGNED_URL_EXPIRY_SECONDS = 3600  # 1 hour
 # Files above this size use Dagster for async processing with progress tracking
 SMALL_FILE_STAGING_THRESHOLD_MB = 50  # 50MB
 
+# Platform-wide ceiling on rows in a single uploaded file, checked at ingest
+# from the measured (or estimated) row count. Equal to the largest tier's
+# `max_single_table_rows` in .github/configs/graph.yml — no tier can materialize
+# a table bigger than this, so a file above it is refused before it burns
+# storage. Smaller tiers are capped tighter by their own `max_single_table_rows`
+# at ingest as well; this is the bound that holds even for a hostile parquet
+# footer that declares an absurd row count against a 100 MB object.
+MAX_ROWS_PER_FILE = 100_000_000
+
 # Row Count Estimation Fallback (bytes per row for different formats)
 FALLBACK_BYTES_PER_ROW_PARQUET = 50  # Compressed format
 FALLBACK_BYTES_PER_ROW_CSV = 200  # Text format with moderate row size

--- a/robosystems/config/defaults.py
+++ b/robosystems/config/defaults.py
@@ -39,6 +39,11 @@ class DatabaseDefaults:
   # instance size.
   EXTENSIONS_POOL_SIZE = 5
   EXTENSIONS_MAX_OVERFLOW = 10
+  # Per-statement ceiling for interactive extensions sessions (request-scoped
+  # reads and command writes). The pool is shared by every tenant, so a
+  # statement that runs unbounded holds a shared connection for everyone;
+  # bulk paths (loader syncs, migrations, backfills) opt out explicitly.
+  EXTENSIONS_STATEMENT_TIMEOUT_MS = 30_000
 
 
 class CacheDefaults:
@@ -273,4 +278,7 @@ SSM_TUNING_PATHS = {
   "database/POOL_RECYCLE": DatabaseDefaults.POOL_RECYCLE,
   "database/EXTENSIONS_POOL_SIZE": DatabaseDefaults.EXTENSIONS_POOL_SIZE,
   "database/EXTENSIONS_MAX_OVERFLOW": DatabaseDefaults.EXTENSIONS_MAX_OVERFLOW,
+  "database/EXTENSIONS_STATEMENT_TIMEOUT_MS": (
+    DatabaseDefaults.EXTENSIONS_STATEMENT_TIMEOUT_MS
+  ),
 }

--- a/robosystems/config/graph_tier.py
+++ b/robosystems/config/graph_tier.py
@@ -266,14 +266,12 @@ class GraphTierConfig:
 
     ``max_file_size_gb`` is **derived from the enforced constant, not read from
     graph.yml**, and is therefore the same for every tier. Upload size is not a
-    tier-scoped product limit: ``ingest_file_cmd`` reads the whole object into
-    memory to count rows, and it does that in the shared API container, so the
-    ceiling is bounded by that container rather than by the tenant's graph
-    instance. Publishing a per-tier figure here previously advertised up to
-    10 GB against a flat 100 MB rejection.
-
-    Raising this means making the row-count path stream; until then the
-    published number tracks the one the write path actually enforces.
+    tier-scoped product limit: ``ingest_file_cmd`` counts rows in the shared
+    API container (footer-only for parquet, streamed for CSV/JSON, off the
+    event loop), so the ceiling is bounded by that container and the S3 round
+    trip rather than by the tenant's graph instance. Publishing a per-tier
+    figure here previously advertised up to 10 GB against a flat 100 MB
+    rejection; the published number tracks the one the write path enforces.
     """
     tier_config = cls.get_tier_config(tier, environment)
     default_limits = {

--- a/robosystems/config/tuning.py
+++ b/robosystems/config/tuning.py
@@ -360,6 +360,14 @@ class TuningConfig:
     )
 
   @classmethod
+  def get_extensions_statement_timeout_ms(cls) -> int:
+    """Per-statement ceiling (ms) for interactive extensions sessions; 0 = none."""
+    return cls.get_int(
+      "database/EXTENSIONS_STATEMENT_TIMEOUT_MS",
+      DatabaseDefaults.EXTENSIONS_STATEMENT_TIMEOUT_MS,
+    )
+
+  @classmethod
   def get_database_pool_timeout(cls) -> int:
     """Get seconds to wait for a connection from the pool."""
     return cls.get_int("database/POOL_TIMEOUT", DatabaseDefaults.POOL_TIMEOUT)

--- a/robosystems/dagster/jobs/extensions.py
+++ b/robosystems/dagster/jobs/extensions.py
@@ -194,7 +194,15 @@ def materialize_extensions_to_graph(
   description="Materialize extensions OLTP data to LadybugDB graph",
 )
 def extensions_materialize_job():
-  """Materialize all extension data from PostgreSQL OLTP to LadybugDB graph."""
+  """Materialize all extension data from PostgreSQL OLTP to LadybugDB graph.
+
+  The per-graph ``materialize_db`` concurrency tag cannot be a job-level tag
+  here (the graph is run config, not a constant like ``sec``), so every
+  launcher must set ``materialize_db=<graph_id>`` on the run — the staleness
+  sensor does; a manual Dagster UI launch should add it too. The per-graph
+  Valkey lock inside ``ExtensionsMaterializer`` is the hard backstop either
+  way; the tag turns a would-be lock refusal into a queued run.
+  """
   materialize_extensions_to_graph()
 
 
@@ -239,7 +247,7 @@ def promote_obligations_for_graph(
     f"dispatch={config.dispatch_handlers})"
   )
 
-  with extensions_session(graph_id) as session:
+  with extensions_session(graph_id, statement_timeout_ms=None) as session:
     result = promote_pending_obligations(
       session,
       graph_id,

--- a/robosystems/dagster/sensors/materialization.py
+++ b/robosystems/dagster/sensors/materialization.py
@@ -126,7 +126,17 @@ def stale_graph_materialization_sensor(context: SensorEvaluationContext):
               }
             }
           },
-          tags={"graph_id": graph_id, "trigger": "stale_sensor"},
+          # materialize_db is the key dagster.yaml's tag_concurrency_limits
+          # serializes on (limit 1 per unique value): two runs COPYing into the
+          # same tenant graph would interleave writes into rel tables that have
+          # no primary key. Queuing the duplicate makes the worst case a
+          # redundant run rather than duplicate edges. sec_materialize carries
+          # the same key as a job-level tag; tenant runs must set it per graph.
+          tags={
+            "graph_id": graph_id,
+            "trigger": "stale_sensor",
+            "materialize_db": graph_id,
+          },
         )
       )
       new_cursor[graph_id] = now.isoformat()

--- a/robosystems/dagster/sensors/scheduled_obligation_promoter.py
+++ b/robosystems/dagster/sensors/scheduled_obligation_promoter.py
@@ -66,7 +66,7 @@ def _has_matured_pending_obligations(graph_id: str, as_of: datetime) -> bool:
   schedule_entry_due event has matured by `as_of`.
   """
   try:
-    with extensions_session(graph_id) as session:
+    with extensions_session(graph_id, statement_timeout_ms=None) as session:
       count = (
         session.query(Event)
         .filter(

--- a/robosystems/dagster/sensors/worker_reaper.py
+++ b/robosystems/dagster/sensors/worker_reaper.py
@@ -186,25 +186,45 @@ def worker_inflight_reaper_sensor(context: SensorEvaluationContext):
 
 
 def _fail_operation_sync(sse_client: Any, task_id: str, attempts: int) -> None:
-  """Mark an SSE operation as failed by updating its metadata directly."""
-  meta_key = f"{SSE_META_PREFIX}{task_id}"
-  meta_json = sse_client.get(meta_key)
-  if not meta_json:
-    return
+  """Mark an SSE operation as failed by updating its metadata directly.
 
+  Compare-and-set on the metadata key: the sensor's staleness decision was
+  made from a snapshot taken earlier in the tick, and a worker can finish
+  the task in between. A terminal status already written by the worker —
+  ``completed`` above all — wins; this only ever moves ``pending`` /
+  ``running`` to ``failed``, and only when it does so does it evict the
+  cached idempotency envelope (this path writes the status directly rather
+  than through the SSE store, so the store's own eviction hook does not
+  run). Without the guard a DLQ'd-but-actually-finished backup would show
+  as failed and become re-dispatchable under its Idempotency-Key.
+  """
+  meta_key = f"{SSE_META_PREFIX}{task_id}"
   try:
-    meta = json.loads(meta_json)
-    meta["status"] = "failed"
-    meta["updated_at"] = datetime.now(UTC).isoformat()
-    sse_client.set(meta_key, json.dumps(meta), keepttl=True)
-  except (json.JSONDecodeError, Exception) as e:
+    with sse_client.pipeline() as pipe:
+      pipe.watch(meta_key)
+      meta_json = pipe.get(meta_key)
+      if not meta_json:
+        pipe.unwatch()
+        return
+      meta = json.loads(meta_json)
+      if meta.get("status") not in ("pending", "running"):
+        pipe.unwatch()
+        logger.info(
+          f"Reaper left {task_id} alone: already terminal "
+          f"({meta.get('status')}) by the time the DLQ decision landed"
+        )
+        return
+      meta["status"] = "failed"
+      meta["updated_at"] = datetime.now(UTC).isoformat()
+      pipe.multi()
+      pipe.set(meta_key, json.dumps(meta), keepttl=True)
+      pipe.execute()
+  except Exception as e:
+    # A WatchError here means the worker wrote first; either way nothing
+    # was changed by us, so there is nothing to evict.
     logger.warning(f"Failed to update SSE metadata for {task_id}: {e}")
     return
 
-  # This writes the terminal status directly rather than through the SSE
-  # store, so the store's own eviction hook does not run: evict the cached
-  # idempotency envelope here too, or the DLQ'd operation replays `pending`
-  # under its Idempotency-Key for the rest of the day.
   from robosystems.middleware.operations import invalidate_operation_idempotency_sync
 
   invalidate_operation_idempotency_sync(task_id)

--- a/robosystems/dagster/sensors/worker_reaper.py
+++ b/robosystems/dagster/sensors/worker_reaper.py
@@ -199,3 +199,12 @@ def _fail_operation_sync(sse_client: Any, task_id: str, attempts: int) -> None:
     sse_client.set(meta_key, json.dumps(meta), keepttl=True)
   except (json.JSONDecodeError, Exception) as e:
     logger.warning(f"Failed to update SSE metadata for {task_id}: {e}")
+    return
+
+  # This writes the terminal status directly rather than through the SSE
+  # store, so the store's own eviction hook does not run: evict the cached
+  # idempotency envelope here too, or the DLQ'd operation replays `pending`
+  # under its Idempotency-Key for the rest of the day.
+  from robosystems.middleware.operations import invalidate_operation_idempotency_sync
+
+  invalidate_operation_idempotency_sync(task_id)

--- a/robosystems/db/extensions.py
+++ b/robosystems/db/extensions.py
@@ -172,7 +172,11 @@ def _search_path_for(graph_id: str) -> str:
   return f"{_sanitize_schema(graph_id)}, public"
 
 
-def _bind_statement(search_path: str, tenant_schema: str | None) -> str:
+def _bind_statement(
+  search_path: str,
+  tenant_schema: str | None,
+  statement_timeout_ms: int | None = None,
+) -> str:
   """The SQL that binds one transaction to ``search_path``.
 
   For a tenant, the bind is guarded: PostgreSQL accepts a ``search_path``
@@ -186,25 +190,37 @@ def _bind_statement(search_path: str, tenant_schema: str | None) -> str:
   the ``SET LOCAL``, and its absence raises ``invalid_schema_name``
   (``3F000``): the same failure a genuinely missing schema produces, which
   the surfaces already translate to "not initialized" (404).
+
+  ``statement_timeout_ms`` adds a ``SET LOCAL statement_timeout`` ahead of
+  the guard, so every statement in the transaction — the guard included —
+  is bounded. Also ``LOCAL``: it ends with the transaction and is never left
+  on the pooled connection.
   """
-  set_local = f"SET LOCAL search_path TO {search_path}"
-  if tenant_schema is None:
-    return set_local
-  # Validated here as well as by the caller: this is the interpolation, and
-  # the guarantee should not depend on statement order in `extensions_session`.
-  tenant_schema = _sanitize_schema(tenant_schema)
-  return (
-    "DO $$ BEGIN "
-    f"IF to_regnamespace('{tenant_schema}') IS NULL THEN "
-    f"RAISE EXCEPTION 'tenant schema \"{tenant_schema}\" does not exist' "
-    "USING ERRCODE = '3F000'; "
-    "END IF; END $$; "
-    f"{set_local}"
-  )
+  statements: list[str] = []
+  if statement_timeout_ms:
+    statements.append(f"SET LOCAL statement_timeout = {int(statement_timeout_ms)}")
+  if tenant_schema is not None:
+    # Validated here as well as by the caller: this is the interpolation, and
+    # the guarantee should not depend on statement order in
+    # `extensions_session`.
+    tenant_schema = _sanitize_schema(tenant_schema)
+    statements.append(
+      "DO $$ BEGIN "
+      f"IF to_regnamespace('{tenant_schema}') IS NULL THEN "
+      f"RAISE EXCEPTION 'tenant schema \"{tenant_schema}\" does not exist' "
+      "USING ERRCODE = '3F000'; "
+      "END IF; END $$"
+    )
+  statements.append(f"SET LOCAL search_path TO {search_path}")
+  return "; ".join(statements)
 
 
 def bind_search_path(
-  session: Session, search_path: str, *, tenant_schema: str | None = None
+  session: Session,
+  search_path: str,
+  *,
+  tenant_schema: str | None = None,
+  statement_timeout_ms: int | None = None,
 ) -> None:
   """Bind ``session`` to ``search_path`` for every transaction it opens.
 
@@ -226,8 +242,13 @@ def bind_search_path(
   begin a transaction on a schema that does not exist — see
   :func:`_bind_statement` for why falling through to ``public`` is the
   failure being prevented.
+
+  ``statement_timeout_ms`` bounds every statement the session runs, per
+  transaction and per statement (a session that commits mid-flow and keeps
+  going gets the bound re-applied with the bind). ``None`` leaves the
+  server default in force.
   """
-  stmt = text(_bind_statement(search_path, tenant_schema))
+  stmt = text(_bind_statement(search_path, tenant_schema, statement_timeout_ms))
 
   @event.listens_for(session, "after_begin")
   def _stamp(_session: Session, transaction: SessionTransaction, connection) -> None:
@@ -236,8 +257,28 @@ def bind_search_path(
     connection.execute(stmt)
 
 
+# Sentinel default for `extensions_session(statement_timeout_ms=...)`: resolve
+# the interactive ceiling from tuning at open time. Distinct from `None`,
+# which is the explicit opt-out for bulk work.
+_INTERACTIVE_TIMEOUT = -1
+
+
+def interactive_statement_timeout_ms() -> int | None:
+  """The per-statement ceiling an interactive extensions session runs under.
+
+  Read from tuning on every call (the tuning layer caches), so an SSM change
+  reaches new sessions without a restart. ``0`` disables the ceiling.
+  """
+  from robosystems.config.tuning import TuningConfig
+
+  timeout_ms = TuningConfig.get_extensions_statement_timeout_ms()
+  return timeout_ms if timeout_ms > 0 else None
+
+
 @contextmanager
-def extensions_session(graph_id: str):
+def extensions_session(
+  graph_id: str, *, statement_timeout_ms: int | None = _INTERACTIVE_TIMEOUT
+):
   """Context manager providing a schema-scoped session for a tenant.
 
   Binds the session's search_path to '{graph_id}, public' so tenant tables
@@ -247,6 +288,18 @@ def extensions_session(graph_id: str):
   The bind is fail-closed: a graph whose schema does not exist (never
   provisioned, or already torn down) raises ``invalid_schema_name`` on the
   session's first statement instead of falling through to ``public``.
+
+  Every statement is bounded by a ``statement_timeout``. The engine's pool
+  is one pool for every tenant, and a statement left to run unbounded holds
+  a shared connection for the duration — a legal-but-expensive aggregate on
+  one tenant's data becomes every other tenant's queue-pool wait. The
+  default is the interactive ceiling (`interactive_statement_timeout_ms`,
+  SSM-tunable, 30s); a bulk path whose single statements legitimately run
+  longer — a loader's full sync, a migration-time backfill — passes
+  ``statement_timeout_ms=None`` to opt out, or a larger explicit value. The
+  ceiling is per statement, not per session: a command that commits between
+  steps and continues is not cut short by it. A cancelled statement raises
+  ``OperationalError`` with SQLSTATE ``57014``; see `is_statement_timeout`.
 
   Special case: `graph_id="library"` routes to the taxonomy library
   (read-only; library content currently lives in the `public` schema,
@@ -269,8 +322,15 @@ def extensions_session(graph_id: str):
   """
   search_path = _search_path_for(graph_id)
   tenant_schema = None if graph_id == LIBRARY_GRAPH_ID else graph_id
+  if statement_timeout_ms == _INTERACTIVE_TIMEOUT:
+    statement_timeout_ms = interactive_statement_timeout_ms()
   session: Session = _get_session_factory()()
-  bind_search_path(session, search_path, tenant_schema=tenant_schema)
+  bind_search_path(
+    session,
+    search_path,
+    tenant_schema=tenant_schema,
+    statement_timeout_ms=statement_timeout_ms,
+  )
   try:
     yield session
     session.commit()
@@ -279,6 +339,22 @@ def extensions_session(graph_id: str):
     raise
   finally:
     session.close()
+
+
+STATEMENT_TIMEOUT_SQLSTATE = "57014"
+
+
+def is_statement_timeout(exc: BaseException) -> bool:
+  """Whether ``exc`` is PostgreSQL cancelling a statement for exceeding
+  ``statement_timeout`` (SQLSTATE ``57014``, ``query_canceled``) — the
+  failure an interactive session's ceiling produces. Surfaces translate it
+  to a timeout the client can act on rather than a generic database fault.
+  """
+  from sqlalchemy.exc import DBAPIError
+
+  if not isinstance(exc, DBAPIError):
+    return False
+  return getattr(exc.orig, "pgcode", None) == STATEMENT_TIMEOUT_SQLSTATE
 
 
 _LIBRARY_IMMUTABLE_TABLES = (

--- a/robosystems/graph_api/core/ladybug/materialization_lock.py
+++ b/robosystems/graph_api/core/ladybug/materialization_lock.py
@@ -9,6 +9,8 @@ Key design:
 - 1-hour TTL: safety net for crashed processes
 - 5s acquire timeout: fail fast if another materialization is running
 - Compare-and-delete via Lua: prevents releasing a lock re-acquired by another process
+- Compare-and-extend via Lua: long runs refresh the TTL at checkpoints, and learn
+  when the lock has lapsed under them instead of continuing to the swap
 - Lock passthrough: callers pass token via X-Materialization-Lock-Token header
 """
 
@@ -33,6 +35,17 @@ DEFAULT_ACQUIRE_TIMEOUT_SECONDS = 5
 _RELEASE_SCRIPT = """
 if redis.call("get", KEYS[1]) == ARGV[1] then
     return redis.call("del", KEYS[1])
+else
+    return 0
+end
+"""
+
+# Lua script for atomic compare-and-extend
+# Only refreshes the TTL if the value matches (a lapsed lock re-acquired by
+# another process must not be extended by its previous holder)
+_EXTEND_SCRIPT = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("expire", KEYS[1], ARGV[2])
 else
     return 0
 end
@@ -65,6 +78,10 @@ class MaterializationLock:
     self.ttl_seconds = ttl_seconds
     self.token = str(uuid.uuid4())
     self._acquired = False
+    # The last backend error seen by ``acquire`` (None when the final attempt
+    # reached Valkey). Lets a caller tell "held by another run" apart from
+    # "lock service unavailable" when acquire returns False.
+    self.last_backend_error: str | None = None
 
   @property
   def acquired(self) -> bool:
@@ -83,6 +100,7 @@ class MaterializationLock:
 
     deadline = time.monotonic() + timeout_seconds
     attempt = 0
+    self.last_backend_error = None
 
     while time.monotonic() < deadline:
       try:
@@ -92,11 +110,13 @@ class MaterializationLock:
           nx=True,
           ex=self.ttl_seconds,
         )
+        self.last_backend_error = None
         if result:
           self._acquired = True
           logger.info(f"Materialization lock acquired: {self.lock_key}")
           return True
       except Exception as e:
+        self.last_backend_error = str(e)
         logger.warning(f"Lock acquire attempt failed: {e}")
 
       attempt += 1
@@ -104,7 +124,46 @@ class MaterializationLock:
       if wait > 0:
         await asyncio.sleep(wait)
 
-    logger.info(f"Materialization lock acquire timed out: {self.lock_key}")
+    if self.last_backend_error:
+      logger.warning(
+        f"Materialization lock acquire gave up on backend errors: "
+        f"{self.lock_key} ({self.last_backend_error})"
+      )
+    else:
+      logger.info(f"Materialization lock acquire timed out: {self.lock_key}")
+    return False
+
+  async def extend(self, ttl_seconds: int | None = None) -> bool:
+    """Reset the TTL to a full window, returning False if the lock is no
+    longer ours.
+
+    A materialization can outlive the TTL that was meant as a crash safety
+    net; refreshing at checkpoints keeps the lock alive for as long as the run
+    is demonstrably still making progress. A False return means the key has
+    expired or been re-acquired by another process — the caller must abort
+    rather than continue to the swap. Backend errors are raised, not swallowed:
+    the caller decides whether a blip is tolerable given the TTL still on the
+    key.
+    """
+    if not self._acquired:
+      return False
+
+    new_ttl = ttl_seconds if ttl_seconds is not None else self.ttl_seconds
+    result = await self.redis.eval(
+      _EXTEND_SCRIPT,
+      1,
+      self.lock_key,
+      self.token,
+      str(new_ttl),
+    )
+    if result == 1:
+      logger.debug(f"Materialization lock extended: {self.lock_key} ({new_ttl}s)")
+      return True
+
+    logger.warning(
+      f"Materialization lock extend failed (token mismatch or expired): {self.lock_key}"
+    )
+    self._acquired = False
     return False
 
   async def release(self) -> bool:

--- a/robosystems/graphql/README.md
+++ b/robosystems/graphql/README.md
@@ -113,6 +113,13 @@ The schema carries three Strawberry limiters, since each resolved field can open
 
 The depth limiter does not count introspection fields, so SDK codegen is unaffected. `OpenTelemetryExtensionSync` is also registered — the `Sync` variant, because the async one breaks `schema.execute_sync(...)`.
 
+Two more extensions guard execution itself (`graphql/execution.py`):
+
+- **`OffloadSyncResolvers`** — every resolver is a plain `def` that opens an OLTP session, and Strawberry runs a sync resolver inline on the event loop. The API is one uvicorn worker, so without this a slow read stalled every request on the task. User-written sync resolvers now run through `run_off_loop` (the same runner limiter the REST operations and MCP tools use); default attribute resolvers and introspection stay inline. It is a no-op when there is no running loop (`execute_sync` in tests, MCP introspection). It must be registered **after** the OpenTelemetry extension — resolve hooks compose with the last extension outermost, and the resolver span has to open inside the thread.
+- **`MaskUnexpectedErrors`** — only deliberate `GraphQLError`s (the `StrawberryGraphQLError`s with a `code`) and parse/validation errors reach `errors[]` verbatim. Anything else — a database fault, a stray Python error — is replaced with `Internal error` (`code: INTERNAL_ERROR`, plus `requestId` for log correlation); a statement cancelled by the extensions session's `statement_timeout` becomes `code: STATEMENT_TIMEOUT` with the same fixed message REST returns as 504.
+
+Every session a resolver opens runs under the interactive per-statement ceiling (`extensions_session` default; `database/EXTENSIONS_STATEMENT_TIMEOUT_MS`, 30s). See `robosystems/db/extensions.py`.
+
 ## Pagination guards
 
 Strawberry has no `Field(ge=…, le=…)` equivalent, so bounds are asserted at the resolver boundary in `resolvers/_common.py`. Pagination arguments are declared **nullable** (`Int`, not `Int! = N`) because generated SDK clients pass explicit `null` for omitted variables, and GraphQL rejects explicit null for a non-null argument even when it has a default. `resolve_pagination` defaults them and then bounds-checks:

--- a/robosystems/graphql/auth.py
+++ b/robosystems/graphql/auth.py
@@ -14,18 +14,26 @@ This mirrors the post-authentication portion of
 
 from __future__ import annotations
 
-from fastapi import HTTPException, status
+from fastapi import HTTPException, Request, status
 
 from robosystems.db.extensions import LIBRARY_GRAPH_ID
 from robosystems.models.core import User
 
 
-def check_graph_access(user: User, graph_id: str) -> None:
+def check_graph_access(
+  user: User, graph_id: str, request: Request | None = None
+) -> None:
   """Verify the authenticated user has read access to `graph_id`, else 403.
 
   Covers both shared repositories (SEC, etc.) and user graphs. The `library`
   sentinel routes to the taxonomy library, shared reference material that
   any authenticated user may read, so no per-graph ACL applies to it.
+
+  A user-graph denial is audited (`AuthorizationDenied`) the way the REST
+  and MCP gates audit theirs: an authenticated account querying graphs it
+  does not belong to is the enumeration signal the detective control is
+  for, and a bare 403 leaves no trail. Repository denials are already
+  audited inside `validate_repository_access`.
   """
   if graph_id == LIBRARY_GRAPH_ID:
     return
@@ -48,6 +56,18 @@ def check_graph_access(user: User, graph_id: str) -> None:
     has_access = _db_check_graph_access(user_id, graph_id)
 
   if not has_access:
+    if not is_shared_repository_or_subgraph(graph_id):
+      from robosystems.security import SecurityAuditLogger
+
+      SecurityAuditLogger.log_authorization_denied(
+        user_id=user_id,
+        resource=f"graph_database:{graph_id}",
+        action="read",
+        ip_address=(
+          request.client.host if request is not None and request.client else None
+        ),
+        endpoint=f"/extensions/{graph_id}/graphql",
+      )
     raise HTTPException(
       status_code=status.HTTP_403_FORBIDDEN,
       detail=f"Access denied to graph: {graph_id}",

--- a/robosystems/graphql/context.py
+++ b/robosystems/graphql/context.py
@@ -43,6 +43,7 @@ from robosystems.db.extensions import LIBRARY_GRAPH_ID
 from robosystems.graphql.auth import check_graph_access
 from robosystems.middleware.auth.dependencies import (
   API_KEY_HEADER,
+  _stash_api_key_identity,
   get_current_user,
 )
 from robosystems.middleware.auth.utils import validate_api_key_with_graph
@@ -120,6 +121,10 @@ async def get_context(
       if user is None:
         # Genuinely invalid, or a key scoped to a different graph → real 401.
         raise
+      # `get_current_user` publishes the principal on its own success path;
+      # this rescue path authenticated outside it, so publish here or the
+      # request stays unattributed downstream.
+      _stash_api_key_identity(request, api_key, user)
     else:
       # Bad/expired Bearer token → real transport-layer auth failure.
       raise
@@ -154,7 +159,7 @@ async def get_context(
   schema_extensions: tuple[str, ...] = ()
   graph_type: str = ""
   if user is not None:
-    check_graph_access(user, graph_id)
+    check_graph_access(user, graph_id, request)
     # Library sentinel — no graph row to load, no per-graph metadata.
     # The `library` extension is always "enabled" for this sentinel.
     if graph_id == LIBRARY_GRAPH_ID:

--- a/robosystems/graphql/execution.py
+++ b/robosystems/graphql/execution.py
@@ -1,0 +1,171 @@
+"""Execution-time guards for the extensions GraphQL surface.
+
+Two Strawberry schema extensions, both concerned with what one tenant's query
+can do to everyone else's — not with what it can read (that is `auth.py`).
+
+`OffloadSyncResolvers` — every resolver in `resolvers/` is a plain ``def``
+that opens an extensions OLTP session, and Strawberry executes a sync
+resolver inline on the event loop. The API runs one uvicorn worker, so an
+OLTP statement running inside a resolver stalled every request on the task
+for its duration. Resolvers now run in the runner thread pool through
+`run_off_loop` — the same limiter the REST operations and MCP tools use, so
+GraphQL reads share the pool-sized ceiling instead of sitting outside it.
+Only user-written sync resolvers are offloaded; the default attribute
+resolvers Strawberry generates for plain fields stay inline (a thread hop
+per scalar field would cost more than it saves), as does introspection.
+
+`MaskUnexpectedErrors` — a resolver exception that is not a deliberate
+GraphQL error reached the client as ``str(exc)``: for a database fault that
+string names tables, constraints, and schemas. Everything that is not a
+parse/validation error or a `GraphQLError` the code raised on purpose is
+replaced with a fixed message; a cancelled statement (the session's
+``statement_timeout``) gets its own code so a client can narrow or retry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Iterator
+from functools import partial
+from typing import Any
+
+from graphql import GraphQLError, GraphQLResolveInfo
+from strawberry.extensions import SchemaExtension
+from strawberry.extensions.utils import is_introspection_field
+from strawberry.schema.schema_converter import GraphQLCoreConverter
+
+from robosystems.db.extensions import is_statement_timeout
+from robosystems.middleware.extensions import STATEMENT_TIMEOUT_DETAIL
+
+INTERNAL_ERROR_MESSAGE = "Internal error"
+INTERNAL_ERROR_CODE = "INTERNAL_ERROR"
+STATEMENT_TIMEOUT_CODE = "STATEMENT_TIMEOUT"
+
+
+def _on_event_loop() -> bool:
+  try:
+    asyncio.get_running_loop()
+  except RuntimeError:
+    return False
+  return True
+
+
+def _is_user_sync_resolver(info: GraphQLResolveInfo) -> bool:
+  """Whether the field being resolved has a resolver someone wrote (as
+  opposed to Strawberry's default attribute getter) and it is synchronous."""
+  field = info.parent_type.fields.get(info.field_name)
+  if field is None:
+    return False
+  definition = field.extensions.get(GraphQLCoreConverter.DEFINITION_BACKREF)
+  resolver = getattr(definition, "base_resolver", None)
+  if resolver is None:
+    return False
+  return not resolver.is_async
+
+
+class OffloadSyncResolvers(SchemaExtension):
+  """Run user-written sync resolvers in the runner thread pool.
+
+  Skipped when there is no running event loop — `schema.execute_sync` from a
+  worker thread (the MCP GraphQL tool's introspection, the unit tests) has
+  nothing to protect and cannot await.
+  """
+
+  def resolve(
+    self,
+    _next: Callable[..., Any],
+    root: Any,
+    info: GraphQLResolveInfo,
+    *args: Any,
+    **kwargs: Any,
+  ) -> Any:
+    if (
+      not _on_event_loop()
+      or is_introspection_field(info)
+      or not _is_user_sync_resolver(info)
+    ):
+      return _next(root, info, *args, **kwargs)
+    # Local import: `middleware.operations` pulls in the platform database
+    # module; the schema must stay importable without one.
+    from robosystems.middleware.operations import run_off_loop
+
+    return run_off_loop(partial(_next, root, info, *args, **kwargs))
+
+
+def _request_id(context: Any) -> str | None:
+  request = None
+  if isinstance(context, dict):
+    request = context.get("request")
+  else:
+    request = getattr(context, "request", None)
+  state = getattr(request, "state", None)
+  return getattr(state, "request_id", None)
+
+
+def _is_deliberate(error: GraphQLError) -> bool:
+  """Parse/validation errors (no original exception) and any `GraphQLError`
+  the code raised on purpose keep their message and extensions."""
+  original = error.original_error
+  return original is None or isinstance(original, GraphQLError)
+
+
+class MaskUnexpectedErrors(SchemaExtension):
+  """Replace unintended resolver exceptions with a fixed message.
+
+  Deliberate errors — `StrawberryGraphQLError` with a ``code`` — pass through
+  untouched, so the documented codes (``LEDGER_NOT_INITIALIZED``,
+  ``UNAUTHENTICATED``, ``EXTENSION_NOT_PROVISIONED``, ...) still reach the
+  client. Everything else is masked; the request id rides in ``extensions``
+  so a report can be matched to the server-side log line, which Strawberry's
+  own `process_errors` already writes with the traceback.
+  """
+
+  def _rewrite(self, error: GraphQLError, request_id: str | None) -> GraphQLError:
+    original = error.original_error
+    if original is not None and is_statement_timeout(original):
+      message = STATEMENT_TIMEOUT_DETAIL
+      code = STATEMENT_TIMEOUT_CODE
+    else:
+      message = INTERNAL_ERROR_MESSAGE
+      code = INTERNAL_ERROR_CODE
+    extensions: dict[str, Any] = {"code": code}
+    if request_id:
+      extensions["requestId"] = request_id
+    return GraphQLError(
+      message=message,
+      nodes=error.nodes,
+      source=error.source,
+      positions=error.positions,
+      path=error.path,
+      original_error=None,
+      extensions=extensions,
+    )
+
+  def _process_result(self, result: Any) -> None:
+    errors = getattr(result, "errors", None)
+    if not errors:
+      return
+    request_id = _request_id(self.execution_context.context)
+    result.errors = [
+      error if _is_deliberate(error) else self._rewrite(error, request_id)
+      for error in errors
+    ]
+
+  def on_operation(self) -> Iterator[None]:
+    yield
+    result = self.execution_context.result
+    if result is None:
+      return
+    if hasattr(result, "errors"):
+      self._process_result(result)
+    elif hasattr(result, "initial_result"):
+      self._process_result(result.initial_result)
+
+
+__all__ = [
+  "INTERNAL_ERROR_CODE",
+  "INTERNAL_ERROR_MESSAGE",
+  "STATEMENT_TIMEOUT_CODE",
+  "MaskUnexpectedErrors",
+  "OffloadSyncResolvers",
+]

--- a/robosystems/graphql/schema.py
+++ b/robosystems/graphql/schema.py
@@ -31,6 +31,7 @@ from strawberry.types import Info
 
 from robosystems.config import env
 from robosystems.graphql.context import GraphQLContext, require_user
+from robosystems.graphql.execution import MaskUnexpectedErrors, OffloadSyncResolvers
 from robosystems.graphql.resolvers.information_block import InformationBlockQuery
 from robosystems.graphql.resolvers.investor import InvestorQuery
 from robosystems.graphql.resolvers.ledger import LedgerQuery
@@ -102,6 +103,12 @@ Query = _build_query_type()
 # provider set up in `middleware/otel/setup.py`). The `Sync` variant works on
 # both sync and async execution paths; the async variant breaks
 # `schema.execute_sync(...)`, which cannot host async context managers.
+#
+# `OffloadSyncResolvers` must come after the OpenTelemetry extension: the
+# resolve hooks compose with the last extension outermost, and the resolver
+# span has to open inside the worker thread around the actual work rather
+# than around a coroutine handle. `MaskUnexpectedErrors` scrubs what reaches
+# `errors[]` — see `graphql/execution.py` for both.
 schema = strawberry.Schema(
   query=Query,
   extensions=[
@@ -109,5 +116,7 @@ schema = strawberry.Schema(
     lambda: MaxAliasesLimiter(max_alias_count=env.EXTENSIONS_GRAPHQL_MAX_ALIASES),
     lambda: MaxTokensLimiter(max_token_count=env.EXTENSIONS_GRAPHQL_MAX_TOKENS),
     OpenTelemetryExtensionSync,
+    OffloadSyncResolvers,
+    MaskUnexpectedErrors,
   ],
 )

--- a/robosystems/middleware/auth/README.md
+++ b/robosystems/middleware/auth/README.md
@@ -234,6 +234,23 @@ Failed API-key validation and failed graph access return the *same* 403 with
 the same message. That conflation is intentional — it denies an attacker an
 oracle for whether a key is valid.
 
+**Read denials are audited too.** The GraphQL gate (`graphql/auth.py`) and the
+MCP gate (`validate_mcp_access(..., "read")`) emit `AuthorizationDenied` when
+an authenticated account is refused a user graph, so an account probing graphs
+it does not belong to trips the same detective control as a refused write.
+Repository denials are audited inside `validate_repository_access`.
+
+**Who acted, exactly.** Every authentication success — JWT and API key, on
+every dependency — publishes the caller through
+`security/request_context.py::publish_principal`: onto `request.state`
+(`user_id` / `auth_user_id` / `auth_method` / `api_key_prefix`) for the
+access log and the rate limiter, and into a request-scoped `ContextVar` that
+the operation audit line and every `SECURITY_AUDIT` event read at write time
+(`request_id`, `auth_method`, `api_key_prefix`). The access-log middleware
+binds `request_id` before the route runs and reads `user_id` after it, so the
+line names the caller. A new authentication branch must publish the principal
+or its requests are unattributed downstream.
+
 ## Caching
 
 `cache.py` caches both positive and negative results in Valkey, keyed by the

--- a/robosystems/middleware/auth/dependencies.py
+++ b/robosystems/middleware/auth/dependencies.py
@@ -19,6 +19,7 @@ from ...logger import logger
 from ...models.core import User
 from ...security import SecurityAuditLogger, SecurityEventType
 from ...security.device_fingerprinting import extract_device_fingerprint
+from ...security.request_context import API_KEY_PREFIX_LENGTH, publish_principal
 from .cache import api_key_cache
 
 # Import JWT helpers from local jwt module to avoid circular imports
@@ -194,19 +195,25 @@ def _stash_api_key_identity(
 
   The first 8 characters are the key's stored identification prefix
   (``UserAPIKey.prefix``), so downstream telemetry can attribute activity
-  to a specific key without access to the raw header. JWT-authenticated
-  requests leave the attribute unset.
+  to a specific key without access to the raw header.
 
-  When the resolved ``user`` is passed, the sanitized principal is also
-  published as ``request.state.auth_user_id`` / ``auth_method``, so
-  downstream consumers that cannot reparse the credential — the rate
-  limiter for URL-token connectors, and eventually opaque OAuth bearer
-  tokens — can identify the caller without re-validating anything.
+  When the resolved ``user`` is passed, the principal is published through
+  `security.request_context.publish_principal`: onto ``request.state``
+  (``user_id`` / ``auth_user_id`` / ``auth_method`` / ``api_key_prefix``)
+  for the access log and the rate limiter, and into the request context so
+  the operation audit and security events below the route can name the
+  credential that acted.
   """
-  request.state.api_key_prefix = api_key[:8]
-  if user is not None:
-    request.state.auth_user_id = str(user.id)
-    request.state.auth_method = auth_method
+  if user is None:
+    request.state.api_key_prefix = api_key[:API_KEY_PREFIX_LENGTH]
+    return
+  publish_principal(request, str(user.id), auth_method, api_key=api_key)
+
+
+def _publish_jwt_identity(request: Request, user_id: str) -> None:
+  """The JWT counterpart of `_stash_api_key_identity`: publish the session
+  principal so JWT-authenticated requests are attributable downstream too."""
+  publish_principal(request, str(user_id), "jwt_token")
 
 
 def _publish_graph_authorization(request: Request, graph_id: str) -> None:
@@ -250,6 +257,7 @@ async def get_optional_user(
       user_id, token_session_version = verify_result
       user = _get_user_for_verified_jwt(user_id, token_session_version)
       if user:
+        _publish_jwt_identity(request, user_id)
         return user
 
   if api_key:
@@ -302,6 +310,7 @@ async def get_current_user(
       user_id, token_session_version = verify_result
       user = _get_user_for_verified_jwt(user_id, token_session_version)
       if user:
+        _publish_jwt_identity(request, user_id)
         SecurityAuditLogger.log_auth_success(
           user_id=str(user_id),
           ip_address=client_ip,
@@ -418,6 +427,7 @@ async def get_current_user_with_graph(
           api_key_cache.cache_jwt_graph_access(str(user_id), graph_id, has_access)
 
         if has_access:
+          _publish_jwt_identity(request, user_id)
           SecurityAuditLogger.log_auth_success(
             user_id=str(user_id),
             ip_address=client_ip,
@@ -695,6 +705,7 @@ async def get_current_user_sse(
       user_id, token_session_version = verify_result
       user = _get_user_for_verified_jwt(user_id, token_session_version)
       if user:
+        _publish_jwt_identity(request, user_id)
         SecurityAuditLogger.log_auth_success(
           user_id=str(user_id),
           ip_address=client_ip,

--- a/robosystems/middleware/auth/distributed_lock.py
+++ b/robosystems/middleware/auth/distributed_lock.py
@@ -28,6 +28,10 @@ class LockAcquisitionResult:
   holder_id: str | None
   ttl_remaining: int | None
   error_message: str | None = None
+  # True when the attempt never got an answer from Redis, so "not acquired"
+  # says nothing about whether the lock is held. Callers that fail closed use
+  # this to report "lock service unavailable" rather than "already in progress".
+  backend_error: bool = False
 
 
 class DistributedLock:
@@ -151,6 +155,7 @@ class DistributedLock:
           holder_id=None,
           ttl_remaining=None,
           error_message=f"Redis error: {e!s}",
+          backend_error=True,
         )
 
     SecurityAuditLogger.log_security_event(

--- a/robosystems/middleware/extensions.py
+++ b/robosystems/middleware/extensions.py
@@ -21,10 +21,11 @@ from typing import Any, ClassVar
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Path
 from pydantic import BaseModel
-from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.exc import DBAPIError, ProgrammingError
 from sqlalchemy.orm import Session
 
 from robosystems.database import get_db_session
+from robosystems.db.extensions import is_statement_timeout
 from robosystems.logger import logger
 from robosystems.middleware.auth.dependencies import require_graph_write_role
 from robosystems.middleware.billing.enforcement import require_graph_access
@@ -70,6 +71,28 @@ def is_schema_missing(exc: ProgrammingError) -> bool:
   return "does not exist" in msg and ("schema" in msg or "relation" in msg)
 
 
+# Client-facing translation of a statement the extensions session ceiling cut
+# short. 504 rather than 500: the request was well-formed and the fault is
+# time, not code — the caller can narrow the request or retry when the
+# tenant's other work has drained. The message never carries the SQL.
+STATEMENT_TIMEOUT_STATUS = 504
+STATEMENT_TIMEOUT_DETAIL = (
+  "The request exceeded the per-statement time limit for this surface. "
+  "Narrow the request (filters, a smaller page) or retry shortly."
+)
+
+
+def statement_timeout_504(op_name: str, graph_id: str) -> HTTPException:
+  """The 504 a cancelled statement surfaces as, logged once at the boundary
+  so the tenant and operation are attributable without the SQL."""
+  logger.warning(f"{op_name} on {graph_id}: statement exceeded the interactive ceiling")
+  return HTTPException(
+    status_code=STATEMENT_TIMEOUT_STATUS,
+    detail=STATEMENT_TIMEOUT_DETAIL,
+    headers={"Retry-After": "5"},
+  )
+
+
 def guard_command_runner(
   runner: Callable[[], Any],
   *,
@@ -88,6 +111,9 @@ def guard_command_runner(
     domain's "not initialized" 404. Anything else is a real database fault:
     logged with its traceback and re-raised (500), never hidden behind the
     friendly 404.
+  - a cancelled statement (the session's ``statement_timeout``) — 504 with
+    a fixed, SQL-free message and ``Retry-After``; see
+    :func:`statement_timeout_504`.
   - ``ValueError`` — a domain refusal the handler did not map. Surfaced as
     422 with its message (the shape every mapped ``ValueError`` already
     takes) and logged so the map gets fixed. The extension dependency has
@@ -106,6 +132,10 @@ def guard_command_runner(
       logger.warning(
         f"{op_name} on {graph_id}: database programming error", exc_info=True
       )
+      raise
+    except DBAPIError as exc:
+      if is_statement_timeout(exc):
+        raise statement_timeout_504(op_name, graph_id) from exc
       raise
     except ValueError as exc:
       logger.warning(f"{op_name} on {graph_id}: unmapped {type(exc).__name__}: {exc}")
@@ -517,6 +547,10 @@ class OperationRegistrar:
           logger.warning(
             f"{op_name} on {graph_id}: database programming error", exc_info=True
           )
+          raise
+        except DBAPIError as exc:
+          if is_statement_timeout(exc):
+            raise statement_timeout_504(op_name, graph_id) from exc
           raise
         except ValueError as exc:
           if not session_bound:

--- a/robosystems/middleware/logging.py
+++ b/robosystems/middleware/logging.py
@@ -20,6 +20,7 @@ from robosystems.logger import (
   log_auth_event,
   security_logger,
 )
+from robosystems.security.request_context import bind_request_id, reset_request_id
 
 logger = api_logger
 
@@ -149,12 +150,13 @@ class StructuredLoggingMiddleware(BaseHTTPMiddleware):
     if any(request.url.path.startswith(path) for path in self.exclude_paths):
       return await call_next(request)
 
-    # Generate request ID for tracing
+    # Generate request ID for tracing. Bound to the request context as well
+    # as request.state so the audit and security events written below the
+    # route handler carry it (`security.request_context`).
     request_id = str(uuid.uuid4())
     request.state.request_id = request_id
+    request_id_token = bind_request_id(request_id)
 
-    # Extract user context if available
-    user_id = getattr(request.state, "user_id", None)
     entity_id = getattr(request.state, "entity_id", None)
 
     # Extract entity from path if it's a entity-scoped endpoint
@@ -177,6 +179,11 @@ class StructuredLoggingMiddleware(BaseHTTPMiddleware):
       response = await call_next(request)
       duration_ms = (time.time() - start_time) * 1000
 
+      # The caller is resolved by the auth dependency inside the route, so
+      # it is only knowable after the response — read it then, or every
+      # access-log line records an anonymous request.
+      user_id = getattr(request.state, "user_id", None)
+
       # Log successful requests using structured logging
       log_api(
         method=request.method,
@@ -194,6 +201,7 @@ class StructuredLoggingMiddleware(BaseHTTPMiddleware):
 
     except Exception as e:
       duration_ms = (time.time() - start_time) * 1000
+      user_id = getattr(request.state, "user_id", None)
 
       # Categorize errors for better searching
       error_category = "application"
@@ -224,6 +232,8 @@ class StructuredLoggingMiddleware(BaseHTTPMiddleware):
 
       # Re-raise the exception to be handled by FastAPI
       raise
+    finally:
+      reset_request_id(request_id_token)
 
 
 class SecurityLoggingMiddleware(BaseHTTPMiddleware):

--- a/robosystems/middleware/mcp/tools/_errors.py
+++ b/robosystems/middleware/mcp/tools/_errors.py
@@ -16,10 +16,21 @@ from typing import Any
 
 from sqlalchemy.exc import ProgrammingError, SQLAlchemyError
 
+from robosystems.db.extensions import is_statement_timeout
 from robosystems.logger import logger
-from robosystems.middleware.extensions import is_schema_missing
+from robosystems.middleware.extensions import (
+  STATEMENT_TIMEOUT_DETAIL,
+  is_schema_missing,
+)
 
 LEDGER_NOT_INITIALIZED = "Ledger not initialized. Connect a data source first."
+
+
+def statement_timeout_answer(tool_name: str) -> dict[str, Any]:
+  """The MCP answer for a statement the session ceiling cancelled — the same
+  fixed text REST returns as 504, so the LLM can narrow or retry."""
+  logger.warning("MCP tool %s exceeded the statement ceiling", tool_name)
+  return {"error": "statement_timeout", "message": STATEMENT_TIMEOUT_DETAIL}
 
 
 def database_failure(
@@ -40,6 +51,8 @@ def database_failure(
     and is_schema_missing(exc)
   ):
     return {"error": "not_initialized", "message": not_initialized_message}
+  if is_statement_timeout(exc):
+    return statement_timeout_answer(tool_name)
   logger.warning("MCP tool %s hit a database error", tool_name, exc_info=True)
   return {
     "error": "command_failed",
@@ -47,4 +60,4 @@ def database_failure(
   }
 
 
-__all__ = ["LEDGER_NOT_INITIALIZED", "database_failure"]
+__all__ = ["LEDGER_NOT_INITIALIZED", "database_failure", "statement_timeout_answer"]

--- a/robosystems/middleware/mcp/tools/registrar.py
+++ b/robosystems/middleware/mcp/tools/registrar.py
@@ -35,8 +35,9 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ValidationError
-from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.exc import DBAPIError, ProgrammingError
 
+from robosystems.db.extensions import is_statement_timeout
 from robosystems.logger import logger
 from robosystems.middleware.extensions import (
   ErrorMap,
@@ -44,6 +45,7 @@ from robosystems.middleware.extensions import (
   OperationSpec,
   is_schema_missing,
 )
+from robosystems.middleware.mcp.tools._errors import statement_timeout_answer
 from robosystems.middleware.operations import (
   fingerprint_body,
   generate_operation_id,
@@ -541,6 +543,10 @@ class _RegistrarMCPTool(BaseTool):
         "error": "command_failed",
         "message": f"{self.spec.name} failed on a database error; see server logs",
       }
+    except DBAPIError as exc:
+      if is_statement_timeout(exc):
+        return statement_timeout_answer(self.spec.name)
+      raise
     except ValueError as exc:
       if not session_bound:
         # The session factory rejected the graph id — not a tenant-schema id.

--- a/robosystems/middleware/operations.py
+++ b/robosystems/middleware/operations.py
@@ -22,7 +22,8 @@ import hashlib
 import inspect
 import json
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Generic, Literal, TypeVar
@@ -34,8 +35,10 @@ from pydantic import BaseModel, ConfigDict, Field
 from robosystems.config.valkey_registry import (
   ValkeyDatabase,
   create_async_redis_client,
+  create_redis_client,
 )
 from robosystems.logger import logger
+from robosystems.security.request_context import audit_context
 from robosystems.utils.ulid import generate_prefixed_ulid
 
 # `default=Any` (PEP 696) keeps unparameterized `OperationEnvelope` loose
@@ -53,6 +56,19 @@ IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60
 # its own retry for a day. A run that outlives the reservation simply loses
 # the in-flight guard — the same behavior as before reservations existed.
 IDEMPOTENCY_RESERVATION_TTL_SECONDS = 5 * 60
+
+# An async operation's pending envelope is cached under its idempotency key
+# for the full 24h; when the operation later fails or is cancelled the
+# terminal-status hook in the SSE event store evicts it, so the caller's
+# retry with the same key dispatches again instead of replaying `pending`.
+# The eviction needs the envelope key from only the operation id, so each
+# pending envelope is bound to its operation under this prefix (a set, since
+# a worker-side dedup can hand two keys the same operation).
+IDEMPOTENCY_BINDING_PREFIX = "op-idem:"
+
+
+def _operation_binding_key(operation_id: str) -> str:
+  return f"{IDEMPOTENCY_BINDING_PREFIX}{operation_id}"
 
 
 def generate_operation_id() -> str:
@@ -480,6 +496,99 @@ class IdempotencyCache:
         },
       )
 
+  async def bind_operation(self, operation_id: str, cache_key: str) -> None:
+    """Record that ``operation_id``'s pending envelope lives under ``cache_key``.
+
+    ``invalidate_operation`` reads this back when the operation reaches a
+    terminal failure. Best-effort like every other write here: a Valkey blip
+    leaves the pending envelope un-evictable for its TTL, not the request
+    failed.
+    """
+    binding_key = _operation_binding_key(operation_id)
+    try:
+      await self._client.sadd(binding_key, cache_key)
+      await self._client.expire(binding_key, IDEMPOTENCY_TTL_SECONDS)
+    except Exception as exc:  # pragma: no cover - defensive
+      logger.warning(
+        "Idempotency operation binding failed",
+        extra={
+          "operation_id": operation_id,
+          "cache_key": cache_key,
+          "error": str(exc),
+        },
+      )
+
+  async def invalidate_operation(self, operation_id: str) -> int:
+    """Evict every envelope bound to ``operation_id``; returns how many.
+
+    Called when the operation fails or is cancelled, so a retry under the
+    same idempotency key dispatches again rather than replaying ``pending``
+    for the rest of the day.
+    """
+    binding_key = _operation_binding_key(operation_id)
+    try:
+      cache_keys = await self._client.smembers(binding_key)
+      if not cache_keys:
+        return 0
+      await self._client.delete(*cache_keys, binding_key)
+    except Exception as exc:  # pragma: no cover - defensive
+      logger.warning(
+        "Idempotency operation invalidation failed",
+        extra={"operation_id": operation_id, "error": str(exc)},
+      )
+      return 0
+    return len(cache_keys)
+
+
+_sync_idempotency_client: Any | None = None
+
+
+def _get_sync_idempotency_client() -> Any:
+  """Sync client on the idempotency DB for the SSE store's sync write path.
+
+  Dagster and background threads record terminal statuses through
+  ``store_event_sync``; they have no event loop to drive ``IdempotencyCache``.
+  """
+  global _sync_idempotency_client
+  if _sync_idempotency_client is None:
+    _sync_idempotency_client = create_redis_client(
+      ValkeyDatabase.OPERATION_IDEMPOTENCY, decode_responses=True
+    )
+  return _sync_idempotency_client
+
+
+async def invalidate_operation_idempotency(operation_id: str) -> int:
+  """Evict the pending envelopes bound to a failed or cancelled operation."""
+  evicted = await get_idempotency_cache().invalidate_operation(operation_id)
+  if evicted:
+    logger.info(
+      "Evicted idempotency envelope for terminal operation",
+      extra={"operation_id": operation_id, "evicted": evicted},
+    )
+  return evicted
+
+
+def invalidate_operation_idempotency_sync(operation_id: str) -> int:
+  """Sync counterpart to ``invalidate_operation_idempotency``."""
+  binding_key = _operation_binding_key(operation_id)
+  try:
+    client = _get_sync_idempotency_client()
+    cache_keys = client.smembers(binding_key)
+    if not cache_keys:
+      return 0
+    client.delete(*cache_keys, binding_key)
+  except Exception as exc:  # pragma: no cover - defensive
+    logger.warning(
+      "Idempotency operation invalidation failed",
+      extra={"operation_id": operation_id, "error": str(exc)},
+    )
+    return 0
+  logger.info(
+    "Evicted idempotency envelope for terminal operation",
+    extra={"operation_id": operation_id, "evicted": len(cache_keys)},
+  )
+  return len(cache_keys)
+
 
 # ---------------------------------------------------------------------------
 # Audit logging
@@ -511,6 +620,12 @@ def log_operation_audit(
   graph lifecycle ops. ``surface`` names the entry point — ``"rest"`` for
   the HTTP operation routes, ``"mcp"`` for tool calls — so the same command
   reached two ways is distinguishable in the stream.
+
+  *Who* is more than ``user_id``: when the call runs inside a request the
+  payload also carries ``request_id`` (correlates to the access-log line and
+  to any security event of the same request) and ``auth_method`` /
+  ``api_key_prefix`` (from `security.request_context`), so a leaked-key
+  incident can be scoped to the credential rather than the whole account.
   """
   payload: dict[str, Any] = {
     "event": event,
@@ -522,6 +637,7 @@ def log_operation_audit(
     "duration_ms": round(duration_ms, 2),
     "status": status,
     "idempotent_replay": idempotent_replay,
+    **audit_context(),
   }
   if idempotency_key is not None:
     # Log only the hash prefix so keys aren't retained verbatim.
@@ -604,12 +720,18 @@ async def check_idempotency(
 
   Returns a cached envelope (with ``idempotent_replay=True``) on a cache hit,
   ``None`` on a miss. Raises ``HTTPException 409`` when the key is reused with
-  a different body.
+  a different body, or while the first request with this key is still
+  between its check and its ``put``.
 
-  Use this before enqueueing any async operation that cannot go through
-  ``execute_operation`` — i.e. ops that return ``wrap_pending`` rather than
-  ``wrap_completed``. The ``event`` parameter is forwarded to
-  ``log_operation_audit``; pass ``"extensions.operation"`` for extension ops.
+  A miss **claims the key** — the same ``SET NX`` reservation
+  ``execute_operation`` takes — so two identical requests inside one
+  another's dispatch window cannot both enqueue. That makes the caller
+  responsible for either recording an envelope under the key or releasing
+  it on every failure path; ``idempotent_dispatch`` does both, and is what
+  routes should use rather than calling this directly.
+
+  The ``event`` parameter is forwarded to ``log_operation_audit``; pass
+  ``"extensions.operation"`` for extension ops.
   """
   if idempotency_key is None:
     return None
@@ -617,6 +739,17 @@ async def check_idempotency(
     cached = await cache.get(
       user_id, graph_id, op_name, idempotency_key, body_fingerprint
     )
+    if cached is None and not await cache.reserve(
+      user_id, graph_id, op_name, idempotency_key, body_fingerprint
+    ):
+      # Another request took the key between our read and our claim: replay
+      # its envelope if it has already been recorded, otherwise report it
+      # in progress rather than dispatching alongside it.
+      cached = await cache.get(
+        user_id, graph_id, op_name, idempotency_key, body_fingerprint
+      )
+      if cached is None:
+        raise IdempotencyInProgressError(op_name)
   except IdempotencyKeyConflictError as exc:
     log_operation_audit(
       operation_name=op_name,
@@ -644,6 +777,103 @@ async def check_idempotency(
     )
     return cached.model_copy(update={"idempotent_replay": True})
   return None
+
+
+class PendingDispatch:
+  """Handle yielded by ``idempotent_dispatch``.
+
+  ``replay`` is the cached envelope when the key has already been used;
+  ``record`` stores the envelope this request produced and, for a pending
+  one, binds it to its operation so a terminal failure can evict it.
+  """
+
+  def __init__(
+    self,
+    cache: IdempotencyCache,
+    *,
+    user_id: str,
+    graph_id: str,
+    operation_name: str,
+    idempotency_key: str | None,
+    body_fingerprint: str,
+    replay: OperationEnvelope | None,
+  ) -> None:
+    self._cache = cache
+    self._user_id = user_id
+    self._graph_id = graph_id
+    self._operation_name = operation_name
+    self._idempotency_key = idempotency_key
+    self._body_fingerprint = body_fingerprint
+    self.replay = replay
+    self.recorded = False
+
+  async def record(self, envelope: OperationEnvelope) -> None:
+    """Cache ``envelope`` under the key and bind a pending one to its operation."""
+    self.recorded = True
+    if self._idempotency_key is None:
+      return
+    await self._cache.put(
+      self._user_id,
+      self._graph_id,
+      self._operation_name,
+      self._idempotency_key,
+      envelope,
+      self._body_fingerprint,
+    )
+    if envelope.status == "pending":
+      await self._cache.bind_operation(
+        envelope.operation_id,
+        compute_idempotency_cache_key(
+          self._user_id, self._graph_id, self._operation_name, self._idempotency_key
+        ),
+      )
+
+
+@asynccontextmanager
+async def idempotent_dispatch(
+  cache: IdempotencyCache,
+  user_id: str,
+  graph_id: str,
+  op_name: str,
+  idempotency_key: str | None,
+  body_fingerprint: str,
+  event: str = "graph.operation",
+) -> AsyncIterator[PendingDispatch]:
+  """Idempotency guard for a route that enqueues work and returns ``pending``.
+
+  Enter it before any side effect. ``replay`` set means the key was already
+  used — return it. Otherwise the key is now reserved for this request:
+  every exit that did not ``record`` an envelope — a validation 4xx, a
+  dispatch failure, a cancellation — releases the reservation so the
+  caller's retry can run, exactly as ``execute_operation`` does for sync
+  operations. Without this, a failed request would answer 409 to its own
+  retry until the reservation expired.
+
+      async with idempotent_dispatch(cache, user_id, graph_id, op, key, fp) as idem:
+        if idem.replay is not None:
+          return idem.replay
+        ...validate, enqueue...
+        envelope = wrap_pending(op, operation_id=..., created_by=user_id)
+        await idem.record(envelope)
+        return envelope
+  """
+  replay = await check_idempotency(
+    cache, user_id, graph_id, op_name, idempotency_key, body_fingerprint, event
+  )
+  handle = PendingDispatch(
+    cache,
+    user_id=user_id,
+    graph_id=graph_id,
+    operation_name=op_name,
+    idempotency_key=idempotency_key,
+    body_fingerprint=body_fingerprint,
+    replay=replay,
+  )
+  try:
+    yield handle
+  finally:
+    if idempotency_key is not None and replay is None and not handle.recorded:
+      await cache.release(user_id, graph_id, op_name, idempotency_key)
 
 
 # ── Runner execution ─────────────────────────────────────────────────────
@@ -952,6 +1182,7 @@ def _log_abandoned_outcome(task: asyncio.Future) -> None:
 
 
 __all__ = [
+  "IDEMPOTENCY_BINDING_PREFIX",
   "IDEMPOTENCY_RESERVATION_TTL_SECONDS",
   "IDEMPOTENCY_TTL_SECONDS",
   "AsyncOperationRunner",
@@ -962,12 +1193,16 @@ __all__ = [
   "OperationEnvelope",
   "OperationRunner",
   "OperationStatus",
+  "PendingDispatch",
   "check_idempotency",
   "compute_idempotency_cache_key",
   "execute_operation",
   "fingerprint_body",
   "generate_operation_id",
   "get_idempotency_cache",
+  "idempotent_dispatch",
+  "invalidate_operation_idempotency",
+  "invalidate_operation_idempotency_sync",
   "log_operation_audit",
   "run_off_loop",
   "wrap_completed",

--- a/robosystems/middleware/sse/event_storage.py
+++ b/robosystems/middleware/sse/event_storage.py
@@ -110,6 +110,43 @@ class OperationMetadata:
 _TERMINAL_FAILURE_STATUSES = frozenset(
   {OperationStatus.FAILED, OperationStatus.CANCELLED}
 )
+_TERMINAL_STATUSES = _TERMINAL_FAILURE_STATUSES | {OperationStatus.COMPLETED}
+
+# The lifecycle only moves forward, and the first terminal status is final:
+# a late or duplicate OPERATION_ERROR after OPERATION_COMPLETED (at-least-once
+# delivery, a reaper racing a finishing worker) must neither flip a finished
+# operation to failed nor evict the idempotency envelope of an operation that
+# succeeded — a client retry under the same key would then dispatch it again.
+_STATUS_PRIORITY = {
+  OperationStatus.PENDING: 0,
+  OperationStatus.RUNNING: 1,
+  OperationStatus.COMPLETED: 2,
+  OperationStatus.FAILED: 2,
+  OperationStatus.CANCELLED: 2,
+}
+
+
+def _next_status(event_type: EventType) -> OperationStatus | None:
+  if event_type == EventType.OPERATION_STARTED:
+    return OperationStatus.RUNNING
+  if event_type == EventType.OPERATION_COMPLETED:
+    return OperationStatus.COMPLETED
+  if event_type == EventType.OPERATION_ERROR:
+    return OperationStatus.FAILED
+  if event_type == EventType.OPERATION_CANCELLED:
+    return OperationStatus.CANCELLED
+  return None
+
+
+def _transition_allowed(current: OperationStatus, new: OperationStatus) -> bool:
+  """Whether ``current`` → ``new`` is a forward move.
+
+  Same-status re-writes are allowed (a completion event may arrive twice and
+  merge result data); a different terminal status after a terminal one is not.
+  """
+  if current in _TERMINAL_STATUSES and new != current:
+    return False
+  return _STATUS_PRIORITY.get(new, 0) >= _STATUS_PRIORITY.get(current, 0)
 
 
 async def _invalidate_idempotency(operation_id: str) -> None:
@@ -369,30 +406,20 @@ class SSEEventStorage:
         metadata_dict = json.loads(str(metadata_json))
         metadata = OperationMetadata(**metadata_dict)
 
-        # Never downgrade a terminal status back to RUNNING.
-        status_priority = {
-          OperationStatus.PENDING: 0,
-          OperationStatus.RUNNING: 1,
-          OperationStatus.COMPLETED: 2,
-          OperationStatus.FAILED: 2,
-          OperationStatus.CANCELLED: 2,
-        }
-        new_status = None
-        if event_type == EventType.OPERATION_STARTED:
-          new_status = OperationStatus.RUNNING
-        elif event_type == EventType.OPERATION_COMPLETED:
-          new_status = OperationStatus.COMPLETED
-        elif event_type == EventType.OPERATION_ERROR:
-          new_status = OperationStatus.FAILED
-        elif event_type == EventType.OPERATION_CANCELLED:
-          new_status = OperationStatus.CANCELLED
+        # Never move a status backwards, and never past its first terminal
+        # state (see `_transition_allowed`).
+        new_status = _next_status(event_type)
 
-        if new_status and status_priority.get(new_status, 0) >= status_priority.get(
-          metadata.status, 0
-        ):
+        if new_status and _transition_allowed(metadata.status, new_status):
+          # Evict only on the transition *into* failure, and only once this
+          # write actually lands: a lost CAS below means another event won
+          # the transition, possibly a completion.
+          entering_failure = (
+            new_status in _TERMINAL_FAILURE_STATUSES
+            and metadata.status not in _TERMINAL_STATUSES
+          )
           metadata.status = new_status
           metadata.updated_at = datetime.now(UTC).isoformat()
-          terminal_failure = new_status in _TERMINAL_FAILURE_STATUSES
 
           if event_type == EventType.OPERATION_COMPLETED:
             # Merge, so a graph_id recorded by the Dagster job survives.
@@ -407,6 +434,7 @@ class SSEEventStorage:
           pipe.multi()
           pipe.setex(metadata_key, self.default_ttl, json.dumps(metadata.to_dict()))
           pipe.execute()
+          terminal_failure = entering_failure
         else:
           pipe.unwatch()
 
@@ -511,30 +539,17 @@ class SSEEventStorage:
       metadata_dict = json.loads(metadata_json)
       metadata = OperationMetadata(**metadata_dict)
 
-      # Never downgrade a terminal status back to RUNNING.
-      status_priority = {
-        OperationStatus.PENDING: 0,
-        OperationStatus.RUNNING: 1,
-        OperationStatus.COMPLETED: 2,
-        OperationStatus.FAILED: 2,
-        OperationStatus.CANCELLED: 2,
-      }
-      new_status = None
-      if event_type == EventType.OPERATION_STARTED:
-        new_status = OperationStatus.RUNNING
-      elif event_type == EventType.OPERATION_COMPLETED:
-        new_status = OperationStatus.COMPLETED
-      elif event_type == EventType.OPERATION_ERROR:
-        new_status = OperationStatus.FAILED
-      elif event_type == EventType.OPERATION_CANCELLED:
-        new_status = OperationStatus.CANCELLED
+      # Never move a status backwards, and never past its first terminal
+      # state (see `_transition_allowed`).
+      new_status = _next_status(event_type)
 
-      if new_status and status_priority.get(new_status, 0) >= status_priority.get(
-        metadata.status, 0
-      ):
+      if new_status and _transition_allowed(metadata.status, new_status):
+        entering_failure = (
+          new_status in _TERMINAL_FAILURE_STATUSES
+          and metadata.status not in _TERMINAL_STATUSES
+        )
         metadata.status = new_status
         metadata.updated_at = datetime.now(UTC).isoformat()
-        terminal_failure = new_status in _TERMINAL_FAILURE_STATUSES
 
         if event_type == EventType.OPERATION_COMPLETED:
           new_result = data.get("result") or {}
@@ -550,6 +565,7 @@ class SSEEventStorage:
           pipe = redis.pipeline()
           pipe.setex(metadata_key, ttl, json.dumps(metadata.to_dict()))
           await pipe.execute()
+          terminal_failure = entering_failure
       else:
         await redis.unwatch()
 

--- a/robosystems/middleware/sse/event_storage.py
+++ b/robosystems/middleware/sse/event_storage.py
@@ -107,6 +107,44 @@ class OperationMetadata:
     return asdict(self)
 
 
+_TERMINAL_FAILURE_STATUSES = frozenset(
+  {OperationStatus.FAILED, OperationStatus.CANCELLED}
+)
+
+
+async def _invalidate_idempotency(operation_id: str) -> None:
+  """Evict the idempotency envelope an async route cached for this operation.
+
+  A route that enqueues work caches a ``pending`` envelope under the caller's
+  Idempotency-Key for 24h. Once the operation fails or is cancelled that
+  envelope would replay ``pending`` to every retry with the same key, so the
+  terminal transition evicts it. Imported lazily: the operations module
+  pulls in FastAPI, which this store must not require.
+  """
+  from robosystems.middleware.operations import invalidate_operation_idempotency
+
+  try:
+    await invalidate_operation_idempotency(operation_id)
+  except Exception as exc:
+    logger.warning(
+      f"Idempotency eviction failed for terminal operation {operation_id}: {exc}"
+    )
+
+
+def _invalidate_idempotency_sync(operation_id: str) -> None:
+  """Sync counterpart to ``_invalidate_idempotency`` for ``store_event_sync``."""
+  from robosystems.middleware.operations import (
+    invalidate_operation_idempotency_sync,
+  )
+
+  try:
+    invalidate_operation_idempotency_sync(operation_id)
+  except Exception as exc:
+    logger.warning(
+      f"Idempotency eviction failed for terminal operation {operation_id}: {exc}"
+    )
+
+
 class SSEEventStorage:
   """Redis-backed SSE event store with automatic TTL expiry.
 
@@ -317,6 +355,7 @@ class SSEEventStorage:
 
     redis = self._get_sync_redis()
     metadata_key = f"{self.metadata_prefix}{operation_id}"
+    terminal_failure = False
 
     with redis.pipeline() as pipe:
       try:
@@ -353,6 +392,7 @@ class SSEEventStorage:
         ):
           metadata.status = new_status
           metadata.updated_at = datetime.now(UTC).isoformat()
+          terminal_failure = new_status in _TERMINAL_FAILURE_STATUSES
 
           if event_type == EventType.OPERATION_COMPLETED:
             # Merge, so a graph_id recorded by the Dagster job survives.
@@ -375,6 +415,9 @@ class SSEEventStorage:
         logger.debug(
           f"[SYNC] Metadata update skipped for {operation_id} due to concurrent modification"
         )
+
+    if terminal_failure:
+      _invalidate_idempotency_sync(operation_id)
 
   def update_operation_result_sync(
     self, operation_id: str, result: dict[str, Any]
@@ -455,6 +498,7 @@ class SSEEventStorage:
 
     redis = await self._get_redis()
     metadata_key = f"{self.metadata_prefix}{operation_id}"
+    terminal_failure = False
 
     try:
       await redis.watch(metadata_key)
@@ -490,6 +534,7 @@ class SSEEventStorage:
       ):
         metadata.status = new_status
         metadata.updated_at = datetime.now(UTC).isoformat()
+        terminal_failure = new_status in _TERMINAL_FAILURE_STATUSES
 
         if event_type == EventType.OPERATION_COMPLETED:
           new_result = data.get("result") or {}
@@ -513,6 +558,9 @@ class SSEEventStorage:
       logger.debug(
         f"Metadata update skipped for {operation_id} due to concurrent modification"
       )
+
+    if terminal_failure:
+      await _invalidate_idempotency(operation_id)
 
   async def get_events(
     self, operation_id: str, from_sequence: int = 0, limit: int | None = None

--- a/robosystems/operations/aws/s3.py
+++ b/robosystems/operations/aws/s3.py
@@ -90,7 +90,16 @@ class S3Client:
 
     return boto3.client(
       "s3",
-      config=BotoConfig(retries={"mode": "adaptive", "max_attempts": 3}),
+      # SigV4 explicitly: botocore still presigns with SigV2 in us-east-1
+      # by default, and a SigV2 URL signs no headers — so the
+      # `ContentLength` the upload presign declares would not bind the PUT.
+      # Under SigV4 `content-length` joins the signed headers and a PUT with
+      # a different length is refused by S3. Every current bucket and region
+      # accepts SigV4; SigV2 has been deprecated by AWS since 2020.
+      config=BotoConfig(
+        signature_version="s3v4",
+        retries={"mode": "adaptive", "max_attempts": 3},
+      ),
       **s3_config,
     )
 

--- a/robosystems/operations/extensions/loader.py
+++ b/robosystems/operations/extensions/loader.py
@@ -558,7 +558,7 @@ class OLTPLoader:
 
     now = datetime.now(UTC)
 
-    with extensions_session(graph_id) as session:
+    with extensions_session(graph_id, statement_timeout_ms=None) as session:
       # ── Pre-sync deletes (full_rebuild only) ───────────────────────
       #
       # This block is constrained as follows:
@@ -1889,7 +1889,7 @@ class OLTPLoader:
     from robosystems.utils.ulid import generate_prefixed_ulid
 
     try:
-      with extensions_session(graph_id) as session:
+      with extensions_session(graph_id, statement_timeout_ms=None) as session:
         # Check if a CoA taxonomy already exists
         existing_coa = (
           session.query(Taxonomy)
@@ -2043,7 +2043,7 @@ class OLTPLoader:
       finally:
         con.close()
 
-      with extensions_session(graph_id) as session:
+      with extensions_session(graph_id, statement_timeout_ms=None) as session:
         # The ledger's own entity by predicate — a shared-in `linked`
         # counterparty must never receive the CompanyInfo overwrite.
         entity = resolve_parent_entity(session)

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -25,9 +25,26 @@ from urllib.parse import urlparse
 
 if TYPE_CHECKING:
   from robosystems.graph_api.client.client import GraphClient
+  from robosystems.graph_api.core.ladybug.materialization_lock import (
+    MaterializationLock,
+  )
 
 from robosystems.logger import logger
 from robosystems.security.error_handling import redact_connection_secrets
+
+# How long ``materialize`` waits for the per-graph lock before giving up.
+_LOCK_ACQUIRE_TIMEOUT_SECONDS = 5
+
+
+class MaterializationLockError(RuntimeError):
+  """The per-graph materialization lock could not be taken, or lapsed mid-run.
+
+  Raised instead of proceeding unlocked. A materialization is a retryable
+  background job — the staleness sensor re-fires within minutes — whereas an
+  unlocked double-writer silently duplicates relationship-table edges (edge
+  tables have no primary key), so the run must fail closed.
+  """
+
 
 # Association types the graph renderer needs. Anything omitted here exists in
 # OLTP but is invisible to the graph — dropping `mapping`, for instance, empties
@@ -1375,8 +1392,9 @@ class ExtensionsMaterializer:
     An existing database takes the blue-green path: a WIP copy is built
     alongside the live graph and swapped in on success, so the live graph keeps
     serving queries and downtime is the length of a file rename. First-time
-    creation builds in place. Errors are collected on the result rather than
-    raised — check ``status``.
+    creation builds in place. Both paths run under the per-graph
+    materialization lock and fail closed if it cannot be taken. Errors are
+    collected on the result rather than raised — check ``status``.
     """
     from robosystems.graph_api.client.factory import get_graph_client
 
@@ -1397,8 +1415,8 @@ class ExtensionsMaterializer:
       return result
 
     # Per-instance busy signal so ASG refresh workflows wait rather than
-    # cycling the node mid-rebuild. The per-graph lock is separate and lives in
-    # _materialize_blue_green.
+    # cycling the node mid-rebuild. The per-graph lock is separate: it is
+    # taken below and wraps both build paths.
     from robosystems.middleware.graph.instance_busy import (
       OP_KIND_EXTENSIONS_MATERIALIZE,
       begin_destructive_op,
@@ -1410,12 +1428,26 @@ class ExtensionsMaterializer:
 
     try:
       async with client:
-        db_exists = await client.database_exists(graph_id)
+        # One per-graph lock for both paths. The first build (no database yet)
+        # is as exposed to a double-writer as a rebuild: a stale-sensor run
+        # and a user-initiated materialize can otherwise both create and COPY
+        # into the same fresh graph. Any cross-plane cap on total concurrent
+        # materializations would attach here, after the per-graph acquire.
+        lock = await self._acquire_lock(graph_id)
+        try:
+          db_exists = await client.database_exists(graph_id)
 
-        if db_exists and rebuild:
-          await self._materialize_blue_green(client, graph_id, entity_id, result)
-        else:
-          await self._materialize_direct(client, graph_id, entity_id, rebuild, result)
+          if db_exists and rebuild:
+            await self._materialize_blue_green(
+              client, graph_id, entity_id, result, lock
+            )
+          else:
+            await self._materialize_direct(
+              client, graph_id, entity_id, rebuild, result, lock
+            )
+        finally:
+          # A no-op if the lock lapsed under us (extend already cleared it).
+          await lock.release()
 
     except Exception as e:
       logger.error(f"Ledger materialization failed for {graph_id}: {e}", exc_info=True)
@@ -1436,6 +1468,67 @@ class ExtensionsMaterializer:
 
     return result
 
+  async def _acquire_lock(self, graph_id: str) -> "MaterializationLock":
+    """Take the per-graph materialization lock, failing closed.
+
+    Every failure mode raises ``MaterializationLockError`` — a lock held by
+    another run, a Valkey outage, or the lock module failing to import. The
+    message tells the two retryable causes apart so an operator reading the
+    result knows whether to wait for the other run or look at Valkey.
+    """
+    try:
+      from robosystems.config.valkey_registry import (
+        ValkeyDatabase,
+        create_async_redis_client,
+      )
+      from robosystems.graph_api.core.ladybug.materialization_lock import (
+        MaterializationLock,
+      )
+
+      redis_client = create_async_redis_client(ValkeyDatabase.LOCKS)
+      lock = MaterializationLock(redis_client, graph_id)
+    except Exception as e:
+      raise MaterializationLockError(
+        f"Materialization lock service unavailable for {graph_id} "
+        f"({e.__class__.__name__}: {e}); retry later"
+      ) from e
+
+    acquired = await lock.acquire(timeout_seconds=_LOCK_ACQUIRE_TIMEOUT_SECONDS)
+    if acquired:
+      return lock
+
+    if lock.last_backend_error:
+      raise MaterializationLockError(
+        f"Materialization lock service unavailable for {graph_id} "
+        f"({lock.last_backend_error}); retry later"
+      )
+    raise MaterializationLockError(
+      f"Materialization lock for {graph_id} is held by another run; retry later"
+    )
+
+  async def _refresh_lock(self, lock: "MaterializationLock | None") -> None:
+    """Checkpoint: push the lock TTL out, or abort if the lock is no longer ours.
+
+    Called once per table. A run longer than the TTL would otherwise lose the
+    lock silently and carry a stale token into the swap while a second run
+    builds against the same graph. A backend error here is tolerated — the key
+    still has whatever TTL remains, and any competing acquire fails closed
+    while the backend is down — but a token mismatch means the lock lapsed
+    and someone else may hold it, so the run stops before it can swap.
+    """
+    if lock is None:
+      return
+    try:
+      still_held = await lock.extend()
+    except Exception as e:
+      logger.warning(f"Materialization lock extend failed for {lock.lock_key}: {e}")
+      return
+    if not still_held:
+      raise MaterializationLockError(
+        f"Materialization lock {lock.lock_key} lapsed mid-run (another run may "
+        "now hold it); aborting before swap"
+      )
+
   async def _materialize_direct(
     self,
     client: "GraphClient",
@@ -1443,6 +1536,7 @@ class ExtensionsMaterializer:
     entity_id: str,
     rebuild: bool,
     result: MaterializeResult,
+    lock: "MaterializationLock | None" = None,
   ) -> None:
     """Build in place — for first-time creation, or when ``rebuild`` is False.
 
@@ -1458,9 +1552,11 @@ class ExtensionsMaterializer:
     enabled_extensions = set(await self._get_graph_extensions(graph_id))
 
     staging_sql = _staging_sql(graph_id, entity_id, connstr)
-    await self._stage_tables(client, graph_id, staging_sql, result, enabled_extensions)
+    await self._stage_tables(
+      client, graph_id, staging_sql, result, enabled_extensions, lock=lock
+    )
 
-    await self._materialize_tables(client, graph_id, result)
+    await self._materialize_tables(client, graph_id, result, lock=lock)
 
   async def _materialize_blue_green(
     self,
@@ -1468,6 +1564,7 @@ class ExtensionsMaterializer:
     graph_id: str,
     entity_id: str,
     result: MaterializeResult,
+    lock: "MaterializationLock | None" = None,
   ) -> None:
     """Build ``{graph_id}-wip`` alongside the live graph and swap on success.
 
@@ -1475,40 +1572,15 @@ class ExtensionsMaterializer:
     file rename. Only a fully clean build is swapped in — a partial one is
     discarded so the last good graph stays active.
 
-    Holds a per-graph materialization lock. If Valkey is unavailable the
-    rebuild proceeds unlocked, so concurrent rebuilds become possible.
+    ``lock`` is the per-graph materialization lock ``materialize`` already
+    holds; its token is passed through to the WIP delete and the swap so the
+    Graph API endpoints do not re-acquire it.
     """
-    from robosystems.graph_api.core.ladybug.materialization_lock import (
-      MaterializationLock,
-    )
-
     wip_id = f"{graph_id}-wip"
-    lock: MaterializationLock | None = None
 
     logger.info(f"Blue-green materialization: building WIP {wip_id}")
 
     try:
-      try:
-        from robosystems.config.valkey_registry import (
-          ValkeyDatabase,
-          create_async_redis_client,
-        )
-
-        redis_client = create_async_redis_client(ValkeyDatabase.LOCKS)
-        lock = MaterializationLock(redis_client, graph_id)
-        acquired = await lock.acquire(timeout_seconds=5)
-        if not acquired:
-          raise RuntimeError(
-            f"Could not acquire materialization lock for {graph_id} "
-            "(another materialization may be in progress)"
-          )
-      except ImportError:
-        logger.warning("Valkey not available — proceeding without materialization lock")
-      except RuntimeError:
-        raise
-      except Exception as e:
-        logger.warning(f"Could not acquire materialization lock: {e}")
-
       # A leftover WIP means a previous run died before cleanup.
       wip_exists = await client.database_exists(wip_id)
       if wip_exists:
@@ -1531,15 +1603,20 @@ class ExtensionsMaterializer:
       connstr = build_postgres_connstr()
       staging_sql = _staging_sql(graph_id, entity_id, connstr)
       await self._stage_tables(
-        client, graph_id, staging_sql, result, enabled_extensions
+        client, graph_id, staging_sql, result, enabled_extensions, lock=lock
       )
 
-      await self._materialize_tables(client, wip_id, result, source_graph_id=graph_id)
+      await self._materialize_tables(
+        client, wip_id, result, source_graph_id=graph_id, lock=lock
+      )
 
       # Only a clean build ships. A 'partial' WIP — one where an edge table
       # failed to COPY — would swap in a ledger whose statements render empty,
       # so the last good graph stays active and staleness is left set to retry.
       if result.status == "success":
+        # Last checkpoint before the swap: a lapsed lock aborts here rather
+        # than carrying a stale token into the rename.
+        await self._refresh_lock(lock)
         logger.info(f"Swapping WIP {wip_id} → active {graph_id}")
         await client.swap_database(graph_id, lock_token=lock.token if lock else None)
         logger.info(f"Blue-green swap complete for {graph_id}")
@@ -1568,9 +1645,6 @@ class ExtensionsMaterializer:
           f"Failed to clean up WIP {wip_id} after blue-green failure: {cleanup_err}"
         )
       raise
-    finally:
-      if lock is not None and lock.acquired:
-        await lock.release()
 
   async def _ensure_database(
     self,
@@ -1649,6 +1723,7 @@ class ExtensionsMaterializer:
     staging_sql: dict[str, str],
     result: MaterializeResult,
     enabled_extensions: set[str],
+    lock: "MaterializationLock | None" = None,
   ) -> None:
     """Create the DuckDB staging tables from PostgreSQL via postgres_scanner.
 
@@ -1666,6 +1741,7 @@ class ExtensionsMaterializer:
       if not sql:
         continue
 
+      await self._refresh_lock(lock)
       try:
         logger.info(f"Staging {table_name} from PostgreSQL → DuckDB")
         # Must be the internal write path: the read-only /tables/query surface
@@ -1690,6 +1766,7 @@ class ExtensionsMaterializer:
     graph_id: str,
     result: MaterializeResult,
     source_graph_id: str | None = None,
+    lock: "MaterializationLock | None" = None,
   ) -> None:
     """COPY the staged DuckDB tables into LadybugDB, nodes before edges.
 
@@ -1705,6 +1782,7 @@ class ExtensionsMaterializer:
     """
     node_tables = set(NODE_TABLES)
     for table_name in result.tables_staged:
+      await self._refresh_lock(lock)
       try:
         logger.info(f"Materializing {table_name} → LadybugDB ({graph_id})")
         response = await client.materialize_table(

--- a/robosystems/operations/graph/commands/create_file_upload.py
+++ b/robosystems/operations/graph/commands/create_file_upload.py
@@ -9,6 +9,7 @@ to stage the result.
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path as PathLib
+from typing import Any
 
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
@@ -168,13 +169,22 @@ async def create_file_upload_cmd(
     s3_client = S3Client()
     bucket = env.USER_DATA_BUCKET
 
+    presign_params: dict[str, Any] = {
+      "Bucket": bucket,
+      "Key": s3_key,
+      "ContentType": request.content_type,
+    }
+    # A declared size is signed into the URL: SigV4 puts Content-Length in the
+    # signed headers, so a PUT of any other length fails the signature at S3
+    # (`content-length-range` is a POST-policy feature and does not apply to a
+    # presigned PUT). Optional because clients that never declare a size still
+    # get a working URL; `ingest-file` measures the real object regardless.
+    if request.file_size_bytes is not None:
+      presign_params["ContentLength"] = request.file_size_bytes
+
     upload_url = s3_client.s3_client.generate_presigned_url(
       "put_object",
-      Params={
-        "Bucket": bucket,
-        "Key": s3_key,
-        "ContentType": request.content_type,
-      },
+      Params=presign_params,
       ExpiresIn=PRESIGNED_URL_EXPIRY_SECONDS,
     )
 

--- a/robosystems/operations/graph/commands/ingest_file.py
+++ b/robosystems/operations/graph/commands/ingest_file.py
@@ -6,7 +6,10 @@ ones are dispatched and the result carries an ``operation_id`` to follow.
 
 from __future__ import annotations
 
+import io
+import re
 import uuid
+from typing import Any
 
 from fastapi import BackgroundTasks, HTTPException, status
 from sqlalchemy.orm import Session
@@ -17,14 +20,215 @@ from robosystems.config.constants import (
   FALLBACK_BYTES_PER_ROW_JSON,
   FALLBACK_BYTES_PER_ROW_PARQUET,
   MAX_FILE_SIZE_MB,
+  MAX_ROWS_PER_FILE,
   SMALL_FILE_STAGING_THRESHOLD_MB,
 )
+from robosystems.config.graph_tier import GraphTierConfig
 from robosystems.logger import logger
+from robosystems.middleware.operations import run_off_loop
 from robosystems.models.api.graphs.tables import FileUploadStatus
 from robosystems.models.core import Graph, GraphFile, GraphTable, User
 from robosystems.operations.aws.s3 import S3Client
 
 __all__ = ["ingest_file_cmd"]
+
+_FALLBACK_BYTES_PER_ROW = {
+  "parquet": FALLBACK_BYTES_PER_ROW_PARQUET,
+  "csv": FALLBACK_BYTES_PER_ROW_CSV,
+  "json": FALLBACK_BYTES_PER_ROW_JSON,
+}
+
+# Parquet locates its metadata from the end of the file: a 4-byte footer length
+# followed by the "PAR1" magic. pyarrow reads the last 64 KiB first, same as
+# here, and only goes back for more when the footer is bigger.
+_PARQUET_TRAILER_BYTES = 8
+_PARQUET_TAIL_READ_BYTES = 64 * 1024
+# A footer is Thrift metadata (schema + row-group index); a legitimate file under
+# the 100 MB cap is nowhere near this. Anything larger is refused as malformed
+# rather than decoded into memory.
+_PARQUET_MAX_FOOTER_BYTES = 16 * 1024 * 1024
+_STREAM_BUFFER_BYTES = 1024 * 1024
+_JSON_WHITESPACE = re.compile(r"[ \t\n\r]*")
+
+
+def _skip_json_whitespace(text: str, index: int) -> int:
+  match = _JSON_WHITESPACE.match(text, index)
+  return match.end() if match else index
+
+
+class _PayloadTooLarge(Exception):
+  """The object yielded more bytes than the size gate admitted."""
+
+
+class _BoundedS3Body(io.RawIOBase):
+  """Raw stream over an S3 body that stops once ``limit`` bytes have been read.
+
+  The size gate ran against HEAD; the presigned PUT stays valid for an hour, so
+  the object can be replaced by a larger one between HEAD and GET. Bounding the
+  read here — rather than trusting ContentLength — is what keeps a swap from
+  turning the count into an unbounded read.
+  """
+
+  def __init__(self, body: Any, limit: int) -> None:
+    super().__init__()
+    self._body = body
+    self._limit = limit
+    self._consumed = 0
+
+  def readable(self) -> bool:
+    return True
+
+  def readinto(self, buffer: Any) -> int:
+    chunk = self._body.read(len(buffer))
+    self._consumed += len(chunk)
+    if self._consumed > self._limit:
+      raise _PayloadTooLarge(f"object exceeded {self._limit:,} bytes while being read")
+    buffer[: len(chunk)] = chunk
+    return len(chunk)
+
+
+def _object_size(s3: Any, bucket: str, key: str) -> int:
+  return int(s3.head_object(Bucket=bucket, Key=key)["ContentLength"])
+
+
+def _read_range(s3: Any, bucket: str, key: str, start: int, end: int) -> bytes:
+  response = s3.get_object(Bucket=bucket, Key=key, Range=f"bytes={start}-{end}")
+  return response["Body"].read()
+
+
+def _parquet_row_count(
+  s3: Any, bucket: str, key: str, file_size: int, byte_limit: int
+) -> int:
+  """Row count from the parquet footer alone — no row group is ever decoded.
+
+  Reading the whole object and decoding it (``pq.read_table``) is what made a
+  100 MB snappy file a multi-GB allocation; the footer carries ``num_rows``
+  and is all a count needs. pyarrow parses metadata relative to the end of the
+  buffer, so a buffer holding only footer + trailer reads like the full file.
+  """
+  import pyarrow.parquet as pq
+  from botocore.exceptions import FlexibleChecksumError
+
+  try:
+    tail_len = min(file_size, _PARQUET_TAIL_READ_BYTES)
+    tail = _read_range(s3, bucket, key, file_size - tail_len, file_size - 1)
+  except FlexibleChecksumError:
+    # LocalStack (and some S3-compatible stores) answer a ranged GET with the
+    # whole object's checksum, which botocore then fails to verify — same
+    # quirk `dagster/resources/storage.py` sidesteps. Real S3 omits the header
+    # for a range. Fall back to one bounded full read; the parse below is
+    # still footer-only, so this costs transfer, not memory.
+    tail = io.BufferedReader(
+      _BoundedS3Body(s3.get_object(Bucket=bucket, Key=key)["Body"], byte_limit),
+      _STREAM_BUFFER_BYTES,
+    ).read()
+    file_size = len(tail)
+  if len(tail) < _PARQUET_TRAILER_BYTES or tail[-4:] != b"PAR1":
+    raise ValueError("missing parquet trailer")
+  footer_len = int.from_bytes(tail[-8:-4], "little")
+  footer_span = footer_len + _PARQUET_TRAILER_BYTES
+  if footer_span > file_size:
+    raise ValueError("parquet footer length exceeds the object")
+  if footer_len > _PARQUET_MAX_FOOTER_BYTES:
+    raise ValueError(f"parquet footer of {footer_len:,} bytes refused")
+  if footer_span > len(tail):
+    tail = _read_range(s3, bucket, key, file_size - footer_span, file_size - 1)
+  return pq.read_metadata(io.BytesIO(tail[-footer_span:])).num_rows
+
+
+def _csv_row_count(body: Any, byte_limit: int, row_cap: int) -> int:
+  """Data rows in a CSV, streamed row by row; stops once past ``row_cap``.
+
+  ``csv.reader`` over a text stream handles quoted newlines without holding
+  more than one record, so memory is bounded by the longest record rather than
+  the file. Counting stops one past the cap because the exact figure of a file
+  that is being refused anyway is not worth the rest of the scan.
+  """
+  import csv
+
+  text = io.TextIOWrapper(
+    io.BufferedReader(_BoundedS3Body(body, byte_limit), _STREAM_BUFFER_BYTES),
+    encoding="utf-8",
+    newline="",
+  )
+  records = 0
+  for _ in csv.reader(text):
+    records += 1
+    if records - 1 > row_cap:
+      break
+  return max(records - 1, 0)
+
+
+def _json_row_count(body: Any, byte_limit: int, row_cap: int) -> int:
+  """Elements of a top-level JSON array; anything else stages as one row.
+
+  Walks the array with ``raw_decode`` one element at a time instead of
+  ``json.loads`` on the whole payload: the text is held once (bounded by the
+  size gate) and elements are decoded and dropped in turn, so a 100 MB array
+  no longer expands into gigabytes of Python objects just to be ``len()``'d.
+  """
+  import json
+
+  text = (
+    io.BufferedReader(_BoundedS3Body(body, byte_limit), _STREAM_BUFFER_BYTES)
+    .read()
+    .decode("utf-8")
+  )
+  index = _skip_json_whitespace(text, 0)
+  if index >= len(text) or text[index] != "[":
+    return 1
+
+  decoder = json.JSONDecoder()
+  count = 0
+  index += 1
+  while True:
+    index = _skip_json_whitespace(text, index)
+    if index >= len(text):
+      raise ValueError("unterminated JSON array")
+    if text[index] == "]":
+      return count
+    _, index = decoder.raw_decode(text, index)
+    count += 1
+    if count > row_cap:
+      return count
+    index = _skip_json_whitespace(text, index)
+    if index < len(text) and text[index] == ",":
+      index += 1
+
+
+def _measure_row_count(
+  s3: Any,
+  bucket: str,
+  key: str,
+  file_format: str,
+  file_size: int,
+  row_cap: int,
+) -> tuple[int | None, bool]:
+  """``(row_count, exact)`` for the object; sync, meant for a worker thread.
+
+  A format that cannot be counted (malformed, unreadable) falls back to the
+  bytes-per-row estimate — same degradation as before — and reports
+  ``exact=False``. Unknown formats yield ``None``. A body that outgrows the
+  size gate mid-read escapes as ``_PayloadTooLarge`` for the caller.
+  """
+  if file_format not in _FALLBACK_BYTES_PER_ROW:
+    return None, False
+  byte_limit = MAX_FILE_SIZE_MB * 1024 * 1024
+  try:
+    if file_format == "parquet":
+      return _parquet_row_count(s3, bucket, key, file_size, byte_limit), True
+    body = s3.get_object(Bucket=bucket, Key=key)["Body"]
+    if file_format == "csv":
+      return _csv_row_count(body, byte_limit, row_cap), True
+    return _json_row_count(body, byte_limit, row_cap), True
+  except _PayloadTooLarge:
+    raise
+  except Exception as e:
+    logger.warning(
+      f"Could not calculate row count for {key} ({file_format}): {e}. "
+      f"Row count will be estimated."
+    )
+    return file_size // _FALLBACK_BYTES_PER_ROW[file_format], False
 
 
 async def ingest_file_cmd(
@@ -42,14 +246,16 @@ async def ingest_file_cmd(
       status_code=status.HTTP_404_NOT_FOUND, detail=f"File {file_id} not found"
     )
 
+  # boto3 clients are safe to share across threads; the S3 calls below run in
+  # a worker thread via ``run_off_loop`` so a 100 MB read never stalls the
+  # single-worker API loop for every other tenant.
   s3_client = S3Client()
   bucket = env.USER_DATA_BUCKET
 
   try:
-    head_response = s3_client.s3_client.head_object(
-      Bucket=bucket, Key=graph_file.s3_key
+    actual_file_size = await run_off_loop(
+      _object_size, s3_client.s3_client, bucket, graph_file.s3_key
     )
-    actual_file_size = head_response["ContentLength"]
   except Exception as e:
     logger.error(f"Failed to get file size from S3: {e}")
     raise HTTPException(
@@ -116,51 +322,46 @@ async def ingest_file_cmd(
       f"Attempted upload: {actual_file_size / (1024**3):.2f} GB",
     )
 
-  actual_row_count = None
+  # The per-file row cap is the tier's per-table materialization cap, bounded
+  # by the platform ceiling: a single file above `max_single_table_rows` can
+  # never materialize on this tier, so it is refused here instead of after it
+  # has been stored and staged. Fallback tracks ladybug-standard, as in
+  # IngestionLimitChecker — a fallback wider than the box defeats the guard.
+  tier_row_cap = GraphTierConfig.get_graph_limits(graph_tier).get(
+    "max_single_table_rows", 2_500_000
+  )
+  row_cap = min(MAX_ROWS_PER_FILE, int(tier_row_cap))
+  file_format = str(graph_file.file_format)
+
   try:
-    file_obj = s3_client.s3_client.get_object(Bucket=bucket, Key=graph_file.s3_key)
-    file_content = file_obj["Body"].read()
-
-    file_format = str(graph_file.file_format)
-    if file_format == "parquet":
-      from io import BytesIO
-
-      import pyarrow.parquet as pq
-
-      parquet_file = pq.read_table(BytesIO(file_content))
-      actual_row_count = parquet_file.num_rows
-    elif file_format == "csv":
-      import csv
-      from io import StringIO
-
-      csv_content = file_content.decode("utf-8")
-      reader = csv.reader(StringIO(csv_content))
-      actual_row_count = sum(1 for _ in reader) - 1
-    elif graph_file.file_format == "json":
-      import json
-
-      json_data = json.loads(file_content)
-      if isinstance(json_data, list):
-        actual_row_count = len(json_data)
-      else:
-        actual_row_count = 1
-
-    logger.info(f"Calculated row count for {graph_file.file_name}: {actual_row_count}")
-  except Exception as e:
-    logger.warning(
-      f"Could not calculate row count for {graph_file.file_name}: {e}. Row count will be estimated."
+    actual_row_count, exact_count = await run_off_loop(
+      _measure_row_count,
+      s3_client.s3_client,
+      bucket,
+      graph_file.s3_key,
+      file_format,
+      actual_file_size,
+      row_cap,
     )
-    if graph_file.file_format == "parquet":
-      actual_row_count = actual_file_size // FALLBACK_BYTES_PER_ROW_PARQUET
-    elif graph_file.file_format == "csv":
-      actual_row_count = actual_file_size // FALLBACK_BYTES_PER_ROW_CSV
-    elif graph_file.file_format == "json":
-      actual_row_count = actual_file_size // FALLBACK_BYTES_PER_ROW_JSON
-    else:
-      actual_row_count = actual_file_size // FALLBACK_BYTES_PER_ROW_CSV
-    logger.info(
-      f"Estimated row count for {graph_file.file_name} ({graph_file.file_format}): {actual_row_count}"
+  except _PayloadTooLarge:
+    raise HTTPException(
+      status_code=status.HTTP_400_BAD_REQUEST,
+      detail=f"File exceeds maximum of {MAX_FILE_SIZE_MB} MB",
     )
+
+  if actual_row_count is not None and actual_row_count > row_cap:
+    raise HTTPException(
+      status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+      detail=(
+        f"File has {'at least ' if exact_count else 'an estimated '}"
+        f"{actual_row_count:,} rows, exceeding the per-file limit of "
+        f"{row_cap:,} rows for tier {graph_tier}"
+      ),
+    )
+  logger.info(
+    f"{'Calculated' if exact_count else 'Estimated'} row count for "
+    f"{graph_file.file_name} ({file_format}): {actual_row_count}"
+  )
 
   graph_file.file_size_bytes = actual_file_size
   graph_file.row_count = actual_row_count

--- a/robosystems/operations/graph/commands/ingest_file.py
+++ b/robosystems/operations/graph/commands/ingest_file.py
@@ -217,10 +217,16 @@ def _measure_row_count(
   try:
     if file_format == "parquet":
       return _parquet_row_count(s3, bucket, key, file_size, byte_limit), True
+    # Closed on every exit: an early stop at the row cap would otherwise
+    # leave the HTTP connection to S3 open until garbage collection, and a
+    # burst of cap-rejected uploads would drain the client's connection pool.
     body = s3.get_object(Bucket=bucket, Key=key)["Body"]
-    if file_format == "csv":
-      return _csv_row_count(body, byte_limit, row_cap), True
-    return _json_row_count(body, byte_limit, row_cap), True
+    try:
+      if file_format == "csv":
+        return _csv_row_count(body, byte_limit, row_cap), True
+      return _json_row_count(body, byte_limit, row_cap), True
+    finally:
+      body.close()
   except _PayloadTooLarge:
     raise
   except Exception as e:

--- a/robosystems/operations/graph/commands/materialize.py
+++ b/robosystems/operations/graph/commands/materialize.py
@@ -25,7 +25,8 @@ async def materialize_cmd(
   - Billing enforcement / write-access check
   - Source auto-detection based on graph type
   - Dry-run limit validation (returns immediately, no lock acquired)
-  - Distributed lock to prevent concurrent materialization
+  - Distributed lock to prevent concurrent materialization (fail-closed:
+    409 when held, 503 + Retry-After when the lock service is unavailable)
   - Content-limit gate (413 if tier limits exceeded)
   - Source routing: extensions (OLTP) vs staged (DuckDB) x direct vs Dagster
 
@@ -89,24 +90,49 @@ async def materialize_cmd(
       "limit_check": limit_check,
     }
 
-  # Acquire distributed lock to prevent concurrent materialization
-  lock = None
+  # Acquire distributed lock to prevent concurrent materialization. This
+  # fails closed: a materialization is a retryable background job (the
+  # staleness sensor re-fires within minutes, and the client can retry), but
+  # an unlocked double-writer silently duplicates relationship-table edges.
+  # A Valkey outage is therefore a 503 with Retry-After, never a lockless run.
+  lock_unavailable = HTTPException(
+    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+    detail=(
+      "Materialization lock service unavailable; retry shortly "
+      "(materialization refuses to run unlocked)"
+    ),
+    headers={"Retry-After": "30"},
+  )
   try:
     redis_client = create_redis_client(ValkeyDatabase.LOCKS)
     lock = DistributedLock(
       redis_client, f"graph_materialize:{graph_id}", ttl_seconds=INGESTION_LOCK_TTL
     )
     lock_result = lock.acquire(blocking=False)
-    if not lock_result.acquired:
-      raise HTTPException(
-        status_code=status.HTTP_409_CONFLICT,
-        detail="Materialization already in progress for this graph",
-      )
-  except HTTPException:
-    raise
   except Exception as e:
     logger.warning(f"Could not acquire distributed lock for {graph_id}: {e}")
-    lock = None  # Degraded mode — proceed without lock
+    raise lock_unavailable from e
+
+  if not lock_result.acquired:
+    if lock_result.backend_error:
+      logger.warning(
+        f"Distributed lock backend error for {graph_id}: {lock_result.error_message}"
+      )
+      raise lock_unavailable
+    raise HTTPException(
+      status_code=status.HTTP_409_CONFLICT,
+      detail="Materialization already in progress for this graph",
+    )
+
+  # The worker releases the lock when the task finishes; lock_id makes that a
+  # compare-and-delete, so a task that outlives the TTL cannot strip a
+  # successor's lock. The lock is not extended from the worker: the
+  # extensions task's own timeout (TASK_TIMEOUTS, 1800s) is half of
+  # INGESTION_LOCK_TTL, so it cannot lapse under a running task, and the
+  # per-graph MaterializationLock inside the run is the one that is extended
+  # at each table checkpoint.
+  lock_key = f"graph_materialize:{graph_id}"
+  lock_id = lock.lock_id
 
   try:
     graph_tier = graph.graph_tier or "ladybug-standard"
@@ -158,7 +184,6 @@ async def materialize_cmd(
     if source == "extensions":
       from robosystems.worker.client import enqueue_task
 
-      lock_key = f"graph_materialize:{graph_id}" if lock else None
       response = await enqueue_task(
         task_type="extensions_materialize",
         graph_id=graph_id,
@@ -166,6 +191,7 @@ async def materialize_cmd(
         params={
           "rebuild": body.rebuild,
           "lock_key": lock_key,
+          "lock_id": lock_id,
         },
       )
       return {
@@ -178,7 +204,6 @@ async def materialize_cmd(
     # Staged path: uploaded parquet files → DuckDB → LadybugDB
     _require_rebuild_for_populated_graph(db, graph_id, rebuild=body.rebuild)
     use_direct = _should_use_direct_materialization(db, graph_id)
-    lock_key = f"graph_materialize:{graph_id}" if lock else None
 
     if use_direct:
       from robosystems.worker.client import enqueue_task
@@ -192,6 +217,7 @@ async def materialize_cmd(
           "rebuild": body.rebuild,
           "materialize_embeddings": body.materialize_embeddings,
           "lock_key": lock_key,
+          "lock_id": lock_id,
         },
       )
       return {
@@ -221,6 +247,7 @@ async def materialize_cmd(
           "job_name": "materialize_graph_job",
           "run_config": run_config,
           "lock_key": lock_key,
+          "lock_id": lock_id,
         },
       )
       return {
@@ -231,8 +258,7 @@ async def materialize_cmd(
       }
 
   except Exception:
-    if lock is not None:
-      lock.release()
+    lock.release()
     raise
 
 

--- a/robosystems/operations/taxonomy_block/resync.py
+++ b/robosystems/operations/taxonomy_block/resync.py
@@ -46,7 +46,7 @@ _TENANT_SCHEMA_SQL = text(
 
 def list_tenant_schemas() -> list[str]:
   """Every provisioned tenant schema name, sorted."""
-  with extensions_session(LIBRARY_GRAPH_ID) as session:
+  with extensions_session(LIBRARY_GRAPH_ID, statement_timeout_ms=None) as session:
     rows = session.execute(_TENANT_SCHEMA_SQL).fetchall()
   return [row[0] for row in rows]
 
@@ -59,7 +59,7 @@ def resync_tenant(graph_id: str, pin: dict[str, str] | None = None) -> CopyStats
   the library UPDATEs, then the ``DO UPDATE`` fan-out runs across all 12 library
   tables on the same connection/transaction.
   """
-  with extensions_session(graph_id) as session:
+  with extensions_session(graph_id, statement_timeout_ms=None) as session:
     session.execute(text(SET_LIBRARY_RESYNC))
     stats = resync_library_into_tenant(session.connection(), graph_id, pin)
   logger.info(

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -81,10 +81,10 @@ from robosystems.middleware.operations import (
   IdempotencyKeyConflictError,
   OperationContext,
   OperationEnvelope,
-  check_idempotency,
   execute_operation,
   fingerprint_body,
   get_idempotency_cache,
+  idempotent_dispatch,
   log_operation_audit,
   wrap_pending,
 )
@@ -1166,7 +1166,7 @@ async def auto_map_elements_op(
   user_id = str(user.id)
   body_fingerprint = fingerprint_body(body)
 
-  replay = await check_idempotency(
+  async with idempotent_dispatch(
     cache,
     user_id,
     graph_id,
@@ -1174,43 +1174,40 @@ async def auto_map_elements_op(
     idempotency_key,
     body_fingerprint,
     event="extensions.operation",
-  )
-  if replay is not None:
-    return replay
+  ) as idem:
+    if idem.replay is not None:
+      return idem.replay
 
-  task_response = await enqueue_task(
-    task_type="operator",
-    graph_id=graph_id,
-    user_id=user_id,
-    params={"operator_type": "mapping", "mapping_id": body.mapping_id},
-  )
-
-  envelope = wrap_pending(
-    op_name,
-    operation_id=task_response["operation_id"],
-    partial_result={
-      "operation_type": task_response.get("operation_type"),
-      "links": task_response.get("_links"),
-      "deduplicated": task_response.get("deduplicated", False),
-    },
-    created_by=user_id,
-  )
-
-  if idempotency_key is not None:
-    await cache.put(
-      user_id, graph_id, op_name, idempotency_key, envelope, body_fingerprint
+    task_response = await enqueue_task(
+      task_type="operator",
+      graph_id=graph_id,
+      user_id=user_id,
+      params={"operator_type": "mapping", "mapping_id": body.mapping_id},
     )
 
-  log_operation_audit(
-    operation_name=op_name,
-    operation_id=envelope.operation_id,
-    user_id=user_id,
-    graph_id=graph_id,
-    duration_ms=0.0,
-    status="pending",
-    idempotency_key=idempotency_key,
-  )
-  return envelope
+    envelope = wrap_pending(
+      op_name,
+      operation_id=task_response["operation_id"],
+      partial_result={
+        "operation_type": task_response.get("operation_type"),
+        "links": task_response.get("_links"),
+        "deduplicated": task_response.get("deduplicated", False),
+      },
+      created_by=user_id,
+    )
+
+    await idem.record(envelope)
+
+    log_operation_audit(
+      operation_name=op_name,
+      operation_id=envelope.operation_id,
+      user_id=user_id,
+      graph_id=graph_id,
+      duration_ms=0.0,
+      status="pending",
+      idempotency_key=idempotency_key,
+    )
+    return envelope
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/robosystems/routers/graphs/connections/sync.py
+++ b/robosystems/routers/graphs/connections/sync.py
@@ -15,10 +15,10 @@ from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
 from robosystems.middleware.operations import (
   IdempotencyCache,
   OperationEnvelope,
-  check_idempotency,
   fingerprint_body,
   generate_operation_id,
   get_idempotency_cache,
+  idempotent_dispatch,
   log_operation_audit,
   wrap_pending,
 )
@@ -87,185 +87,186 @@ async def sync_connection(
 
   body_fp = fingerprint_body(request)
 
-  replay = await check_idempotency(
+  async with idempotent_dispatch(
     cache, user_id, graph_id, op_name, idempotency_key, body_fp
-  )
-  if replay is not None:
-    return replay
+  ) as idem:
+    if idem.replay is not None:
+      return idem.replay
 
-  # Initialize robustness components
-  components = create_robustness_components()
-  operation_timeout = None
+    # Initialize robustness components
+    components = create_robustness_components()
+    operation_timeout = None
 
-  # Record operation start metrics
-  record_operation_start(
-    operation_name="sync_connection",
-    endpoint="/v1/graphs/{graph_id}/connections/{connection_id}/sync",
-    graph_id=graph_id,
-    user_id=current_user.id,
-    metadata={"connection_id": connection_id},
-  )
-
-  try:
-    # Check circuit breaker before processing
-    components["circuit_breaker"].check_circuit(graph_id, "connection_sync")
-
-    # Set up timeout coordination for sync operations (these can be long-running)
-    operation_timeout = components["timeout_coordinator"].calculate_timeout(
-      operation_type="external_service",
-      complexity_factors={
-        "operation": "sync_connection",
-        "is_sync_operation": True,
-        "expected_complexity": "high",  # Sync operations can be complex
-      },
-    )
-
-    # Log the request with operation logger
-    components["operation_logger"].log_external_service_call(
+    # Record operation start metrics
+    record_operation_start(
+      operation_name="sync_connection",
       endpoint="/v1/graphs/{graph_id}/connections/{connection_id}/sync",
-      service_name="connection_service",
-      operation="sync_connection",
-      duration_ms=0.0,  # Will be updated on completion
-      status="processing",
       graph_id=graph_id,
       user_id=current_user.id,
       metadata={"connection_id": connection_id},
     )
 
-    # Validate, lock, and dispatch via the shared kernel (also behind
-    # the `sync-connection` MCP tool); map domain exceptions to the
-    # HTTP contract this endpoint has always had.
     try:
-      dispatch = await dispatch_connection_sync(
+      # Check circuit breaker before processing
+      components["circuit_breaker"].check_circuit(graph_id, "connection_sync")
+
+      # Set up timeout coordination for sync operations (these can be long-running)
+      operation_timeout = components["timeout_coordinator"].calculate_timeout(
+        operation_type="external_service",
+        complexity_factors={
+          "operation": "sync_connection",
+          "is_sync_operation": True,
+          "expected_complexity": "high",  # Sync operations can be complex
+        },
+      )
+
+      # Log the request with operation logger
+      components["operation_logger"].log_external_service_call(
+        endpoint="/v1/graphs/{graph_id}/connections/{connection_id}/sync",
+        service_name="connection_service",
+        operation="sync_connection",
+        duration_ms=0.0,  # Will be updated on completion
+        status="processing",
         graph_id=graph_id,
-        connection_id=connection_id,
-        user_id=str(current_user.id),
-        full_rebuild=request.full_rebuild,
-        since_date=request.since_date,
-        sync_options=request.sync_options,
-        dispatch_timeout=operation_timeout,
+        user_id=current_user.id,
+        metadata={"connection_id": connection_id},
       )
-    except ConnectionNotFoundError:
-      raise create_error_response(
-        status_code=status.HTTP_404_NOT_FOUND,
-        detail="Connection not found",
-        code=ErrorCode.NOT_FOUND,
+
+      # Validate, lock, and dispatch via the shared kernel (also behind
+      # the `sync-connection` MCP tool); map domain exceptions to the
+      # HTTP contract this endpoint has always had.
+      try:
+        dispatch = await dispatch_connection_sync(
+          graph_id=graph_id,
+          connection_id=connection_id,
+          user_id=str(current_user.id),
+          full_rebuild=request.full_rebuild,
+          since_date=request.since_date,
+          sync_options=request.sync_options,
+          dispatch_timeout=operation_timeout,
+        )
+      except ConnectionNotFoundError:
+        raise create_error_response(
+          status_code=status.HTTP_404_NOT_FOUND,
+          detail="Connection not found",
+          code=ErrorCode.NOT_FOUND,
+        )
+      except SyncInProgressError as e:
+        raise create_error_response(
+          status_code=status.HTTP_409_CONFLICT,
+          detail=str(e),
+          code=ErrorCode.OPERATION_FAILED,
+        )
+
+      provider = dispatch["provider"]
+      task_id = dispatch["task_id"]
+
+      # Record successful operation
+      record_operation_success(
+        components=components,
+        operation_name="sync_connection",
+        endpoint="/v1/graphs/{graph_id}/connections/{connection_id}/sync",
+        graph_id=graph_id,
+        user_id=current_user.id,
+        metadata={
+          "connection_id": connection_id,
+          "provider": provider,
+          "task_id": task_id,
+        },
       )
-    except SyncInProgressError as e:
+
+      operation_id = generate_operation_id()
+      envelope = wrap_pending(
+        op_name,
+        operation_id=operation_id,
+        partial_result={
+          "message": f"{provider.upper()} sync started",
+          "connection_id": connection_id,
+          "task_id": task_id,
+        },
+        created_by=user_id,
+      )
+
+      # The task id here is the provider's Dagster run, not an SSE operation, so
+      # the pending envelope has no terminal-status hook to evict it; the
+      # reservation still keeps a concurrent retry from dispatching twice.
+      await idem.record(envelope)
+
+      log_operation_audit(
+        operation_name=op_name,
+        operation_id=operation_id,
+        user_id=user_id,
+        graph_id=graph_id,
+        duration_ms=0.0,
+        status="pending",
+        idempotency_key=idempotency_key,
+        event="graph.operation",
+      )
+      return envelope
+
+    except TimeoutError:
+      # Record circuit breaker failure and timeout metrics
+      record_operation_failure(
+        components=components,
+        operation_name="sync_connection",
+        endpoint="/v1/graphs/{graph_id}/connections/{connection_id}/sync",
+        graph_id=graph_id,
+        user_id=current_user.id,
+        error_type="timeout",
+        timeout_seconds=operation_timeout,
+      )
+
+      timeout_str = f" after {operation_timeout}s" if operation_timeout else ""
+      logger.error(f"Connection sync timeout{timeout_str} for user {current_user.id}")
       raise create_error_response(
-        status_code=status.HTTP_409_CONFLICT,
-        detail=str(e),
+        status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+        detail="Connection sync timed out",
         code=ErrorCode.OPERATION_FAILED,
       )
+    except HTTPException:
+      # Record circuit breaker failure for HTTP exceptions
+      record_operation_failure(
+        components=components,
+        operation_name="sync_connection",
+        endpoint="/v1/graphs/{graph_id}/connections/{connection_id}/sync",
+        graph_id=graph_id,
+        user_id=current_user.id,
+        error_type="http_exception",
+      )
+      raise
+    except (ProviderUnavailableError, ValueError) as e:
+      # Handle disabled provider errors as client errors
+      record_operation_failure(
+        components=components,
+        operation_name="sync_connection",
+        endpoint="/v1/graphs/{graph_id}/connections/{connection_id}/sync",
+        graph_id=graph_id,
+        user_id=current_user.id,
+        error_type="provider_disabled",
+        error_message=str(e),
+      )
 
-    provider = dispatch["provider"]
-    task_id = dispatch["task_id"]
+      logger.warning(f"Provider not available for sync: {e}")
+      raise create_error_response(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="The requested provider is not available.",
+        code=ErrorCode.FORBIDDEN,
+      )
+    except Exception as e:
+      # Record circuit breaker failure for general exceptions
+      record_operation_failure(
+        components=components,
+        operation_name="sync_connection",
+        endpoint="/v1/graphs/{graph_id}/connections/{connection_id}/sync",
+        graph_id=graph_id,
+        user_id=current_user.id,
+        error_type=type(e).__name__,
+        error_message=str(e),
+      )
 
-    # Record successful operation
-    record_operation_success(
-      components=components,
-      operation_name="sync_connection",
-      endpoint="/v1/graphs/{graph_id}/connections/{connection_id}/sync",
-      graph_id=graph_id,
-      user_id=current_user.id,
-      metadata={
-        "connection_id": connection_id,
-        "provider": provider,
-        "task_id": task_id,
-      },
-    )
-
-    operation_id = generate_operation_id()
-    envelope = wrap_pending(
-      op_name,
-      operation_id=operation_id,
-      partial_result={
-        "message": f"{provider.upper()} sync started",
-        "connection_id": connection_id,
-        "task_id": task_id,
-      },
-      created_by=user_id,
-    )
-
-    # Known limitation: cache.put is after task dispatch. See create_graph for details.
-    if idempotency_key is not None:
-      await cache.put(user_id, graph_id, op_name, idempotency_key, envelope, body_fp)
-
-    log_operation_audit(
-      operation_name=op_name,
-      operation_id=operation_id,
-      user_id=user_id,
-      graph_id=graph_id,
-      duration_ms=0.0,
-      status="pending",
-      idempotency_key=idempotency_key,
-      event="graph.operation",
-    )
-    return envelope
-
-  except TimeoutError:
-    # Record circuit breaker failure and timeout metrics
-    record_operation_failure(
-      components=components,
-      operation_name="sync_connection",
-      endpoint="/v1/graphs/{graph_id}/connections/{connection_id}/sync",
-      graph_id=graph_id,
-      user_id=current_user.id,
-      error_type="timeout",
-      timeout_seconds=operation_timeout,
-    )
-
-    timeout_str = f" after {operation_timeout}s" if operation_timeout else ""
-    logger.error(f"Connection sync timeout{timeout_str} for user {current_user.id}")
-    raise create_error_response(
-      status_code=status.HTTP_504_GATEWAY_TIMEOUT,
-      detail="Connection sync timed out",
-      code=ErrorCode.OPERATION_FAILED,
-    )
-  except HTTPException:
-    # Record circuit breaker failure for HTTP exceptions
-    record_operation_failure(
-      components=components,
-      operation_name="sync_connection",
-      endpoint="/v1/graphs/{graph_id}/connections/{connection_id}/sync",
-      graph_id=graph_id,
-      user_id=current_user.id,
-      error_type="http_exception",
-    )
-    raise
-  except (ProviderUnavailableError, ValueError) as e:
-    # Handle disabled provider errors as client errors
-    record_operation_failure(
-      components=components,
-      operation_name="sync_connection",
-      endpoint="/v1/graphs/{graph_id}/connections/{connection_id}/sync",
-      graph_id=graph_id,
-      user_id=current_user.id,
-      error_type="provider_disabled",
-      error_message=str(e),
-    )
-
-    logger.warning(f"Provider not available for sync: {e}")
-    raise create_error_response(
-      status_code=status.HTTP_403_FORBIDDEN,
-      detail="The requested provider is not available.",
-      code=ErrorCode.FORBIDDEN,
-    )
-  except Exception as e:
-    # Record circuit breaker failure for general exceptions
-    record_operation_failure(
-      components=components,
-      operation_name="sync_connection",
-      endpoint="/v1/graphs/{graph_id}/connections/{connection_id}/sync",
-      graph_id=graph_id,
-      user_id=current_user.id,
-      error_type=type(e).__name__,
-      error_message=str(e),
-    )
-
-    logger.error("Failed to sync connection %s", connection_id, exc_info=True)
-    raise create_error_response(
-      status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-      detail="Failed to sync connection",
-      code=ErrorCode.INTERNAL_ERROR,
-    )
+      logger.error("Failed to sync connection %s", connection_id, exc_info=True)
+      raise create_error_response(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Failed to sync connection",
+        code=ErrorCode.INTERNAL_ERROR,
+      )

--- a/robosystems/routers/graphs/content_ops.py
+++ b/robosystems/routers/graphs/content_ops.py
@@ -31,9 +31,9 @@ from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
 from robosystems.middleware.operations import (
   IdempotencyCache,
   OperationEnvelope,
-  check_idempotency,
   fingerprint_body,
   get_idempotency_cache,
+  idempotent_dispatch,
   log_operation_audit,
   wrap_completed,
   wrap_pending,
@@ -584,47 +584,46 @@ async def ingest_file_op(
   user_id = str(user.id)
   body_fp = fingerprint_body(body)
 
-  replay = await check_idempotency(
+  async with idempotent_dispatch(
     cache, user_id, graph_id, op_name, idempotency_key, body_fp
-  )
-  if replay is not None:
-    return replay
+  ) as idem:
+    if idem.replay is not None:
+      return idem.replay
 
-  result = await ingest_file_cmd(
-    graph_id=graph_id,
-    file_id=body.file_id,
-    ingest_to_graph=body.ingest_to_graph,
-    current_user=user,
-    db=db,
-    background_tasks=background_tasks,
-  )
-
-  # Async staging (Dagster) returns an operation_id → pending; direct staging with
-  # no follow-on ingest completes inline → completed.
-  if result.get("operation_id"):
-    envelope = wrap_pending(
-      op_name,
-      operation_id=result["operation_id"],
-      partial_result=result,
-      created_by=user_id,
+    result = await ingest_file_cmd(
+      graph_id=graph_id,
+      file_id=body.file_id,
+      ingest_to_graph=body.ingest_to_graph,
+      current_user=user,
+      db=db,
+      background_tasks=background_tasks,
     )
-  else:
-    envelope = wrap_completed(op_name, result=result, created_by=user_id)
 
-  if idempotency_key is not None:
-    await cache.put(user_id, graph_id, op_name, idempotency_key, envelope, body_fp)
+    # Async staging (Dagster) returns an operation_id → pending; direct staging
+    # with no follow-on ingest completes inline → completed.
+    if result.get("operation_id"):
+      envelope = wrap_pending(
+        op_name,
+        operation_id=result["operation_id"],
+        partial_result=result,
+        created_by=user_id,
+      )
+    else:
+      envelope = wrap_completed(op_name, result=result, created_by=user_id)
 
-  log_operation_audit(
-    operation_name=op_name,
-    operation_id=envelope.operation_id,
-    user_id=user_id,
-    graph_id=graph_id,
-    duration_ms=0.0,
-    status=envelope.status,
-    idempotency_key=idempotency_key,
-    event=_AUDIT_EVENT,
-  )
-  return envelope
+    await idem.record(envelope)
+
+    log_operation_audit(
+      operation_name=op_name,
+      operation_id=envelope.operation_id,
+      user_id=user_id,
+      graph_id=graph_id,
+      duration_ms=0.0,
+      status=envelope.status,
+      idempotency_key=idempotency_key,
+      event=_AUDIT_EVENT,
+    )
+    return envelope
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/robosystems/routers/graphs/main.py
+++ b/robosystems/routers/graphs/main.py
@@ -14,9 +14,9 @@ from robosystems.middleware.auth.dependencies import (
 from robosystems.middleware.operations import (
   IdempotencyCache,
   OperationEnvelope,
-  check_idempotency,
   fingerprint_body,
   get_idempotency_cache,
+  idempotent_dispatch,
   log_operation_audit,
   wrap_pending,
 )
@@ -358,144 +358,148 @@ async def create_graph(
   _graph_id = "new"
   body_fp = fingerprint_body(request)
 
-  replay = await check_idempotency(
+  # The key is reserved from here until the pending envelope is recorded, so
+  # a concurrent retry cannot dispatch a second creation, and every exit that
+  # does not record — a 402/403 from the checks below, an enqueue failure —
+  # releases it.
+  async with idempotent_dispatch(
     cache, user_id, _graph_id, op_name, idempotency_key, body_fp
-  )
-  if replay is not None:
-    return replay
+  ) as idem:
+    if idem.replay is not None:
+      return idem.replay
 
-  try:
-    # Check org's graph limits
-    user_orgs = OrgUser.get_user_orgs(current_user.id, db)
-    if not user_orgs:
-      # Reachable, not exceptional: removal from a last org leaves an account
-      # with no membership, and every other org-resolving surface answers 403
-      # here. A 500 would file an ordinary authorization outcome as a server
-      # fault and count against the API's error rate.
-      _raise_http_exception(
-        status_code=status.HTTP_403_FORBIDDEN,
-        error_code="org_not_found",
-        message=(
-          "You are not a member of any organization, so there is nothing to "
-          "bill a new graph to. Please contact support."
-        ),
-      )
+    try:
+      # Check org's graph limits
+      user_orgs = OrgUser.get_user_orgs(current_user.id, db)
+      if not user_orgs:
+        # Reachable, not exceptional: removal from a last org leaves an account
+        # with no membership, and every other org-resolving surface answers 403
+        # here. A 500 would file an ordinary authorization outcome as a server
+        # fault and count against the API's error rate.
+        _raise_http_exception(
+          status_code=status.HTTP_403_FORBIDDEN,
+          error_code="org_not_found",
+          message=(
+            "You are not a member of any organization, so there is nothing to "
+            "bill a new graph to. Please contact support."
+          ),
+        )
 
-    membership = user_orgs[0]
-    org_id = membership.org_id
+      membership = user_orgs[0]
+      org_id = membership.org_id
 
-    # Creating a graph starts a recurring charge on the org's payment method
-    # and consumes org quota, so it is an owner/admin action. Members cannot
-    # add a payment method either (checkout is owner-only), so without this a
-    # member could commit the org's stored card without its billing
-    # administrators knowing until the invoice arrived.
-    if not membership.can_create_graphs():
-      _raise_http_exception(
-        status_code=status.HTTP_403_FORBIDDEN,
-        error_code="graph_creation_requires_admin",
-        message=(
-          "Only organization owners and admins can create graphs. "
-          "Ask an owner or admin to create one, or to grant you access to "
-          "an existing graph."
-        ),
-      )
+      # Creating a graph starts a recurring charge on the org's payment method
+      # and consumes org quota, so it is an owner/admin action. Members cannot
+      # add a payment method either (checkout is owner-only), so without this a
+      # member could commit the org's stored card without its billing
+      # administrators knowing until the invoice arrived.
+      if not membership.can_create_graphs():
+        _raise_http_exception(
+          status_code=status.HTTP_403_FORBIDDEN,
+          error_code="graph_creation_requires_admin",
+          message=(
+            "Only organization owners and admins can create graphs. "
+            "Ask an owner or admin to create one, or to grant you access to "
+            "an existing graph."
+          ),
+        )
 
-    org_limits = OrgLimits.get_or_create_for_org(org_id, db)
+      org_limits = OrgLimits.get_or_create_for_org(org_id, db)
 
-    can_create, reason = org_limits.can_create_graph(db)
-    if not can_create:
-      _raise_http_exception(
-        status_code=status.HTTP_403_FORBIDDEN,
-        error_code="graph_limit_reached",
-        message=reason,
-      )
+      can_create, reason = org_limits.can_create_graph(db)
+      if not can_create:
+        _raise_http_exception(
+          status_code=status.HTTP_403_FORBIDDEN,
+          error_code="graph_limit_reached",
+          message=reason,
+        )
 
-    tier_map = {
-      "ladybug-standard": GraphTier.LADYBUG_STANDARD,
-      "ladybug-large": GraphTier.LADYBUG_LARGE,
-      "ladybug-xlarge": GraphTier.LADYBUG_XLARGE,
-    }
-    graph_tier = tier_map.get(request.instance_tier.lower(), GraphTier.LADYBUG_STANDARD)
-
-    can_provision, billing_error = check_can_provision_graph(
-      user_id=current_user.id,
-      requested_tier=graph_tier,
-      session=db,
-    )
-    if not can_provision:
-      _raise_http_exception(
-        status_code=status.HTTP_402_PAYMENT_REQUIRED,
-        error_code="payment_required",
-        message=billing_error or "Valid payment method required to create graphs.",
-      )
-
-    is_entity = request.initial_entity is not None
-    entity_data = None
-    if is_entity:
-      entity_data = {
-        **request.initial_entity.model_dump(),
-        "extensions": request.metadata.schema_extensions,
+      tier_map = {
+        "ladybug-standard": GraphTier.LADYBUG_STANDARD,
+        "ladybug-large": GraphTier.LADYBUG_LARGE,
+        "ladybug-xlarge": GraphTier.LADYBUG_XLARGE,
       }
+      graph_tier = tier_map.get(
+        request.instance_tier.lower(), GraphTier.LADYBUG_STANDARD
+      )
 
-    logger.info(
-      f"Enqueuing graph creation: user={current_user.id}, "
-      f"type={'entity' if is_entity else 'generic'}, tier={request.instance_tier}"
-    )
+      can_provision, billing_error = check_can_provision_graph(
+        user_id=current_user.id,
+        requested_tier=graph_tier,
+        session=db,
+      )
+      if not can_provision:
+        _raise_http_exception(
+          status_code=status.HTTP_402_PAYMENT_REQUIRED,
+          error_code="payment_required",
+          message=billing_error or "Valid payment method required to create graphs.",
+        )
 
-    response = await enqueue_task(
-      task_type="graph_creation",
-      graph_id=None,
-      user_id=user_id,
-      params={
-        "graph_type": "entity" if is_entity else "generic",
-        "graph_name": request.metadata.graph_name,
-        "tier": request.instance_tier,
-        "schema_extensions": request.metadata.schema_extensions,
-        "custom_schema": request.custom_schema.model_dump()
-        if request.custom_schema
-        else None,
-        "entity_data": entity_data,
-        "create_entity": request.create_entity if is_entity else False,
-        "description": request.metadata.description,
-        "tags": request.tags or [],
-      },
-    )
+      is_entity = request.initial_entity is not None
+      entity_data = None
+      if is_entity:
+        entity_data = {
+          **request.initial_entity.model_dump(),
+          "extensions": request.metadata.schema_extensions,
+        }
 
-    operation_id = response["operation_id"]
-    envelope = wrap_pending(
-      op_name,
-      operation_id=operation_id,
-      partial_result=response,
-      created_by=user_id,
-    )
+      logger.info(
+        f"Enqueuing graph creation: user={current_user.id}, "
+        f"type={'entity' if is_entity else 'generic'}, tier={request.instance_tier}"
+      )
 
-    # Known limitation: cache.put is after enqueue_task. A Valkey failure here
-    # leaves the task dispatched without idempotency protection — the next retry
-    # would dispatch again. Fixing requires a two-phase write (placeholder before
-    # dispatch, update after), which is a systemic change tracked separately.
-    if idempotency_key is not None:
-      await cache.put(user_id, _graph_id, op_name, idempotency_key, envelope, body_fp)
+      response = await enqueue_task(
+        task_type="graph_creation",
+        graph_id=None,
+        user_id=user_id,
+        params={
+          "graph_type": "entity" if is_entity else "generic",
+          "graph_name": request.metadata.graph_name,
+          "tier": request.instance_tier,
+          "schema_extensions": request.metadata.schema_extensions,
+          "custom_schema": request.custom_schema.model_dump()
+          if request.custom_schema
+          else None,
+          "entity_data": entity_data,
+          "create_entity": request.create_entity if is_entity else False,
+          "description": request.metadata.description,
+          "tags": request.tags or [],
+        },
+      )
 
-    log_operation_audit(
-      operation_name=op_name,
-      operation_id=operation_id,
-      user_id=user_id,
-      graph_id=_graph_id,
-      duration_ms=0.0,
-      status="pending",
-      idempotency_key=idempotency_key,
-      event="graph.operation",
-    )
-    return envelope
+      operation_id = response["operation_id"]
+      envelope = wrap_pending(
+        op_name,
+        operation_id=operation_id,
+        partial_result=response,
+        created_by=user_id,
+      )
 
-  except HTTPException:
-    raise
-  except Exception as e:
-    logger.error(f"Failed to create graph creation operation: {e}", exc_info=True)
-    raise HTTPException(
-      status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-      detail="Failed to create graph creation operation.",
-    )
+      # The pending envelope is bound to the operation: should creation later
+      # fail, the terminal-status hook evicts it so a retry under the same key
+      # dispatches again instead of replaying `pending` for 24h.
+      await idem.record(envelope)
+
+      log_operation_audit(
+        operation_name=op_name,
+        operation_id=operation_id,
+        user_id=user_id,
+        graph_id=_graph_id,
+        duration_ms=0.0,
+        status="pending",
+        idempotency_key=idempotency_key,
+        event="graph.operation",
+      )
+      return envelope
+
+    except HTTPException:
+      raise
+    except Exception as e:
+      logger.error(f"Failed to create graph creation operation: {e}", exc_info=True)
+      raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Failed to create graph creation operation.",
+      )
 
 
 @router.get(

--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -554,6 +554,10 @@ async def call_mcp_tool(
     operation_type = _get_mcp_operation_type(graph_id)
     repository = await get_graph_repository(graph_id, operation_type)
 
+    # The structured formatter keeps only its known top-level fields plus
+    # `metadata`; the tool name and access class live there so the read-tool
+    # trail (who ran which tool on which graph, under which credential) is
+    # searchable rather than buried in the message text.
     api_logger.info(
       f"MCP tool execution started: {tool_call.name}",
       extra={
@@ -561,11 +565,13 @@ async def call_mcp_tool(
         "action": "tool_started",
         "user_id": str(current_user.id),
         "database": graph_id,
-        "tool_name": tool_call.name,
-        "access_type": access_type,
-        "is_write": is_write_query,
+        "request_id": getattr(full_request.state, "request_id", None),
         "metadata": {
           "endpoint": "/v1/graphs/{graph_id}/mcp/call-tool",
+          "tool_name": tool_call.name,
+          "access_type": access_type,
+          "is_write": is_write_query,
+          "api_key_prefix": getattr(full_request.state, "api_key_prefix", None),
           "arguments_size": len(str(tool_call.arguments)) if tool_call.arguments else 0,
         },
       },

--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -571,7 +571,7 @@ async def call_mcp_tool(
           "tool_name": tool_call.name,
           "access_type": access_type,
           "is_write": is_write_query,
-          "api_key_prefix": getattr(full_request.state, "api_key_prefix", None),
+          "api_key_prefix": key_prefix,
           "arguments_size": len(str(tool_call.arguments)) if tool_call.arguments else 0,
         },
       },

--- a/robosystems/routers/graphs/mcp/handlers.py
+++ b/robosystems/routers/graphs/mcp/handlers.py
@@ -105,6 +105,17 @@ async def validate_mcp_access(
           detail=f"Write access denied to graph {graph_id}; your role is read-only.",
         )
     elif not GraphUser.user_has_access(current_user.id, graph_id, db):
+      # A read attempt on a graph the caller is not a member of is the
+      # enumeration signal — audited like the write gate above, so a probe
+      # trips the same detective control rather than only a 403.
+      from robosystems.security import SecurityAuditLogger
+
+      SecurityAuditLogger.log_authorization_denied(
+        user_id=str(current_user.id),
+        resource=graph_id,
+        action="read",
+        endpoint="mcp",
+      )
       raise HTTPException(status_code=403, detail=f"Access denied to graph {graph_id}")
 
     from robosystems.middleware.billing.enforcement import require_graph_access

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -742,8 +742,12 @@ async def _handle_tools_call(
       "action": "tool_started",
       "user_id": str(current_user.id),
       "database": graph_id,
-      "tool_name": name,
-      "access_type": access_type,
+      "request_id": getattr(request.state, "request_id", None),
+      "metadata": {
+        "tool_name": name,
+        "access_type": access_type,
+        "api_key_prefix": getattr(request.state, "api_key_prefix", None),
+      },
     },
   )
 

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -746,7 +746,7 @@ async def _handle_tools_call(
       "metadata": {
         "tool_name": name,
         "access_type": access_type,
-        "api_key_prefix": getattr(request.state, "api_key_prefix", None),
+        "api_key_prefix": key_prefix,
       },
     },
   )

--- a/robosystems/routers/graphs/operations.py
+++ b/robosystems/routers/graphs/operations.py
@@ -32,11 +32,11 @@ from robosystems.middleware.operations import (
   IdempotencyKeyConflictError,
   OperationContext,
   OperationEnvelope,
-  check_idempotency,
   execute_operation,
   fingerprint_body,
   generate_operation_id,
   get_idempotency_cache,
+  idempotent_dispatch,
   log_operation_audit,
   wrap_completed,
   wrap_pending,
@@ -170,38 +170,35 @@ async def create_subgraph_op(
 
   if body.fork_parent:
     # Async path — enqueue worker task, return pending envelope
-    replay = await check_idempotency(
+    async with idempotent_dispatch(
       cache, user_id, graph_id, op_name, idempotency_key, fingerprint_body(body)
-    )
-    if replay is not None:
-      return replay
+    ) as idem:
+      if idem.replay is not None:
+        return idem.replay
 
-    result = await create_subgraph(
-      request=body, graph_id=graph_id, current_user=user, db=db
-    )
-    operation_id = result.get("operation_id", generate_operation_id())
-
-    envelope = wrap_pending(
-      op_name,
-      operation_id=operation_id,
-      partial_result=result,
-      created_by=user_id,
-    )
-    if idempotency_key is not None:
-      await cache.put(
-        user_id, graph_id, op_name, idempotency_key, envelope, fingerprint_body(body)
+      result = await create_subgraph(
+        request=body, graph_id=graph_id, current_user=user, db=db
       )
-    log_operation_audit(
-      operation_name=op_name,
-      operation_id=envelope.operation_id,
-      user_id=user_id,
-      graph_id=graph_id,
-      duration_ms=0.0,
-      status="pending",
-      idempotency_key=idempotency_key,
-      event=_AUDIT_EVENT,
-    )
-    return envelope
+      operation_id = result.get("operation_id", generate_operation_id())
+
+      envelope = wrap_pending(
+        op_name,
+        operation_id=operation_id,
+        partial_result=result,
+        created_by=user_id,
+      )
+      await idem.record(envelope)
+      log_operation_audit(
+        operation_name=op_name,
+        operation_id=envelope.operation_id,
+        user_id=user_id,
+        graph_id=graph_id,
+        duration_ms=0.0,
+        status="pending",
+        idempotency_key=idempotency_key,
+        event=_AUDIT_EVENT,
+      )
+      return envelope
 
   # Sync path — create immediately
   ctx = _ctx(
@@ -659,122 +656,121 @@ async def create_backup_op(
   user_id = str(user.id)
   body_fp = fingerprint_body(body)
 
-  replay = await check_idempotency(
+  async with idempotent_dispatch(
     cache, user_id, graph_id, op_name, idempotency_key, body_fp
-  )
-  if replay is not None:
-    return replay
+  ) as idem:
+    if idem.replay is not None:
+      return idem.replay
 
-  verify_admin_access(user, graph_id, db)
+    verify_admin_access(user, graph_id, db)
 
-  if is_shared_repository_or_subgraph(graph_id):
-    raise HTTPException(
-      status_code=status.HTTP_403_FORBIDDEN,
-      detail=f"Creating backups is not allowed on shared repository '{graph_id}'.",
+    if is_shared_repository_or_subgraph(graph_id):
+      raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=f"Creating backups is not allowed on shared repository '{graph_id}'.",
+      )
+
+    if not env.BACKUP_CREATION_ENABLED:
+      raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Backup creation is currently disabled.",
+      )
+
+    if body.backup_format != "full_dump":
+      raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="Only 'full_dump' backup format is currently supported",
+      )
+
+    # Cap retention to the tier's maximum. Unconditional: a missing graph row
+    # or tier falls back to the smallest tier's cap rather than skipping the
+    # clamp — an uncapped value would be accepted here and then destroyed by
+    # the 90-day S3 lifecycle rule, leaving a COMPLETED record pointing at a
+    # deleted object.
+    graph_record = Graph.get_by_id(graph_id, db)
+    backup_tier = (
+      str(graph_record.graph_tier)
+      if graph_record and graph_record.graph_tier
+      else "ladybug-standard"
     )
+    backup_limits = GraphTierConfig.get_backup_limits(backup_tier)
+    tier_max = backup_limits.get("backup_retention_days", 7)
+    effective_retention_days = min(body.retention_days, tier_max)
 
-  if not env.BACKUP_CREATION_ENABLED:
-    raise HTTPException(
-      status_code=status.HTTP_403_FORBIDDEN,
-      detail="Backup creation is currently disabled.",
-    )
-
-  if body.backup_format != "full_dump":
-    raise HTTPException(
-      status_code=status.HTTP_400_BAD_REQUEST,
-      detail="Only 'full_dump' backup format is currently supported",
-    )
-
-  # Cap retention to the tier's maximum. Unconditional: a missing graph row
-  # or tier falls back to the smallest tier's cap rather than skipping the
-  # clamp — an uncapped value would be accepted here and then destroyed by
-  # the 90-day S3 lifecycle rule, leaving a COMPLETED record pointing at a
-  # deleted object.
-  graph_record = Graph.get_by_id(graph_id, db)
-  backup_tier = (
-    str(graph_record.graph_tier)
-    if graph_record and graph_record.graph_tier
-    else "ladybug-standard"
-  )
-  backup_limits = GraphTierConfig.get_backup_limits(backup_tier)
-  tier_max = backup_limits.get("backup_retention_days", 7)
-  effective_retention_days = min(body.retention_days, tier_max)
-
-  # Enforce the per-tier daily limit that /limits and /tiers have been
-  # publishing all along. Same fail-small posture as the retention clamp: an
-  # unresolvable tier gets the smallest allowance rather than an exemption.
-  # A negative limit means unlimited (the xlarge tier).
-  max_per_day = backup_limits.get("max_backups_per_day", 2)
-  reservation_id = _reserve_backup_slot(
-    graph_id=graph_id,
-    user_id=user_id,
-    max_per_day=max_per_day,
-    backup_tier=backup_tier,
-    retention_days=effective_retention_days,
-    db=db,
-  )
-
-  run_config = build_graph_job_config(
-    "backup_graph_job",
-    graph_id=graph_id,
-    user_id=user_id,
-    backup_type="full",
-    backup_format=body.backup_format,
-    retention_days=effective_retention_days,
-    compression=True,
-    initiated_by="user",
-    backup_id=reservation_id,
-  )
-
-  try:
-    response = await enqueue_task(
-      task_type="dagster_job_monitor",
+    # Enforce the per-tier daily limit that /limits and /tiers have been
+    # publishing all along. Same fail-small posture as the retention clamp: an
+    # unresolvable tier gets the smallest allowance rather than an exemption.
+    # A negative limit means unlimited (the xlarge tier).
+    max_per_day = backup_limits.get("max_backups_per_day", 2)
+    reservation_id = _reserve_backup_slot(
       graph_id=graph_id,
       user_id=user_id,
-      params={"job_name": "backup_graph_job", "run_config": run_config},
+      max_per_day=max_per_day,
+      backup_tier=backup_tier,
+      retention_days=effective_retention_days,
+      db=db,
     )
-  except Exception:
-    # Release the slot rather than leaving a PENDING row holding quota for a
-    # job that will never run. FAILED rows are excluded from the count.
-    _release_backup_slot(reservation_id, db)
-    raise
-  operation_id = response["operation_id"]
 
-  envelope = wrap_pending(
-    op_name,
-    operation_id=operation_id,
-    partial_result={
-      "status": "accepted",
-      "message": (
-        "Backup creation started"
-        if effective_retention_days == body.retention_days
-        else (
-          f"Backup creation started (retention capped to "
-          f"{effective_retention_days} days, the {backup_tier} maximum)"
-        )
-      ),
-      "retention_days": effective_retention_days,
-      "monitoring": {
-        "sse_endpoint": f"/v1/operations/{operation_id}/stream",
+    run_config = build_graph_job_config(
+      "backup_graph_job",
+      graph_id=graph_id,
+      user_id=user_id,
+      backup_type="full",
+      backup_format=body.backup_format,
+      retention_days=effective_retention_days,
+      compression=True,
+      initiated_by="user",
+      backup_id=reservation_id,
+    )
+
+    try:
+      response = await enqueue_task(
+        task_type="dagster_job_monitor",
+        graph_id=graph_id,
+        user_id=user_id,
+        params={"job_name": "backup_graph_job", "run_config": run_config},
+      )
+    except Exception:
+      # Release the slot rather than leaving a PENDING row holding quota for a
+      # job that will never run. FAILED rows are excluded from the count.
+      _release_backup_slot(reservation_id, db)
+      raise
+    operation_id = response["operation_id"]
+
+    envelope = wrap_pending(
+      op_name,
+      operation_id=operation_id,
+      partial_result={
+        "status": "accepted",
+        "message": (
+          "Backup creation started"
+          if effective_retention_days == body.retention_days
+          else (
+            f"Backup creation started (retention capped to "
+            f"{effective_retention_days} days, the {backup_tier} maximum)"
+          )
+        ),
+        "retention_days": effective_retention_days,
+        "monitoring": {
+          "sse_endpoint": f"/v1/operations/{operation_id}/stream",
+        },
       },
-    },
-    created_by=user_id,
-  )
+      created_by=user_id,
+    )
 
-  if idempotency_key is not None:
-    await cache.put(user_id, graph_id, op_name, idempotency_key, envelope, body_fp)
+    await idem.record(envelope)
 
-  log_operation_audit(
-    operation_name=op_name,
-    operation_id=operation_id,
-    user_id=user_id,
-    graph_id=graph_id,
-    duration_ms=0.0,
-    status="pending",
-    idempotency_key=idempotency_key,
-    event=_AUDIT_EVENT,
-  )
-  return envelope
+    log_operation_audit(
+      operation_name=op_name,
+      operation_id=operation_id,
+      user_id=user_id,
+      graph_id=graph_id,
+      duration_ms=0.0,
+      status="pending",
+      idempotency_key=idempotency_key,
+      event=_AUDIT_EVENT,
+    )
+    return envelope
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -823,37 +819,36 @@ async def change_tier_op(
   user_id = str(user.id)
   body_fp = fingerprint_body(body)
 
-  replay = await check_idempotency(
+  async with idempotent_dispatch(
     cache, user_id, graph_id, op_name, idempotency_key, body_fp
-  )
-  if replay is not None:
-    return replay
+  ) as idem:
+    if idem.replay is not None:
+      return idem.replay
 
-  operation_id = await change_graph_tier_cmd(graph_id, body.new_tier, user, db)
+    operation_id = await change_graph_tier_cmd(graph_id, body.new_tier, user, db)
 
-  envelope = wrap_pending(
-    op_name,
-    operation_id=operation_id,
-    partial_result={
-      "new_tier": body.new_tier,
-    },
-    created_by=user_id,
-  )
+    envelope = wrap_pending(
+      op_name,
+      operation_id=operation_id,
+      partial_result={
+        "new_tier": body.new_tier,
+      },
+      created_by=user_id,
+    )
 
-  if idempotency_key is not None:
-    await cache.put(user_id, graph_id, op_name, idempotency_key, envelope, body_fp)
+    await idem.record(envelope)
 
-  log_operation_audit(
-    operation_name=op_name,
-    operation_id=operation_id,
-    user_id=user_id,
-    graph_id=graph_id,
-    duration_ms=0.0,
-    status="pending",
-    idempotency_key=idempotency_key,
-    event=_AUDIT_EVENT,
-  )
-  return envelope
+    log_operation_audit(
+      operation_name=op_name,
+      operation_id=operation_id,
+      user_id=user_id,
+      graph_id=graph_id,
+      duration_ms=0.0,
+      status="pending",
+      idempotency_key=idempotency_key,
+      event=_AUDIT_EVENT,
+    )
+    return envelope
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -960,42 +955,41 @@ async def materialize_op(
 
   body_fp = fingerprint_body(body)
 
-  replay = await check_idempotency(
+  async with idempotent_dispatch(
     cache, user_id, graph_id, op_name, idempotency_key, body_fp
-  )
-  if replay is not None:
-    return replay
+  ) as idem:
+    if idem.replay is not None:
+      return idem.replay
 
-  result = await materialize_cmd(graph_id, body, user, db)
+    result = await materialize_cmd(graph_id, body, user, db)
 
-  if body.dry_run:
-    envelope = wrap_completed(op_name, result=result, created_by=user_id)
-  else:
-    operation_id = (
-      result.operation_id
-      if hasattr(result, "operation_id")
-      else result.get("operation_id", generate_operation_id())
+    if body.dry_run:
+      envelope = wrap_completed(op_name, result=result, created_by=user_id)
+    else:
+      operation_id = (
+        result.operation_id
+        if hasattr(result, "operation_id")
+        else result.get("operation_id", generate_operation_id())
+      )
+      envelope = wrap_pending(
+        op_name,
+        operation_id=operation_id,
+        partial_result=result
+        if isinstance(result, dict)
+        else result.model_dump(mode="json"),
+        created_by=user_id,
+      )
+
+    await idem.record(envelope)
+
+    log_operation_audit(
+      operation_name=op_name,
+      operation_id=envelope.operation_id,
+      user_id=user_id,
+      graph_id=graph_id,
+      duration_ms=0.0,
+      status=envelope.status,
+      idempotency_key=idempotency_key,
+      event=_AUDIT_EVENT,
     )
-    envelope = wrap_pending(
-      op_name,
-      operation_id=operation_id,
-      partial_result=result
-      if isinstance(result, dict)
-      else result.model_dump(mode="json"),
-      created_by=user_id,
-    )
-
-  if idempotency_key is not None:
-    await cache.put(user_id, graph_id, op_name, idempotency_key, envelope, body_fp)
-
-  log_operation_audit(
-    operation_name=op_name,
-    operation_id=envelope.operation_id,
-    user_id=user_id,
-    graph_id=graph_id,
-    duration_ms=0.0,
-    status=envelope.status,
-    idempotency_key=idempotency_key,
-    event=_AUDIT_EVENT,
-  )
-  return envelope
+    return envelope

--- a/robosystems/scripts/framework_validate.py
+++ b/robosystems/scripts/framework_validate.py
@@ -974,7 +974,7 @@ def run_coverage(graphs: dict[str, str]) -> list[CoverageResult]:
   results: list[CoverageResult] = []
   for label, graph_id in graphs.items():
     try:
-      with extensions_session(graph_id) as session:
+      with extensions_session(graph_id, statement_timeout_ms=None) as session:
         results.append(measure_coverage(session, label, graph_id))
     except Exception as exc:  # graph deprovisioned / schema missing
       results.append(CoverageResult(label=label, graph_id=graph_id, available=False))
@@ -1036,7 +1036,7 @@ def format_coverage(results: list[CoverageResult]) -> str:
 def validate_framework(keep: bool = False) -> GapReport:
   """Provision a reference tenant and run the structural + package checks."""
   with reference_tenant(keep=keep) as rt:
-    with extensions_session(rt.graph_id) as session:
+    with extensions_session(rt.graph_id, statement_timeout_ms=None) as session:
       report = run_structural(session, rt.styles)
       run_package_integrity(session, report)
       return report
@@ -1084,7 +1084,7 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
   with reference_tenant(keep=args.keep) as rt:
-    with extensions_session(rt.graph_id) as session:
+    with extensions_session(rt.graph_id, statement_timeout_ms=None) as session:
       report = run_structural(session, rt.styles)
       run_package_integrity(session, report)
       if not args.summary:

--- a/robosystems/security/audit_logger.py
+++ b/robosystems/security/audit_logger.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from ..config import env
 from ..logger import logger
+from .request_context import audit_context
 
 
 class SecurityEventType(Enum):
@@ -241,6 +242,11 @@ class SecurityAuditLogger:
       "user_agent": user_agent,
       "endpoint": endpoint,
       "details": details or {},
+      # Request correlation and credential attribution, when inside a
+      # request: the request id ties the event to the access-log line, and
+      # the api_key_prefix scopes an incident to the credential that acted.
+      # Absent outside a request; never overrides what the caller supplied.
+      **audit_context(),
     }
 
     # Log as structured JSON for security monitoring

--- a/robosystems/security/request_context.py
+++ b/robosystems/security/request_context.py
@@ -1,0 +1,134 @@
+"""Request-scoped identity, readable anywhere below the route handler.
+
+Authentication resolves the caller in a FastAPI dependency and returns a
+`User`; nothing below that layer — the operation audit line, the security
+event writer, a runner thread — is handed the request. So the audit trail
+recorded *who* as a bare ``user_id`` and could not say which credential
+acted, and the request id minted by the logging middleware never reached
+the events written during that request.
+
+Two `ContextVar`s close that gap without threading a request object through
+every signature: the logging middleware binds the request id before the
+route runs, and every successful authentication publishes a
+:class:`RequestPrincipal`. Both survive ``await`` without leaking across
+concurrent requests, follow the request into `anyio.to_thread` runner
+threads (which copy the context), and are absent — ``None`` — outside a
+request, which callers must treat as "unknown", never as "anonymous".
+
+`publish_principal` also mirrors the identity onto ``request.state``
+(``user_id`` / ``auth_user_id`` / ``auth_method`` / ``api_key_prefix``), the
+channel the access-log middleware reads after the response, since a value
+set inside the route's task is not visible back in the middleware's own
+context.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from typing import Any
+
+# The first 8 characters of an API key are its stored identification prefix
+# (``UserAPIKey.prefix``): enough to name the credential in an incident
+# without ever writing the secret.
+API_KEY_PREFIX_LENGTH = 8
+
+
+@dataclass(frozen=True)
+class RequestPrincipal:
+  user_id: str
+  auth_method: str
+  api_key_prefix: str | None = None
+
+  def audit_fields(self) -> dict[str, Any]:
+    fields: dict[str, Any] = {"auth_method": self.auth_method}
+    if self.api_key_prefix:
+      fields["api_key_prefix"] = self.api_key_prefix
+    return fields
+
+
+_request_id: ContextVar[str | None] = ContextVar("robosystems_request_id", default=None)
+_principal: ContextVar[RequestPrincipal | None] = ContextVar(
+  "robosystems_request_principal", default=None
+)
+
+
+def bind_request_id(request_id: str) -> Token[str | None]:
+  return _request_id.set(request_id)
+
+
+def reset_request_id(token: Token[str | None]) -> None:
+  _request_id.reset(token)
+
+
+def current_request_id() -> str | None:
+  return _request_id.get()
+
+
+def bind_principal(
+  principal: RequestPrincipal | None,
+) -> Token[RequestPrincipal | None]:
+  return _principal.set(principal)
+
+
+def reset_principal(token: Token[RequestPrincipal | None]) -> None:
+  _principal.reset(token)
+
+
+def current_principal() -> RequestPrincipal | None:
+  return _principal.get()
+
+
+def publish_principal(
+  request: Any,
+  user_id: str,
+  auth_method: str,
+  api_key: str | None = None,
+) -> RequestPrincipal:
+  """Record the authenticated caller for the rest of this request.
+
+  Called from every authentication success branch. ``request`` is the
+  Starlette request (typed loosely so this module stays import-free of the
+  web layer); its ``state`` receives the same fields the ContextVar carries.
+  """
+  prefix = api_key[:API_KEY_PREFIX_LENGTH] if api_key else None
+  principal = RequestPrincipal(
+    user_id=str(user_id), auth_method=auth_method, api_key_prefix=prefix
+  )
+  bind_principal(principal)
+  state = getattr(request, "state", None)
+  if state is not None:
+    state.user_id = principal.user_id
+    state.auth_user_id = principal.user_id
+    state.auth_method = auth_method
+    if prefix is not None:
+      state.api_key_prefix = prefix
+  return principal
+
+
+def audit_context() -> dict[str, Any]:
+  """The request-scoped fields an audit or security event should carry:
+  ``request_id`` when inside a request, plus the principal's credential
+  attribution when one has authenticated. Empty outside a request."""
+  fields: dict[str, Any] = {}
+  request_id = current_request_id()
+  if request_id:
+    fields["request_id"] = request_id
+  principal = current_principal()
+  if principal is not None:
+    fields.update(principal.audit_fields())
+  return fields
+
+
+__all__ = [
+  "API_KEY_PREFIX_LENGTH",
+  "RequestPrincipal",
+  "audit_context",
+  "bind_principal",
+  "bind_request_id",
+  "current_principal",
+  "current_request_id",
+  "publish_principal",
+  "reset_principal",
+  "reset_request_id",
+]

--- a/robosystems/worker/tasks/base.py
+++ b/robosystems/worker/tasks/base.py
@@ -55,21 +55,42 @@ class BaseTask(ABC):
     status = await self.manager.get_operation_status(self.task_id)
     return status == OperationStatus.CANCELLED
 
-  def release_lock(self, lock_key: str | None) -> None:
-    """Release a distributed lock by key. Safe to call with None."""
+  def release_lock(self, lock_key: str | None, lock_id: str | None = None) -> None:
+    """Release the distributed lock the enqueuing API call took for this task.
+
+    Safe to call with None. ``lock_id`` (defaulting to ``params["lock_id"]``)
+    makes the release a compare-and-delete: a task that finishes after the
+    lock's TTL lapsed and a successor re-acquired it must not strip the
+    successor's lock. Only a task enqueued without a ``lock_id`` — one queued
+    before the API started passing it — falls back to the unconditional
+    delete, so its lock is not stranded for the full TTL.
+    """
     if not lock_key:
       return
 
     from robosystems.logger import get_logger
 
     logger = get_logger(__name__)
+    lock_id = lock_id or self.params.get("lock_id")
 
     try:
       from robosystems.config.valkey_registry import ValkeyDatabase, create_redis_client
+      from robosystems.middleware.auth.distributed_lock import release_lock_by_id
 
       redis_client = create_redis_client(ValkeyDatabase.LOCKS)
-      redis_client.delete(f"lock:{lock_key}")
-      redis_client.close()
-      logger.debug(f"Released lock: {lock_key}")
+      try:
+        if lock_id:
+          if release_lock_by_id(redis_client, lock_key, lock_id):
+            logger.debug(f"Released lock: {lock_key}")
+          else:
+            logger.warning(
+              f"Lock {lock_key} was not released: not held by this task "
+              "(expired or re-acquired by a successor)"
+            )
+        else:
+          redis_client.delete(f"lock:{lock_key}")
+          logger.debug(f"Released lock (no lock_id, unconditional): {lock_key}")
+      finally:
+        redis_client.close()
     except Exception as e:
       logger.warning(f"Failed to release lock {lock_key}: {e}")

--- a/tests/dagster/test_materialization_sensor.py
+++ b/tests/dagster/test_materialization_sensor.py
@@ -57,6 +57,27 @@ class TestStaleGraphSensor:
     # run_key uses graph_stale_at, not now — enables Dagster deduplication
     assert stale_at.isoformat() in result[0].run_key
 
+  def test_run_request_carries_per_graph_concurrency_tag(self):
+    """dagster.yaml serializes runs on ``materialize_db`` (limit 1 per unique
+    value). Without the tag, a stale-sensor run and a manual launch for the
+    same graph could COPY into it concurrently."""
+    stale_at = datetime.now(UTC) - timedelta(seconds=60)
+    graphs = [_make_graph("kg123", stale_at=stale_at)]
+
+    with patch(
+      "robosystems.dagster.sensors.materialization.db_session_factory"
+    ) as mock_db:
+      mock_session = MagicMock()
+      mock_db.return_value = mock_session
+      mock_session.query.return_value.filter.return_value.all.return_value = graphs
+
+      context = build_sensor_context()
+      result = list(stale_graph_materialization_sensor(context))
+
+    assert result[0].tags["materialize_db"] == "kg123"
+    assert result[0].tags["graph_id"] == "kg123"
+    assert result[0].tags["trigger"] == "stale_sensor"
+
   def test_skips_in_progress_graph(self):
     stale_at = datetime.now(UTC) - timedelta(seconds=60)
     graphs = [_make_graph("kg123", stale_at=stale_at)]

--- a/tests/dagster/test_worker_reaper.py
+++ b/tests/dagster/test_worker_reaper.py
@@ -1,43 +1,131 @@
 """The reaper's DLQ path writes the terminal status straight into the SSE
 metadata key, bypassing the store's eviction hook — so it must evict the
-idempotency envelope itself."""
+idempotency envelope itself, and only when its own write is the one that
+made the operation terminal."""
 
 from __future__ import annotations
 
 import json
 from unittest.mock import MagicMock, patch
 
+import redis
+
 from robosystems.dagster.sensors.worker_reaper import _fail_operation_sync
 
 
-def test_dlq_failure_evicts_the_idempotency_envelope():
+class _FakePipeline:
+  """A WATCH/MULTI/EXEC pipeline over one in-memory key.
+
+  ``interleave`` runs between the reaper's read and its EXEC, standing in for a
+  worker that finishes the task in that window — the store then raises
+  ``WatchError`` exactly as redis-py does when a watched key changed.
+  """
+
+  def __init__(self, store: dict, interleave=None):
+    self.store = store
+    self.interleave = interleave
+    self.queued: list = []
+    self.watching = False
+    self.executed = False
+
+  def __enter__(self):
+    return self
+
+  def __exit__(self, *exc):
+    return False
+
+  def watch(self, key):
+    self.watching = key
+
+  def unwatch(self):
+    self.watching = False
+
+  def get(self, key):
+    return self.store.get(key)
+
+  def multi(self):
+    self.queued = []
+
+  def set(self, key, value, keepttl=False):
+    self.queued.append((key, value))
+
+  def execute(self):
+    if self.interleave is not None:
+      self.interleave(self.store)
+      raise redis.WatchError("watched key changed")
+    for key, value in self.queued:
+      self.store[key] = value
+    self.executed = True
+
+
+def _client(store: dict, interleave=None) -> MagicMock:
   sse = MagicMock()
-  sse.get.return_value = json.dumps({"status": "running"})
+  pipeline = _FakePipeline(store, interleave)
+  sse.pipeline.return_value = pipeline
+  sse._pipeline = pipeline
+  return sse
+
+
+def _key(task_id: str) -> str:
+  from robosystems.dagster.sensors.worker_reaper import SSE_META_PREFIX
+
+  return f"{SSE_META_PREFIX}{task_id}"
+
+
+def test_dlq_failure_evicts_the_idempotency_envelope():
+  store = {_key("op_123"): json.dumps({"status": "running"})}
   with patch(
     "robosystems.middleware.operations.invalidate_operation_idempotency_sync"
   ) as evict:
-    _fail_operation_sync(sse, "op_123", attempts=3)
-  written = json.loads(sse.set.call_args.args[1])
-  assert written["status"] == "failed"
+    _fail_operation_sync(_client(store), "op_123", attempts=3)
+  assert json.loads(store[_key("op_123")])["status"] == "failed"
   evict.assert_called_once_with("op_123")
 
 
 def test_missing_metadata_evicts_nothing():
-  sse = MagicMock()
-  sse.get.return_value = None
   with patch(
     "robosystems.middleware.operations.invalidate_operation_idempotency_sync"
   ) as evict:
-    _fail_operation_sync(sse, "op_missing", attempts=3)
+    _fail_operation_sync(_client({}), "op_missing", attempts=3)
+  evict.assert_not_called()
+
+
+def test_an_operation_that_already_completed_is_left_alone():
+  """The staleness decision came from an earlier snapshot; by the time the
+  DLQ write runs the worker may have finished. Completed wins — no flip to
+  failed, no eviction, or a retry under the same key would run it again."""
+  store = {_key("op_done"): json.dumps({"status": "completed"})}
+  with patch(
+    "robosystems.middleware.operations.invalidate_operation_idempotency_sync"
+  ) as evict:
+    _fail_operation_sync(_client(store), "op_done", attempts=3)
+  assert json.loads(store[_key("op_done")])["status"] == "completed"
+  evict.assert_not_called()
+
+
+def test_worker_completing_between_read_and_write_wins():
+  """Same race, one step later: the worker's completion lands after the
+  reaper read `running` but before its EXEC. The WATCH fails the reaper's
+  write; nothing is flipped and nothing is evicted."""
+  store = {_key("op_race"): json.dumps({"status": "running"})}
+
+  def worker_finishes(s):
+    s[_key("op_race")] = json.dumps({"status": "completed"})
+
+  with patch(
+    "robosystems.middleware.operations.invalidate_operation_idempotency_sync"
+  ) as evict:
+    _fail_operation_sync(_client(store, worker_finishes), "op_race", attempts=3)
+  assert json.loads(store[_key("op_race")])["status"] == "completed"
   evict.assert_not_called()
 
 
 def test_metadata_write_failure_does_not_evict():
   """If the status write fails the operation is not terminal yet; leaving the
   envelope in place is the honest state."""
-  sse = MagicMock()
-  sse.get.return_value = json.dumps({"status": "running"})
-  sse.set.side_effect = RuntimeError("valkey down")
+  store = {_key("op_x"): json.dumps({"status": "running"})}
+  sse = _client(store)
+  sse._pipeline.execute = MagicMock(side_effect=RuntimeError("valkey down"))
   with patch(
     "robosystems.middleware.operations.invalidate_operation_idempotency_sync"
   ) as evict:

--- a/tests/dagster/test_worker_reaper.py
+++ b/tests/dagster/test_worker_reaper.py
@@ -1,0 +1,45 @@
+"""The reaper's DLQ path writes the terminal status straight into the SSE
+metadata key, bypassing the store's eviction hook — so it must evict the
+idempotency envelope itself."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from robosystems.dagster.sensors.worker_reaper import _fail_operation_sync
+
+
+def test_dlq_failure_evicts_the_idempotency_envelope():
+  sse = MagicMock()
+  sse.get.return_value = json.dumps({"status": "running"})
+  with patch(
+    "robosystems.middleware.operations.invalidate_operation_idempotency_sync"
+  ) as evict:
+    _fail_operation_sync(sse, "op_123", attempts=3)
+  written = json.loads(sse.set.call_args.args[1])
+  assert written["status"] == "failed"
+  evict.assert_called_once_with("op_123")
+
+
+def test_missing_metadata_evicts_nothing():
+  sse = MagicMock()
+  sse.get.return_value = None
+  with patch(
+    "robosystems.middleware.operations.invalidate_operation_idempotency_sync"
+  ) as evict:
+    _fail_operation_sync(sse, "op_missing", attempts=3)
+  evict.assert_not_called()
+
+
+def test_metadata_write_failure_does_not_evict():
+  """If the status write fails the operation is not terminal yet; leaving the
+  envelope in place is the honest state."""
+  sse = MagicMock()
+  sse.get.return_value = json.dumps({"status": "running"})
+  sse.set.side_effect = RuntimeError("valkey down")
+  with patch(
+    "robosystems.middleware.operations.invalidate_operation_idempotency_sync"
+  ) as evict:
+    _fail_operation_sync(sse, "op_x", attempts=3)
+  evict.assert_not_called()

--- a/tests/db/test_extensions_isolation.py
+++ b/tests/db/test_extensions_isolation.py
@@ -186,6 +186,41 @@ def test_refuses_the_next_transaction_after_the_schema_is_dropped(engine, tenant
       session.execute(_WHOAMI)
 
 
+def test_statement_timeout_cancels_a_slow_statement(engine, tenants):
+  """A statement past the ceiling is cancelled server-side (SQLSTATE 57014) —
+  the client's own timeout is not what frees the shared connection."""
+  with pytest.raises(OperationalError) as exc_info:
+    with extensions_session(GRAPH_A, statement_timeout_ms=100) as session:
+      session.execute(text("select pg_sleep(2)"))
+  assert ext.is_statement_timeout(exc_info.value)
+
+
+def test_statement_timeout_is_transaction_local(engine, tenants):
+  """The ceiling never outlives the transaction: after a bounded session,
+  every idle pooled connection is back on the server default."""
+  with extensions_session(GRAPH_A, statement_timeout_ms=100) as session:
+    assert session.execute(text("show statement_timeout")).scalar() == "100ms"
+    session.commit()
+    # Re-applied on the next transaction of the same session.
+    assert session.execute(text("show statement_timeout")).scalar() == "100ms"
+  conns = [engine.connect() for _ in range(engine.pool.checkedin())]
+  try:
+    for conn in conns:
+      assert conn.execute(text("show statement_timeout")).scalar() != "100ms"
+  finally:
+    for conn in conns:
+      conn.close()
+
+
+def test_opted_out_session_runs_unbounded(engine, tenants):
+  with extensions_session(GRAPH_A, statement_timeout_ms=None) as session:
+    default = session.execute(text("show statement_timeout")).scalar()
+  assert default != "100ms"
+  with extensions_session(GRAPH_A) as session:
+    interactive = session.execute(text("show statement_timeout")).scalar()
+  assert interactive == f"{ext.interactive_statement_timeout_ms() // 1000}s"
+
+
 def test_library_sentinel_binds_public_only(engine):
   """The `library` sentinel reads the canonical library (`public`), with no
   tenant-schema binding — so a library read can't be scoped to a tenant."""
@@ -242,9 +277,47 @@ def test_commits_and_closes_on_success():
   ):
     with extensions_session(GRAPH_A) as yielded:
       assert yielded is session
-  bind.assert_called_once_with(session, f"{GRAPH_A}, public", tenant_schema=GRAPH_A)
+  bind.assert_called_once_with(
+    session,
+    f"{GRAPH_A}, public",
+    tenant_schema=GRAPH_A,
+    statement_timeout_ms=ext.interactive_statement_timeout_ms(),
+  )
   session.commit.assert_called_once()
   session.close.assert_called_once()
+
+
+def test_bulk_callers_opt_out_of_the_statement_timeout():
+  """``statement_timeout_ms=None`` is the explicit opt-out; an explicit value
+  is passed through as given, and the default resolves the tunable."""
+  session = MagicMock(name="session")
+  factory = MagicMock(return_value=session)
+  with (
+    patch.object(ext, "_get_session_factory", return_value=factory),
+    patch.object(ext, "bind_search_path") as bind,
+    patch.object(ext, "interactive_statement_timeout_ms", return_value=12_345),
+  ):
+    with extensions_session(GRAPH_A, statement_timeout_ms=None):
+      pass
+    with extensions_session(GRAPH_A, statement_timeout_ms=90_000):
+      pass
+    with extensions_session(GRAPH_A):
+      pass
+  timeouts = [call.kwargs["statement_timeout_ms"] for call in bind.call_args_list]
+  assert timeouts == [None, 90_000, 12_345]
+
+
+def test_interactive_timeout_zero_means_unbounded():
+  with patch(
+    "robosystems.config.tuning.TuningConfig.get_extensions_statement_timeout_ms",
+    return_value=0,
+  ):
+    assert ext.interactive_statement_timeout_ms() is None
+  with patch(
+    "robosystems.config.tuning.TuningConfig.get_extensions_statement_timeout_ms",
+    return_value=30_000,
+  ):
+    assert ext.interactive_statement_timeout_ms() == 30_000
 
 
 def test_bind_statement_guards_tenants_and_not_the_library():
@@ -259,6 +332,28 @@ def test_bind_statement_guards_tenants_and_not_the_library():
   # The interpolation validates its own input, independent of the caller.
   with pytest.raises(ValueError):
     ext._bind_statement("kg00000000000000aa, public", "kg00000000000000aa') --")
+
+
+def test_bind_statement_puts_the_timeout_ahead_of_the_guard():
+  """The ceiling is ``SET LOCAL`` and comes first, so the guard and every
+  statement after it are bounded; ``None``/``0`` emit no timeout at all."""
+  bounded = ext._bind_statement(f"{GRAPH_A}, public", GRAPH_A, 30_000)
+  assert bounded.startswith("SET LOCAL statement_timeout = 30000; DO $$")
+  assert bounded.endswith(f"SET LOCAL search_path TO {GRAPH_A}, public")
+  library = ext._bind_statement("public", None, 5_000)
+  assert library == (
+    "SET LOCAL statement_timeout = 5000; SET LOCAL search_path TO public"
+  )
+  assert "statement_timeout" not in ext._bind_statement("public", None, None)
+  assert "statement_timeout" not in ext._bind_statement("public", None, 0)
+
+
+def test_is_statement_timeout_matches_only_query_canceled():
+  cancelled = OperationalError("stmt", {}, MagicMock(pgcode="57014"))
+  other = OperationalError("stmt", {}, MagicMock(pgcode="40001"))
+  assert ext.is_statement_timeout(cancelled)
+  assert not ext.is_statement_timeout(other)
+  assert not ext.is_statement_timeout(RuntimeError("boom"))
 
 
 def test_no_bypass_of_the_scoped_session_factory():

--- a/tests/graph_api/core/ladybug/test_materialization_lock.py
+++ b/tests/graph_api/core/ladybug/test_materialization_lock.py
@@ -105,3 +105,109 @@ class TestMaterializationLock:
     assert lock.token == "my-token-123"
     assert lock.acquired is True
     assert lock.lock_key == "materialize_lock:kg123"
+
+
+class TestAcquireBackendErrorSignal:
+  """``acquire`` returning False must be distinguishable between "held by
+  another run" and "the lock service is unavailable" — the caller fails closed
+  either way, but the message it surfaces differs."""
+
+  @pytest.mark.asyncio
+  async def test_held_by_another_run_leaves_no_backend_error(self):
+    redis = AsyncMock()
+    redis.set = AsyncMock(return_value=False)
+    lock = MaterializationLock(redis, "kg123")
+
+    assert await lock.acquire(timeout_seconds=0.05) is False
+    assert lock.last_backend_error is None
+
+  @pytest.mark.asyncio
+  async def test_backend_outage_records_last_error(self):
+    redis = AsyncMock()
+    redis.set = AsyncMock(side_effect=ConnectionError("Connection refused"))
+    lock = MaterializationLock(redis, "kg123")
+
+    assert await lock.acquire(timeout_seconds=0.05) is False
+    assert lock.acquired is False
+    assert lock.last_backend_error == "Connection refused"
+
+  @pytest.mark.asyncio
+  async def test_success_after_blip_clears_error(self):
+    redis = AsyncMock()
+    redis.set = AsyncMock(side_effect=[ConnectionError("blip"), True])
+    lock = MaterializationLock(redis, "kg123")
+
+    assert await lock.acquire(timeout_seconds=1) is True
+    assert lock.last_backend_error is None
+
+
+class TestExtend:
+  @pytest.mark.asyncio
+  async def test_extend_with_matching_token_refreshes_ttl(self):
+    redis = AsyncMock()
+    redis.set = AsyncMock(return_value=True)
+    redis.eval = AsyncMock(return_value=1)
+    lock = MaterializationLock(redis, "kg123", ttl_seconds=1234)
+    await lock.acquire(timeout_seconds=1)
+
+    assert await lock.extend() is True
+    assert lock.acquired is True
+    args = redis.eval.await_args.args
+    # Compare-and-extend: script, 1 key, our key, our token, the full TTL.
+    assert args[1] == 1
+    assert args[2] == "materialize_lock:kg123"
+    assert args[3] == lock.token
+    assert args[4] == "1234"
+
+  @pytest.mark.asyncio
+  async def test_extend_with_wrong_token_reports_lock_lost(self):
+    """The Lua script returns 0 when the stored value is not our token — the
+    lock expired and was re-acquired by another process. The instance must
+    then consider itself no longer the holder so a later release is a no-op."""
+    redis = AsyncMock()
+    redis.set = AsyncMock(return_value=True)
+    redis.eval = AsyncMock(return_value=0)
+    lock = MaterializationLock(redis, "kg123")
+    await lock.acquire(timeout_seconds=1)
+
+    assert await lock.extend() is False
+    assert lock.acquired is False
+
+    # release() after a lost lock does not touch the key.
+    redis.eval.reset_mock()
+    assert await lock.release() is False
+    redis.eval.assert_not_awaited()
+
+  @pytest.mark.asyncio
+  async def test_extend_without_acquire_is_false(self):
+    redis = AsyncMock()
+    lock = MaterializationLock(redis, "kg123")
+
+    assert await lock.extend() is False
+    redis.eval.assert_not_awaited()
+
+  @pytest.mark.asyncio
+  async def test_extend_backend_error_propagates(self):
+    """Unlike acquire/release, extend raises on a backend error: the caller
+    decides whether the remaining TTL makes a blip tolerable."""
+    redis = AsyncMock()
+    redis.set = AsyncMock(return_value=True)
+    redis.eval = AsyncMock(side_effect=ConnectionError("blip"))
+    lock = MaterializationLock(redis, "kg123")
+    await lock.acquire(timeout_seconds=1)
+
+    with pytest.raises(ConnectionError):
+      await lock.extend()
+    # Still considered held: nothing proved the token was lost.
+    assert lock.acquired is True
+
+  @pytest.mark.asyncio
+  async def test_extend_script_compares_token(self):
+    """Pin the Lua: get == token guards the expire (a stale holder must not
+    push out someone else's TTL)."""
+    from robosystems.graph_api.core.ladybug.materialization_lock import (
+      _EXTEND_SCRIPT,
+    )
+
+    assert 'redis.call("get", KEYS[1]) == ARGV[1]' in _EXTEND_SCRIPT
+    assert 'redis.call("expire", KEYS[1], ARGV[2])' in _EXTEND_SCRIPT

--- a/tests/graphql/extensions/test_context.py
+++ b/tests/graphql/extensions/test_context.py
@@ -149,8 +149,12 @@ class TestGetContextAuthContract:
     assert ctx["user"] is user
     # Re-validated against THIS graph (the URL scope), reusing the request db.
     mock_scoped.assert_called_once_with("rfsc_scoped_to_this_graph", GRAPH_ID, db)
+    # The rescue path authenticated outside `get_current_user`, so it must
+    # publish the principal itself or the request stays unattributed.
+    assert request.state.user_id == "usr_owner"
+    assert request.state.api_key_prefix == "rfsc_sco"
     # Graph access is still enforced on top of key validation.
-    mock_check.assert_called_once_with(user, GRAPH_ID)
+    mock_check.assert_called_once_with(user, GRAPH_ID, request)
 
   async def test_bearer_failure_does_not_trigger_graph_scoped_retry(self):
     """The graph-scoped retry is for pure API-key requests only. A failed
@@ -219,7 +223,7 @@ class TestGetContextAuthContract:
     assert ctx["graph_id"] == GRAPH_ID
     assert ctx["schema_extensions"] == ("roboledger", "roboinvestor")
     assert ctx["graph_type"] == "entity"
-    mock_check.assert_called_once_with(user, GRAPH_ID)
+    mock_check.assert_called_once_with(user, GRAPH_ID, request)
     mock_meta.assert_called_once_with(GRAPH_ID, db)
 
   async def test_valid_credentials_but_no_graph_access_raises_403(self):
@@ -413,7 +417,7 @@ class TestSubgraphGuard:
       )
 
     assert ctx["graph_id"] == "sec"
-    mock_check.assert_called_once_with(user, "sec")
+    mock_check.assert_called_once_with(user, "sec", request)
 
 
 @pytest.mark.asyncio
@@ -483,3 +487,71 @@ class TestGetContextLifecycleGate:
 
     assert ctx["graph_type"] == "library"
     gate.assert_not_called()
+
+
+class TestCheckGraphAccessAudit:
+  """A user-graph read denial through the GraphQL gate is audited; repository
+  denials are audited by `validate_repository_access` itself, so the gate
+  must not double-count them."""
+
+  def test_user_graph_denial_emits_authorization_denied(self):
+    from robosystems.graphql.auth import check_graph_access
+
+    user = MagicMock()
+    user.id = "usr_probe"
+    request = _make_request(headers={})
+    request.client.host = "203.0.113.9"
+    with (
+      patch(
+        "robosystems.middleware.auth.dependencies._db_check_graph_access",
+        return_value=False,
+      ),
+      patch(
+        "robosystems.security.SecurityAuditLogger.log_authorization_denied"
+      ) as denied,
+    ):
+      with pytest.raises(HTTPException) as exc:
+        check_graph_access(user, GRAPH_ID, request)
+    assert exc.value.status_code == 403
+    denied.assert_called_once_with(
+      user_id="usr_probe",
+      resource=f"graph_database:{GRAPH_ID}",
+      action="read",
+      ip_address="203.0.113.9",
+      endpoint=f"/extensions/{GRAPH_ID}/graphql",
+    )
+
+  def test_repository_denial_is_not_double_counted(self):
+    from robosystems.graphql.auth import check_graph_access
+
+    user = MagicMock()
+    user.id = "usr_probe"
+    with (
+      patch(
+        "robosystems.middleware.graph.utils.MultiTenantUtils.validate_repository_access",
+        return_value=False,
+      ),
+      patch(
+        "robosystems.security.SecurityAuditLogger.log_authorization_denied"
+      ) as denied,
+    ):
+      with pytest.raises(HTTPException):
+        check_graph_access(user, "sec", _make_request(headers={}))
+    denied.assert_not_called()
+
+  def test_granted_access_emits_nothing(self):
+    from robosystems.graphql.auth import check_graph_access
+
+    user = MagicMock()
+    user.id = "usr_member"
+    with (
+      patch(
+        "robosystems.middleware.auth.dependencies._db_check_graph_access",
+        return_value=True,
+      ),
+      patch(
+        "robosystems.security.SecurityAuditLogger.log_authorization_denied"
+      ) as denied,
+    ):
+      check_graph_access(user, GRAPH_ID, _make_request(headers={}))
+    denied.assert_not_called()

--- a/tests/graphql/extensions/test_execution.py
+++ b/tests/graphql/extensions/test_execution.py
@@ -1,0 +1,137 @@
+"""The execution-time guards: sync resolvers leave the event loop, and only
+deliberate errors reach ``errors[]`` verbatim."""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import strawberry
+from sqlalchemy.exc import IntegrityError, OperationalError
+from strawberry.exceptions import StrawberryGraphQLError
+
+from robosystems.graphql.execution import (
+  INTERNAL_ERROR_CODE,
+  INTERNAL_ERROR_MESSAGE,
+  STATEMENT_TIMEOUT_CODE,
+  MaskUnexpectedErrors,
+  OffloadSyncResolvers,
+)
+
+_LEAKY_SQL = 'INSERT INTO "kg00000000000000aa".entities (id) VALUES (%(id)s)'
+
+
+@strawberry.type
+class Leaf:
+  label: str
+
+
+@strawberry.type
+class Query:
+  @strawberry.field
+  def thread_ident(self) -> str:
+    return str(threading.get_ident())
+
+  @strawberry.field
+  def leaf(self) -> Leaf:
+    return Leaf(label="x")
+
+  @strawberry.field
+  def integrity(self) -> str:
+    raise IntegrityError(_LEAKY_SQL, {"id": "secret"}, Exception("duplicate key"))
+
+  @strawberry.field
+  def timeout(self) -> str:
+    raise OperationalError(_LEAKY_SQL, {}, MagicMock(pgcode="57014"))
+
+  @strawberry.field
+  def deliberate(self) -> str:
+    raise StrawberryGraphQLError(
+      message="Ledger not initialized", extensions={"code": "LEDGER_NOT_INITIALIZED"}
+    )
+
+  @strawberry.field
+  def plain_python(self) -> str:
+    raise KeyError("column_that_names_the_schema")
+
+
+schema = strawberry.Schema(
+  query=Query, extensions=[OffloadSyncResolvers, MaskUnexpectedErrors]
+)
+
+
+def _ctx(request_id: str | None = "req_abc") -> dict:
+  request = SimpleNamespace(state=SimpleNamespace(request_id=request_id))
+  return {"request": request}
+
+
+class TestOffloadSyncResolvers:
+  @pytest.mark.asyncio
+  async def test_sync_resolver_runs_off_the_loop_thread(self) -> None:
+    result = await schema.execute("{ threadIdent }", context_value=_ctx())
+    assert not result.errors
+    assert result.data["threadIdent"] != str(threading.get_ident())
+
+  @pytest.mark.asyncio
+  async def test_default_field_resolvers_stay_inline(self) -> None:
+    """Attribute getters on returned objects are not worth a thread hop; the
+    offload only wraps resolvers someone wrote."""
+    result = await schema.execute("{ leaf { label } }", context_value=_ctx())
+    assert not result.errors
+    assert result.data == {"leaf": {"label": "x"}}
+
+  def test_no_running_loop_runs_inline(self) -> None:
+    """`execute_sync` from a worker thread has no loop to protect and cannot
+    await — the resolver runs where it is called."""
+    result = schema.execute_sync("{ threadIdent }", context_value=_ctx())
+    assert not result.errors
+    assert result.data["threadIdent"] == str(threading.get_ident())
+
+  def test_introspection_is_untouched(self) -> None:
+    result = schema.execute_sync("{ __typename }", context_value=_ctx())
+    assert result.data == {"__typename": "Query"}
+
+
+class TestMaskUnexpectedErrors:
+  def test_database_fault_is_masked_and_carries_the_request_id(self) -> None:
+    result = schema.execute_sync("{ integrity }", context_value=_ctx("req_42"))
+    assert result.errors is not None and len(result.errors) == 1
+    error = result.errors[0]
+    assert error.message == INTERNAL_ERROR_MESSAGE
+    assert error.extensions == {"code": INTERNAL_ERROR_CODE, "requestId": "req_42"}
+    assert "kg00000000000000aa" not in str(error)
+    assert "secret" not in str(error)
+    assert error.path == ["integrity"]
+
+  def test_plain_python_error_is_masked(self) -> None:
+    result = schema.execute_sync("{ plainPython }", context_value=_ctx())
+    assert result.errors[0].message == INTERNAL_ERROR_MESSAGE
+    assert "column_that_names_the_schema" not in result.errors[0].message
+
+  def test_statement_timeout_gets_its_own_code(self) -> None:
+    result = schema.execute_sync("{ timeout }", context_value=_ctx())
+    error = result.errors[0]
+    assert error.extensions["code"] == STATEMENT_TIMEOUT_CODE
+    assert "INSERT" not in error.message
+    assert "time limit" in error.message
+
+  def test_deliberate_graphql_error_passes_through(self) -> None:
+    result = schema.execute_sync("{ deliberate }", context_value=_ctx())
+    error = result.errors[0]
+    assert error.message == "Ledger not initialized"
+    assert error.extensions == {"code": "LEDGER_NOT_INITIALIZED"}
+
+  def test_validation_error_passes_through(self) -> None:
+    result = schema.execute_sync("{ noSuchField }", context_value=_ctx())
+    assert result.errors[0].message.startswith("Cannot query field")
+
+  def test_missing_request_id_omits_the_extension_key(self) -> None:
+    result = schema.execute_sync("{ integrity }", context_value=_ctx(None))
+    assert result.errors[0].extensions == {"code": INTERNAL_ERROR_CODE}
+
+  @pytest.mark.asyncio
+  async def test_masking_applies_on_the_async_path_too(self) -> None:
+    result = await schema.execute("{ integrity }", context_value=_ctx())
+    assert result.errors[0].message == INTERNAL_ERROR_MESSAGE

--- a/tests/graphql/extensions/test_schema_limits.py
+++ b/tests/graphql/extensions/test_schema_limits.py
@@ -65,9 +65,28 @@ class TestAliasLimiter:
 class TestRealSchemaWiring:
   """The limiters must actually be attached to the served schema."""
 
-  def test_real_schema_configures_four_extensions(self) -> None:
-    # 3 query-bounding limiters + the OpenTelemetry tracing extension.
-    assert len(real_schema.extensions) == 4
+  def test_real_schema_configures_six_extensions(self) -> None:
+    # 3 query-bounding limiters + OpenTelemetry tracing + the two execution
+    # guards (resolver offload, error masking).
+    assert len(real_schema.extensions) == 6
+
+  def test_offload_is_outside_tracing_and_masking_is_last(self) -> None:
+    """Resolve hooks compose with the last extension outermost, so the offload
+    must follow tracing for the span to wrap the work in the thread."""
+    from strawberry.extensions.tracing.opentelemetry import (
+      OpenTelemetryExtensionSync,
+    )
+
+    from robosystems.graphql.execution import (
+      MaskUnexpectedErrors,
+      OffloadSyncResolvers,
+    )
+
+    ordered = [ext for ext in real_schema.extensions if isinstance(ext, type)]
+    assert ordered.index(OpenTelemetryExtensionSync) < ordered.index(
+      OffloadSyncResolvers
+    )
+    assert ordered[-1] is MaskUnexpectedErrors
 
   def test_real_schema_rejects_overdeep_query(self) -> None:
     """Depth validation runs before resolvers, so no auth context is needed.

--- a/tests/middleware/auth/test_dependencies.py
+++ b/tests/middleware/auth/test_dependencies.py
@@ -691,6 +691,16 @@ class TestGetCurrentUser:
     assert mock_verify_jwt.call_count == 1
     assert mock_verify_jwt.call_args.args[0] == "valid.jwt.token"
     mock_audit_logger.log_auth_success.assert_called_once()
+    # A JWT success publishes the principal like the API-key path does, so
+    # the access log and the audit trail can name the caller.
+    assert self.mock_request.state.user_id == user_id
+    assert self.mock_request.state.auth_method == "jwt_token"
+    from robosystems.security.request_context import current_principal
+
+    principal = current_principal()
+    assert principal is not None
+    assert principal.user_id == user_id
+    assert principal.api_key_prefix is None
 
   @pytest.mark.asyncio
   @patch("robosystems.middleware.auth.dependencies.verify_jwt_claims")

--- a/tests/middleware/mcp/test_registrar.py
+++ b/tests/middleware/mcp/test_registrar.py
@@ -719,6 +719,30 @@ class TestRegistrarToolExecute:
     assert "INSERT" not in result["message"]
 
   @pytest.mark.asyncio
+  async def test_cancelled_statement_is_a_timeout_answer(self) -> None:
+    from sqlalchemy.exc import OperationalError
+
+    def raising_cmd(session, body, created_by: str):
+      raise OperationalError(
+        "SELECT * FROM t WHERE v = %(v)s", {"v": "secret"}, MagicMock(pgcode="57014")
+      )
+
+    tool = _RegistrarMCPTool(
+      client=_client(user_id="usr_1"),
+      spec=_spec(command=raising_cmd),
+      registrar=_registrar_stub(),
+    )
+    with patch(
+      "robosystems.middleware.mcp.tools.registrar.require_graph_extension_mcp",
+      return_value=MagicMock(),
+    ):
+      result = await tool.execute({"id": "x", "value": 0})
+
+    assert result["error"] == "statement_timeout"
+    assert "secret" not in result["message"]
+    assert "SELECT" not in result["message"]
+
+  @pytest.mark.asyncio
   async def test_schema_missing_is_not_initialized(self) -> None:
     from sqlalchemy.exc import ProgrammingError
 

--- a/tests/middleware/sse/test_event_storage.py
+++ b/tests/middleware/sse/test_event_storage.py
@@ -758,6 +758,170 @@ class TestSSEEventStorage:
       mock_pipe.unwatch.assert_called_once()
 
 
+def _running_metadata(operation_id: str = "op123") -> str:
+  return json.dumps(
+    {
+      "operation_id": operation_id,
+      "operation_type": "backup",
+      "user_id": "user456",
+      "graph_id": "kg789",
+      "status": "running",
+      "created_at": "2023-01-01T12:00:00Z",
+      "updated_at": "2023-01-01T12:30:00Z",
+      "error_message": None,
+      "result_data": None,
+    }
+  )
+
+
+class TestTerminalFailureEvictsIdempotency:
+  """A route that enqueues work caches a `pending` envelope under the caller's
+  Idempotency-Key. When the operation fails or is cancelled that envelope
+  must go, or every retry with the same key replays `pending` for 24h."""
+
+  def _async_storage(self, metadata_json: str | None) -> SSEEventStorage:
+    mock_redis = AsyncMock()
+    mock_redis.get.return_value = metadata_json
+    mock_redis.ttl.return_value = 600
+    # setex is queued synchronously on the pipeline; only execute is awaited.
+    pipe = Mock()
+    pipe.execute = AsyncMock()
+    mock_redis.pipeline = Mock(return_value=pipe)
+    return SSEEventStorage(redis_client=mock_redis)
+
+  @pytest.mark.parametrize(
+    "event_type",
+    [EventType.OPERATION_ERROR, EventType.OPERATION_CANCELLED],
+  )
+  async def test_failed_or_cancelled_transition_evicts(self, event_type):
+    storage = self._async_storage(_running_metadata())
+    with patch(
+      "robosystems.middleware.sse.event_storage._invalidate_idempotency",
+      new_callable=AsyncMock,
+    ) as evict:
+      await storage._update_operation_metadata(
+        "op123", event_type, {"error": "disk full", "reason": "user"}
+      )
+    evict.assert_awaited_once_with("op123")
+
+  async def test_completed_transition_does_not_evict(self):
+    storage = self._async_storage(_running_metadata())
+    with patch(
+      "robosystems.middleware.sse.event_storage._invalidate_idempotency",
+      new_callable=AsyncMock,
+    ) as evict:
+      await storage._update_operation_metadata(
+        "op123", EventType.OPERATION_COMPLETED, {"result": {"ok": True}}
+      )
+    evict.assert_not_awaited()
+
+  async def test_unknown_operation_does_not_evict(self):
+    storage = self._async_storage(None)
+    with patch(
+      "robosystems.middleware.sse.event_storage._invalidate_idempotency",
+      new_callable=AsyncMock,
+    ) as evict:
+      await storage._update_operation_metadata(
+        "op_missing", EventType.OPERATION_ERROR, {"error": "x"}
+      )
+    evict.assert_not_awaited()
+
+  async def test_eviction_reaches_the_bound_envelope_key(self):
+    """End to end through the real `IdempotencyCache` on an in-memory client:
+    the envelope the route cached is gone after the FAILED transition, and
+    an unrelated envelope survives."""
+    from robosystems.middleware import operations as ops
+    from robosystems.middleware.operations import (
+      IdempotencyCache,
+      compute_idempotency_cache_key,
+      wrap_pending,
+    )
+
+    store: dict = {}
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=lambda k: store.get(k))
+
+    async def _set(k, v, ex=None, nx=False):
+      store[k] = v
+      return True
+
+    async def _delete(*keys):
+      return sum(1 for k in keys if store.pop(k, None) is not None)
+
+    async def _sadd(k, *members):
+      store.setdefault(k, set()).update(members)
+      return len(members)
+
+    client.set = AsyncMock(side_effect=_set)
+    client.delete = AsyncMock(side_effect=_delete)
+    client.sadd = AsyncMock(side_effect=_sadd)
+    client.smembers = AsyncMock(side_effect=lambda k: set(store.get(k, set())))
+    client.expire = AsyncMock(return_value=True)
+    cache = IdempotencyCache(client=client)
+
+    failed = wrap_pending("create-backup", operation_id="op123")
+    other = wrap_pending("create-backup", operation_id="op_other")
+    await cache.put("u", "kg789", "create-backup", "k-failed", failed, "fp")
+    await cache.put("u", "kg789", "create-backup", "k-other", other, "fp")
+    await cache.bind_operation(
+      "op123", compute_idempotency_cache_key("u", "kg789", "create-backup", "k-failed")
+    )
+
+    storage = self._async_storage(_running_metadata())
+    with patch.object(ops, "get_idempotency_cache", return_value=cache):
+      await storage._update_operation_metadata(
+        "op123", EventType.OPERATION_ERROR, {"error": "disk full"}
+      )
+
+    assert await cache.get("u", "kg789", "create-backup", "k-failed", "fp") is None
+    survivor = await cache.get("u", "kg789", "create-backup", "k-other", "fp")
+    assert survivor is not None and survivor.operation_id == "op_other"
+
+  def _sync_storage(self, metadata_json: str | None) -> SSEEventStorage:
+    mock_redis = Mock()
+    mock_redis.get.return_value = metadata_json
+    mock_pipe = Mock()
+    mock_redis.pipeline.return_value.__enter__ = Mock(return_value=mock_pipe)
+    mock_redis.pipeline.return_value.__exit__ = Mock(return_value=False)
+    storage = SSEEventStorage()
+    storage._sync_redis = mock_redis
+    return storage
+
+  @pytest.mark.parametrize(
+    "event_type",
+    [EventType.OPERATION_ERROR, EventType.OPERATION_CANCELLED],
+  )
+  def test_sync_failed_or_cancelled_transition_evicts(self, event_type):
+    storage = self._sync_storage(_running_metadata())
+    with patch(
+      "robosystems.middleware.sse.event_storage._invalidate_idempotency_sync"
+    ) as evict:
+      storage._update_operation_metadata_sync(
+        "op123", event_type, {"error": "dagster run failed"}
+      )
+    evict.assert_called_once_with("op123")
+
+  def test_sync_completed_transition_does_not_evict(self):
+    storage = self._sync_storage(_running_metadata())
+    with patch(
+      "robosystems.middleware.sse.event_storage._invalidate_idempotency_sync"
+    ) as evict:
+      storage._update_operation_metadata_sync(
+        "op123", EventType.OPERATION_COMPLETED, {"result": {"ok": True}}
+      )
+    evict.assert_not_called()
+
+  def test_sync_unknown_operation_does_not_evict(self):
+    storage = self._sync_storage(None)
+    with patch(
+      "robosystems.middleware.sse.event_storage._invalidate_idempotency_sync"
+    ) as evict:
+      storage._update_operation_metadata_sync(
+        "op_missing", EventType.OPERATION_ERROR, {"error": "x"}
+      )
+    evict.assert_not_called()
+
+
 class TestGetEventStorage:
   """Test global event storage instance."""
 

--- a/tests/middleware/sse/test_event_storage.py
+++ b/tests/middleware/sse/test_event_storage.py
@@ -758,14 +758,14 @@ class TestSSEEventStorage:
       mock_pipe.unwatch.assert_called_once()
 
 
-def _running_metadata(operation_id: str = "op123") -> str:
+def _running_metadata(operation_id: str = "op123", status: str = "running") -> str:
   return json.dumps(
     {
       "operation_id": operation_id,
       "operation_type": "backup",
       "user_id": "user456",
       "graph_id": "kg789",
-      "status": "running",
+      "status": status,
       "created_at": "2023-01-01T12:00:00Z",
       "updated_at": "2023-01-01T12:30:00Z",
       "error_message": None,
@@ -812,6 +812,53 @@ class TestTerminalFailureEvictsIdempotency:
     ) as evict:
       await storage._update_operation_metadata(
         "op123", EventType.OPERATION_COMPLETED, {"result": {"ok": True}}
+      )
+    evict.assert_not_awaited()
+
+  @pytest.mark.parametrize(
+    "event_type",
+    [EventType.OPERATION_ERROR, EventType.OPERATION_CANCELLED],
+  )
+  async def test_late_failure_after_completion_neither_flips_nor_evicts(
+    self, event_type
+  ):
+    """At-least-once delivery: a duplicate or late error event after the
+    completion must not turn a finished operation into a failed one, and must
+    not evict the envelope of an operation that succeeded — a retry under
+    the same key would dispatch it again."""
+    storage = self._async_storage(_running_metadata(status="completed"))
+    pipe = storage._redis_client.pipeline.return_value
+    with patch(
+      "robosystems.middleware.sse.event_storage._invalidate_idempotency",
+      new_callable=AsyncMock,
+    ) as evict:
+      await storage._update_operation_metadata("op123", event_type, {"error": "late"})
+    evict.assert_not_awaited()
+    pipe.setex.assert_not_called()
+
+  async def test_repeated_failure_event_evicts_only_once(self):
+    storage = self._async_storage(_running_metadata(status="failed"))
+    with patch(
+      "robosystems.middleware.sse.event_storage._invalidate_idempotency",
+      new_callable=AsyncMock,
+    ) as evict:
+      await storage._update_operation_metadata(
+        "op123", EventType.OPERATION_ERROR, {"error": "again"}
+      )
+    evict.assert_not_awaited()
+
+  async def test_lost_cas_does_not_evict(self):
+    """The transition was computed but another writer won the WATCH: nothing
+    of ours landed, so nothing is evicted (the winner may be a completion)."""
+    storage = self._async_storage(_running_metadata())
+    pipe = storage._redis_client.pipeline.return_value
+    pipe.execute = AsyncMock(side_effect=RuntimeError("WatchError"))
+    with patch(
+      "robosystems.middleware.sse.event_storage._invalidate_idempotency",
+      new_callable=AsyncMock,
+    ) as evict:
+      await storage._update_operation_metadata(
+        "op123", EventType.OPERATION_ERROR, {"error": "x"}
       )
     evict.assert_not_awaited()
 
@@ -908,6 +955,32 @@ class TestTerminalFailureEvictsIdempotency:
     ) as evict:
       storage._update_operation_metadata_sync(
         "op123", EventType.OPERATION_COMPLETED, {"result": {"ok": True}}
+      )
+    evict.assert_not_called()
+
+  def test_sync_late_failure_after_completion_neither_flips_nor_evicts(self):
+    storage = self._sync_storage(_running_metadata(status="completed"))
+    mock_pipe = storage._sync_redis.pipeline.return_value.__enter__.return_value
+    mock_pipe.get.return_value = _running_metadata(status="completed")
+    with patch(
+      "robosystems.middleware.sse.event_storage._invalidate_idempotency_sync"
+    ) as evict:
+      storage._update_operation_metadata_sync(
+        "op123", EventType.OPERATION_ERROR, {"error": "late"}
+      )
+    evict.assert_not_called()
+    mock_pipe.setex.assert_not_called()
+
+  def test_sync_lost_cas_does_not_evict(self):
+    storage = self._sync_storage(_running_metadata())
+    mock_pipe = storage._sync_redis.pipeline.return_value.__enter__.return_value
+    mock_pipe.get.return_value = _running_metadata()
+    mock_pipe.execute.side_effect = RuntimeError("WatchError")
+    with patch(
+      "robosystems.middleware.sse.event_storage._invalidate_idempotency_sync"
+    ) as evict:
+      storage._update_operation_metadata_sync(
+        "op123", EventType.OPERATION_ERROR, {"error": "x"}
       )
     evict.assert_not_called()
 

--- a/tests/middleware/test_extensions.py
+++ b/tests/middleware/test_extensions.py
@@ -257,12 +257,31 @@ class TestIdempotencyCache:
       store[key] = value
       return True
 
-    async def _delete(key: str) -> None:
-      store.pop(key, None)
+    async def _delete(*keys: str) -> int:
+      return sum(1 for key in keys if store.pop(key, None) is not None)
+
+    # Sets back the operation → envelope-key bindings; a set is stored in the
+    # same dict so `store` stays the single view of what the cache holds.
+    async def _sadd(key: str, *members: str) -> int:
+      current = store.setdefault(key, set())
+      assert isinstance(current, set)
+      added = len(set(members) - current)
+      current.update(members)
+      return added
+
+    async def _smembers(key: str) -> set[str]:
+      current = store.get(key)
+      return set(current) if isinstance(current, set) else set()
+
+    async def _expire(key: str, seconds: int) -> bool:
+      return key in store
 
     mock_client.get = AsyncMock(side_effect=_get)
     mock_client.set = AsyncMock(side_effect=_set)
     mock_client.delete = AsyncMock(side_effect=_delete)
+    mock_client.sadd = AsyncMock(side_effect=_sadd)
+    mock_client.smembers = AsyncMock(side_effect=_smembers)
+    mock_client.expire = AsyncMock(side_effect=_expire)
 
     return IdempotencyCache(client=mock_client), mock_client, store
 
@@ -422,6 +441,75 @@ class TestIdempotencyCache:
 # ---------------------------------------------------------------------------
 
 
+class TestIdempotencyCacheOperationBinding:
+  """`bind_operation` / `invalidate_operation` — the link between an async
+  operation and the pending envelope its route cached, which the SSE
+  terminal-status hook uses to evict that envelope on failure."""
+
+  def _make_cache(self):
+    return TestIdempotencyCache()._make_cache()
+
+  @pytest.mark.asyncio
+  async def test_invalidate_evicts_every_bound_envelope_and_the_binding(
+    self,
+  ) -> None:
+    cache, client, store = self._make_cache()
+    env = wrap_pending("create-backup", operation_id="op_1")
+    # Two callers, two keys, one deduplicated worker task: both envelopes hang
+    # off the same operation and both must go when it fails.
+    await cache.put("u1", "g", "create-backup", "k1", env, "fp")
+    await cache.put("u2", "g", "create-backup", "k2", env, "fp")
+    key1 = compute_idempotency_cache_key("u1", "g", "create-backup", "k1")
+    key2 = compute_idempotency_cache_key("u2", "g", "create-backup", "k2")
+    await cache.bind_operation("op_1", key1)
+    await cache.bind_operation("op_1", key2)
+    # The binding lives as long as the envelope it points at.
+    assert client.expire.call_args.args[1] == IDEMPOTENCY_TTL_SECONDS
+
+    assert await cache.invalidate_operation("op_1") == 2
+    assert store == {}
+    assert await cache.get("u1", "g", "create-backup", "k1", "fp") is None
+    assert await cache.get("u2", "g", "create-backup", "k2", "fp") is None
+
+  @pytest.mark.asyncio
+  async def test_invalidate_unknown_operation_is_a_noop(self) -> None:
+    cache, client, store = self._make_cache()
+    env = wrap_pending("materialize", operation_id="op_other")
+    await cache.put("u", "g", "materialize", "k", env, "fp")
+    assert await cache.invalidate_operation("op_never_bound") == 0
+    # An unrelated envelope is untouched and nothing was deleted.
+    assert len(store) == 1
+    client.delete.assert_not_called()
+
+  @pytest.mark.asyncio
+  async def test_module_level_invalidate_uses_the_shared_cache(self) -> None:
+    cache, _client, store = self._make_cache()
+    env = wrap_pending("create-graph", operation_id="op_2")
+    await cache.put("u", "new", "create-graph", "k", env, "fp")
+    await cache.bind_operation(
+      "op_2", compute_idempotency_cache_key("u", "new", "create-graph", "k")
+    )
+    with patch.object(middleware_module, "get_idempotency_cache", return_value=cache):
+      assert await middleware_module.invalidate_operation_idempotency("op_2") == 1
+    assert store == {}
+
+  def test_sync_invalidate_mirrors_the_async_path(self) -> None:
+    from unittest.mock import MagicMock
+
+    store: dict[str, Any] = {"idem:g:op:abc": "{}", "op-idem:op_3": {"idem:g:op:abc"}}
+    client = MagicMock()
+    client.smembers = MagicMock(side_effect=lambda k: set(store.get(k, set())))
+    client.delete = MagicMock(
+      side_effect=lambda *keys: sum(1 for k in keys if store.pop(k, None))
+    )
+    with patch.object(
+      middleware_module, "_get_sync_idempotency_client", return_value=client
+    ):
+      assert middleware_module.invalidate_operation_idempotency_sync("op_3") == 1
+      assert store == {}
+      assert middleware_module.invalidate_operation_idempotency_sync("op_3") == 0
+
+
 class TestLogOperationAudit:
   """Verifies the audit log payload shape.
 
@@ -465,6 +553,41 @@ class TestLogOperationAudit:
     assert "idempotency_key_hash" in audit
     assert audit["idempotency_key_hash"] != "caller-provided-key"
     assert len(audit["idempotency_key_hash"]) == 16
+    # Outside a request there is no correlation or credential to attribute.
+    assert "request_id" not in audit
+    assert "api_key_prefix" not in audit
+
+  def test_inside_a_request_the_credential_and_request_id_are_attributed(
+    self,
+  ) -> None:
+    from robosystems.security.request_context import (
+      RequestPrincipal,
+      bind_principal,
+      bind_request_id,
+      reset_principal,
+      reset_request_id,
+    )
+
+    rid = bind_request_id("req_audit")
+    ptoken = bind_principal(RequestPrincipal("usr_abc", "api_key", "rfs_abcd"))
+    try:
+      with patch.object(middleware_module.logger, "info") as info_mock:
+        log_operation_audit(
+          operation_name="close-period",
+          operation_id="op_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+          user_id="usr_abc",
+          graph_id="kg1",
+          duration_ms=1.0,
+          status="completed",
+        )
+    finally:
+      reset_principal(ptoken)
+      reset_request_id(rid)
+
+    audit = self._get_audit_payload(info_mock)
+    assert audit["request_id"] == "req_audit"
+    assert audit["auth_method"] == "api_key"
+    assert audit["api_key_prefix"] == "rfs_abcd"
 
   def test_failed_logs_at_error_with_error_field(self) -> None:
     with (
@@ -533,6 +656,8 @@ class _FakeIdempotencyCache:
     self.store: dict[tuple[str, str, str, str], tuple[OperationEnvelope, str]] = {}
     # Keys reserved by an in-flight run: key → body fingerprint.
     self.pending: dict[tuple[str, str, str, str], str] = {}
+    # operation_id → envelope cache keys bound to it.
+    self.bindings: dict[str, set[str]] = {}
 
   async def get(
     self,
@@ -592,6 +717,9 @@ class _FakeIdempotencyCache:
     self.pending.pop(k, None)
     self.store[k] = (envelope, body_fingerprint)
 
+  async def bind_operation(self, operation_id: str, cache_key: str) -> None:
+    self.bindings.setdefault(operation_id, set()).add(cache_key)
+
 
 def _make_ctx(**overrides: Any) -> OperationContext:
   defaults: dict[str, Any] = {
@@ -604,6 +732,180 @@ def _make_ctx(**overrides: Any) -> OperationContext:
   }
   defaults.update(overrides)
   return OperationContext(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# check_idempotency / idempotent_dispatch — the async (pending) route guard
+# ---------------------------------------------------------------------------
+
+
+class TestCheckIdempotency:
+  """`check_idempotency` claims the key on a miss, exactly as the sync
+  dispatcher does, so two identical async requests cannot both enqueue."""
+
+  @pytest.mark.asyncio
+  async def test_miss_reserves_the_key(self) -> None:
+    cache = _FakeIdempotencyCache()
+    with patch.object(middleware_module.logger, "info"):
+      result = await middleware_module.check_idempotency(
+        cache, "usr_1", "kg1", "create-backup", "key-1", "fp"
+      )
+    assert result is None
+    assert ("usr_1", "kg1", "create-backup", "key-1") in cache.pending
+
+  @pytest.mark.asyncio
+  async def test_concurrent_second_call_is_409_in_progress(self) -> None:
+    cache = _FakeIdempotencyCache()
+    with patch.object(middleware_module.logger, "info"):
+      await middleware_module.check_idempotency(
+        cache, "usr_1", "kg1", "create-backup", "key-1", "fp"
+      )
+    with (
+      patch.object(middleware_module.logger, "info"),
+      patch.object(middleware_module.logger, "error"),
+    ):
+      with pytest.raises(HTTPException) as exc_info:
+        await middleware_module.check_idempotency(
+          cache, "usr_1", "kg1", "create-backup", "key-1", "fp"
+        )
+    assert exc_info.value.status_code == 409
+    assert "still in progress" in str(exc_info.value.detail)
+
+  @pytest.mark.asyncio
+  async def test_lost_reservation_replays_a_recorded_envelope(self) -> None:
+    """The other holder recorded its envelope between our read and our claim."""
+    cache = _FakeIdempotencyCache()
+    recorded = wrap_pending("create-backup", operation_id="op_first")
+
+    original_reserve = cache.reserve
+
+    async def _lose_the_race(*args: Any, **kwargs: Any) -> bool:
+      await cache.put("usr_1", "kg1", "create-backup", "key-1", recorded, "fp")
+      return False
+
+    cache.reserve = _lose_the_race  # type: ignore[method-assign]
+    try:
+      with patch.object(middleware_module.logger, "info"):
+        replay = await middleware_module.check_idempotency(
+          cache, "usr_1", "kg1", "create-backup", "key-1", "fp"
+        )
+    finally:
+      cache.reserve = original_reserve  # type: ignore[method-assign]
+    assert replay is not None
+    assert replay.operation_id == "op_first"
+    assert replay.idempotent_replay is True
+
+  @pytest.mark.asyncio
+  async def test_lost_reservation_without_envelope_is_409(self) -> None:
+    """The other holder released between our two reads (its dispatch failed)."""
+    cache = _FakeIdempotencyCache()
+
+    async def _lose_the_race(*args: Any, **kwargs: Any) -> bool:
+      return False
+
+    cache.reserve = _lose_the_race  # type: ignore[method-assign]
+    with (
+      patch.object(middleware_module.logger, "info"),
+      patch.object(middleware_module.logger, "error"),
+    ):
+      with pytest.raises(HTTPException) as exc_info:
+        await middleware_module.check_idempotency(
+          cache, "usr_1", "kg1", "create-backup", "key-1", "fp"
+        )
+    assert exc_info.value.status_code == 409
+
+  @pytest.mark.asyncio
+  async def test_no_key_neither_reads_nor_reserves(self) -> None:
+    cache = _FakeIdempotencyCache()
+    assert (
+      await middleware_module.check_idempotency(
+        cache, "usr_1", "kg1", "create-backup", None, "fp"
+      )
+      is None
+    )
+    assert cache.pending == {}
+
+
+class TestIdempotentDispatch:
+  """The context manager every async route wraps its enqueue in."""
+
+  def _args(self, cache: _FakeIdempotencyCache, key: str | None = "key-1"):
+    return (cache, "usr_1", "kg1", "create-backup", key, "fp")
+
+  @pytest.mark.asyncio
+  async def test_records_and_binds_a_pending_envelope(self) -> None:
+    cache = _FakeIdempotencyCache()
+    with patch.object(middleware_module.logger, "info"):
+      async with middleware_module.idempotent_dispatch(*self._args(cache)) as idem:
+        assert idem.replay is None
+        envelope = wrap_pending("create-backup", operation_id="op_1")
+        await idem.record(envelope)
+    k = ("usr_1", "kg1", "create-backup", "key-1")
+    assert k not in cache.pending
+    assert cache.store[k][0].operation_id == "op_1"
+    assert cache.bindings == {
+      "op_1": {compute_idempotency_cache_key("usr_1", "kg1", "create-backup", "key-1")}
+    }
+
+  @pytest.mark.asyncio
+  async def test_completed_envelope_is_recorded_but_not_bound(self) -> None:
+    """A dry-run or inline path completes in the envelope; there is no
+    operation whose failure could later evict it."""
+    cache = _FakeIdempotencyCache()
+    with patch.object(middleware_module.logger, "info"):
+      async with middleware_module.idempotent_dispatch(*self._args(cache)) as idem:
+        await idem.record(wrap_completed("create-backup", {"ok": True}))
+    assert len(cache.store) == 1
+    assert cache.bindings == {}
+
+  @pytest.mark.asyncio
+  async def test_dispatch_failure_releases_the_reservation(self) -> None:
+    cache = _FakeIdempotencyCache()
+    with patch.object(middleware_module.logger, "info"):
+      with pytest.raises(RuntimeError, match="queue down"):
+        async with middleware_module.idempotent_dispatch(*self._args(cache)):
+          raise RuntimeError("queue down")
+    assert cache.pending == {}
+    assert cache.store == {}
+    # ...so the retry executes rather than being told "in progress".
+    with patch.object(middleware_module.logger, "info"):
+      async with middleware_module.idempotent_dispatch(*self._args(cache)) as idem:
+        assert idem.replay is None
+
+  @pytest.mark.asyncio
+  async def test_validation_4xx_before_dispatch_releases_too(self) -> None:
+    cache = _FakeIdempotencyCache()
+    with patch.object(middleware_module.logger, "info"):
+      with pytest.raises(HTTPException):
+        async with middleware_module.idempotent_dispatch(*self._args(cache)):
+          raise HTTPException(status_code=403, detail="not admin")
+    assert cache.pending == {}
+
+  @pytest.mark.asyncio
+  async def test_replay_path_does_not_touch_the_key(self) -> None:
+    cache = _FakeIdempotencyCache()
+    recorded = wrap_pending("create-backup", operation_id="op_first")
+    await cache.put("usr_1", "kg1", "create-backup", "key-1", recorded, "fp")
+    with patch.object(middleware_module.logger, "info"):
+      async with middleware_module.idempotent_dispatch(*self._args(cache)) as idem:
+        assert idem.replay is not None
+        assert idem.replay.operation_id == "op_first"
+        assert idem.replay.idempotent_replay is True
+    # Still cached, still not reserved by anyone.
+    assert len(cache.store) == 1
+    assert cache.pending == {}
+
+  @pytest.mark.asyncio
+  async def test_no_key_is_a_pass_through(self) -> None:
+    cache = _FakeIdempotencyCache()
+    async with middleware_module.idempotent_dispatch(
+      *self._args(cache, key=None)
+    ) as idem:
+      assert idem.replay is None
+      await idem.record(wrap_pending("create-backup", operation_id="op_1"))
+    assert cache.store == {}
+    assert cache.pending == {}
+    assert cache.bindings == {}
 
 
 class TestExecuteOperationHappyPath:

--- a/tests/operations/extensions/test_materialize.py
+++ b/tests/operations/extensions/test_materialize.py
@@ -1,6 +1,6 @@
 """Tests for extensions materialization pipeline."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -699,20 +699,21 @@ class TestPartialStatusAndSwapGate:
 
     assert result.status == "failed"
 
-  async def _run_blue_green(self, final_status: str):
+  async def _run_blue_green(self, final_status: str, lock=None):
     """Drive _materialize_blue_green with a stubbed pipeline."""
     materializer = self._materializer()
     result = MaterializeResult(graph_id=GRAPH_ID)
 
-    async def fake_materialize_tables(client, graph_id, res, source_graph_id=None):
+    async def fake_materialize_tables(
+      client, graph_id, res, source_graph_id=None, lock=None
+    ):
       res.status = final_status
 
     client = AsyncMock()
     client.database_exists.return_value = False
 
-    lock = AsyncMock()
-    lock.acquire.return_value = True
-    lock.acquired = True
+    if lock is None:
+      lock = _held_lock()
 
     with (
       patch.object(materializer, "_ensure_database", new=AsyncMock()),
@@ -725,16 +726,10 @@ class TestPartialStatusAndSwapGate:
         "robosystems.operations.extensions.materialize.build_postgres_connstr",
         return_value=CONNSTR,
       ),
-      patch(
-        "robosystems.graph_api.core.ladybug.materialization_lock.MaterializationLock",
-        return_value=lock,
-      ),
-      patch(
-        "robosystems.config.valkey_registry.create_async_redis_client",
-        return_value=AsyncMock(),
-      ),
     ):
-      await materializer._materialize_blue_green(client, GRAPH_ID, ENTITY_ID, result)
+      await materializer._materialize_blue_green(
+        client, GRAPH_ID, ENTITY_ID, result, lock
+      )
 
     return client
 
@@ -754,6 +749,269 @@ class TestPartialStatusAndSwapGate:
   async def test_error_build_does_not_swap(self):
     client = await self._run_blue_green("error")
     client.swap_database.assert_not_called()
+
+  @pytest.mark.asyncio
+  async def test_clean_build_passes_lock_token_to_swap(self):
+    lock = _held_lock(token="tok-123")
+    client = await self._run_blue_green("success", lock=lock)
+    client.swap_database.assert_called_once_with(GRAPH_ID, lock_token="tok-123")
+
+  @pytest.mark.asyncio
+  async def test_lapsed_lock_aborts_before_swap(self):
+    """A lock that lapsed mid-run (extend sees a token mismatch) must abort
+    the run and abandon the WIP rather than swap with a stale token — another
+    run may now hold the lock and be building against the same graph."""
+    from robosystems.operations.extensions.materialize import (
+      MaterializationLockError,
+    )
+
+    lock = _held_lock()
+    lock.extend.return_value = False
+
+    with pytest.raises(MaterializationLockError):
+      await self._run_blue_green("success", lock=lock)
+
+  @pytest.mark.asyncio
+  async def test_lapsed_lock_abandons_wip(self):
+    from robosystems.operations.extensions.materialize import (
+      MaterializationLockError,
+    )
+
+    materializer = self._materializer()
+    result = MaterializeResult(graph_id=GRAPH_ID)
+    lock = _held_lock(token="tok-abc")
+    lock.extend.return_value = False
+
+    async def fake_materialize_tables(
+      client, graph_id, res, source_graph_id=None, lock=None
+    ):
+      res.status = "success"
+
+    client = AsyncMock()
+    # WIP does not exist before the build; exists once the build is abandoned.
+    client.database_exists.side_effect = [False, True]
+
+    with (
+      patch.object(materializer, "_ensure_database", new=AsyncMock()),
+      patch.object(
+        materializer, "_get_graph_extensions", new=AsyncMock(return_value=[])
+      ),
+      patch.object(materializer, "_stage_tables", new=AsyncMock()),
+      patch.object(materializer, "_materialize_tables", new=fake_materialize_tables),
+      patch(
+        "robosystems.operations.extensions.materialize.build_postgres_connstr",
+        return_value=CONNSTR,
+      ),
+      pytest.raises(MaterializationLockError),
+    ):
+      await materializer._materialize_blue_green(
+        client, GRAPH_ID, ENTITY_ID, result, lock
+      )
+
+    client.swap_database.assert_not_called()
+    client.delete_database.assert_called_once_with(
+      f"{GRAPH_ID}-wip", preserve_duckdb=True, lock_token="tok-abc"
+    )
+
+  @pytest.mark.asyncio
+  async def test_extend_backend_error_is_tolerated(self):
+    """A Valkey blip during extend is not a lost lock: the key still carries
+    its remaining TTL and competing acquires fail closed while Valkey is down."""
+    lock = _held_lock()
+    lock.extend.side_effect = ConnectionError("valkey blip")
+
+    client = await self._run_blue_green("success", lock=lock)
+    client.swap_database.assert_called_once()
+
+  @pytest.mark.asyncio
+  async def test_lock_refreshed_per_materialized_table(self):
+    materializer = self._materializer()
+    result = MaterializeResult(graph_id=GRAPH_ID)
+    result.tables_staged = ["Entity", "Element", "ENTRY_HAS_LINE_ITEM"]
+    lock = _held_lock()
+
+    client = AsyncMock()
+    client.materialize_table.return_value = {"rows_ingested": 1}
+
+    await materializer._materialize_tables(client, GRAPH_ID, result, lock=lock)
+
+    assert lock.extend.await_count == 3
+
+  @pytest.mark.asyncio
+  async def test_lapsed_lock_stops_materialize_tables_before_next_copy(self):
+    from robosystems.operations.extensions.materialize import (
+      MaterializationLockError,
+    )
+
+    materializer = self._materializer()
+    result = MaterializeResult(graph_id=GRAPH_ID)
+    result.tables_staged = ["Entity", "Element"]
+    lock = _held_lock()
+    lock.extend.side_effect = [True, False]
+
+    client = AsyncMock()
+    client.materialize_table.return_value = {"rows_ingested": 1}
+
+    with pytest.raises(MaterializationLockError):
+      await materializer._materialize_tables(client, GRAPH_ID, result, lock=lock)
+
+    # The second table never COPYs once the lock is known to be gone.
+    assert client.materialize_table.await_count == 1
+
+
+def _held_lock(token: str = "tok"):
+  """A MaterializationLock stand-in that is held and extends cleanly."""
+  lock = AsyncMock()
+  lock.token = token
+  lock.lock_key = f"materialize_lock:{GRAPH_ID}"
+  lock.acquired = True
+  lock.acquire.return_value = True
+  lock.extend.return_value = True
+  lock.release.return_value = True
+  lock.last_backend_error = None
+  return lock
+
+
+class TestMaterializeLockGate:
+  """``materialize`` takes the per-graph lock around BOTH build paths and
+  fails closed when it cannot — an unlocked double-writer silently duplicates
+  relationship-table edges, whereas a refused run is retried by the sensor."""
+
+  def _client(self, db_exists: bool):
+    client = AsyncMock()
+    client.database_exists.return_value = db_exists
+    client.execute_write.return_value = {"success": True}
+    client.materialize_table.return_value = {"rows_ingested": 1}
+    client.create_database.return_value = {"success": True}
+    client.install_schema.return_value = {"success": True}
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client._instance_id = "i-test"
+    return client
+
+  async def _run(self, db_exists: bool, lock):
+    from robosystems.operations.extensions.materialize import ExtensionsMaterializer
+
+    client = self._client(db_exists)
+    schema_loader = MagicMock()
+    schema_loader.return_value.nodes = {}
+    schema_loader.return_value.relationships = {}
+    materializer = ExtensionsMaterializer()
+
+    with (
+      patch(
+        "robosystems.graph_api.client.factory.get_graph_client",
+        return_value=client,
+      ),
+      patch.object(
+        _env(),
+        "EXTENSIONS_DATABASE_URL",
+        "postgresql://postgres:postgres@pg:5432/extensions",
+      ),
+      patch(
+        "robosystems.graph_api.core.ladybug.materialization_lock.MaterializationLock",
+        MagicMock(return_value=lock),
+      ),
+      patch(
+        "robosystems.config.valkey_registry.create_async_redis_client",
+        return_value=AsyncMock(),
+      ),
+      patch(
+        "robosystems.middleware.graph.instance_busy.begin_destructive_op",
+        new=AsyncMock(),
+      ),
+      patch(
+        "robosystems.middleware.graph.instance_busy.end_destructive_op",
+        new=AsyncMock(),
+      ),
+      patch("robosystems.schemas.loader.get_contextual_schema_loader", schema_loader),
+    ):
+      result = await materializer.materialize(GRAPH_ID)
+
+    return client, result
+
+  @pytest.mark.asyncio
+  async def test_first_build_path_acquires_lock(self):
+    lock = _held_lock()
+    client, result = await self._run(db_exists=False, lock=lock)
+
+    lock.acquire.assert_awaited_once()
+    lock.release.assert_awaited_once()
+    # No database yet -> direct path (create + COPY in place), no swap.
+    client.create_database.assert_awaited()
+    client.swap_database.assert_not_called()
+    assert result.status == "success"
+
+  @pytest.mark.asyncio
+  async def test_rebuild_path_acquires_lock_and_passes_token(self):
+    lock = _held_lock(token="tok-bg")
+    client, result = await self._run(db_exists=True, lock=lock)
+
+    lock.acquire.assert_awaited_once()
+    lock.release.assert_awaited_once()
+    client.swap_database.assert_awaited_once_with(GRAPH_ID, lock_token="tok-bg")
+    assert result.status == "success"
+
+  @pytest.mark.asyncio
+  async def test_lock_held_by_another_run_fails_closed(self):
+    lock = _held_lock()
+    lock.acquire.return_value = False
+    lock.acquired = False
+    client, result = await self._run(db_exists=False, lock=lock)
+
+    assert result.status == "error"
+    assert "held by another run" in result.errors[0]
+    client.create_database.assert_not_called()
+    client.execute_write.assert_not_called()
+
+  @pytest.mark.asyncio
+  async def test_lock_backend_outage_fails_closed(self):
+    """A Valkey outage must NOT degrade to an unlocked run, and the message
+    must say the lock service is unavailable, not that another run holds it."""
+    lock = _held_lock()
+    lock.acquire.return_value = False
+    lock.acquired = False
+    lock.last_backend_error = "Connection refused"
+    client, result = await self._run(db_exists=True, lock=lock)
+
+    assert result.status == "error"
+    assert "lock service unavailable" in result.errors[0]
+    assert "held by another run" not in result.errors[0]
+    client.execute_write.assert_not_called()
+    client.swap_database.assert_not_called()
+
+  @pytest.mark.asyncio
+  async def test_lock_construction_failure_fails_closed(self):
+    """A lock that cannot even be constructed (Valkey client factory raising)
+    used to proceed unlocked; it must now refuse the run."""
+    from robosystems.operations.extensions.materialize import ExtensionsMaterializer
+
+    client = self._client(db_exists=False)
+    materializer = ExtensionsMaterializer()
+
+    with (
+      patch(
+        "robosystems.graph_api.client.factory.get_graph_client",
+        return_value=client,
+      ),
+      patch(
+        "robosystems.config.valkey_registry.create_async_redis_client",
+        side_effect=RuntimeError("no valkey"),
+      ),
+      patch(
+        "robosystems.middleware.graph.instance_busy.begin_destructive_op",
+        new=AsyncMock(),
+      ),
+      patch(
+        "robosystems.middleware.graph.instance_busy.end_destructive_op",
+        new=AsyncMock(),
+      ),
+    ):
+      result = await materializer.materialize(GRAPH_ID)
+
+    assert result.status == "error"
+    assert "lock service unavailable" in result.errors[0]
+    client.create_database.assert_not_called()
 
 
 class TestScenarioExclusion:

--- a/tests/operations/graph/commands/test_create_file_upload_size_gate.py
+++ b/tests/operations/graph/commands/test_create_file_upload_size_gate.py
@@ -86,3 +86,64 @@ async def test_declared_size_at_the_limit_is_allowed_through_the_gate():
 async def test_omitted_size_skips_the_gate():
   """The field is optional; existing clients that omit it are unaffected."""
   await _assert_size_gate_passed(None)
+
+
+# ── Signing the declared length into the presigned PUT ──────────────────
+
+
+async def _presign_params(file_size_bytes: int | None) -> dict:
+  """Run the command with S3 stubbed and return the Params it presigned."""
+  graph = MagicMock()
+  graph.graph_type = "generic"
+  s3 = MagicMock()
+  s3.s3_client.generate_presigned_url.return_value = "https://s3/put"
+
+  with (
+    patch(
+      "robosystems.middleware.billing.enforcement.require_graph_access",
+      return_value=graph,
+    ),
+    patch(
+      "robosystems.operations.graph.commands.create_file_upload.get_universal_repository",
+      return_value=MagicMock(),
+    ),
+    patch(
+      "robosystems.operations.graph.commands.create_file_upload.S3Client",
+      return_value=s3,
+    ),
+    patch("robosystems.models.core.GraphTable.get_by_name", return_value=MagicMock()),
+    patch(
+      "robosystems.models.core.GraphFile.create",
+      return_value=MagicMock(id="file_1"),
+    ),
+    patch(
+      "robosystems.operations.graph.commands.create_file_upload.get_endpoint_metrics",
+      return_value=MagicMock(),
+    ),
+  ):
+    await create_file_upload_cmd(
+      graph_id="kg123",
+      request=_request(file_size_bytes),
+      current_user=MagicMock(id="user123"),
+      db=MagicMock(),
+    )
+
+  s3.s3_client.generate_presigned_url.assert_called_once()
+  call = s3.s3_client.generate_presigned_url.call_args
+  assert call.args[0] == "put_object"
+  return call.kwargs["Params"]
+
+
+@pytest.mark.asyncio
+async def test_declared_size_is_signed_into_the_presigned_put():
+  """SigV4 signs Content-Length, so a PUT of any other size fails at S3."""
+  params = await _presign_params(12_345)
+  assert params["ContentLength"] == 12_345
+  assert params["ContentType"] == "text/csv"
+
+
+@pytest.mark.asyncio
+async def test_undeclared_size_leaves_content_length_unsigned():
+  """Clients that never send a size (the integration template) keep working."""
+  params = await _presign_params(None)
+  assert "ContentLength" not in params

--- a/tests/operations/graph/commands/test_ingest_file_row_count.py
+++ b/tests/operations/graph/commands/test_ingest_file_row_count.py
@@ -1,0 +1,326 @@
+"""Tests for the ingest-file row count and row cap.
+
+Counting must never decode the whole object: parquet reads its footer only,
+CSV streams, JSON walks the array element by element. The count runs in a
+worker thread (``run_off_loop``) so a 100 MB read cannot stall the API loop,
+and a file over the per-file row cap is refused before it is stored.
+"""
+
+import io
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from fastapi import HTTPException
+
+from robosystems.config.constants import MAX_FILE_SIZE_MB, MAX_ROWS_PER_FILE
+from robosystems.middleware.graph.ingestion_limits import IngestionLimitChecker
+from robosystems.operations.graph.commands import ingest_file as module
+from robosystems.operations.graph.commands.ingest_file import (
+  _csv_row_count,
+  _json_row_count,
+  _measure_row_count,
+  _parquet_row_count,
+  _PayloadTooLarge,
+  ingest_file_cmd,
+)
+
+MB = 1024**2
+BYTE_LIMIT = MAX_FILE_SIZE_MB * MB
+
+
+def _parquet_bytes(rows: int, columns: int = 2, row_group_size: int = 10_000) -> bytes:
+  table = pa.table({f"c{i}": list(range(rows)) for i in range(columns)})
+  buf = io.BytesIO()
+  pq.write_table(table, buf, row_group_size=row_group_size)
+  return buf.getvalue()
+
+
+class _RangeS3:
+  """Just enough of a boto3 S3 client to serve GetObject with a Range header."""
+
+  def __init__(self, data: bytes) -> None:
+    self.data = data
+    self.ranges: list[tuple[int, int]] = []
+    self.full_reads = 0
+
+  def get_object(self, Bucket: str, Key: str, Range: str | None = None) -> dict:
+    if Range is None:
+      self.full_reads += 1
+      return {"Body": io.BytesIO(self.data)}
+    start, end = (int(part) for part in Range.removeprefix("bytes=").split("-"))
+    self.ranges.append((start, end))
+    return {"Body": io.BytesIO(self.data[start : end + 1])}
+
+
+# ── Parquet: footer only ────────────────────────────────────────────────
+
+
+def test_parquet_count_comes_from_footer_not_read_table():
+  data = _parquet_bytes(rows=25_000)
+  s3 = _RangeS3(data)
+
+  with patch.object(pq, "read_table") as read_table:
+    count = _parquet_row_count(s3, "bucket", "k.parquet", len(data), BYTE_LIMIT)
+
+  assert count == 25_000
+  read_table.assert_not_called()
+  # One tail read covering the footer; never the whole object.
+  assert s3.full_reads == 0
+  assert len(s3.ranges) == 1
+  start, end = s3.ranges[0]
+  assert end == len(data) - 1
+  assert end - start + 1 <= 64 * 1024 < len(data)
+
+
+def test_parquet_footer_larger_than_tail_read_fetches_exact_footer_range():
+  # Many columns and tiny row groups inflate the footer past the 64 KiB tail.
+  data = _parquet_bytes(rows=20_000, columns=60, row_group_size=200)
+  footer_len = int.from_bytes(data[-8:-4], "little")
+  assert footer_len > 64 * 1024
+  s3 = _RangeS3(data)
+
+  with patch.object(pq, "read_table") as read_table:
+    count = _parquet_row_count(s3, "bucket", "k.parquet", len(data), BYTE_LIMIT)
+
+  assert count == 20_000
+  read_table.assert_not_called()
+  assert s3.full_reads == 0
+  assert s3.ranges[-1] == (len(data) - footer_len - 8, len(data) - 1)
+
+
+def test_parquet_ranged_checksum_quirk_falls_back_to_bounded_full_read():
+  """S3-compatible stores that fail botocore's range checksum still count exactly."""
+  from botocore.exceptions import FlexibleChecksumError
+
+  data = _parquet_bytes(rows=1_234)
+  s3 = _RangeS3(data)
+
+  def ranged_get(Bucket, Key, Range=None):
+    if Range is not None:
+      raise FlexibleChecksumError(error_msg="mismatch")
+    return {"Body": io.BytesIO(data)}
+
+  s3.get_object = ranged_get  # type: ignore[method-assign]
+  with patch.object(pq, "read_table") as read_table:
+    count = _parquet_row_count(s3, "bucket", "k.parquet", len(data), BYTE_LIMIT)
+
+  assert count == 1_234
+  read_table.assert_not_called()
+
+
+def test_parquet_without_trailer_is_not_counted():
+  s3 = _RangeS3(b"definitely not parquet" * 100)
+  with pytest.raises(ValueError):
+    _parquet_row_count(s3, "bucket", "k.parquet", len(s3.data), BYTE_LIMIT)
+
+
+def test_parquet_hostile_footer_length_is_refused_before_decoding():
+  # Trailer claims a footer larger than the object itself.
+  data = b"x" * 100 + (10**6).to_bytes(4, "little") + b"PAR1"
+  s3 = _RangeS3(data)
+  with pytest.raises(ValueError):
+    _parquet_row_count(s3, "bucket", "k.parquet", len(data), BYTE_LIMIT)
+
+
+# ── CSV / JSON: streamed, bounded, capped ───────────────────────────────
+
+
+def test_csv_count_handles_quoted_newlines_and_excludes_header():
+  body = io.BytesIO(b'a,b\n1,"multi\nline"\n2,z\n')
+  assert _csv_row_count(body, BYTE_LIMIT, MAX_ROWS_PER_FILE) == 2
+
+
+def test_csv_count_stops_one_past_the_cap():
+  body = io.BytesIO(b"h\n" + b"r\n" * 1_000)
+  assert _csv_row_count(body, BYTE_LIMIT, row_cap=10) == 11
+
+
+def test_json_count_walks_array_without_loading_it_whole():
+  payload = json.dumps([{"a": i, "s": 'q"]x'} for i in range(500)]).encode()
+  with patch("json.loads") as loads:
+    count = _json_row_count(io.BytesIO(payload), BYTE_LIMIT, MAX_ROWS_PER_FILE)
+  assert count == 500
+  loads.assert_not_called()
+
+
+def test_json_object_counts_as_one_row_and_cap_short_circuits():
+  assert _json_row_count(io.BytesIO(b'{"a": 1}'), BYTE_LIMIT, 10) == 1
+  payload = json.dumps(list(range(1_000))).encode()
+  assert _json_row_count(io.BytesIO(payload), BYTE_LIMIT, row_cap=3) == 4
+
+
+def test_body_that_outgrows_the_size_gate_is_cut_off():
+  """The object was swapped for a bigger one between HEAD and GET."""
+  body = io.BytesIO(b"h\n" + b"row\n" * 10_000)
+  with pytest.raises(_PayloadTooLarge):
+    _csv_row_count(body, byte_limit=1_000, row_cap=MAX_ROWS_PER_FILE)
+
+
+def test_measure_falls_back_to_estimate_when_count_fails():
+  s3 = MagicMock()
+  s3.get_object.side_effect = RuntimeError("boom")
+  count, exact = _measure_row_count(s3, "b", "k.csv", "csv", 2_000, MAX_ROWS_PER_FILE)
+  assert exact is False
+  assert count == 2_000 // module.FALLBACK_BYTES_PER_ROW_CSV
+
+
+def test_measure_lets_payload_overflow_escape_the_estimate_fallback():
+  s3 = MagicMock()
+  s3.get_object.return_value = {"Body": io.BytesIO(b"h\n" + b"row\n" * 10_000)}
+  with (
+    patch.object(module, "MAX_FILE_SIZE_MB", 0),
+    pytest.raises(_PayloadTooLarge),
+  ):
+    _measure_row_count(s3, "b", "k.csv", "csv", 40_000, MAX_ROWS_PER_FILE)
+
+
+# ── The command: off-loop and capped ────────────────────────────────────
+
+
+def _storage_ok() -> dict:
+  return {
+    "allowed": True,
+    "retryable": False,
+    "errors": [],
+    "total_storage_gb": 1.0,
+    "enforced_storage_gb": 1.0,
+    "limit_gb": 20.0,
+    "usage_percentage": None,
+    "status": "healthy",
+    "databases": [],
+    "items": [],
+  }
+
+
+def _cmd_mocks(file_format: str, file_size: int):
+  graph_file = MagicMock()
+  graph_file.graph_id = "kg123"
+  graph_file.s3_key = f"uploads/kg123/file.{file_format}"
+  graph_file.file_format = file_format
+  graph_file.file_name = f"file.{file_format}"
+
+  graph = MagicMock()
+  graph.parent_graph_id = None
+  graph.graph_tier = "ladybug-standard"
+
+  s3 = MagicMock()
+  s3.s3_client.head_object.return_value = {"ContentLength": file_size}
+
+  return (
+    s3,
+    patch("robosystems.models.core.GraphFile.get_by_id", return_value=graph_file),
+    patch(
+      "robosystems.operations.graph.commands.ingest_file.S3Client", return_value=s3
+    ),
+    patch("robosystems.models.core.Graph.get_by_id", return_value=graph),
+    patch.object(
+      IngestionLimitChecker,
+      "check_instance_storage",
+      new_callable=AsyncMock,
+      return_value=_storage_ok(),
+    ),
+  )
+
+
+async def _run() -> dict:
+  return await ingest_file_cmd(
+    graph_id="kg123",
+    file_id="file_1",
+    ingest_to_graph=False,
+    current_user=MagicMock(),
+    db=MagicMock(),
+    background_tasks=MagicMock(),
+  )
+
+
+@pytest.mark.asyncio
+async def test_blocking_s3_work_runs_through_run_off_loop():
+  s3, files, s3_patch, graph, storage = _cmd_mocks("csv", 10 * MB)
+  s3.s3_client.get_object.return_value = {"Body": io.BytesIO(b"h\n1\n2\n")}
+
+  async def passthrough(func, *args):
+    return func(*args)
+
+  with (
+    files,
+    s3_patch,
+    graph,
+    storage,
+    patch.object(
+      module, "run_off_loop", new=AsyncMock(side_effect=passthrough)
+    ) as off_loop,
+  ):
+    await _run()
+
+  # HEAD and the read/count each go through the worker-thread seam; nothing
+  # touches S3 directly on the loop.
+  assert off_loop.await_count == 2
+  assert off_loop.await_args_list[0].args[0] is module._object_size
+  assert off_loop.await_args_list[1].args[0] is module._measure_row_count
+  s3.s3_client.head_object.assert_called_once()
+  s3.s3_client.get_object.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_file_over_row_cap_is_refused():
+  s3, files, s3_patch, graph, storage = _cmd_mocks("csv", 10 * MB)
+  s3.s3_client.get_object.return_value = {"Body": io.BytesIO(b"h\n" + b"r\n" * 50)}
+
+  with (
+    files,
+    s3_patch,
+    graph,
+    storage,
+    patch.object(module, "MAX_ROWS_PER_FILE", 10),
+  ):
+    with pytest.raises(HTTPException) as exc:
+      await _run()
+
+  assert exc.value.status_code == 413
+  assert "per-file limit of 10 rows" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_row_cap_is_the_tier_table_cap_when_tighter():
+  """A single file above the tier's `max_single_table_rows` can never materialize."""
+  s3, files, s3_patch, graph, storage = _cmd_mocks("csv", 10 * MB)
+  s3.s3_client.get_object.return_value = {"Body": io.BytesIO(b"h\n" + b"r\n" * 50)}
+
+  with (
+    files,
+    s3_patch,
+    graph,
+    storage,
+    patch.object(
+      module.GraphTierConfig,
+      "get_graph_limits",
+      return_value={"max_single_table_rows": 20},
+    ),
+  ):
+    with pytest.raises(HTTPException) as exc:
+      await _run()
+
+  assert exc.value.status_code == 413
+  assert "per-file limit of 20 rows for tier ladybug-standard" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_object_grown_past_size_gate_is_rejected_not_estimated():
+  """HEAD passed the size gate, but the body read past it — refuse, don't guess."""
+  s3, files, s3_patch, graph, storage = _cmd_mocks("csv", 100)
+
+  with (
+    files,
+    s3_patch,
+    graph,
+    storage,
+    patch.object(module, "_measure_row_count", side_effect=_PayloadTooLarge("grew")),
+  ):
+    with pytest.raises(HTTPException) as exc:
+      await _run()
+
+  assert exc.value.status_code == 400
+  assert str(MAX_FILE_SIZE_MB) in str(exc.value.detail)

--- a/tests/operations/graph/commands/test_materialize_freeze.py
+++ b/tests/operations/graph/commands/test_materialize_freeze.py
@@ -8,9 +8,22 @@ breaks this routing, this test fails loudly before it can reach production.
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+from fastapi import HTTPException
+
+from robosystems.middleware.auth.distributed_lock import LockAcquisitionResult
 from robosystems.models.api.graphs.operations import MaterializeOp
 
 GRAPH = "kgentity00000001"
+
+
+def _acquired_lock(lock_id: str = "lock-id-1"):
+  lock = MagicMock()
+  lock.lock_id = lock_id
+  lock.acquire.return_value = LockAcquisitionResult(
+    acquired=True, lock_id=lock_id, holder_id=lock_id, ttl_remaining=3600
+  )
+  return lock
 
 
 async def test_materialize_extensions_routes_to_extensions_worker():
@@ -34,10 +47,13 @@ async def test_materialize_extensions_routes_to_extensions_worker():
       "robosystems.config.shared_repositories.is_shared_repository_or_subgraph",
       return_value=False,
     ),
-    # Force the degraded lock path (no redis in tests) — caught, lock=None, proceeds.
     patch(
       "robosystems.config.valkey_registry.create_redis_client",
-      side_effect=RuntimeError("no redis in test"),
+      return_value=MagicMock(),
+    ),
+    patch(
+      "robosystems.middleware.auth.distributed_lock.DistributedLock",
+      return_value=_acquired_lock(),
     ),
     patch(
       "robosystems.middleware.graph.ingestion_limits.IngestionLimitChecker.check_materialization_limits",
@@ -55,5 +71,110 @@ async def test_materialize_extensions_routes_to_extensions_worker():
   kwargs = enqueue.await_args.kwargs
   assert kwargs["task_type"] == "extensions_materialize"
   assert kwargs["graph_id"] == GRAPH
+  # The worker releases the API-side lock by compare-and-delete, so it needs
+  # the lock_id as well as the key.
+  assert kwargs["params"]["lock_key"] == f"graph_materialize:{GRAPH}"
+  assert kwargs["params"]["lock_id"] == "lock-id-1"
   assert result["status"] == "queued"
   assert result["operation_id"] == "op_test"
+
+
+class TestMaterializeLockFailsClosed:
+  """The API-side lock used to degrade to an unlocked run when Valkey was
+  unreachable. A materialization is retryable; an unlocked double-writer
+  duplicates edges silently — so the lock failing is a 503, never a bypass."""
+
+  def _common_patches(self):
+    graph = MagicMock()
+    graph.graph_type = "entity"
+    graph.graph_tier = "ladybug-standard"
+    return (
+      patch(
+        "robosystems.middleware.billing.enforcement.require_graph_access",
+        return_value=graph,
+      ),
+      patch("robosystems.middleware.robustness.CircuitBreakerManager"),
+      patch(
+        "robosystems.config.shared_repositories.is_shared_repository_or_subgraph",
+        return_value=False,
+      ),
+      patch(
+        "robosystems.worker.client.enqueue_task",
+        new=AsyncMock(return_value={"operation_id": "op_test"}),
+      ),
+    )
+
+  async def _run(self, lock_patch):
+    from robosystems.operations.graph.commands.materialize import materialize_cmd
+
+    user = MagicMock()
+    user.id = "user_1"
+    patches = self._common_patches()
+    with patches[0], patches[1] as cb, patches[2], patches[3] as enqueue, lock_patch:
+      cb.return_value.check_circuit.return_value = None
+      with pytest.raises(HTTPException) as exc_info:
+        await materialize_cmd(
+          GRAPH, MaterializeOp(source="extensions"), user, MagicMock()
+        )
+    enqueue.assert_not_awaited()
+    return exc_info.value
+
+  @pytest.mark.asyncio
+  async def test_redis_client_failure_is_503_with_retry_after(self):
+    exc = await self._run(
+      patch(
+        "robosystems.config.valkey_registry.create_redis_client",
+        side_effect=RuntimeError("no redis"),
+      )
+    )
+    assert exc.status_code == 503
+    assert exc.headers is not None and exc.headers.get("Retry-After") == "30"
+    assert "lock service unavailable" in str(exc.detail)
+
+  @pytest.mark.asyncio
+  async def test_lock_backend_error_is_503(self):
+    """DistributedLock.acquire swallows RedisError into a not-acquired result;
+    that must read as 'service unavailable', not 'already in progress'."""
+    lock = MagicMock()
+    lock.acquire.return_value = LockAcquisitionResult(
+      acquired=False,
+      lock_id=None,
+      holder_id=None,
+      ttl_remaining=None,
+      error_message="Redis error: Connection refused",
+      backend_error=True,
+    )
+    with patch(
+      "robosystems.config.valkey_registry.create_redis_client",
+      return_value=MagicMock(),
+    ):
+      exc = await self._run(
+        patch(
+          "robosystems.middleware.auth.distributed_lock.DistributedLock",
+          return_value=lock,
+        )
+      )
+    assert exc.status_code == 503
+    assert exc.headers is not None and exc.headers.get("Retry-After") == "30"
+
+  @pytest.mark.asyncio
+  async def test_lock_held_is_409(self):
+    lock = MagicMock()
+    lock.acquire.return_value = LockAcquisitionResult(
+      acquired=False,
+      lock_id=None,
+      holder_id="someone-else",
+      ttl_remaining=100,
+      error_message="Lock is currently held by another process",
+    )
+    with patch(
+      "robosystems.config.valkey_registry.create_redis_client",
+      return_value=MagicMock(),
+    ):
+      exc = await self._run(
+        patch(
+          "robosystems.middleware.auth.distributed_lock.DistributedLock",
+          return_value=lock,
+        )
+      )
+    assert exc.status_code == 409

--- a/tests/operations/taxonomy_block/test_resync.py
+++ b/tests/operations/taxonomy_block/test_resync.py
@@ -18,7 +18,10 @@ _MODULE = "robosystems.operations.taxonomy_block.resync"
 
 def _session_cm(session: MagicMock):
   @contextmanager
-  def _cm(graph_id: str):
+  def _cm(graph_id: str, *, statement_timeout_ms=None):
+    # Migration-time fan-out is a bulk path: it must opt out of the
+    # interactive per-statement ceiling.
+    assert statement_timeout_ms is None
     yield session
 
   return _cm

--- a/tests/routers/extensions/roboledger/test_operations.py
+++ b/tests/routers/extensions/roboledger/test_operations.py
@@ -147,6 +147,10 @@ class _FakeCache:
       body_fingerprint,
     )
 
+  async def bind_operation(self, operation_id, cache_key):
+    self.bindings = getattr(self, "bindings", {})
+    self.bindings.setdefault(operation_id, set()).add(cache_key)
+
 
 class TestUpdateEntityOp:
   @pytest.mark.asyncio
@@ -287,6 +291,35 @@ class TestUpdateEntityOp:
 
     assert exc.value.status_code == 404
     assert "not initialized" in exc.value.detail
+
+  @pytest.mark.asyncio
+  async def test_cancelled_statement_is_a_504_without_the_sql(self) -> None:
+    """A statement the session ceiling cut short surfaces as a retryable 504
+    with a fixed message — never the SQL, never a bare 500."""
+    from sqlalchemy.exc import OperationalError
+
+    body = UpdateEntityRequest(name="New Name")
+
+    with patch(
+      "robosystems.routers.extensions.roboledger.operations.extensions_session",
+      side_effect=OperationalError(
+        "UPDATE entities SET name = %(n)s",
+        {"n": "secret"},
+        MagicMock(pgcode="57014"),
+      ),
+    ):
+      with pytest.raises(HTTPException) as exc:
+        await update_entity_op(
+          body=body,
+          graph_id=GRAPH_ID,
+          user=_make_user(),
+          idempotency_key=None,
+          cache=_FakeCache(),
+        )
+
+    assert exc.value.status_code == 504
+    assert "secret" not in exc.value.detail
+    assert exc.value.headers == {"Retry-After": "5"}
 
   @pytest.mark.asyncio
   async def test_other_programming_error_is_not_a_404(self) -> None:
@@ -461,6 +494,44 @@ class TestAutoMapElementsOp:
     assert first.idempotent_replay is False
     # Replayed call: idempotent_replay=True (the fix under test)
     assert second.idempotent_replay is True
+
+  @pytest.mark.asyncio
+  async def test_fresh_enqueue_binds_the_operation_to_its_envelope_key(
+    self,
+  ) -> None:
+    """The pending envelope is bound to the worker task's operation id so a
+    failed run can evict it (a retry then dispatches again instead of
+    replaying `pending` for 24h)."""
+    from robosystems.middleware.operations import compute_idempotency_cache_key
+
+    body = AutoMapElementsOperation(mapping_id="map_bind")
+    cache = _FakeCache()
+    task_response = {
+      "operation_id": "op_01BINDTEST0000000000000000",
+      "operation_type": "operator",
+      "_links": {},
+      "deduplicated": False,
+    }
+
+    with patch(
+      "robosystems.worker.client.enqueue_task",
+      return_value=task_response,
+    ):
+      await auto_map_elements_op(
+        body=body,
+        graph_id=GRAPH_ID,
+        user=_make_user(),
+        idempotency_key="bind-key",
+        cache=cache,
+      )
+
+    assert cache.bindings == {
+      "op_01BINDTEST0000000000000000": {
+        compute_idempotency_cache_key(
+          "usr_test123", GRAPH_ID, "auto-map-elements", "bind-key"
+        )
+      }
+    }
 
   @pytest.mark.asyncio
   async def test_idempotent_replay_does_not_poison_cached_instance(self) -> None:

--- a/tests/routers/graphs/mcp/test_mcp_handlers.py
+++ b/tests/routers/graphs/mcp/test_mcp_handlers.py
@@ -132,6 +132,31 @@ class TestValidateMcpAccess:
       assert exc_info.value.status_code == 403
 
   @pytest.mark.asyncio
+  async def test_user_graph_read_denial_is_audited(self):
+    """A read on a graph the caller is not a member of emits the same
+    AuthorizationDenied event the write gate does — the enumeration signal."""
+    with (
+      patch(
+        "robosystems.config.shared_repositories.is_shared_repository_or_subgraph",
+        return_value=False,
+      ),
+      patch(
+        "robosystems.models.core.GraphUser.user_has_access",
+        return_value=False,
+      ),
+      patch(
+        "robosystems.security.SecurityAuditLogger.log_authorization_denied"
+      ) as denied,
+    ):
+      with pytest.raises(HTTPException):
+        await validate_mcp_access(
+          "kg01234567890abcdef", _make_mock_user(), Mock(), "read"
+        )
+    denied.assert_called_once()
+    assert denied.call_args.kwargs["action"] == "read"
+    assert denied.call_args.kwargs["resource"] == "kg01234567890abcdef"
+
+  @pytest.mark.asyncio
   async def test_user_graph_write_requires_write_role(self):
     """Write operations on a user graph require the write role, not bare membership."""
     with (

--- a/tests/routers/graphs/test_graph_tier_upgrade.py
+++ b/tests/routers/graphs/test_graph_tier_upgrade.py
@@ -110,6 +110,95 @@ class TestUpgradeTierEndpoint:
       del app.dependency_overrides[get_idempotency_cache]
 
   @pytest.mark.unit
+  def test_idempotency_key_reserves_records_and_binds(self, client, mock_user):
+    """With an Idempotency-Key the route claims the key before dispatch,
+    caches the pending envelope, and binds it to the operation for eviction
+    on failure."""
+    from robosystems.database import get_async_db_session
+    from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+    from robosystems.middleware.operations import (
+      compute_idempotency_cache_key,
+      get_idempotency_cache,
+    )
+
+    mock_cache = AsyncMock()
+    mock_cache.get = AsyncMock(return_value=None)
+    mock_cache.reserve = AsyncMock(return_value=True)
+
+    app.dependency_overrides[get_current_user_with_graph] = lambda: mock_user
+    app.dependency_overrides[get_async_db_session] = lambda: MagicMock()
+    app.dependency_overrides[get_idempotency_cache] = lambda: mock_cache
+
+    try:
+      with patch(
+        f"{CMD_MODULE}.change_graph_tier_cmd",
+        new_callable=AsyncMock,
+        return_value="op_test_abc123",
+      ):
+        response = client.post(
+          f"/v1/graphs/{VALID_TEST_GRAPH_ID}/operations/change-tier",
+          json={"new_tier": "ladybug-large"},
+          headers={"Idempotency-Key": "tier-key-1"},
+        )
+
+      assert response.status_code == 202
+      mock_cache.reserve.assert_awaited_once()
+      mock_cache.put.assert_awaited_once()
+      mock_cache.bind_operation.assert_awaited_once_with(
+        "op_test_abc123",
+        compute_idempotency_cache_key(
+          "test-user-123", VALID_TEST_GRAPH_ID, "change-tier", "tier-key-1"
+        ),
+      )
+      mock_cache.release.assert_not_awaited()
+    finally:
+      del app.dependency_overrides[get_current_user_with_graph]
+      del app.dependency_overrides[get_async_db_session]
+      del app.dependency_overrides[get_idempotency_cache]
+
+  @pytest.mark.unit
+  def test_failed_dispatch_releases_the_reservation(self, client, mock_user):
+    """A dispatch that raises leaves no reservation behind, so the caller's
+    retry with the same key runs instead of answering 409."""
+    from fastapi import HTTPException
+
+    from robosystems.database import get_async_db_session
+    from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+    from robosystems.middleware.operations import get_idempotency_cache
+
+    mock_cache = AsyncMock()
+    mock_cache.get = AsyncMock(return_value=None)
+    mock_cache.reserve = AsyncMock(return_value=True)
+
+    app.dependency_overrides[get_current_user_with_graph] = lambda: mock_user
+    app.dependency_overrides[get_async_db_session] = lambda: MagicMock()
+    app.dependency_overrides[get_idempotency_cache] = lambda: mock_cache
+
+    try:
+      with patch(
+        f"{CMD_MODULE}.change_graph_tier_cmd",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(status_code=402, detail="payment required"),
+      ):
+        response = client.post(
+          f"/v1/graphs/{VALID_TEST_GRAPH_ID}/operations/change-tier",
+          json={"new_tier": "ladybug-large"},
+          headers={"Idempotency-Key": "tier-key-2"},
+        )
+
+      assert response.status_code == 402
+      mock_cache.reserve.assert_awaited_once()
+      mock_cache.put.assert_not_awaited()
+      mock_cache.bind_operation.assert_not_awaited()
+      mock_cache.release.assert_awaited_once_with(
+        "test-user-123", VALID_TEST_GRAPH_ID, "change-tier", "tier-key-2"
+      )
+    finally:
+      del app.dependency_overrides[get_current_user_with_graph]
+      del app.dependency_overrides[get_async_db_session]
+      del app.dependency_overrides[get_idempotency_cache]
+
+  @pytest.mark.unit
   def test_rejects_invalid_tier(self, client, mock_user):
     """Invalid tier values are rejected with 422."""
     from robosystems.middleware.auth.dependencies import get_current_user_with_graph

--- a/tests/routers/graphs/test_write_role_gates.py
+++ b/tests/routers/graphs/test_write_role_gates.py
@@ -172,7 +172,7 @@ class TestConnectionWriteRoleGates:
     with (
       patch(f"{SYNC}.require_graph_write_role", gate),
       patch(f"{SYNC}.dispatch_connection_sync") as dispatch,
-      patch(f"{SYNC}.check_idempotency") as idem,
+      patch(f"{SYNC}.idempotent_dispatch") as idem,
     ):
       with pytest.raises(HTTPException) as exc:
         asyncio.run(

--- a/tests/security/test_request_context.py
+++ b/tests/security/test_request_context.py
@@ -1,0 +1,176 @@
+"""Request-scoped identity: the request id and the authenticated principal
+reach the audit trail below the route handler, and the access log names the
+caller."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from robosystems.security import SecurityAuditLogger, SecurityEventType
+from robosystems.security.request_context import (
+  RequestPrincipal,
+  audit_context,
+  bind_principal,
+  bind_request_id,
+  current_principal,
+  current_request_id,
+  publish_principal,
+  reset_principal,
+  reset_request_id,
+)
+
+
+class TestPublishPrincipal:
+  def test_publishes_to_state_and_context(self):
+    request = SimpleNamespace(state=SimpleNamespace())
+    principal = publish_principal(
+      request, "usr_1", "api_key", api_key="rfs_abcdefghijklmnop"
+    )
+    try:
+      assert request.state.user_id == "usr_1"
+      assert request.state.auth_user_id == "usr_1"
+      assert request.state.auth_method == "api_key"
+      assert request.state.api_key_prefix == "rfs_abcd"
+      assert current_principal() == principal
+      assert principal.api_key_prefix == "rfs_abcd"
+    finally:
+      bind_principal(None)
+
+  def test_jwt_principal_has_no_key_prefix(self):
+    request = SimpleNamespace(state=SimpleNamespace())
+    principal = publish_principal(request, "usr_2", "jwt_token")
+    try:
+      assert principal.api_key_prefix is None
+      assert not hasattr(request.state, "api_key_prefix")
+      assert audit_context() == {"auth_method": "jwt_token"}
+    finally:
+      bind_principal(None)
+
+  def test_audit_context_is_empty_outside_a_request(self):
+    assert current_request_id() is None
+    assert current_principal() is None
+    assert audit_context() == {}
+
+  def test_audit_context_carries_request_id_and_credential(self):
+    rid = bind_request_id("req_1")
+    ptoken = bind_principal(
+      RequestPrincipal("usr_3", "api_key", api_key_prefix="rfs_1234")
+    )
+    try:
+      assert audit_context() == {
+        "request_id": "req_1",
+        "auth_method": "api_key",
+        "api_key_prefix": "rfs_1234",
+      }
+    finally:
+      reset_principal(ptoken)
+      reset_request_id(rid)
+    assert audit_context() == {}
+
+
+class TestContextPropagation:
+  @pytest.mark.asyncio
+  async def test_follows_the_request_into_a_runner_thread(self):
+    """`run_off_loop` copies the request context into the worker thread, so
+    an operation running there still sees the principal."""
+    from robosystems.middleware.operations import run_off_loop
+
+    token = bind_principal(RequestPrincipal("usr_t", "api_key", "rfs_tttt"))
+    try:
+      seen = await run_off_loop(current_principal)
+    finally:
+      reset_principal(token)
+    assert seen is not None and seen.user_id == "usr_t"
+
+  @pytest.mark.asyncio
+  async def test_does_not_leak_between_concurrent_tasks(self):
+    async def one_request(user_id: str) -> str | None:
+      bind_principal(RequestPrincipal(user_id, "jwt_token"))
+      await asyncio.sleep(0.01)
+      principal = current_principal()
+      return principal.user_id if principal else None
+
+    seen = await asyncio.gather(one_request("a"), one_request("b"))
+    assert seen == ["a", "b"]
+    assert current_principal() is None
+
+
+class TestSecurityEventsCarryTheContext:
+  @patch("robosystems.security.audit_logger._publish_security_metrics")
+  @patch("robosystems.security.audit_logger.env")
+  @patch("robosystems.security.audit_logger.logger")
+  def test_authorization_denied_carries_request_id_and_key(
+    self, mock_logger, mock_env, _publish
+  ):
+    mock_env.ENVIRONMENT = "prod"
+    mock_env.SECURITY_AUDIT_ENABLED = True
+    rid = bind_request_id("req_9")
+    ptoken = bind_principal(RequestPrincipal("usr_9", "api_key", "rfs_9999"))
+    try:
+      SecurityAuditLogger.log_authorization_denied(
+        user_id="usr_9", resource="graph_database:kg1", action="read"
+      )
+    finally:
+      reset_principal(ptoken)
+      reset_request_id(rid)
+    line = mock_logger.warning.call_args.args[0]
+    payload = json.loads(line.removeprefix("SECURITY_AUDIT: "))
+    assert payload["event_type"] == SecurityEventType.AUTHORIZATION_DENIED.value
+    assert payload["user_id"] == "usr_9"
+    assert payload["request_id"] == "req_9"
+    assert payload["api_key_prefix"] == "rfs_9999"
+    assert payload["auth_method"] == "api_key"
+
+  @patch("robosystems.security.audit_logger._publish_security_metrics")
+  @patch("robosystems.security.audit_logger.env")
+  @patch("robosystems.security.audit_logger.logger")
+  def test_outside_a_request_the_fields_are_absent(self, mock_logger, mock_env, _p):
+    mock_env.ENVIRONMENT = "prod"
+    mock_env.SECURITY_AUDIT_ENABLED = True
+    SecurityAuditLogger.log_authorization_denied(
+      user_id="usr_0", resource="graph_database:kg1", action="read"
+    )
+    payload = json.loads(
+      mock_logger.warning.call_args.args[0].removeprefix("SECURITY_AUDIT: ")
+    )
+    assert "request_id" not in payload
+    assert "api_key_prefix" not in payload
+
+
+class TestAccessLogAttribution:
+  """The access-log line reads the caller after the route ran, and the
+  request id bound by the middleware is visible inside the route."""
+
+  def _app(self) -> FastAPI:
+    from robosystems.middleware.logging import StructuredLoggingMiddleware
+
+    app = FastAPI()
+    app.add_middleware(StructuredLoggingMiddleware)
+
+    @app.get("/v1/things")
+    async def things(request: Request):
+      publish_principal(request, "usr_route", "api_key", api_key="rfs_routeKEY")
+      return {"request_id_in_route": current_request_id()}
+
+    return app
+
+  def test_user_id_is_read_after_the_route_ran(self):
+    with patch("robosystems.middleware.logging.log_api") as mock_log_api:
+      response = TestClient(self._app()).get("/v1/things")
+    assert response.status_code == 200
+    kwargs = mock_log_api.call_args.kwargs
+    assert kwargs["user_id"] == "usr_route"
+    assert kwargs["request_id"] == response.headers["X-Request-ID"]
+    assert response.json()["request_id_in_route"] == response.headers["X-Request-ID"]
+
+  def test_request_id_binding_is_reset_after_the_request(self):
+    with patch("robosystems.middleware.logging.log_api"):
+      TestClient(self._app()).get("/v1/things")
+    assert current_request_id() is None

--- a/tests/worker/test_base_task.py
+++ b/tests/worker/test_base_task.py
@@ -1,7 +1,7 @@
 """Tests for the BaseTask class."""
 
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -80,3 +80,98 @@ def test_task_attributes(task):
   assert task.graph_id == "kg0123456789abcdef"
   assert task.user_id == "user_01TEST"
   assert task.params == {"key": "value"}
+
+
+class TestReleaseLock:
+  """``release_lock`` must be a compare-and-delete when the enqueuing API
+  passed its lock_id: a task finishing after the lock's TTL lapsed must not
+  strip the lock a successor has since acquired."""
+
+  def _task(self, mock_manager, params):
+    return ConcreteTask(
+      task_id="op_01TEST",
+      graph_id="kg0123456789abcdef",
+      user_id="user_01TEST",
+      params=params,
+      manager=mock_manager,
+    )
+
+  def test_none_lock_key_is_noop(self, mock_manager):
+    task = self._task(mock_manager, {})
+    with patch(
+      "robosystems.config.valkey_registry.create_redis_client"
+    ) as create_client:
+      task.release_lock(None)
+    create_client.assert_not_called()
+
+  def test_release_with_lock_id_uses_compare_and_delete(self, mock_manager):
+    task = self._task(mock_manager, {"lock_id": "abc"})
+    redis_client = MagicMock()
+    with (
+      patch(
+        "robosystems.config.valkey_registry.create_redis_client",
+        return_value=redis_client,
+      ),
+      patch(
+        "robosystems.middleware.auth.distributed_lock.release_lock_by_id",
+        return_value=True,
+      ) as release_by_id,
+    ):
+      task.release_lock("graph_materialize:kg1")
+
+    release_by_id.assert_called_once_with(redis_client, "graph_materialize:kg1", "abc")
+    redis_client.delete.assert_not_called()
+    redis_client.close.assert_called_once()
+
+  def test_explicit_lock_id_wins_over_params(self, mock_manager):
+    task = self._task(mock_manager, {"lock_id": "from-params"})
+    redis_client = MagicMock()
+    with (
+      patch(
+        "robosystems.config.valkey_registry.create_redis_client",
+        return_value=redis_client,
+      ),
+      patch(
+        "robosystems.middleware.auth.distributed_lock.release_lock_by_id",
+        return_value=True,
+      ) as release_by_id,
+    ):
+      task.release_lock("graph_materialize:kg1", lock_id="explicit")
+
+    release_by_id.assert_called_once_with(
+      redis_client, "graph_materialize:kg1", "explicit"
+    )
+
+  def test_release_without_lock_id_falls_back_to_delete(self, mock_manager):
+    """Tasks enqueued before the API passed lock_id carry only the key; they
+    still release unconditionally so their lock is not stranded for the TTL."""
+    task = self._task(mock_manager, {})
+    redis_client = MagicMock()
+    with (
+      patch(
+        "robosystems.config.valkey_registry.create_redis_client",
+        return_value=redis_client,
+      ),
+      patch(
+        "robosystems.middleware.auth.distributed_lock.release_lock_by_id",
+      ) as release_by_id,
+    ):
+      task.release_lock("graph_materialize:kg1")
+
+    release_by_id.assert_not_called()
+    redis_client.delete.assert_called_once_with("lock:graph_materialize:kg1")
+
+  def test_release_lock_by_id_is_compare_and_delete(self):
+    """Pin the helper the worker relies on: a mismatched lock_id leaves the
+    key alone."""
+    from robosystems.middleware.auth.distributed_lock import release_lock_by_id
+
+    redis_client = MagicMock()
+    redis_client.eval.return_value = 0
+
+    assert release_lock_by_id(redis_client, "graph_materialize:kg1", "stale") is False
+    args = redis_client.eval.call_args.args
+    assert args[1] == 1
+    assert args[2] == "lock:graph_materialize:kg1"
+    assert args[3] == "stale"
+    redis_client.delete.assert_not_called()


### PR DESCRIPTION
## Summary

Pre-onboarding hardening pass over the extensions data plane — the availability, detectability and async-correctness follow-up to the multi-tenancy resilience review (#1211–#1213). No authorization semantics change; every fix makes the shared plane hold under load, leave a trail on denial, and keep background operations retryable. Design record and residuals: `local/RoboSystems/specs/security/pre-onboarding-hardening.md`.

- **Extensions OLTP: per-statement ceiling on interactive sessions.** `extensions_session` binds `SET LOCAL statement_timeout` with the search_path (SSM `database/EXTENSIONS_STATEMENT_TIMEOUT_MS`, default 30s); loader / Dagster / migration paths opt out. A cancelled statement is a 504 + `Retry-After` on REST, `statement_timeout` on MCP, `STATEMENT_TIMEOUT` on GraphQL.
- **GraphQL: resolvers off the event loop; unexpected errors masked.** Sync resolvers now run under the shared runner limiter (`OffloadSyncResolvers`); only deliberate `GraphQLError`s reach `errors[]` verbatim (`MaskUnexpectedErrors`, with `requestId`).
- **Ingest: row counting off the loop, per-file row cap, signed Content-Length.** Parquet is footer-only (ranged GET), CSV is streamed record by record, JSON arrays are walked element by element over a text held once (bounded by the size gate — not streamed); the S3 body is closed on every exit. The upload presign signs `ContentLength` when declared and the S3 client is pinned to SigV4 (verified locally that `content-length` joins `X-Amz-SignedHeaders`; the HEAD-measured size in ingest stays authoritative).
- **Read-path audit + attribution.** GraphQL and MCP read denials on user graphs emit `AuthorizationDenied` (same alarm as the write gates). Every auth success publishes a request-scoped principal; the access log now records the caller (it was `user_id=None` on every line); audit lines and security events carry `request_id`, `auth_method`, `api_key_prefix`.
- **Async idempotency**: reserve on miss, release on failed dispatch, evict the pending envelope on the transition into FAILED/CANCELLED (incl. the reaper's DLQ path, now a compare-and-set) — a failed backup/subgraph/materialize is retryable again under the same key. The first terminal status is final: a late/duplicate error after a completion neither flips the record nor evicts the key.
- **Materialization lock**: fail closed (503/409), one lock over both build paths, compare-token extend per table, compare-and-delete release, `materialize_db` tag on tenant sensor runs.

## Deploy notes

- New SSM tunable `database/EXTENSIONS_STATEMENT_TIMEOUT_MS` (defaults in code; `0` disables).
- S3 presigned URLs are now SigV4 — same-region buckets only (true today).
- Materialization now refuses to run when Valkey is unreachable rather than proceeding unlocked; the staleness sensor retries.

## Test plan

- [x] `just test-code` clean
- [x] `just test` — 13,362 passed (incl. real-DB tests for the session ceiling)
- [ ] Staging: a GraphQL read against a tenant graph while a `pg_sleep(60)` runs on another tenant's session; confirm the API stays responsive and the sleeping session gets 504/`STATEMENT_TIMEOUT`
- [ ] Staging: probe a non-member graph via GraphQL/MCP with a valid key; confirm `AuthorizationDenied` in the security stream with `api_key_prefix` + `request_id`
