### PR TITLE
fix(graph): validate identifiers probed from uploaded files before building staging SQL

### DIFF
--- a/robosystems/graph_api/core/duckdb/README.md
+++ b/robosystems/graph_api/core/duckdb/README.md
@@ -152,6 +152,16 @@ SQL, values are bound as parameters, and paths are resolved through
 `get_duckdb_staging_path` with a defense-in-depth check that the result stays
 under the base directory.
 
+Column names are tenant-controlled too — they are probed from the uploaded
+file and become identifiers in the staging DDL. `create_table` and
+`insert_into_table` refuse any probed name outside
+`^[A-Za-z_][A-Za-z0-9_]*$` (max 128 chars) with a 400 before building SQL
+(`validate_column_names`), and every identifier interpolation goes through
+`quote_identifier`, which doubles embedded quotes. The validator is the
+barrier; the quoting is defense in depth for the next interpolation site
+someone adds. `tests/graph_api/core/duckdb/test_staging_identifiers.py` drives
+both against real DuckDB.
+
 ## Incremental loads
 
 Pass `file_id_map` at create time and each row carries its source file's ID:

--- a/robosystems/graph_api/core/duckdb/__init__.py
+++ b/robosystems/graph_api/core/duckdb/__init__.py
@@ -8,6 +8,8 @@ from .manager import (
   TableInfo,
   TableQueryRequest,
   TableQueryResponse,
+  quote_identifier,
+  validate_column_names,
   validate_table_name,
 )
 from .pool import (
@@ -28,5 +30,7 @@ __all__ = [
   "TableQueryResponse",
   "get_duckdb_pool",
   "initialize_duckdb_pool",
+  "quote_identifier",
+  "validate_column_names",
   "validate_table_name",
 ]

--- a/robosystems/graph_api/core/duckdb/manager.py
+++ b/robosystems/graph_api/core/duckdb/manager.py
@@ -30,6 +30,49 @@ def validate_table_name(table_name: str) -> None:
     )
 
 
+_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_IDENTIFIER_MAX_LENGTH = 128
+
+
+def validate_column_names(column_names: list[str], *, source: str) -> None:
+  """Refuse any probed column name outside ``[A-Za-z_][A-Za-z0-9_]*`` with a 400.
+
+  Column names read from an uploaded file are tenant-controlled and are
+  interpolated into staging DDL as identifiers. Quoting alone is not the
+  barrier — rejection is, because it fails loudly, is testable, and does not
+  depend on every interpolation site getting the escape right. The class
+  matches what a graph property name can be, so nothing a legitimate file
+  needs is excluded. ``source`` names the file or table in the error.
+  """
+  for name in column_names:
+    if (
+      not isinstance(name, str)
+      or len(name) > _IDENTIFIER_MAX_LENGTH
+      or not _IDENTIFIER_PATTERN.match(name)
+    ):
+      shown = repr(name)[:80]
+      logger.warning(f"Invalid column name rejected in {source}: {shown}")
+      raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=(
+          f"Invalid column name {shown} in {source}. Column names must start "
+          "with a letter or underscore and contain only letters, digits and "
+          f"underscores (max {_IDENTIFIER_MAX_LENGTH} characters)."
+        ),
+      )
+
+
+def quote_identifier(name: str) -> str:
+  """Double-quote a SQL identifier, doubling any embedded quote.
+
+  Every identifier interpolated into staging SQL goes through here, so a
+  name that slipped past ``validate_column_names`` still cannot terminate the
+  identifier it is quoted into. Defense in depth behind the validator, never
+  a substitute for it.
+  """
+  return '"' + name.replace('"', '""') + '"'
+
+
 def validate_table_name_decorator(func):
   """Validate a method's ``table_name``, whether passed by keyword, on a
   request object, or as the first positional argument."""
@@ -153,6 +196,13 @@ def _interrupt_after(conn, timeout: float, timed_out: dict):
     timer.cancel()
 
 
+def _dedup_col_expr(column: str, null_cols: set[str]) -> str:
+  """``FIRST("c") AS "c"`` for a carried column, ``NULL AS "c"`` for one the
+  caller asked to keep in the schema but skip the data of."""
+  quoted = quote_identifier(column)
+  return f"NULL AS {quoted}" if column in null_cols else f"FIRST({quoted}) AS {quoted}"
+
+
 class DuckDBTableManager:
   """Create, load, query and drop the DuckDB staging tables that feed
   LadybugDB ingestion.
@@ -200,12 +250,11 @@ class DuckDBTableManager:
       null_cols = null_columns or set()
       dedupe_cols = ["identifier"]
       other_cols = [c for c in column_names if c not in dedupe_cols]
-      select_parts = [f'"{c}"' for c in dedupe_cols] + [
-        f'NULL AS "{c}"' if c in null_cols else f'FIRST("{c}") AS "{c}"'
-        for c in other_cols
+      select_parts = [quote_identifier(c) for c in dedupe_cols] + [
+        _dedup_col_expr(c, null_cols) for c in other_cols
       ]
       select_clause = ", ".join(select_parts)
-      group_by_clause = ", ".join(f'"{c}"' for c in dedupe_cols)
+      group_by_clause = ", ".join(quote_identifier(c) for c in dedupe_cols)
 
       return f"""
         CREATE OR REPLACE TABLE {quoted_table} AS
@@ -221,8 +270,7 @@ class DuckDBTableManager:
       other_cols = [c for c in column_names if c not in dedupe_cols]
       # Build select: src, dst first, then FIRST() for other columns
       select_parts = ['"from" AS src', '"to" AS dst'] + [
-        f'NULL AS "{c}"' if c in null_cols else f'FIRST("{c}") AS "{c}"'
-        for c in other_cols
+        _dedup_col_expr(c, null_cols) for c in other_cols
       ]
       select_clause = ", ".join(select_parts)
 
@@ -299,15 +347,12 @@ class DuckDBTableManager:
       dedupe_cols = ["identifier"]
       other_cols = [c for c in column_names if c not in dedupe_cols]
       select_parts = (
-        [f'"{c}"' for c in dedupe_cols]
-        + [
-          f'NULL AS "{c}"' if c in null_cols else f'FIRST("{c}") AS "{c}"'
-          for c in other_cols
-        ]
+        [quote_identifier(c) for c in dedupe_cols]
+        + [_dedup_col_expr(c, null_cols) for c in other_cols]
         + ["FIRST(file_id) AS file_id"]
       )
       select_clause = ", ".join(select_parts)
-      group_by_clause = ", ".join(f'"{c}"' for c in dedupe_cols)
+      group_by_clause = ", ".join(quote_identifier(c) for c in dedupe_cols)
 
       return f"""
         CREATE OR REPLACE TABLE {quoted_table} AS
@@ -322,10 +367,7 @@ class DuckDBTableManager:
       other_cols = [c for c in column_names if c not in ["from", "to"]]
       select_parts = (
         ["src", "dst"]
-        + [
-          f'NULL AS "{c}"' if c in null_cols else f'FIRST("{c}") AS "{c}"'
-          for c in other_cols
-        ]
+        + [_dedup_col_expr(c, null_cols) for c in other_cols]
         + ["FIRST(file_id) AS file_id"]
       )
       select_clause = ", ".join(select_parts)
@@ -391,6 +433,11 @@ class DuckDBTableManager:
           [sample_file],
         ).description
         column_names = [col[0] for col in probe_result]
+        # Names read from an uploaded file are tenant-controlled; refuse
+        # anything outside the identifier class before any SQL is built.
+        validate_column_names(
+          column_names, source=f"file {sample_file.rsplit('/', 1)[-1]}"
+        )
         has_identifier = "identifier" in column_names
         has_from_to = "from" in column_names and "to" in column_names
 
@@ -461,6 +508,8 @@ class DuckDBTableManager:
           row_count=row_count,
         )
 
+    except HTTPException:
+      raise
     except Exception as e:
       logger.error(f"Failed to create table {request.table_name}: {e}")
       raise HTTPException(
@@ -555,6 +604,7 @@ class DuckDBTableManager:
             f"SELECT * FROM {parquet_read} LIMIT 0"
           ).description
           parquet_columns = [col[0] for col in parquet_probe]
+          validate_column_names(parquet_columns, source="the uploaded file")
           parquet_has_from_to = "from" in parquet_columns and "to" in parquet_columns
 
           # Schema evolution: add parquet columns the table lacks, which
@@ -573,7 +623,8 @@ class DuckDBTableManager:
             for col_name in new_cols:
               col_type = parquet_type_map.get(col_name, "VARCHAR")
               conn.execute(
-                f'ALTER TABLE {quoted_table} ADD COLUMN "{col_name}" {col_type}'
+                f"ALTER TABLE {quoted_table} ADD COLUMN "
+                f"{quote_identifier(col_name)} {col_type}"
               )
               logger.info(
                 f"Schema evolution: added column {col_name} ({col_type}) "
@@ -604,18 +655,19 @@ class DuckDBTableManager:
               if null_cols and "to" in null_cols:
                 return 'NULL AS "dst"'
               return '"to" AS dst'
+            quoted_col = quote_identifier(table_col)
             if null_cols and table_col in null_cols:
-              return f'NULL AS "{table_col}"'
+              return f"NULL AS {quoted_col}"
             # Target has a column the source parquet lacks — schema evolution
             # only adds source columns, never drops stale target-only ones.
             # NULL it rather than referencing a nonexistent source column,
             # which raises "Values list 't' does not have a column named ...".
             if table_col not in parquet_columns:
-              return f'NULL AS "{table_col}"'
-            return f't."{table_col}"'
+              return f"NULL AS {quoted_col}"
+            return f"t.{quoted_col}"
 
           select_expr = ", ".join(_explicit_col_expr(c) for c in post_cols)
-          insert_cols_clause = ", ".join(f'"{c}"' for c in post_cols)
+          insert_cols_clause = ", ".join(quote_identifier(c) for c in post_cols)
 
           if has_identifier:
             intra_dedup = 'QUALIFY ROW_NUMBER() OVER (PARTITION BY "identifier") = 1'
@@ -666,6 +718,7 @@ class DuckDBTableManager:
             f"SELECT * FROM {parquet_read} LIMIT 0"
           ).description
           append_columns = [col[0] for col in append_parquet_probe]
+          validate_column_names(append_columns, source="the uploaded file")
           table_probe = conn.execute(
             f"SELECT * FROM {quoted_table} LIMIT 0"
           ).description
@@ -676,7 +729,8 @@ class DuckDBTableManager:
             for col_name in new_append_cols:
               col_type = append_type_map.get(col_name, "VARCHAR")
               conn.execute(
-                f'ALTER TABLE {quoted_table} ADD COLUMN "{col_name}" {col_type}'
+                f"ALTER TABLE {quoted_table} ADD COLUMN "
+                f"{quote_identifier(col_name)} {col_type}"
               )
               logger.info(
                 f"Schema evolution: added column {col_name} ({col_type}) "
@@ -687,7 +741,10 @@ class DuckDBTableManager:
 
           if null_cols:
             append_expr = ", ".join(
-              f'NULL AS "{c}"' if c in null_cols else f'"{c}"' for c in append_columns
+              f"NULL AS {quote_identifier(c)}"
+              if c in null_cols
+              else quote_identifier(c)
+              for c in append_columns
             )
             sql = f"INSERT INTO {quoted_table} SELECT {append_expr}{file_id_suffix} FROM {parquet_read}"
           else:
@@ -725,6 +782,8 @@ class DuckDBTableManager:
           row_count=rows_added,
         )
 
+    except HTTPException:
+      raise
     except Exception as e:
       logger.error(f"Failed to insert into table {request.table_name}: {e}")
       raise HTTPException(

--- a/robosystems/graph_api/routers/databases/tables/materialize.py
+++ b/robosystems/graph_api/routers/databases/tables/materialize.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path
 from fastapi import status as http_status
 
 from robosystems.config import env
+from robosystems.graph_api.core.duckdb import quote_identifier
 from robosystems.graph_api.core.ladybug import get_ladybug_service
 from robosystems.graph_api.models.fork import (
   ForkFromParentRequest,
@@ -184,12 +185,13 @@ def _build_type_safe_select(
   for col_name, duck_type in source_columns:
     if col_name in exclude:
       continue
+    quoted = quote_identifier(col_name)
     if col_name in nullify:
-      parts.append(f'NULL::{duck_type} AS "{col_name}"')
+      parts.append(f"NULL::{duck_type} AS {quoted}")
     elif duck_type.upper().startswith("DECIMAL"):
-      parts.append(f'CAST("{col_name}" AS DOUBLE) AS "{col_name}"')
+      parts.append(f"CAST({quoted} AS DOUBLE) AS {quoted}")
     else:
-      parts.append(f'"{col_name}"')
+      parts.append(quoted)
   return ", ".join(parts)
 
 
@@ -220,18 +222,19 @@ def _build_reconciled_select(
   # rel tables but COPY requires them. DuckDB uses src/dst (from/to are reserved).
   for implicit_col in ("from", "to", "src", "dst"):
     if implicit_col in source_set and implicit_col not in target_name_set:
-      parts.append(f'"{implicit_col}"')
+      parts.append(quote_identifier(implicit_col))
 
   for col_name, lbug_type in target_columns:
     if col_name in exclude:
       continue
     duck_type = _lbug_type_to_duck(lbug_type)
+    quoted = quote_identifier(col_name)
     if col_name in nullify:
-      parts.append(f"NULL::{duck_type} AS {col_name}")
+      parts.append(f"NULL::{duck_type} AS {quoted}")
     elif col_name in source_set:
-      parts.append(f"TRY_CAST({col_name} AS {duck_type}) AS {col_name}")
+      parts.append(f"TRY_CAST({quoted} AS {duck_type}) AS {quoted}")
     else:
-      parts.append(f"NULL::{duck_type} AS {col_name}")
+      parts.append(f"NULL::{duck_type} AS {quoted}")
   return ", ".join(parts)
 
 

--- a/robosystems/operations/graph/commands/ingest_file.py
+++ b/robosystems/operations/graph/commands/ingest_file.py
@@ -60,6 +60,26 @@ class _PayloadTooLarge(Exception):
   """The object yielded more bytes than the size gate admitted."""
 
 
+# Column names become SQL identifiers in the staging layer; the graph API
+# refuses anything outside this class and so does the edge, where the tenant
+# gets the 400 directly instead of a staging warning in a log.
+_COLUMN_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
+
+
+class _InvalidColumnName(Exception):
+  """The file declares a column whose name cannot be a staging identifier."""
+
+  def __init__(self, name: object):
+    self.name = name
+    super().__init__(repr(name)[:80])
+
+
+def _validate_column_names(names: list[str]) -> None:
+  for name in names:
+    if not isinstance(name, str) or not _COLUMN_NAME.match(name):
+      raise _InvalidColumnName(name)
+
+
 class _BoundedS3Body(io.RawIOBase):
   """Raw stream over an S3 body that stops once ``limit`` bytes have been read.
 
@@ -133,7 +153,11 @@ def _parquet_row_count(
     raise ValueError(f"parquet footer of {footer_len:,} bytes refused")
   if footer_span > len(tail):
     tail = _read_range(s3, bucket, key, file_size - footer_span, file_size - 1)
-  return pq.read_metadata(io.BytesIO(tail[-footer_span:])).num_rows
+  metadata = pq.read_metadata(io.BytesIO(tail[-footer_span:]))
+  # Top-level Arrow names — what the staging probe sees. ``ParquetSchema.names``
+  # would give leaf paths (``embedding.list.element``) and reject a list column.
+  _validate_column_names(list(metadata.schema.to_arrow_schema().names))
+  return metadata.num_rows
 
 
 def _csv_row_count(body: Any, byte_limit: int, row_cap: int) -> int:
@@ -227,7 +251,7 @@ def _measure_row_count(
       return _json_row_count(body, byte_limit, row_cap), True
     finally:
       body.close()
-  except _PayloadTooLarge:
+  except (_PayloadTooLarge, _InvalidColumnName):
     raise
   except Exception as e:
     logger.warning(
@@ -353,6 +377,15 @@ async def ingest_file_cmd(
     raise HTTPException(
       status_code=status.HTTP_400_BAD_REQUEST,
       detail=f"File exceeds maximum of {MAX_FILE_SIZE_MB} MB",
+    )
+  except _InvalidColumnName as e:
+    raise HTTPException(
+      status_code=status.HTTP_400_BAD_REQUEST,
+      detail=(
+        f"Invalid column name {e} in {graph_file.file_name}. Column names must "
+        "start with a letter or underscore and contain only letters, digits "
+        "and underscores (max 128 characters)."
+      ),
     )
 
   if actual_row_count is not None and actual_row_count > row_cap:

--- a/tests/graph_api/core/duckdb/test_staging_identifiers.py
+++ b/tests/graph_api/core/duckdb/test_staging_identifiers.py
@@ -1,0 +1,267 @@
+"""Column names probed from an uploaded file are tenant-controlled and are
+interpolated into staging DDL as identifiers. Two layers hold: the validator
+refuses anything outside the identifier class before SQL is built, and every
+interpolation site quotes through ``quote_identifier`` so a name that somehow
+got past the validator still cannot terminate the identifier it sits in.
+
+These tests drive real DuckDB. A test that only inspected the generated
+string would pass against a broken escape.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from fastapi import HTTPException
+
+from robosystems.graph_api.core.duckdb.manager import (
+  DuckDBTableManager,
+  quote_identifier,
+  validate_column_names,
+)
+from robosystems.graph_api.models.tables import TableCreateRequest
+
+# Against the pre-fix ``create_table`` this name stages a table with columns
+# ``identifier, benign, injected`` and the subquery's result in the row. It
+# references ``identifier`` so the binder is satisfied, and ends in ``--`` so
+# the second interpolation of the name (every column appears twice in the
+# template) is swallowed as a comment and the statement parses.
+HOSTILE = 'identifier") AS "benign", (SELECT 42) AS "injected" --'
+
+
+class _OneConnectionPool:
+  """Stands in for ``get_duckdb_pool()``: hands out one real connection."""
+
+  def __init__(self, conn: duckdb.DuckDBPyConnection):
+    self.conn = conn
+
+  @contextmanager
+  def get_connection(self, graph_id: str):
+    yield self.conn
+
+
+def _write_parquet(path, columns: dict[str, list]) -> str:
+  pq.write_table(pa.table(columns), str(path))
+  return str(path)
+
+
+def _request(table_name: str, files: list[str], **kw) -> TableCreateRequest:
+  # ``model_construct`` skips the ``s3://`` field validator so a local file
+  # can stand in for the uploaded object.
+  return TableCreateRequest.model_construct(
+    graph_id="kg0123456789abcdef",
+    table_name=table_name,
+    s3_pattern=files,
+    file_id_map=kw.pop("file_id_map", None),
+    null_columns=kw.pop("null_columns", None),
+    deduplicate=kw.pop("deduplicate", True),
+    timeout_seconds=1800,
+  )
+
+
+@pytest.fixture
+def conn():
+  c = duckdb.connect(":memory:")
+  yield c
+  c.close()
+
+
+@pytest.fixture
+def manager(conn, monkeypatch):
+  monkeypatch.setattr(
+    "robosystems.graph_api.core.duckdb.manager.get_duckdb_pool",
+    lambda: _OneConnectionPool(conn),
+  )
+  return DuckDBTableManager()
+
+
+@pytest.mark.unit
+class TestValidateColumnNames:
+  def test_accepts_the_identifier_class(self):
+    validate_column_names(
+      ["identifier", "from", "to", "_private", "camelCase", "UPPER", "a1_b2"],
+      source="t",
+    )
+
+  @pytest.mark.parametrize(
+    "name",
+    [
+      HOSTILE,
+      'a"b',
+      "has space",
+      "has-hyphen",
+      "has.dot",
+      "1leading_digit",
+      "",
+      "semi;colon",
+      "new\nline",
+      "x" * 129,
+    ],
+  )
+  def test_rejects_everything_outside_it(self, name):
+    with pytest.raises(HTTPException) as e:
+      validate_column_names(["identifier", name], source="file f.parquet")
+    assert e.value.status_code == 400
+    assert "file f.parquet" in e.value.detail
+    assert repr(name)[:40] in e.value.detail
+
+  def test_rejects_non_strings(self):
+    with pytest.raises(HTTPException) as e:
+      validate_column_names([None], source="t")  # type: ignore[list-item]
+    assert e.value.status_code == 400
+
+
+@pytest.mark.unit
+class TestQuoteIdentifier:
+  def test_wraps_and_doubles_embedded_quotes(self):
+    assert quote_identifier("plain") == '"plain"'
+    assert quote_identifier('a"b') == '"a""b"'
+    assert quote_identifier(HOSTILE) == '"' + HOSTILE.replace('"', '""') + '"'
+
+  def test_round_trips_through_duckdb(self, conn):
+    conn.execute(f"CREATE TABLE t ({quote_identifier(HOSTILE)} INTEGER)")
+    (name,) = [row[0] for row in conn.execute("DESCRIBE t").fetchall()]
+    assert name == HOSTILE
+
+
+@pytest.mark.unit
+class TestCreateTableRefusesHostileColumns:
+  def test_benign_file_stages(self, manager, conn, tmp_path):
+    """Positive control: the harness really runs the staging SQL."""
+    f = _write_parquet(
+      tmp_path / "ok.parquet",
+      {"identifier": ["a", "a", "b"], "amount": [1, 1, 2]},
+    )
+    resp = manager.create_table(_request("Thing", [f]))
+    assert resp.status == "success"
+    assert resp.row_count == 2
+    assert conn.execute('SELECT count(*) FROM "Thing"').fetchone()[0] == 2
+
+  def test_hostile_column_is_refused_before_any_sql_runs(self, manager, conn, tmp_path):
+    f = _write_parquet(tmp_path / "bad.parquet", {"identifier": ["a"], HOSTILE: [7]})
+    with pytest.raises(HTTPException) as e:
+      manager.create_table(_request("Thing", [f]))
+    assert e.value.status_code == 400
+    assert "Invalid column name" in e.value.detail
+    assert conn.execute("SHOW TABLES").fetchall() == []
+
+  def test_hostile_column_is_refused_on_the_file_id_path(self, manager, conn, tmp_path):
+    f = _write_parquet(tmp_path / "bad.parquet", {"identifier": ["a"], HOSTILE: [7]})
+    with pytest.raises(HTTPException) as e:
+      manager.create_table(_request("Thing", [f], file_id_map={f: "file_1"}))
+    assert e.value.status_code == 400
+    assert conn.execute("SHOW TABLES").fetchall() == []
+
+  def test_the_400_is_not_rewrapped_as_a_500(self, manager, tmp_path):
+    f = _write_parquet(tmp_path / "bad.parquet", {"identifier": ["a"], "a b": [1]})
+    with pytest.raises(HTTPException) as e:
+      manager.create_table(_request("Thing", [f]))
+    assert e.value.status_code == 400
+
+
+@pytest.mark.unit
+class TestInsertIntoTableRefusesHostileColumns:
+  @pytest.fixture
+  def staged(self, manager, conn, tmp_path):
+    f = _write_parquet(tmp_path / "seed.parquet", {"identifier": ["a"], "amount": [1]})
+    manager.create_table(_request("Thing", [f]))
+    return conn
+
+  @pytest.mark.parametrize("deduplicate", [True, False])
+  def test_hostile_new_column_is_refused(self, manager, staged, tmp_path, deduplicate):
+    """Schema evolution would ALTER TABLE ... ADD COLUMN with the probed name."""
+    f = _write_parquet(
+      tmp_path / "more.parquet",
+      {"identifier": ["b"], "amount": [2], HOSTILE: [3]},
+    )
+    with pytest.raises(HTTPException) as e:
+      manager.insert_into_table(_request("Thing", [f], deduplicate=deduplicate))
+    assert e.value.status_code == 400
+    cols = [r[0] for r in staged.execute('DESCRIBE "Thing"').fetchall()]
+    assert cols == ["identifier", "amount"]
+    assert staged.execute('SELECT count(*) FROM "Thing"').fetchone()[0] == 1
+
+  @pytest.mark.parametrize("deduplicate", [True, False])
+  def test_benign_append_still_works(self, manager, staged, tmp_path, deduplicate):
+    f = _write_parquet(
+      tmp_path / "more.parquet",
+      {"identifier": ["b"], "amount": [2], "added_later": ["x"]},
+    )
+    resp = manager.insert_into_table(_request("Thing", [f], deduplicate=deduplicate))
+    assert resp.status == "success"
+    assert resp.row_count == 1
+    cols = [r[0] for r in staged.execute('DESCRIBE "Thing"').fetchall()]
+    assert cols == ["identifier", "amount", "added_later"]
+
+
+@pytest.mark.unit
+class TestQuotingHoldsWithoutTheValidator:
+  """Defense in depth: drive the SQL builders directly with hostile names,
+  bypassing the validator, and check DuckDB produces exactly those column
+  names — never an ``injected`` one."""
+
+  def _parquet(self, tmp_path, extra: dict[str, list]) -> str:
+    return _write_parquet(tmp_path / "h.parquet", {"identifier": ["a", "a"], **extra})
+
+  def test_build_table_sql(self, conn, tmp_path):
+    f = self._parquet(tmp_path, {HOSTILE: [1, 2]})
+    sql = DuckDBTableManager()._build_table_sql(
+      '"T"',
+      has_identifier=True,
+      has_from_to=False,
+      use_list=False,
+      column_names=["identifier", HOSTILE],
+    )
+    conn.execute(sql, [f])
+    cols = [r[0] for r in conn.execute('DESCRIBE "T"').fetchall()]
+    assert cols == ["identifier", HOSTILE]
+    assert "injected" not in cols and "benign" not in cols
+    assert conn.execute('SELECT count(*) FROM "T"').fetchone()[0] == 1
+
+  def test_build_table_sql_with_null_column(self, conn, tmp_path):
+    f = self._parquet(tmp_path, {HOSTILE: [1, 2]})
+    sql = DuckDBTableManager()._build_table_sql(
+      '"T"',
+      has_identifier=True,
+      has_from_to=False,
+      use_list=False,
+      column_names=["identifier", HOSTILE],
+      null_columns={HOSTILE},
+    )
+    conn.execute(sql, [f])
+    cols = [r[0] for r in conn.execute('DESCRIBE "T"').fetchall()]
+    assert cols == ["identifier", HOSTILE]
+
+  def test_build_table_sql_with_file_id(self, conn, tmp_path):
+    f = self._parquet(tmp_path, {HOSTILE: [1, 2]})
+    sql = DuckDBTableManager()._build_table_sql_with_file_id(
+      '"T"',
+      has_identifier=True,
+      has_from_to=False,
+      s3_files=[f],
+      file_id_map={f: "file_1"},
+      column_names=["identifier", HOSTILE],
+    )
+    conn.execute(sql)
+    cols = [r[0] for r in conn.execute('DESCRIBE "T"').fetchall()]
+    assert cols == ["identifier", HOSTILE, "file_id"]
+
+  def test_relationship_shape(self, conn, tmp_path):
+    f = _write_parquet(
+      tmp_path / "r.parquet",
+      {"from": ["a", "a"], "to": ["b", "b"], HOSTILE: [1, 2]},
+    )
+    sql = DuckDBTableManager()._build_table_sql(
+      '"R"',
+      has_identifier=False,
+      has_from_to=True,
+      use_list=False,
+      column_names=["from", "to", HOSTILE],
+    )
+    conn.execute(sql, [f])
+    cols = [r[0] for r in conn.execute('DESCRIBE "R"').fetchall()]
+    assert cols == ["src", "dst", HOSTILE]

--- a/tests/graph_api/routers/databases/tables/test_materialize_helpers.py
+++ b/tests/graph_api/routers/databases/tables/test_materialize_helpers.py
@@ -185,8 +185,8 @@ class TestReconciledSelect:
       source_table="staged",
     )
 
-    assert "TRY_CAST(identifier AS VARCHAR) AS identifier" in select
-    assert "TRY_CAST(value AS BIGINT) AS value" in select
+    assert 'TRY_CAST("identifier" AS VARCHAR) AS "identifier"' in select
+    assert 'TRY_CAST("value" AS BIGINT) AS "value"' in select
 
   def test_missing_source_columns_become_typed_nulls(self):
     """DuckDB infers all-NULL staged columns as INT32; without the typed NULL
@@ -197,7 +197,7 @@ class TestReconciledSelect:
       source_table="staged",
     )
 
-    assert "NULL::DOUBLE AS added_later" in select
+    assert 'NULL::DOUBLE AS "added_later"' in select
 
   def test_relationship_key_columns_are_passed_through_first(self):
     """TABLE_INFO omits from/to for rel tables, but COPY requires them."""
@@ -226,8 +226,8 @@ class TestReconciledSelect:
     )
 
     columns = [part.strip() for part in select.split(",")]
-    from_columns = [c for c in columns if c.endswith("from") or c == '"from"']
-    assert from_columns == ["TRY_CAST(from AS VARCHAR) AS from"], (
+    from_columns = [c for c in columns if c.endswith('"from"')]
+    assert from_columns == ['TRY_CAST("from" AS VARCHAR) AS "from"'], (
       "the implicit pass-through must be skipped when TABLE_INFO already "
       f"declares the column, else COPY gets it twice: {select}"
     )
@@ -250,7 +250,7 @@ class TestReconciledSelect:
       null_cols={"embedding"},
     )
 
-    assert "NULL::FLOAT[384] AS embedding" in select
+    assert 'NULL::FLOAT[384] AS "embedding"' in select
     assert "TRY_CAST(embedding" not in select
 
 

--- a/tests/graph_api/routers/databases/tables/test_tables_materialize.py
+++ b/tests/graph_api/routers/databases/tables/test_tables_materialize.py
@@ -240,6 +240,6 @@ def test_build_reconciled_select_nulls_missing_target_cols():
   ]
   source = ["identifier", "type"]
   expr = materialize._build_reconciled_select(target, source, "Classification")
-  assert "NULL::VARCHAR AS category" in expr
-  assert "TRY_CAST(identifier AS VARCHAR)" in expr
-  assert "TRY_CAST(type AS VARCHAR)" in expr
+  assert 'NULL::VARCHAR AS "category"' in expr
+  assert 'TRY_CAST("identifier" AS VARCHAR)' in expr
+  assert 'TRY_CAST("type" AS VARCHAR)' in expr

--- a/tests/operations/graph/commands/test_ingest_file_row_count.py
+++ b/tests/operations/graph/commands/test_ingest_file_row_count.py
@@ -324,3 +324,64 @@ async def test_object_grown_past_size_gate_is_rejected_not_estimated():
 
   assert exc.value.status_code == 400
   assert str(MAX_FILE_SIZE_MB) in str(exc.value.detail)
+
+
+# ── Column names: identifiers in the staging layer ──────────────────────
+
+
+def _parquet_with_columns(names: list[str]) -> bytes:
+  table = pa.table({name: [1, 2, 3] for name in names})
+  buf = io.BytesIO()
+  pq.write_table(table, buf)
+  return buf.getvalue()
+
+
+def test_parquet_column_names_outside_the_identifier_class_are_refused():
+  from robosystems.operations.graph.commands.ingest_file import _InvalidColumnName
+
+  hostile = 'identifier") AS "benign", (SELECT 42) AS "injected" --'
+  data = _parquet_with_columns(["identifier", hostile])
+  with pytest.raises(_InvalidColumnName) as exc:
+    _parquet_row_count(_RangeS3(data), "bucket", "k.parquet", len(data), BYTE_LIMIT)
+  assert exc.value.name == hostile
+
+
+def test_parquet_list_and_struct_columns_are_judged_by_their_top_level_name():
+  """Leaf paths like ``embedding.list.element`` must not trip the check."""
+  table = pa.table(
+    {"identifier": ["a"], "embedding": [[1.0, 2.0]], "nested": [{"x": 1}]}
+  )
+  buf = io.BytesIO()
+  pq.write_table(table, buf)
+  data = buf.getvalue()
+  assert (
+    _parquet_row_count(_RangeS3(data), "bucket", "k.parquet", len(data), BYTE_LIMIT)
+    == 1
+  )
+
+
+def test_invalid_column_name_is_not_swallowed_into_an_estimate():
+  """Unlike a malformed file, a hostile column name must surface, not degrade
+  to the bytes-per-row fallback and proceed to staging."""
+  from robosystems.operations.graph.commands.ingest_file import _InvalidColumnName
+
+  data = _parquet_with_columns(["identifier", "a b"])
+  with pytest.raises(_InvalidColumnName):
+    _measure_row_count(
+      _RangeS3(data), "bucket", "k.parquet", "parquet", len(data), MAX_ROWS_PER_FILE
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_with_invalid_column_name_gets_a_400_naming_it():
+  data = _parquet_with_columns(["identifier", "has-hyphen"])
+  s3, files, s3_patch, graph, storage = _cmd_mocks("parquet", len(data))
+  s3.s3_client.get_object.side_effect = _RangeS3(data).get_object
+
+  with files, s3_patch, graph, storage:
+    with pytest.raises(HTTPException) as exc:
+      await _run()
+
+  assert exc.value.status_code == 400
+  assert "'has-hyphen'" in str(exc.value.detail)
+  assert "file.parquet" in str(exc.value.detail)


### PR DESCRIPTION
Column names probed from an uploaded file are interpolated into the DuckDB staging DDL as SQL identifiers. This hardens that path:

- Refuse any probed column name outside \`^[A-Za-z_][A-Za-z0-9_]*\$\` (max 128 chars) with a 400 — at the ingest-file edge (from the parquet footer's top-level Arrow names) and again in \`create_table\` / \`insert_into_table\` before any SQL is built.
- Route every identifier interpolation in the staging and materialize paths through a shared \`quote_identifier\` helper (doubles embedded quotes) as defense in depth.

Producer-safety confirmed: every compiled schema's property names (SEC, roboledger, roboinvestor) are already in-class, so no legitimate ingest is affected.

Regression tests drive real DuckDB with a crafted parquet file rather than asserting on generated strings. Full graph_api + operations/graph + dagster suites green.