### PR TITLE
fix(auth): require re-authentication and an interactive session to change email

### DIFF
--- a/robosystems/dagster/jobs/notifications.py
+++ b/robosystems/dagster/jobs/notifications.py
@@ -28,6 +28,7 @@ class SendEmailConfig(Config):
   org_name: str | None = None  # For org_invitation emails
   inviter_name: str | None = None  # For org_invitation emails
   passkey_name: str | None = None  # For passkey_enrolled emails
+  new_email: str | None = None  # For email_changed notice (masked new address)
 
 
 class EmailResult:
@@ -139,6 +140,15 @@ def send_email_op(context: OpExecutionContext, config: SendEmailConfig) -> dict:
           app=config.app,
         )
       )
+    elif config.email_type == "email_changed":
+      success = loop.run_until_complete(
+        ses_service.send_email_changed_notice(
+          user_email=config.to_email,
+          user_name=config.user_name,
+          new_email=config.new_email or "a new address",
+          app=config.app,
+        )
+      )
     else:
       raise ValueError(f"Unknown email type: {config.email_type}")
 
@@ -226,6 +236,7 @@ def build_email_job_config(
   org_name: str | None = None,
   inviter_name: str | None = None,
   passkey_name: str | None = None,
+  new_email: str | None = None,
 ) -> dict:
   """Build the Dagster run_config for send_email_job.
 
@@ -259,6 +270,9 @@ def build_email_job_config(
 
   if passkey_name:
     config["passkey_name"] = passkey_name
+
+  if new_email:
+    config["new_email"] = new_email
 
   run_config: dict = {
     "ops": {

--- a/robosystems/models/api/user.py
+++ b/robosystems/models/api/user.py
@@ -1,5 +1,7 @@
 """User management API models."""
 
+from typing import Any
+
 from pydantic import BaseModel, EmailStr, Field
 
 
@@ -59,12 +61,27 @@ class UserResponse(BaseModel):
 
 
 class UpdateUserRequest(BaseModel):
-  """Request model for updating user profile."""
+  """Request model for updating user profile.
+
+  Changing ``email`` re-authenticates: a fresh proof (password re-entry or a
+  ``mgmt``-flow passkey assertion) must accompany the request, exactly as
+  passkey enrollment and removal require. Name-only updates need no proof.
+  """
 
   name: str | None = Field(
     None, min_length=1, max_length=100, description="User's display name"
   )
   email: EmailStr | None = Field(None, description="User's email address")
+  reauth_password: str | None = Field(
+    None,
+    description="Password re-entry, required to change email for a "
+    "password-holding account",
+  )
+  reauth_assertion: dict[str, Any] | None = Field(
+    None,
+    description="A fresh mgmt-flow passkey assertion, required to change email "
+    "for a passkey-only account",
+  )
 
 
 class UpdatePasswordRequest(BaseModel):

--- a/robosystems/operations/aws/ses.py
+++ b/robosystems/operations/aws/ses.py
@@ -164,6 +164,7 @@ class SESEmailService:
       "passkey_enrolled": self._passkey_enrolled_template(
         app_name, user_name, template_data
       ),
+      "email_changed": self._email_changed_template(app_name, user_name, template_data),
     }
 
     return templates.get(
@@ -283,6 +284,41 @@ If you didn't request this, no action is needed. Your password will not change.
 A passkey ({passkey_name}) was just added to your {app_name} account. It can now be used to sign in.
 
 If you didn't add this passkey, reset your password immediately and remove it from your account's security settings.
+
+{app_name}""",
+    }
+
+  @staticmethod
+  def _email_changed_template(
+    app_name: str, user_name: str, data: dict[str, Any]
+  ) -> dict[str, str]:
+    # Goes to the PREVIOUS address. new_email is already masked by the caller,
+    # but escape anyway — user_name is attacker-controllable on a takeover.
+    new_email = data.get("new_email", "a new address")
+    safe_new_email = html.escape(str(new_email))
+    safe_user_name = html.escape(str(user_name))
+
+    content = (
+      _paragraph(f"Hi {safe_user_name},")
+      + _paragraph(
+        f"The email address on your {app_name} account was just changed to "
+        f"{safe_new_email}. You are receiving this at your previous address."
+      )
+      + '<div style="margin-top:24px;padding:16px;background-color:#fef2f2;border:1px solid #fecaca;border-radius:8px;">'
+      + '<p style="margin:0;font-size:13px;line-height:1.5;color:#991b1b;">'
+      "If you didn't make this change, contact support immediately — someone "
+      "may have access to your account."
+      "</p></div>"
+    )
+
+    return {
+      "subject": f"The email on your {app_name} account was changed",
+      "html": _base_template(app_name, content),
+      "text": f"""Hi {user_name},
+
+The email address on your {app_name} account was just changed to {new_email}. You are receiving this at your previous address.
+
+If you didn't make this change, contact support immediately — someone may have access to your account.
 
 {app_name}""",
     }
@@ -586,6 +622,23 @@ View usage details: {url}
     }
 
     return await self.send_email("passkey_enrolled", user_email, template_data)
+
+  async def send_email_changed_notice(
+    self,
+    user_email: str,
+    user_name: str,
+    new_email: str,
+    app: str = "robosystems",
+  ) -> bool:
+    """Security notification to the PREVIOUS address that the account's email
+    was changed. ``new_email`` is expected pre-masked by the caller."""
+    template_data = {
+      "user_name": user_name,
+      "app_name": _APP_DISPLAY_NAMES.get(app, _APP_DISPLAY_NAMES[_DEFAULT_APP]),
+      "new_email": new_email,
+    }
+
+    return await self.send_email("email_changed", user_email, template_data)
 
   async def send_org_invitation_email(
     self,

--- a/robosystems/routers/user/main.py
+++ b/robosystems/routers/user/main.py
@@ -9,7 +9,10 @@ from ...config import env
 from ...config.constants import EMAIL_TOKEN_EXPIRY_HOURS
 from ...database import get_db_session
 from ...logger import logger
-from ...middleware.auth.dependencies import get_current_user
+from ...middleware.auth.dependencies import (
+  get_current_user,
+  get_optional_jwt_user,
+)
 from ...middleware.otel.metrics import (
   endpoint_metrics_decorator,
   get_endpoint_metrics,
@@ -27,6 +30,7 @@ from ...models.api.user import (
   UserResponse,
 )
 from ...models.core import User, UserToken
+from ...operations import passkeys as passkey_ops
 from ...security import SecurityAuditLogger, SecurityEventType
 from ...security.input_validation import (
   sanitize_string,
@@ -35,6 +39,17 @@ from ...security.input_validation import (
 from ..auth.utils import detect_app_source
 
 router = APIRouter(tags=["User"])
+
+
+def _mask_email(email: str | None) -> str:
+  """``jane@example.com`` -> ``j***@example.com`` for the change notice, which
+  goes to the OLD address and should hint at the new one without disclosing it
+  in full."""
+  if not email or "@" not in email:
+    return "a new address"
+  local, _, domain = email.partition("@")
+  shown = local[0] if local else ""
+  return f"{shown}***@{domain}"
 
 
 @router.get(
@@ -103,11 +118,22 @@ async def update_user_profile(
   request: UpdateUserRequest,
   fastapi_request: Request,
   background_tasks: BackgroundTasks,
-  current_user: User = Depends(get_current_user),
+  current_user: User | None = Depends(get_optional_jwt_user),
   db: Session = Depends(get_db_session),
   _rate_limit: None = Depends(user_management_rate_limit_dependency),
 ) -> UserResponse:
-  user_id = getattr(current_user, "id", None) if current_user else None
+  # Interactive session only. A programmatic API key must never reach a route
+  # that can change the sign-in address — changing email plus the public
+  # password-reset flow would otherwise be a full account takeover from a key
+  # that legitimately lives in CI configs and connector URLs. Same rule the
+  # passkey surfaces enforce (middleware/auth/dependencies.py get_optional_jwt_user).
+  if current_user is None:
+    raise create_error_response(
+      status_code=status.HTTP_401_UNAUTHORIZED,
+      detail="An interactive session is required to update your profile",
+      code=ErrorCode.UNAUTHORIZED,
+    )
+  user_id = getattr(current_user, "id", None)
 
   try:
     update_data = request.model_dump(exclude_unset=True)
@@ -138,7 +164,37 @@ async def update_user_profile(
           code=ErrorCode.INVALID_INPUT,
         )
 
-      sanitized_email = sanitize_string(update_data["email"], max_length=254)
+      # Re-authenticate before changing the sign-in address, exactly as passkey
+      # enrollment/removal do. A live proof (password or a fresh mgmt-flow
+      # passkey assertion) is required; a valid session alone is not enough.
+      try:
+        passkey_ops.verify_reauth(
+          db,
+          current_user,
+          password=request.reauth_password,
+          assertion=request.reauth_assertion,
+        )
+      except passkey_ops.ReauthInvalidError:
+        client_ip = fastapi_request.client.host if fastapi_request.client else None
+        SecurityAuditLogger.log_security_event(
+          event_type=SecurityEventType.AUTH_FAILURE,
+          user_id=str(user_id),
+          ip_address=client_ip,
+          user_agent=fastapi_request.headers.get("user-agent"),
+          endpoint="/v1/user",
+          details={"action": "email_change_reauth_failed"},
+          risk_level="medium",
+        )
+        raise create_error_response(
+          status_code=status.HTTP_401_UNAUTHORIZED,
+          detail="Re-authentication is required to change your email",
+          code=ErrorCode.UNAUTHORIZED,
+        )
+
+      # Store lowercase: User.create/update and get_by_email all normalize, and
+      # a mixed-case address written here would silently never match at login
+      # or password reset (both lowercase their input before the lookup).
+      sanitized_email = sanitize_string(update_data["email"], max_length=254).lower()
       existing_user = User.get_by_email(sanitized_email, db)
       if existing_user:
         metrics_instance = get_endpoint_metrics()
@@ -165,19 +221,40 @@ async def update_user_profile(
 
     if "name" in update_data:
       user_in_session.name = sanitize_string(update_data["name"], max_length=100)
-    if "email" in update_data:
-      user_in_session.email = (
-        sanitized_email if sanitized_email else update_data["email"]
-      )
-      if sanitized_email:
-        email_changed = True
-        if env.EMAIL_VERIFICATION_ENABLED:
-          user_in_session.email_verified = False
+    # Only write email on a real change (sanitized_email is set only when the
+    # requested address differs from the current one and passed reauth). This
+    # is also where the previous address is captured for the change notice.
+    previous_email: str | None = None
+    if sanitized_email:
+      previous_email = str(user_in_session.email) if user_in_session.email else None
+      user_in_session.email = sanitized_email
+      email_changed = True
+      if env.EMAIL_VERIFICATION_ENABLED:
+        user_in_session.email_verified = False
 
     user_in_session.updated_at = datetime.now(UTC)
 
     db.commit()
     db.refresh(user_in_session)
+
+    # Tell the PREVIOUS address its account's email was changed — the one
+    # signal the account owner still receives if this change was hostile. Sent
+    # regardless of EMAIL_VERIFICATION_ENABLED; a fire-and-forget notice whose
+    # failure never fails the request (the Dagster op's own send is best-effort).
+    if email_changed and previous_email:
+      app = detect_app_source(fastapi_request)
+      background_tasks.add_task(
+        run_and_monitor_dagster_job,
+        job_name="send_email_job",
+        operation_id=None,
+        run_config=build_email_job_config(
+          email_type="email_changed",
+          to_email=previous_email,
+          user_name=user_in_session.name or "there",
+          new_email=_mask_email(user_in_session.email),
+          app=app,
+        ),
+      )
 
     # Queue verification email for new email address
     if email_changed and env.EMAIL_VERIFICATION_ENABLED:

--- a/robosystems/routers/user/main.py
+++ b/robosystems/routers/user/main.py
@@ -156,7 +156,14 @@ async def update_user_profile(
     sanitized_email = None
     email_changed = False
 
-    if "email" in update_data and update_data["email"] != current_user.email:
+    # Case-insensitive so submitting your own current address (in any case) is a
+    # no-op rather than prompting reauth and then 409-ing against your own row
+    # (User.get_by_email lowercases its lookup).
+    current_email_lower = (current_user.email or "").lower()
+    if (
+      "email" in update_data
+      and update_data["email"].strip().lower() != current_email_lower
+    ):
       if not validate_email(update_data["email"]):
         raise create_error_response(
           status_code=status.HTTP_400_BAD_REQUEST,
@@ -237,12 +244,13 @@ async def update_user_profile(
     db.commit()
     db.refresh(user_in_session)
 
+    app_source = detect_app_source(fastapi_request) if email_changed else None
+
     # Tell the PREVIOUS address its account's email was changed — the one
     # signal the account owner still receives if this change was hostile. Sent
     # regardless of EMAIL_VERIFICATION_ENABLED; a fire-and-forget notice whose
     # failure never fails the request (the Dagster op's own send is best-effort).
     if email_changed and previous_email:
-      app = detect_app_source(fastapi_request)
       background_tasks.add_task(
         run_and_monitor_dagster_job,
         job_name="send_email_job",
@@ -252,7 +260,7 @@ async def update_user_profile(
           to_email=previous_email,
           user_name=user_in_session.name or "there",
           new_email=_mask_email(user_in_session.email),
-          app=app,
+          app=app_source or "roboledger",
         ),
       )
 
@@ -270,7 +278,7 @@ async def update_user_profile(
         user_agent=user_agent,
       )
 
-      app = detect_app_source(fastapi_request)
+      app = app_source or detect_app_source(fastapi_request)
 
       run_config = build_email_job_config(
         email_type="email_verification",

--- a/robosystems/routers/user/password.py
+++ b/robosystems/routers/user/password.py
@@ -1,6 +1,5 @@
 """User password management endpoints."""
 
-import bcrypt
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
@@ -71,9 +70,8 @@ async def update_user_password(
         code=ErrorCode.INVALID_INPUT,
       )
 
-    if not bcrypt.checkpw(
-      request.current_password.encode("utf-8"),
-      user_with_password.password_hash.encode("utf-8"),
+    if not PasswordSecurity.verify_password(
+      request.current_password, user_with_password.password_hash
     ):
       metrics_instance = get_endpoint_metrics()
       metrics_instance.record_business_event(
@@ -112,10 +110,11 @@ async def update_user_password(
         code=ErrorCode.INVALID_INPUT,
       )
 
-    salt = bcrypt.gensalt()
-    new_password_hash = bcrypt.hashpw(
-      request.new_password.encode("utf-8"), salt
-    ).decode("utf-8")
+    # Hash through the policy function (BCRYPT_ROUNDS), not a bare gensalt():
+    # registration and reset both hash at the policy cost, and a bare
+    # bcrypt.gensalt() defaults to cost 12, silently downgrading every account
+    # that changes its password below the configured work factor.
+    new_password_hash = PasswordSecurity.hash_password(request.new_password)
 
     user_in_session = User.get_by_id(user_id, db)
     if not user_in_session:

--- a/tests/operations/aws/test_ses.py
+++ b/tests/operations/aws/test_ses.py
@@ -123,6 +123,49 @@ class TestSESEmailService:
     assert "home" in message["Body"]["Html"]["Data"]
 
   @pytest.mark.asyncio
+  async def test_send_email_changed_notice_goes_to_previous_address(
+    self, ses_service, mock_ses_client
+  ):
+    """The change notice is a security email sent to the OLD address; it names
+    the masked new address and warns the reader if they didn't do it."""
+    mock_ses_client.send_email.return_value = {"MessageId": "msg-chg"}
+
+    result = await ses_service.send_email_changed_notice(
+      user_email="old@example.com",
+      user_name="Old Owner",
+      new_email="n***@example.com",
+      app="robosystems",
+    )
+
+    assert result is True
+    call_args = mock_ses_client.send_email.call_args
+    assert call_args.kwargs["Destination"]["ToAddresses"] == ["old@example.com"]
+    html = call_args.kwargs["Message"]["Body"]["Html"]["Data"]
+    assert "n***@example.com" in html
+    assert "changed" in call_args.kwargs["Message"]["Subject"]["Data"].lower()
+    assert "didn't" in html or "contact support" in html.lower()
+
+  @pytest.mark.asyncio
+  async def test_send_email_changed_notice_escapes_user_name(
+    self, ses_service, mock_ses_client
+  ):
+    """user_name is attacker-controllable on a takeover — it must be escaped
+    so the very address change that triggered the email can't inject markup."""
+    mock_ses_client.send_email.return_value = {"MessageId": "msg-chg2"}
+
+    await ses_service.send_email_changed_notice(
+      user_email="old@example.com",
+      user_name="<script>alert(1)</script>",
+      new_email="n***@example.com",
+    )
+
+    html = mock_ses_client.send_email.call_args.kwargs["Message"]["Body"]["Html"][
+      "Data"
+    ]
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+
+  @pytest.mark.asyncio
   async def test_send_email_with_client_error(self, ses_service, mock_ses_client):
     """Test handling of AWS client errors."""
     mock_ses_client.send_email.side_effect = ClientError(

--- a/tests/routers/test_api_workflows.py
+++ b/tests/routers/test_api_workflows.py
@@ -54,6 +54,7 @@ class TestUserRegistrationWorkflow:
       call for call in business_calls if call[1]["event_type"] == "user_registered"
     ]
     assert len(registration_events) >= 1
+    jwt_token = register_response.json()["token"]
 
     # Step 2: Create API key for the user
     api_key, plain_key = UserAPIKey.create(
@@ -77,13 +78,20 @@ class TestUserRegistrationWorkflow:
     assert profile_data["email"] == "integration@example.com"
     assert profile_data["name"] == "Integration Test User"
 
-    # Step 4: Update user profile
+    # Step 4: Update user profile. The route is interactive-session-only, so the
+    # API key is refused; the web session (JWT) updates the profile, and an
+    # email change carries a re-auth proof.
     update_data = {
       "name": "Updated Integration User",
       "email": "updated-integration@example.com",
+      "reauth_password": "S3cur3P@ssw0rd!2024",
     }
 
-    update_response = client.put("/v1/user/", json=update_data, headers=headers)
+    refused = client.put("/v1/user/", json=update_data, headers=headers)
+    assert refused.status_code == 401
+
+    session_headers = {"Authorization": f"Bearer {jwt_token}"}
+    update_response = client.put("/v1/user/", json=update_data, headers=session_headers)
     assert update_response.status_code == 200
 
     updated_data = update_response.json()

--- a/tests/routers/user/test_user_profile.py
+++ b/tests/routers/user/test_user_profile.py
@@ -39,7 +39,10 @@ class TestUserProfile:
   def client_with_user(self, mock_user):
     """Create test client with mocked user authentication."""
     from main import app
-    from robosystems.middleware.auth.dependencies import get_current_user
+    from robosystems.middleware.auth.dependencies import (
+      get_current_user,
+      get_optional_jwt_user,
+    )
     from robosystems.middleware.rate_limits import (
       analytics_rate_limit_dependency,
       auth_rate_limit_dependency,
@@ -54,8 +57,10 @@ class TestUserProfile:
       user_management_rate_limit_dependency,
     )
 
-    # Mock the authentication dependency
+    # Mock the authentication dependency. The profile PUT route is JWT-only
+    # (get_optional_jwt_user); GET still takes get_current_user.
     app.dependency_overrides[get_current_user] = lambda: mock_user
+    app.dependency_overrides[get_optional_jwt_user] = lambda: mock_user
 
     # Disable rate limiting during tests
     app.dependency_overrides[auth_rate_limit_dependency] = lambda: None
@@ -141,7 +146,10 @@ class TestUserProfile:
     """Create test client with real test user authentication."""
     from main import app
     from robosystems.database import get_db_session
-    from robosystems.middleware.auth.dependencies import get_current_user
+    from robosystems.middleware.auth.dependencies import (
+      get_current_user,
+      get_optional_jwt_user,
+    )
     from robosystems.middleware.rate_limits import (
       subscription_aware_rate_limit_dependency,
       user_management_rate_limit_dependency,
@@ -157,6 +165,7 @@ class TestUserProfile:
 
     # Override dependencies
     app.dependency_overrides[get_current_user] = lambda: mock_user
+    app.dependency_overrides[get_optional_jwt_user] = lambda: mock_user
     app.dependency_overrides[user_management_rate_limit_dependency] = lambda: None
     app.dependency_overrides[subscription_aware_rate_limit_dependency] = lambda: None
 
@@ -172,45 +181,146 @@ class TestUserProfile:
     # Reset the dependency overrides
     app.dependency_overrides = {}
 
+  @patch("robosystems.routers.user.main.passkey_ops.verify_reauth")
   @patch("robosystems.routers.user.main.get_endpoint_metrics")
   @patch("robosystems.security.audit_logger.SecurityAuditLogger.log_security_event")
   def test_update_user_profile_success(
     self,
     mock_log_security_event,
     mock_get_endpoint_metrics,
+    mock_verify_reauth,
     client_with_real_user: TestClient,
     db_session,
     test_user,
   ):
-    """Test successful user profile update."""
+    """A name + email update with a valid reauth proof succeeds, stores the
+    address lowercased, and notifies the previous address of the change."""
     import uuid
+
+    from robosystems.dagster.jobs.notifications import (
+      build_email_job_config as real_build_email_job_config,
+    )
 
     # Ensure test_user is in the database
     db_session.merge(test_user)
     db_session.commit()
+    previous_email = test_user.email
 
     # Mock the metrics instance
     mock_metrics_instance = Mock()
     mock_metrics_instance.record_business_event = Mock()
     mock_get_endpoint_metrics.return_value = mock_metrics_instance
 
-    # Create unique email for update
-    new_email = f"updated-test+{str(uuid.uuid4())[:8]}@example.com"
-    update_data = {"name": "Updated Test User", "email": new_email}
+    # Create unique email for update (mixed case: must be stored lowercase)
+    new_email = f"Updated-Test+{str(uuid.uuid4())[:8]}@Example.com"
+    update_data = {
+      "name": "Updated Test User",
+      "email": new_email,
+      "reauth_password": "irrelevant-because-verify-is-mocked",
+    }
 
-    response = client_with_real_user.put("/v1/user/", json=update_data)
+    # The autouse mock_email_dagster_jobs fixture mocks both the job runner and
+    # build_email_job_config in this module; restore the real config builder so
+    # the queued run_config can be inspected.
+    with (
+      patch(
+        "robosystems.routers.user.main.build_email_job_config",
+        real_build_email_job_config,
+      ),
+      patch(
+        "robosystems.routers.user.main.run_and_monitor_dagster_job"
+      ) as mock_run_job,
+    ):
+      response = client_with_real_user.put("/v1/user/", json=update_data)
 
     assert response.status_code == 200
     data = response.json()
 
-    # Check updated data
     assert data["name"] == "Updated Test User"
-    assert data["email"] == new_email
+    assert data["email"] == new_email.lower()
+    mock_verify_reauth.assert_called_once()
 
-    # Verify the user was actually updated in the database
+    # Verify the user was actually updated in the database, lowercased
     db_session.refresh(test_user)
     assert test_user.name == "Updated Test User"
-    assert test_user.email == new_email
+    assert test_user.email == new_email.lower()
+
+    # The previous address was notified with the email_changed job
+    changed_jobs = [
+      c
+      for c in mock_run_job.call_args_list
+      if c.kwargs["run_config"]["ops"]["send_email_op"]["config"]["email_type"]
+      == "email_changed"
+    ]
+    assert len(changed_jobs) == 1
+    cfg = changed_jobs[0].kwargs["run_config"]["ops"]["send_email_op"]["config"]
+    assert cfg["to_email"] == previous_email
+    assert cfg["new_email"].startswith(new_email[0].lower())
+    assert cfg["new_email"].endswith("@example.com")
+
+  def test_email_change_from_api_key_is_refused(
+    self, client_with_real_user: TestClient, db_session, test_user
+  ):
+    """A programmatic key must never reach the email-change path — the route is
+    JWT-only. With no interactive session, the request is 401 before any write.
+
+    This is the account-takeover block: email change + the public reset flow
+    would otherwise be a full takeover from a key that lives in CI configs.
+    """
+    from main import app
+    from robosystems.middleware.auth.dependencies import get_optional_jwt_user
+
+    db_session.merge(test_user)
+    db_session.commit()
+    original_email = test_user.email
+
+    # Simulate an API-key caller: the JWT-only dependency yields no user.
+    app.dependency_overrides[get_optional_jwt_user] = lambda: None
+    try:
+      response = client_with_real_user.put(
+        "/v1/user/", json={"email": "attacker@evil.example"}
+      )
+    finally:
+      app.dependency_overrides.pop(get_optional_jwt_user, None)
+
+    assert response.status_code == 401
+    db_session.refresh(test_user)
+    assert test_user.email == original_email
+
+  @patch("robosystems.routers.user.main.passkey_ops.verify_reauth")
+  def test_email_change_without_reauth_is_refused(
+    self, mock_verify_reauth, client_with_real_user: TestClient, db_session, test_user
+  ):
+    """Even with an interactive session, changing email without a valid proof
+    is refused — a hijacked session must not be able to change the address."""
+    from robosystems.operations.passkeys import ReauthInvalidError
+
+    mock_verify_reauth.side_effect = ReauthInvalidError("nope")
+    db_session.merge(test_user)
+    db_session.commit()
+    original_email = test_user.email
+
+    response = client_with_real_user.put(
+      "/v1/user/", json={"email": "someone-else@example.com"}
+    )
+
+    assert response.status_code == 401
+    db_session.refresh(test_user)
+    assert test_user.email == original_email
+
+  @patch("robosystems.routers.user.main.run_and_monitor_dagster_job")
+  def test_name_only_update_needs_no_reauth(
+    self, mock_run_job, client_with_real_user: TestClient, db_session, test_user
+  ):
+    """A name-only change needs no reauth and queues no email jobs."""
+    db_session.merge(test_user)
+    db_session.commit()
+
+    response = client_with_real_user.put("/v1/user/", json={"name": "Just A Name"})
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "Just A Name"
+    assert mock_run_job.call_count == 0
 
   def test_update_user_profile_empty_data(self, client_with_user: TestClient):
     """Test user profile update with no data."""
@@ -221,12 +331,17 @@ class TestUserProfile:
     # Handle structured error response
     assert "no fields provided" in data["detail"]["detail"].lower()
 
+  @patch("robosystems.routers.user.main.passkey_ops.verify_reauth")
   @patch("robosystems.models.core.User.get_by_id")
   @patch("robosystems.models.core.User.get_by_email")
   def test_update_user_profile_email_conflict(
-    self, mock_get_by_email, mock_get_by_id, client_with_user: TestClient
+    self,
+    mock_get_by_email,
+    mock_get_by_id,
+    mock_verify_reauth,
+    client_with_user: TestClient,
   ):
-    """Test user profile update with email already in use."""
+    """Test user profile update with email already in use (past reauth)."""
     # Mock the user lookup to return our mock user
     mock_get_by_id.return_value = client_with_user.mock_user
 
@@ -236,7 +351,7 @@ class TestUserProfile:
     existing_user.email = "existing@example.com"
     mock_get_by_email.return_value = existing_user
 
-    update_data = {"email": "existing@example.com"}
+    update_data = {"email": "existing@example.com", "reauth_password": "pw"}
 
     response = client_with_user.put("/v1/user/", json=update_data)
 
@@ -529,7 +644,9 @@ class TestUserAPIKeys:
   def client_with_api_keys(self, mock_user_with_api_keys):
     """Create test client with mocked user that has API keys."""
     from main import app
-    from robosystems.middleware.auth.dependencies import get_current_user
+    from robosystems.middleware.auth.dependencies import (
+      get_current_user,
+    )
     from robosystems.middleware.rate_limits import (
       analytics_rate_limit_dependency,
       auth_rate_limit_dependency,
@@ -830,7 +947,9 @@ class TestUserPasswordUpdate:
   def client_with_password_user(self, mock_user_with_password):
     """Create test client with mocked user for password tests."""
     from main import app
-    from robosystems.middleware.auth.dependencies import get_current_user
+    from robosystems.middleware.auth.dependencies import (
+      get_current_user,
+    )
     from robosystems.middleware.rate_limits import (
       analytics_rate_limit_dependency,
       auth_rate_limit_dependency,
@@ -917,6 +1036,43 @@ class TestUserPasswordUpdate:
     client_with_password_user.mock_user.invalidate_sessions.assert_called_once_with(
       mock_db
     )
+
+  @patch("robosystems.models.core.User.get_by_id")
+  def test_update_password_hashes_at_policy_cost(
+    self, mock_get_by_id, client_with_password_user: TestClient
+  ):
+    """A password change must hash at the policy work factor (BCRYPT_ROUNDS=14),
+    not bcrypt's default cost 12 — a bare gensalt() silently downgraded every
+    changed password to a quarter of the offline-cracking cost."""
+    from unittest.mock import MagicMock
+
+    from main import app
+    from robosystems.database import get_db_session
+    from robosystems.security.password import PasswordSecurity
+
+    mock_db = MagicMock()
+
+    def mock_get_db():
+      yield mock_db
+
+    app.dependency_overrides[get_db_session] = mock_get_db
+    user = client_with_password_user.mock_user
+    mock_get_by_id.return_value = user
+
+    response = client_with_password_user.put(
+      "/v1/user/password",
+      json={
+        "current_password": "originalPassword123",
+        "new_password": "Tr0pic@lBreeze#99",
+        "confirm_password": "Tr0pic@lBreeze#99",
+      },
+    )
+    del app.dependency_overrides[get_db_session]
+
+    assert response.status_code == 200
+    stored = user.password_hash
+    assert stored.startswith(f"$2b${PasswordSecurity.BCRYPT_ROUNDS:02d}$"), stored
+    assert PasswordSecurity.verify_password("Tr0pic@lBreeze#99", stored)
 
   @patch("robosystems.models.core.User.get_by_id")
   def test_update_password_wrong_current(
@@ -1021,7 +1177,9 @@ class TestUserEndpointsMetrics:
   def client_with_metrics_user(self, mock_user_for_metrics):
     """Create test client with mocked user for metrics tests."""
     from main import app
-    from robosystems.middleware.auth.dependencies import get_current_user
+    from robosystems.middleware.auth.dependencies import (
+      get_current_user,
+    )
     from robosystems.middleware.rate_limits import (
       analytics_rate_limit_dependency,
       auth_rate_limit_dependency,

--- a/tests/routers/user/test_user_profile.py
+++ b/tests/routers/user/test_user_profile.py
@@ -309,6 +309,31 @@ class TestUserProfile:
     assert test_user.email == original_email
 
   @patch("robosystems.routers.user.main.run_and_monitor_dagster_job")
+  @patch("robosystems.routers.user.main.passkey_ops.verify_reauth")
+  def test_own_email_in_different_case_is_a_noop(
+    self,
+    mock_verify_reauth,
+    mock_run_job,
+    client_with_real_user: TestClient,
+    db_session,
+    test_user,
+  ):
+    """Submitting your own address in a different case must not prompt reauth
+    or 409 against your own row — it is not a change."""
+    db_session.merge(test_user)
+    db_session.commit()
+
+    response = client_with_real_user.put(
+      "/v1/user/", json={"email": test_user.email.upper()}
+    )
+
+    assert response.status_code == 200
+    mock_verify_reauth.assert_not_called()
+    assert mock_run_job.call_count == 0
+    db_session.refresh(test_user)
+    assert test_user.email == test_user.email.lower()
+
+  @patch("robosystems.routers.user.main.run_and_monitor_dagster_job")
   def test_name_only_update_needs_no_reauth(
     self, mock_run_job, client_with_real_user: TestClient, db_session, test_user
   ):


### PR DESCRIPTION
Hardens the account-email change path on `PUT /v1/user`:

- **Interactive session only.** The route now uses the JWT-only dependency, so a programmatic API key cannot reach it — matching the rule the passkey surfaces already enforce (a programmatic credential must not be able to mint or pivot to an interactive one).
- **Re-authentication on email change.** Changing the email requires a fresh proof — password re-entry or a `mgmt`-flow passkey assertion — exactly as passkey enrollment and removal do. Name-only updates need no proof.
- **Notice to the previous address.** On an email change, the old address is emailed a security notice naming the (masked) new address. New `email_changed` SES template + notification-job wiring.
- **Lowercase the stored email.** A mixed-case address would never match at login or password reset (both lowercase their input first). Prod checked: 0 of 22 users affected, so this is forward-looking only.
- **Password change hashes at the policy work factor** instead of bcrypt's default cost, so a password change no longer silently downgrades the hash. The current-password check goes through the same `PasswordSecurity` path (consistent >72-byte handling).

Tests: takeover-from-API-key is refused, email change without reauth is refused, name-only needs no reauth, the notice is queued to the previous address, the address is stored lowercased, and a changed password is hashed at cost 14. Full user/auth/ses/dagster suites green.

Note for SDK consumers: `PUT /v1/user` called with only an `X-API-Key` (no bearer) now returns 401. The frontends use JWT and are unaffected; no integration/template path updates the profile. Rides a client minor.