### PR TITLE
fix(auth): publish the request principal on the inline JWT branches

### DIFF
--- a/robosystems/routers/auth/email_verification.py
+++ b/robosystems/routers/auth/email_verification.py
@@ -7,6 +7,7 @@ from robosystems.middleware.sse import (
   build_email_job_config,
   run_and_monitor_dagster_job,
 )
+from robosystems.security.request_context import publish_principal
 
 from ...config.constants import (
   EMAIL_TOKEN_EXPIRY_HOURS,
@@ -73,6 +74,8 @@ async def get_current_user_for_email_verification(
       detail="Token session has been invalidated",
       headers={"WWW-Authenticate": "Bearer"},
     )
+
+  publish_principal(request, str(user.id), "jwt_token")
 
   # Log successful authentication
   client_ip = request.client.host if request.client else None

--- a/robosystems/routers/auth/session.py
+++ b/robosystems/routers/auth/session.py
@@ -11,6 +11,8 @@ from fastapi import (
 )
 from sqlalchemy.orm import Session
 
+from robosystems.security.request_context import publish_principal
+
 from ...config import env
 from ...config.constants import JWT_EXPIRY_HOURS, TOKEN_GRACE_PERIOD_MINUTES
 from ...database import get_async_db_session
@@ -92,6 +94,8 @@ async def get_me(
         detail="Token session has been invalidated",
         headers={"WWW-Authenticate": "Bearer"},
       )
+
+    publish_principal(fastapi_request, str(user.id), "jwt_token")
 
     return {
       "id": user.id,
@@ -248,6 +252,8 @@ async def refresh_session(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Token session has been invalidated",
       )
+
+    publish_principal(fastapi_request, str(user.id), "jwt_token")
 
     # Revoke the old token before issuing a new one
     revoke_success = revoke_jwt_token(jwt_token, reason="session_refresh")

--- a/robosystems/routers/auth/sso.py
+++ b/robosystems/routers/auth/sso.py
@@ -18,6 +18,8 @@ from fastapi import (
 )
 from sqlalchemy.orm import Session
 
+from robosystems.security.request_context import publish_principal
+
 from ...config import env
 from ...config.constants import JWT_EXPIRY_HOURS, TOKEN_GRACE_PERIOD_MINUTES
 from ...database import get_async_db_session
@@ -106,6 +108,8 @@ async def generate_sso_token(
         detail="Token session has been invalidated",
         headers={"WWW-Authenticate": "Bearer"},
       )
+
+    publish_principal(request, str(user.id), "jwt_token")
 
     # Create temporary SSO token
     sso_token, token_id = create_sso_token(user.id, session=session)

--- a/tests/routers/auth/test_session.py
+++ b/tests/routers/auth/test_session.py
@@ -134,6 +134,11 @@ class TestGetMe:
     assert args[0] == "valid_jwt_token"
     assert "user_agent" in args[1]  # Device fingerprint dict
     mock_get_by_id.assert_called_once_with("user_123", mock_session)
+    # This endpoint authenticates inline rather than through the shared
+    # dependency, so it must publish the principal itself or the access log
+    # records the request as anonymous.
+    assert mock_request.state.user_id == "user_123"
+    assert mock_request.state.auth_method == "jwt_token"
 
   async def test_get_me_no_token(self):
     """Test getting current user with no token."""


### PR DESCRIPTION
## Summary

Post-deploy observation on v1.9.7: the access log now attributes API-key and graph-dependency requests (`/v1/graphs/*/query/cypher` → user id present), but `GET /v1/auth/me` still logged `user_id=null`. Four auth routes verify the JWT inline rather than through `get_current_user` — `/me`, `/refresh`, the SSO bridge, email verification — so they never published the principal #1215 introduced. Each now calls `publish_principal` once the user and session version check out.

Follow-up to #1215; the "every authentication success branch must publish" rule from `middleware/auth/README.md` now holds for all of them.

## Test plan
- [x] `just test-code` clean; `tests/routers/auth` + `tests/security/test_request_context.py` green (225)
- [x] `/me` test asserts `request.state.user_id` / `auth_method` after success