### PR TITLE
fix(security): make dormant public-API controls actually enforce

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,6 +38,7 @@ from robosystems.middleware.otel.metrics import (
   record_request_metrics,
 )
 from robosystems.middleware.rate_limits import RateLimitHeaderMiddleware
+from robosystems.middleware.request_size import RequestSizeLimitMiddleware
 from robosystems.routers import (
   auth_router_v1,
   billing_router_v1,
@@ -252,6 +253,22 @@ def create_app() -> FastAPI:
     ],
     expose_headers=["X-Request-ID", "X-Rate-Limit-Remaining", "X-Rate-Limit-Reset"],
     max_age=3600,  # Cache preflight requests for 1 hour
+  )
+
+  # Bound request-body size on the internet-facing surface, inside CORS but
+  # outside logging/db/rate-limit — FastAPI reads the body before dependencies
+  # run, so an unbounded body is a pre-auth allocation nothing downstream can
+  # cap. The Stripe webhook reads its body before verifying the signature, so
+  # it carries a tighter limit.
+  from robosystems.config.constants import (
+    PUBLIC_MAX_REQUEST_SIZE,
+    WEBHOOK_MAX_REQUEST_SIZE,
+  )
+
+  app.add_middleware(
+    RequestSizeLimitMiddleware,
+    max_body_size=PUBLIC_MAX_REQUEST_SIZE,
+    path_limits=[("/admin/v1/webhooks/", WEBHOOK_MAX_REQUEST_SIZE)],
   )
 
   # Add logging middleware (order matters - first added = outermost layer)

--- a/robosystems/config/constants.py
+++ b/robosystems/config/constants.py
@@ -24,6 +24,15 @@ DEFAULT_GRAPH_API_PORT = 8001
 MAX_QUERY_LENGTH = 10000  # characters
 MAX_ERROR_MESSAGE_LENGTH = 1000  # characters
 
+# Public API request-body size limits (bytes). Presigned uploads go straight to
+# S3, so request bodies to the public API are JSON/form payloads and small; the
+# limit bounds an unbounded-body allocation on the internet-facing surface,
+# which auth and rate limiting cannot — FastAPI reads the body before solving
+# dependencies. The webhook limit is tighter because a Stripe event is small
+# and its body is read (await request.body()) before the signature is checked.
+PUBLIC_MAX_REQUEST_SIZE = 10 * 1024 * 1024  # 10 MB
+WEBHOOK_MAX_REQUEST_SIZE = 512 * 1024  # 512 KB
+
 # Batch Processing
 DEFAULT_BATCH_SIZE = 5000  # Optimized for Graph API bulk ingestion
 MIN_BATCH_SIZE = 1

--- a/robosystems/config/defaults.py
+++ b/robosystems/config/defaults.py
@@ -228,7 +228,11 @@ class LimitsDefaults:
   These values control quotas and resource limits that can be adjusted at runtime.
   """
 
-  ORG_GRAPHS_DEFAULT = 10  # Default max graphs per organization
+  # Safe-by-default: the code default is the floor, so SSM can only ever
+  # RAISE the cap, never a permissive fallback. An org bootstrapped during
+  # an SSM blip snapshots THIS value into org_limits.max_graphs durably, so
+  # the code default must be the conservative one. Prod SSM sets it to 1.
+  ORG_GRAPHS_DEFAULT = 1  # Default max graphs per organization
 
 
 # SSM Parameter paths for tunables

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -63,6 +63,12 @@ try:
   # class definition. This populates the cache so individual get_parameter_value
   # calls don't each make a separate SSM API call (which can fail under load).
   _preloaded_flags = preload_feature_flags()
+  # Whether the batched SSM read actually returned flags. Read by
+  # EnvValidator in deployed environments: a boot that could not reach SSM
+  # serves its whole life on code defaults, so it must refuse to start rather
+  # than silently run with permissive fallbacks. Always {} (→ False) outside
+  # prod/staging by design; the validator only asserts on it when deployed.
+  FEATURE_FLAGS_PRELOADED = bool(_preloaded_flags)
   if _preloaded_flags:
     print(f"Preloaded {len(_preloaded_flags)} feature flags from SSM")
   elif os.getenv("ENVIRONMENT", "dev") in ("prod", "staging"):
@@ -71,6 +77,7 @@ except Exception as _e:
   # If parameter_store can't be imported, fall back to default values
   # Catch all exceptions (not just ImportError) to handle transitive failures
   PARAMETER_STORE_AVAILABLE = False
+  FEATURE_FLAGS_PRELOADED = False
   print(
     f"WARNING: Parameter store unavailable ({type(_e).__name__}: {_e}). "
     "All feature flags will use defaults (false)."
@@ -361,6 +368,12 @@ class EnvConfig:
   # ==========================================================================
   # 1. CORE APPLICATION CONFIGURATION
   # ==========================================================================
+
+  # SSM Parameter Store reachability, captured at import. EnvValidator asserts
+  # on these in deployed environments (see validation.py): a boot that could
+  # not read SSM would serve its whole life on code defaults.
+  PARAMETER_STORE_AVAILABLE = PARAMETER_STORE_AVAILABLE
+  FEATURE_FLAGS_PRELOADED = FEATURE_FLAGS_PRELOADED
 
   # Environment and debugging
   ENVIRONMENT = get_str_env("ENVIRONMENT", "dev")

--- a/robosystems/config/validation.py
+++ b/robosystems/config/validation.py
@@ -216,6 +216,34 @@ class EnvValidator:
         "PASSKEYS_ENABLED — their auth rate buckets are no-ops without it"
       )
 
+    # Parameter Store reachability. In a deployed environment, a boot that
+    # could not read SSM serves its entire life on code defaults — flags are
+    # resolved once at import — which means registration open, no CAPTCHA, no
+    # email verification, and (below) no rate limiting. Refuse to boot instead
+    # of silently serving inert controls.
+    if deployed:
+      if not getattr(env_config, "PARAMETER_STORE_AVAILABLE", False):
+        errors.append(
+          "PARAMETER_STORE_AVAILABLE is False in a deployed environment — SSM "
+          "could not be reached, so every feature flag would fall back to its "
+          "code default. Refusing to boot on inert controls."
+        )
+      elif not getattr(env_config, "FEATURE_FLAGS_PRELOADED", False):
+        errors.append(
+          "No feature flags were preloaded from SSM in a deployed environment "
+          "— the batched read returned nothing, so controls would run on code "
+          "defaults. Refusing to boot on inert controls."
+        )
+      # Belt and braces: rate limiting must be on in any deployed environment.
+      # The checks above catch the cause (SSM unreachable); this catches the
+      # symptom regardless of cause — RATE_LIMIT_ENABLED false here is the tell
+      # of a read that fell back to the (false) code default.
+      if not getattr(env_config, "RATE_LIMIT_ENABLED", False):
+        errors.append(
+          "RATE_LIMIT_ENABLED is false in a deployed environment — this is the "
+          "signature of an SSM read that fell back to defaults. Refusing to boot."
+        )
+
     # Validate value ranges and formats
     EnvValidator._validate_urls(env_config, errors)
     EnvValidator._validate_paths(env_config, warnings)

--- a/robosystems/middleware/rate_limits/__init__.py
+++ b/robosystems/middleware/rate_limits/__init__.py
@@ -34,6 +34,7 @@ from .rate_limiting import (
   sync_operations_rate_limit_dependency,
   tasks_management_rate_limit_dependency,
   user_management_rate_limit_dependency,
+  webhook_rate_limit_dependency,
 )
 from .repository_rate_limits import (
   BLOCKED_SHARED_ENDPOINTS,
@@ -91,4 +92,5 @@ __all__ = [
   "sync_operations_rate_limit_dependency",
   "tasks_management_rate_limit_dependency",
   "user_management_rate_limit_dependency",
+  "webhook_rate_limit_dependency",
 ]

--- a/robosystems/middleware/rate_limits/rate_limiting.py
+++ b/robosystems/middleware/rate_limits/rate_limiting.py
@@ -606,6 +606,19 @@ def billing_rate_limit_dependency(request: Request):
   request.state.billing_rate_limit_limit = limit
 
 
+def webhook_rate_limit_dependency(request: Request):
+  """Per-source-IP limit for inbound provider webhooks (Stripe).
+
+  The body is signature-verified downstream, so this only bounds pre-verify
+  body reads and retries from one source. Fails open (the default): a Redis
+  outage must not drop legitimate billing events — the signature check is the
+  security control, this is DoS defense in depth. Generous, because Stripe
+  legitimately bursts redeliveries.
+  """
+  limit = get_int_env("RATE_LIMIT_WEBHOOK", "1200")  # anonymous → 120/min per IP
+  return create_custom_rate_limit_dependency(limit, 60, "webhook")(request)
+
+
 def public_api_rate_limit_dependency(request: Request):
   """Rate limiting for public API endpoints (no auth required)."""
   # More generous for anonymous users since these endpoints are meant to be public

--- a/robosystems/middleware/request_size.py
+++ b/robosystems/middleware/request_size.py
@@ -1,0 +1,157 @@
+"""Request-body size limiting for the public API.
+
+The internet-facing app reads a request body into memory before authentication
+or rate limiting runs — FastAPI/Starlette resolve the body during dependency
+and model validation, and some routes (the Stripe webhook) call
+``await request.body()`` explicitly before any check. So an unbounded body is a
+pre-auth memory-allocation DoS that nothing downstream can bound.
+
+This ASGI middleware enforces the cap in two places:
+
+1. the ``Content-Length`` header (every conforming client sets it), rejected
+   before the app is invoked; and
+2. the streamed body itself, byte-counted as the middleware buffers it, so a
+   chunked request with no ``Content-Length`` cannot slip an unbounded body
+   past the header check. The graph-API size middleware documents this second
+   gap and does not close it; this one does.
+
+The body is buffered in the middleware and replayed to the app, so the cap is
+enforced without depending on how a downstream route or middleware handles a
+mid-read failure — an oversized request is answered with a 413 and the app is
+never invoked for it. The public API never stream-consumes a request body
+(uploads go straight to S3 via presigned PUT), so buffering up to the limit
+costs nothing a body read would not have cost anyway.
+
+A per-path override lets one family (the webhook) carry a tighter limit than
+the default.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from robosystems.config.constants import PUBLIC_MAX_REQUEST_SIZE
+from robosystems.logger import logger
+
+
+class RequestSizeLimitMiddleware:
+  """Reject request bodies larger than a per-path byte limit with a 413."""
+
+  def __init__(
+    self,
+    app: ASGIApp,
+    *,
+    max_body_size: int = PUBLIC_MAX_REQUEST_SIZE,
+    path_limits: Sequence[tuple[str, int]] = (),
+  ) -> None:
+    self.app = app
+    self.max_body_size = max_body_size
+    # Longest prefix first so a specific path wins over a broader one.
+    self.path_limits = tuple(
+      sorted(path_limits, key=lambda item: len(item[0]), reverse=True)
+    )
+    logger.info(
+      "Request Size Limit Middleware initialized - "
+      f"default {self.max_body_size:,} bytes"
+      + (f", {len(self.path_limits)} path override(s)" if self.path_limits else "")
+    )
+
+  def _limit_for(self, path: str) -> int:
+    for prefix, limit in self.path_limits:
+      if path.startswith(prefix):
+        return limit
+    return self.max_body_size
+
+  async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+    if scope["type"] != "http":
+      await self.app(scope, receive, send)
+      return
+
+    path = scope.get("path", "")
+    limit = self._limit_for(path)
+
+    content_length = _content_length(scope)
+    if content_length is not None and content_length > limit:
+      await self._reject(send, path, content_length, limit, source="content-length")
+      return
+
+    # Buffer the body, enforcing the cap as it arrives. Reject before invoking
+    # the app if it overflows — a chunked request with no Content-Length is
+    # bounded here, not merely at the header.
+    buffered: list[Message] = []
+    received = 0
+    while True:
+      message = await receive()
+      if message["type"] != "http.request":
+        buffered.append(message)
+        break
+      received += len(message.get("body", b""))
+      if received > limit:
+        await self._reject(send, path, received, limit, source="stream")
+        return
+      buffered.append(message)
+      if not message.get("more_body", False):
+        break
+
+    replay = _iter_messages(buffered, receive)
+    await self.app(scope, replay, send)
+
+  async def _reject(
+    self,
+    send: Send,
+    path: str,
+    size: int,
+    limit: int,
+    *,
+    source: str,
+  ) -> None:
+    logger.warning(
+      f"Request body too large on {path}: {size:,} bytes exceeds {limit:,} ({source})"
+    )
+    body = (
+      b'{"detail":"Request body too large. Max allowed: '
+      + str(limit).encode()
+      + b' bytes"}'
+    )
+    await send(
+      {
+        "type": "http.response.start",
+        "status": 413,
+        "headers": [
+          (b"content-type", b"application/json"),
+          (b"content-length", str(len(body)).encode()),
+        ],
+      }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+def _iter_messages(buffered: list[Message], receive: Receive) -> Receive:
+  """Replay the buffered request messages, then fall through to live receive.
+
+  Falling through matters for a client disconnect that arrives after the body:
+  the app awaits ``receive`` again and gets the real ``http.disconnect``.
+  """
+  index = 0
+
+  async def replay() -> Message:
+    nonlocal index
+    if index < len(buffered):
+      message = buffered[index]
+      index += 1
+      return message
+    return await receive()
+
+  return replay
+
+
+def _content_length(scope: Scope) -> int | None:
+  for name, value in scope.get("headers", ()):
+    if name == b"content-length":
+      try:
+        return int(value)
+      except ValueError:
+        return None
+  return None

--- a/robosystems/middleware/request_size.py
+++ b/robosystems/middleware/request_size.py
@@ -122,6 +122,11 @@ class RequestSizeLimitMiddleware:
         "headers": [
           (b"content-type", b"application/json"),
           (b"content-length", str(len(body)).encode()),
+          # We answer without consuming the (over-limit) request body. On an
+          # HTTP/1.1 keep-alive connection the unread bytes would otherwise be
+          # read as the start of the next request and desync the stream, so
+          # signal the server to close the connection after this response.
+          (b"connection", b"close"),
         ],
       }
     )

--- a/robosystems/routers/admin/webhooks.py
+++ b/robosystems/routers/admin/webhooks.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from ...database import SessionFactory, get_db_session
 from ...logger import get_logger
+from ...middleware.rate_limits import webhook_rate_limit_dependency
 from ...models.core.billing import BillingAuditLog
 from ...operations.providers.payment_provider import get_payment_provider
 from ...security.audit_logger import SecurityAuditLogger, SecurityEventType
@@ -165,6 +166,7 @@ Webhooks are verified using Stripe signature before processing.""",
 async def handle_stripe_webhook(
   request: Request,
   db: Session = Depends(get_db_session),
+  _rate_limit: None = Depends(webhook_rate_limit_dependency),
 ):
   """Handle Stripe webhook events."""
   try:

--- a/robosystems/security/auth_protection.py
+++ b/robosystems/security/auth_protection.py
@@ -6,10 +6,12 @@ delay tiers into timed blocks. IPs are keyed by hash, never stored in clear.
 """
 
 import hashlib
+import json
 import time
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from enum import Enum
 
+from ..logger import logger
 from ..middleware.rate_limits import rate_limit_cache
 from ..security import SecurityAuditLogger, SecurityEventType
 
@@ -52,6 +54,8 @@ class AdvancedAuthProtection:
 
   # Progressive delay configuration (seconds)
   PROGRESSIVE_DELAYS = {
+    0: 0,  # no failures: no delay (without this, min(0, 8) misses and falls
+    #       back to the 8th-failure value — a fresh IP charged 15 minutes)
     1: 1,  # 1st failure: 1 second
     2: 2,  # 2nd failure: 2 seconds
     3: 5,  # 3rd failure: 5 seconds
@@ -141,6 +145,39 @@ class AdvancedAuthProtection:
         },
       )
 
+  @staticmethod
+  def _dump(value) -> str:
+    """Serialize to a JSON string. The cache backs onto redis, whose encoder
+    accepts only str/bytes/int/float — a raw dict or list raises DataError and
+    the whole layer silently no-ops (which is exactly how it went dead)."""
+    return json.dumps(value)
+
+  @staticmethod
+  def _load(raw):
+    """Parse a cached value. decode_responses=True hands back a str, so the
+    stored JSON must be parsed before use; already-decoded values pass through
+    (the strict test fake stores the same JSON string)."""
+    if raw is None:
+      return None
+    if isinstance(raw, (bytes, bytearray)):
+      raw = raw.decode("utf-8")
+    if isinstance(raw, str):
+      return json.loads(raw)
+    return raw
+
+  @classmethod
+  def _dump_assessment(cls, assessment: "IPThreatAssessment") -> str:
+    data = asdict(assessment)
+    data["threat_level"] = assessment.threat_level.value
+    return json.dumps(data)
+
+  @classmethod
+  def _load_assessment(cls, raw) -> "IPThreatAssessment":
+    data = cls._load(raw)
+    data = dict(data)
+    data["threat_level"] = ThreatLevel(data["threat_level"])
+    return IPThreatAssessment(**data)
+
   @classmethod
   def _update_attempt_history(cls, ip_address: str, attempt: AuthAttempt) -> None:
     """Update attempt history for an IP address."""
@@ -148,7 +185,7 @@ class AdvancedAuthProtection:
 
     try:
       # Get existing attempts (last 24 hours)
-      attempts_data = rate_limit_cache.get(key) or []
+      attempts_data = cls._load(rate_limit_cache.get(key)) or []
 
       # Add new attempt
       attempts_data.append(
@@ -165,11 +202,13 @@ class AdvancedAuthProtection:
       attempts_data = [a for a in attempts_data if a["timestamp"] > cutoff]
 
       # Store back in cache (expire in 25 hours to be safe)
-      rate_limit_cache.set(key, attempts_data, expire=86400 + 3600)
+      rate_limit_cache.set(key, cls._dump(attempts_data), expire=86400 + 3600)
 
-    except Exception:
-      # If cache fails, continue without storing
-      pass
+    except Exception as e:
+      # Auth must not fail because the threat store is unreachable or corrupt;
+      # but log the type so a real breakage is visible, not silently swallowed
+      # the way this layer's failures were for months.
+      logger.warning(f"auth threat: attempt history not stored ({type(e).__name__})")
 
   @classmethod
   def _update_threat_assessment(cls, ip_address: str, attempt: AuthAttempt) -> None:
@@ -181,7 +220,7 @@ class AdvancedAuthProtection:
       assessment_data = rate_limit_cache.get(key)
 
       if assessment_data:
-        assessment = IPThreatAssessment(**assessment_data)
+        assessment = cls._load_assessment(assessment_data)
       else:
         assessment = IPThreatAssessment(
           threat_level=ThreatLevel.LOW,
@@ -227,11 +266,10 @@ class AdvancedAuthProtection:
           assessment.block_expires = None
 
       # Store assessment (expire in 25 hours)
-      rate_limit_cache.set(key, assessment.__dict__, expire=86400 + 3600)
+      rate_limit_cache.set(key, cls._dump_assessment(assessment), expire=86400 + 3600)
 
-    except Exception:
-      # If cache fails, continue without storing
-      pass
+    except Exception as e:
+      logger.warning(f"auth threat: assessment not stored ({type(e).__name__})")
 
   @classmethod
   def get_ip_threat_assessment(cls, ip_address: str) -> IPThreatAssessment:
@@ -241,7 +279,7 @@ class AdvancedAuthProtection:
     try:
       assessment_data = rate_limit_cache.get(key)
       if assessment_data:
-        assessment = IPThreatAssessment(**assessment_data)
+        assessment = cls._load_assessment(assessment_data)
 
         # Check if block has expired
         if assessment.is_blocked and assessment.block_expires:
@@ -250,8 +288,8 @@ class AdvancedAuthProtection:
             assessment.block_expires = None
 
         return assessment
-    except Exception:
-      pass
+    except Exception as e:
+      logger.warning(f"auth threat: assessment not read ({type(e).__name__})")
 
     # Return default assessment
     return IPThreatAssessment(
@@ -284,9 +322,11 @@ class AdvancedAuthProtection:
         # Update cache
         key = cls._get_threat_key(ip_address)
         try:
-          rate_limit_cache.set(key, assessment.__dict__, expire=86400 + 3600)
-        except Exception:
-          pass
+          rate_limit_cache.set(
+            key, cls._dump_assessment(assessment), expire=86400 + 3600
+          )
+        except Exception as e:
+          logger.warning(f"auth threat: block clear not stored ({type(e).__name__})")
 
     return False, None
 
@@ -308,13 +348,13 @@ class AdvancedAuthProtection:
     # Check if we're still in delay period
     delay_key = cls._get_delay_key(ip_address)
     try:
-      last_delay_time = rate_limit_cache.get(delay_key)
+      last_delay_time = cls._load(rate_limit_cache.get(delay_key))
       if last_delay_time:
-        elapsed = time.time() - last_delay_time
+        elapsed = time.time() - float(last_delay_time)
         if elapsed < delay:
           return int(delay - elapsed)
-    except Exception:
-      pass
+    except Exception as e:
+      logger.warning(f"auth threat: progressive delay not read ({type(e).__name__})")
 
     return 0
 
@@ -324,9 +364,9 @@ class AdvancedAuthProtection:
     delay_key = cls._get_delay_key(ip_address)
     try:
       # Record the delay application time
-      rate_limit_cache.set(delay_key, time.time(), expire=3600)  # 1 hour max
-    except Exception:
-      pass
+      rate_limit_cache.set(delay_key, cls._dump(time.time()), expire=3600)  # 1 hour
+    except Exception as e:
+      logger.warning(f"auth threat: progressive delay not stored ({type(e).__name__})")
 
   @classmethod
   def get_security_headers(cls, ip_address: str) -> dict[str, str]:

--- a/tests/config/test_validation.py
+++ b/tests/config/test_validation.py
@@ -40,6 +40,54 @@ class MockEnvConfig:
     self.EMAIL_VERIFICATION_ENABLED = True
     self.CAPTCHA_ENABLED = False
     self.BILLING_ENABLED = False
+    # SSM reachability signals, healthy by default; the deployed-env assertion
+    # in validation.py reads these.
+    self.PARAMETER_STORE_AVAILABLE = True
+    self.FEATURE_FLAGS_PRELOADED = True
+
+
+class TestParameterStoreReachability:
+  """A deployed boot that could not read SSM would serve its whole life on code
+  defaults — registration open, no rate limiting. It must refuse to start."""
+
+  def _prod(self):
+    cfg = MockEnvConfig()
+    cfg.ENVIRONMENT = "prod"
+    cfg.GRAPH_API_KEY = "k"
+    return cfg
+
+  def test_healthy_prod_passes(self):
+    with patch("os.getenv", return_value=None):
+      EnvValidator.validate_required_vars(self._prod())  # does not raise
+
+  def test_param_store_unavailable_refuses_boot(self):
+    cfg = self._prod()
+    cfg.PARAMETER_STORE_AVAILABLE = False
+    with patch("os.getenv", return_value=None):
+      with pytest.raises(ConfigValidationError):
+        EnvValidator.validate_required_vars(cfg)
+
+  def test_no_flags_preloaded_refuses_boot(self):
+    cfg = self._prod()
+    cfg.FEATURE_FLAGS_PRELOADED = False
+    with patch("os.getenv", return_value=None):
+      with pytest.raises(ConfigValidationError):
+        EnvValidator.validate_required_vars(cfg)
+
+  def test_rate_limit_off_in_prod_refuses_boot(self):
+    cfg = self._prod()
+    cfg.RATE_LIMIT_ENABLED = False
+    with patch("os.getenv", return_value=None):
+      with pytest.raises(ConfigValidationError):
+        EnvValidator.validate_required_vars(cfg)
+
+  def test_dev_is_never_subject_to_the_reachability_assertion(self):
+    cfg = MockEnvConfig()  # ENVIRONMENT="dev"
+    cfg.PARAMETER_STORE_AVAILABLE = False
+    cfg.FEATURE_FLAGS_PRELOADED = False
+    cfg.RATE_LIMIT_ENABLED = False
+    with patch("os.getenv", return_value=None):
+      EnvValidator.validate_required_vars(cfg)  # does not raise
 
 
 class TestConfigValidationError:

--- a/tests/middleware/test_request_size.py
+++ b/tests/middleware/test_request_size.py
@@ -1,0 +1,105 @@
+"""The public-app request-body size limit rejects oversized bodies with a 413,
+by Content-Length and — the gap the graph-API version leaves open — by the
+streamed bytes of a chunked request with no Content-Length. It enforces the cap
+in the middleware, before the app is invoked, so it does not depend on how a
+downstream route handles a mid-read failure.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from robosystems.middleware.request_size import RequestSizeLimitMiddleware
+
+
+def _app(**kwargs) -> FastAPI:
+  app = FastAPI()
+
+  # An inner BaseHTTPMiddleware to prove the cap holds through the task-group
+  # machinery a BaseHTTPMiddleware wraps receive in.
+  class _Inner(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+      return await call_next(request)
+
+  @app.post("/echo")
+  async def echo(request: Request):
+    return {"len": len(await request.body())}
+
+  @app.get("/ping")
+  async def ping():
+    return {"ok": True}
+
+  app.add_middleware(_Inner)
+  app.add_middleware(RequestSizeLimitMiddleware, **kwargs)
+  return app
+
+
+@pytest.mark.unit
+class TestRequestSizeLimit:
+  def test_body_within_limit_passes(self):
+    client = TestClient(_app(max_body_size=1000))
+    r = client.post("/echo", content=b"x" * 500)
+    assert r.status_code == 200
+    assert r.json() == {"len": 500}
+
+  def test_content_length_over_limit_is_413(self):
+    client = TestClient(_app(max_body_size=1000))
+    r = client.post("/echo", content=b"x" * 2000)
+    assert r.status_code == 413
+    assert "too large" in r.json()["detail"].lower()
+
+  def test_chunked_body_over_limit_is_413(self):
+    """No Content-Length; the cap must hold on the streamed bytes."""
+    client = TestClient(_app(max_body_size=1000))
+
+    def gen():
+      for _ in range(30):
+        yield b"x" * 100  # 3000 bytes, no Content-Length
+
+    r = client.post("/echo", content=gen())
+    assert r.status_code == 413
+
+  def test_chunked_body_within_limit_passes(self):
+    client = TestClient(_app(max_body_size=1000))
+
+    def gen():
+      yield b"x" * 300
+
+    r = client.post("/echo", content=gen())
+    assert r.status_code == 200
+    assert r.json() == {"len": 300}
+
+  def test_empty_body_and_get_pass(self):
+    client = TestClient(_app(max_body_size=1000))
+    assert client.get("/ping").status_code == 200
+    assert client.post("/echo", content=b"").json() == {"len": 0}
+
+  def test_per_path_override_is_tighter(self):
+    client = TestClient(_app(max_body_size=1_000_000, path_limits=[("/echo", 100)]))
+    # Under the default but over the /echo override.
+    r = client.post("/echo", content=b"x" * 500)
+    assert r.status_code == 413
+
+  def test_longest_prefix_wins(self):
+    client = TestClient(
+      _app(
+        max_body_size=10,
+        path_limits=[("/", 10), ("/echo", 10_000)],
+      )
+    )
+    # /echo matches the longer, more permissive prefix.
+    r = client.post("/echo", content=b"x" * 500)
+    assert r.status_code == 200
+
+  def test_malformed_content_length_falls_through_to_stream_cap(self):
+    client = TestClient(_app(max_body_size=100))
+    # A non-integer Content-Length is ignored; the stream cap still applies.
+    r = client.post(
+      "/echo", content=b"x" * 500, headers={"content-length": "not-a-number"}
+    )
+    # httpx will recompute a valid Content-Length, so this still rejects on
+    # whichever path fires — the point is it is not accepted.
+    assert r.status_code == 413

--- a/tests/middleware/test_request_size.py
+++ b/tests/middleware/test_request_size.py
@@ -50,6 +50,8 @@ class TestRequestSizeLimit:
     r = client.post("/echo", content=b"x" * 2000)
     assert r.status_code == 413
     assert "too large" in r.json()["detail"].lower()
+    # Answered without consuming the body → the connection must not be reused.
+    assert r.headers.get("connection", "").lower() == "close"
 
   def test_chunked_body_over_limit_is_413(self):
     """No Content-Length; the cap must hold on the streamed bytes."""

--- a/tests/models/core/org/test_org_limits_model.py
+++ b/tests/models/core/org/test_org_limits_model.py
@@ -128,9 +128,13 @@ class TestOrgLimitsModel:
     # Create default limits
     limits = OrgLimits.create_default_limits("new_org_id", mock_session)
 
-    # Check that defaults were applied
+    # Check that defaults were applied. Assert against the configured default
+    # rather than a literal — the safe code default is intentionally the floor
+    # (1) so an SSM blip cannot durably over-provision an org.
+    from robosystems.config.tuning import TuningConfig
+
     assert limits.org_id == "new_org_id"
-    assert limits.max_graphs == 10  # env.ORG_GRAPHS_DEFAULT_LIMIT
+    assert limits.max_graphs == TuningConfig.get_org_graphs_default_limit()
 
     # Verify database operations were called
     mock_session.add.assert_called_once()

--- a/tests/security/test_auth_protection.py
+++ b/tests/security/test_auth_protection.py
@@ -28,6 +28,16 @@ def mock_cache():
       return value
 
     def set(self, key, value, expire=None):
+      # As strict as redis-py's encoder: it accepts only str/bytes/int/float
+      # and raises DataError on a dict or list. The production bug this suite
+      # missed for months was code handing the cache a raw dict; a fake that
+      # round-trips arbitrary objects can never catch it. Storing a decoded
+      # copy also proves the code parses on read rather than leaning on the
+      # fake returning live Python objects.
+      if not isinstance(value, (str, bytes, int, float)):
+        raise TypeError(
+          f"redis accepts only str/bytes/int/float, got {type(value).__name__}"
+        )
       expire_at = time.time() + expire if expire else None
       store[key] = (value, expire_at)
 
@@ -113,6 +123,35 @@ class TestGetIpThreatAssessment:
       mock_time.time.return_value = time.time() + 100000
       assessment = AdvancedAuthProtection.get_ip_threat_assessment(ip)
       assert assessment.is_blocked is False
+
+
+class TestLayerRoundTripsThroughRedis:
+  """The layer was dead for months because it handed the cache raw dicts, which
+  redis rejects, and read back str it never parsed. These pin the round-trip
+  against the redis-strict fake."""
+
+  def test_progressive_delay_is_zero_for_a_fresh_ip(self):
+    # The latent bug the encode fix exposes: min(0, 8) is not a delay key, so
+    # a zero-failure IP fell back to the 8th-failure value (900s). A brand-new
+    # visitor must never be told to wait a quarter of an hour.
+    assert AdvancedAuthProtection.get_progressive_delay("203.0.113.7") == 0
+
+  def test_assessment_persists_as_a_redis_compatible_string(self, mock_cache):
+    ip = "203.0.113.8"
+    AdvancedAuthProtection.record_auth_attempt(ip, success=False)
+    # The strict fake would have raised on a dict; assert the stored value is a
+    # str and that it re-reads as the same failure count.
+    stored = [v for (v, _exp) in mock_cache.values()]
+    assert stored and all(isinstance(v, str) for v in stored)
+    assert AdvancedAuthProtection.get_ip_threat_assessment(ip).failed_attempts == 1
+
+  def test_progressive_delay_applies_after_a_failure(self):
+    ip = "203.0.113.9"
+    for _ in range(3):
+      AdvancedAuthProtection.record_auth_attempt(ip, success=False)
+    AdvancedAuthProtection.apply_progressive_delay(ip)
+    # 3rd-failure delay is 5s; the window was just opened, so >0 remains.
+    assert AdvancedAuthProtection.get_progressive_delay(ip) > 0
 
 
 class TestRecordAuthAttempt:


### PR DESCRIPTION
Several controls existed in the codebase but weren't actually enforcing on the public API. This wires them:

**Request-body size limit (public app).** A new ASGI `RequestSizeLimitMiddleware` bounds body size on the internet-facing surface — by `Content-Length` and by the streamed bytes of a chunked request with no `Content-Length` (closing the gap the graph_api size middleware documents). FastAPI reads the body before dependencies run, so an unbounded body was a pre-auth allocation nothing downstream could cap. The Stripe webhook — which reads its body before verifying the signature — carries a tighter per-path limit and a per-source-IP rate limit.

**Parameter-store reachability.** A deployed boot that couldn't read SSM would serve its whole life on permissive code defaults (flags resolve once at import). `EnvValidator` now refuses to start in a deployed environment when the store is unreachable, no flags preloaded, or rate limiting is off.

**`ORG_GRAPHS_DEFAULT` code default 10 → 1.** The value is snapshotted into `org_limits.max_graphs` at org bootstrap, so a permissive default during an SSM blip durably over-provisions. The safe value becomes the floor; SSM can only raise it. (The four feature-flag defaults are deliberately left as-is — billing-off is intentional for dev/dedicated/forks; the reachability assertion is their safety net.)

**Auth threat store.** The IP-threat/progressive-delay layer stored raw dicts, which redis rejects, so it silently no-op'd — and read back `str` it never parsed. Values are now JSON-encoded/decoded, the progressive-delay table gets a zero-failure key (a fresh IP was being charged the 8th-failure delay), failures are logged instead of swallowed, and the test fake is made as strict as redis so this class of bug can't pass CI again.

⚠️ **Behavior change:** the auth-threat fix activates IP-based login escalation that was inert for months — logins now escalate (a 15-minute IP block after repeated failures). This shares the axis of the existing per-IP auth limiter; the thresholds are tunable, and NAT-shared-IP lockout is worth watching after deploy.

Tests: new size-limit middleware suite (Content-Length + chunked + per-path override), reachability-assertion suite across environments, auth round-trip through a redis-strict fake incl. the zero-delay case. Full middleware/config/security/auth suites green (3031 passed).