### PR TITLE
fix(graph): restore the backup-export grace period and let teardown converge

### DIFF
--- a/robosystems/middleware/auth/dependencies.py
+++ b/robosystems/middleware/auth/dependencies.py
@@ -529,11 +529,13 @@ async def _resolve_user_with_graph(
   )
 
 
-def require_graph_access(allow_deprovisioned: bool = False):
+def graph_access_dependency(allow_deprovisioned: bool = False):
   """Build the graph-membership dependency.
 
-  The default instance (``get_current_user_with_graph``) denies a torn-down
-  graph. ``allow_deprovisioned=True`` is used by exactly the backup-list and
+  Named to avoid colliding with ``billing.enforcement.require_graph_access``
+  (a different check with a different signature). The default instance
+  (``get_current_user_with_graph``) denies a torn-down graph.
+  ``allow_deprovisioned=True`` is used by exactly the backup-list and
   backup-download routes so a departing org's OWNER/ADMIN can export during the
   grace period; it must not be applied to any other route (see
   ``GraphUser.get_effective_role``).
@@ -553,13 +555,13 @@ def require_graph_access(allow_deprovisioned: bool = False):
 
 # Default graph-membership dependency: denies deprovisioned graphs. Every
 # existing `Depends(get_current_user_with_graph)` keeps its behavior.
-get_current_user_with_graph = require_graph_access()
+get_current_user_with_graph = graph_access_dependency()
 
 # The one sanctioned deprovisioned-tolerant variant, used by exactly the
 # backup-list and backup-download routes so a departing org's OWNER/ADMIN can
 # export during the grace period. A named singleton (not an inline
-# `require_graph_access(True)`) so it is a stable, overridable dependency.
-get_current_user_with_deprovisioned_graph = require_graph_access(
+# `graph_access_dependency(True)`) so it is a stable, overridable dependency.
+get_current_user_with_deprovisioned_graph = graph_access_dependency(
   allow_deprovisioned=True
 )
 

--- a/robosystems/middleware/auth/dependencies.py
+++ b/robosystems/middleware/auth/dependencies.py
@@ -110,18 +110,23 @@ def _db_get_user_by_id(user_id: str) -> User | None:
     sess.close()
 
 
-def _db_check_graph_access(user_id: str, graph_id: str) -> bool:
+def _db_check_graph_access(
+  user_id: str, graph_id: str, *, allow_deprovisioned: bool = False
+) -> bool:
   """Check graph access using a short-lived session.
 
   Same rationale as ``_db_get_user_by_id`` — avoid holding a pool
-  connection for the entire request duration.
+  connection for the entire request duration. ``allow_deprovisioned`` is
+  threaded only from the backup export path (see ``get_effective_role``).
   """
   from ...database import SessionFactory
   from ...models.core import GraphUser
 
   sess = SessionFactory()
   try:
-    return GraphUser.user_has_access(user_id, graph_id, sess)
+    return GraphUser.user_has_access(
+      user_id, graph_id, sess, allow_deprovisioned=allow_deprovisioned
+    )
   finally:
     sess.close()
 
@@ -372,10 +377,12 @@ async def get_current_user(
   )
 
 
-async def get_current_user_with_graph(
+async def _resolve_user_with_graph(
   request: Request,
   graph_id: str,
-  api_key: str = Security(API_KEY_HEADER),
+  api_key: str,
+  *,
+  allow_deprovisioned: bool = False,
 ) -> User:
   """Authenticate the caller and confirm they have access to `graph_id`.
 
@@ -383,7 +390,10 @@ async def get_current_user_with_graph(
   `require_graph_write_role`, since a viewer passes this check.
 
   Raises 401 when authentication fails and 403 when the graph is not the
-  caller's.
+  caller's. ``allow_deprovisioned`` is set only by the backup export routes so
+  a departing customer's org OWNER/ADMIN can still reach a torn-down graph's
+  backups during the grace period; it bypasses the cached access decision and
+  is not persisted back into the cache, so it can never leak to another route.
   """
   client_ip = request.client.host if request.client else None
   user_agent = request.headers.get("user-agent")
@@ -405,7 +415,14 @@ async def get_current_user_with_graph(
       user = _get_user_for_verified_jwt(user_id, token_session_version)
 
       if user and bool(user.is_active):
-        has_access = api_key_cache.get_cached_jwt_graph_access(str(user_id), graph_id)
+        # The deprovisioned-allowed path computes fresh: a cached decision was
+        # made under the default (gone → denied), and the result must not be
+        # written back or a later default-path request would see it.
+        has_access = (
+          None
+          if allow_deprovisioned
+          else api_key_cache.get_cached_jwt_graph_access(str(user_id), graph_id)
+        )
 
         if has_access is None:
           from robosystems.config.shared_repositories import (
@@ -416,15 +433,19 @@ async def get_current_user_with_graph(
 
           if is_shared_repository_or_subgraph(graph_id):
             # Resolves a subgraph to its parent repository before checking.
+            # Shared repositories are never deprovisioned, so the flag is moot.
             has_access = MultiTenantUtils.validate_repository_access(
               graph_id,
               user_id,
               "read",
             )
           else:
-            has_access = _db_check_graph_access(user_id, graph_id)
+            has_access = _db_check_graph_access(
+              user_id, graph_id, allow_deprovisioned=allow_deprovisioned
+            )
 
-          api_key_cache.cache_jwt_graph_access(str(user_id), graph_id, has_access)
+          if not allow_deprovisioned:
+            api_key_cache.cache_jwt_graph_access(str(user_id), graph_id, has_access)
 
         if has_access:
           _publish_jwt_identity(request, user_id)
@@ -464,7 +485,9 @@ async def get_current_user_with_graph(
     )
 
   if api_key:
-    user = validate_api_key_with_graph(api_key, graph_id)
+    user = validate_api_key_with_graph(
+      api_key, graph_id, allow_deprovisioned=allow_deprovisioned
+    )
     if user:
       _stash_api_key_identity(request, api_key, user)
       SecurityAuditLogger.log_auth_success(
@@ -504,6 +527,41 @@ async def get_current_user_with_graph(
     detail="Authentication required",
     headers={"WWW-Authenticate": "Bearer, ApiKey"},
   )
+
+
+def require_graph_access(allow_deprovisioned: bool = False):
+  """Build the graph-membership dependency.
+
+  The default instance (``get_current_user_with_graph``) denies a torn-down
+  graph. ``allow_deprovisioned=True`` is used by exactly the backup-list and
+  backup-download routes so a departing org's OWNER/ADMIN can export during the
+  grace period; it must not be applied to any other route (see
+  ``GraphUser.get_effective_role``).
+  """
+
+  async def dependency(
+    request: Request,
+    graph_id: str,
+    api_key: str = Security(API_KEY_HEADER),
+  ) -> User:
+    return await _resolve_user_with_graph(
+      request, graph_id, api_key, allow_deprovisioned=allow_deprovisioned
+    )
+
+  return dependency
+
+
+# Default graph-membership dependency: denies deprovisioned graphs. Every
+# existing `Depends(get_current_user_with_graph)` keeps its behavior.
+get_current_user_with_graph = require_graph_access()
+
+# The one sanctioned deprovisioned-tolerant variant, used by exactly the
+# backup-list and backup-download routes so a departing org's OWNER/ADMIN can
+# export during the grace period. A named singleton (not an inline
+# `require_graph_access(True)`) so it is a stable, overridable dependency.
+get_current_user_with_deprovisioned_graph = require_graph_access(
+  allow_deprovisioned=True
+)
 
 
 async def get_current_user_with_graph_or_url_token(

--- a/robosystems/middleware/auth/utils.py
+++ b/robosystems/middleware/auth/utils.py
@@ -204,6 +204,8 @@ def validate_api_key_with_graph(
   graph_id: str,
   db_session: Session | None = None,
   require_scoped: bool = False,
+  *,
+  allow_deprovisioned: bool = False,
 ) -> User | None:
   """Validate an API key against a graph and return its user.
 
@@ -215,6 +217,11 @@ def validate_api_key_with_graph(
 
   Returns None for an invalid key or an unauthorized graph, without
   distinguishing the two.
+
+  ``allow_deprovisioned`` is threaded only from the backup export path: it
+  relaxes the gone-graph denial in ``get_effective_role`` and bypasses the
+  cached graph-access decision (which was made under the default, gone →
+  denied), so the relaxation can never be written back into the cache.
   """
   if not api_key or not graph_id:
     return None
@@ -232,8 +239,10 @@ def validate_api_key_with_graph(
     logger.debug(f"Cached API key is inactive: {api_key_hash[:8]}...")
     return None
 
-  cached_graph_access = _safe_cache_call(
-    "get_cached_graph_access", api_key_hash, graph_id
+  cached_graph_access = (
+    None
+    if allow_deprovisioned
+    else _safe_cache_call("get_cached_graph_access", api_key_hash, graph_id)
   )
 
   if cached_api_key and cached_graph_access is not None:
@@ -347,7 +356,12 @@ def validate_api_key_with_graph(
         "read",
       )
     else:
-      has_access = GraphUser.user_has_access(key_record.user_id, graph_id, sess)
+      has_access = GraphUser.user_has_access(
+        key_record.user_id,
+        graph_id,
+        sess,
+        allow_deprovisioned=allow_deprovisioned,
+      )
     if not has_access:
       # Key is valid; only the graph decision is negative. Cache both.
       try:
@@ -358,7 +372,10 @@ def validate_api_key_with_graph(
           user_data,
           is_active=key_record.is_active,
         )
-        _safe_cache_call("cache_graph_access", api_key_hash, graph_id, has_access=False)
+        if not allow_deprovisioned:
+          _safe_cache_call(
+            "cache_graph_access", api_key_hash, graph_id, has_access=False
+          )
       except Exception as e:
         logger.error(f"Failed to cache API key + graph validation result: {e}")
       return None
@@ -373,7 +390,11 @@ def validate_api_key_with_graph(
         user_data,
         is_active=key_record.is_active,
       )
-      _safe_cache_call("cache_graph_access", api_key_hash, graph_id, has_access=True)
+      # Do not persist a positive decision reached under allow_deprovisioned:
+      # a later default-path request would read it and grant access to a graph
+      # that is gone.
+      if not allow_deprovisioned:
+        _safe_cache_call("cache_graph_access", api_key_hash, graph_id, has_access=True)
     except Exception as e:
       logger.error(f"Failed to cache API key + graph validation result: {e}")
 

--- a/robosystems/models/core/graph/graph_user.py
+++ b/robosystems/models/core/graph/graph_user.py
@@ -179,7 +179,12 @@ class GraphUser(Model):
 
   @classmethod
   def get_effective_role(
-    cls, user_id: str, graph_id: str, session: Session
+    cls,
+    user_id: str,
+    graph_id: str,
+    session: Session,
+    *,
+    allow_deprovisioned: bool = False,
   ) -> tuple[GraphRole | None, bool]:
     """Resolve the user's effective role on a graph, as ``(role, implicit)``.
 
@@ -198,6 +203,13 @@ class GraphUser(Model):
     so every surface that authorizes through this resolver (REST, GraphQL,
     MCP, the extensions registrar) denies in one place. A subgraph row that
     exists is held to the same standard as its parent.
+
+    ``allow_deprovisioned`` is the one sanctioned exception, passed only from
+    the backup-list and backup-download paths so a departing customer's org
+    OWNER/ADMIN can still export during the published grace period. It relaxes
+    the gone-graph denial *only*; a missing graph still resolves to no role,
+    and every other authorizer keeps the default. Do not widen its use — the
+    gone-graph denial is a tenant-isolation control.
     """
     from robosystems.middleware.graph.types import parse_graph_id
     from robosystems.models.core.graph.graph import Graph, GraphStatus
@@ -214,9 +226,10 @@ class GraphUser(Model):
     parent_row = by_id.get(parent_id)
     if parent_row is None:
       return None, False
-    for row in by_id.values():
-      if row.status == GraphStatus.DEPROVISIONED.value or row.deleted_at is not None:
-        return None, False
+    if not allow_deprovisioned:
+      for row in by_id.values():
+        if row.status == GraphStatus.DEPROVISIONED.value or row.deleted_at is not None:
+          return None, False
 
     explicit_role: GraphRole | None = None
     membership = (
@@ -244,14 +257,23 @@ class GraphUser(Model):
     return explicit_role, False
 
   @classmethod
-  def user_has_access(cls, user_id: str, graph_id: str, session: Session) -> bool:
+  def user_has_access(
+    cls,
+    user_id: str,
+    graph_id: str,
+    session: Session,
+    *,
+    allow_deprovisioned: bool = False,
+  ) -> bool:
     """
     Check if a user has access to a specific graph.
 
     Access comes from an explicit GraphUser row (on the parent graph for
     subgraphs) or implicitly from OWNER/ADMIN role in the owning org.
     """
-    role, _ = cls.get_effective_role(user_id, graph_id, session)
+    role, _ = cls.get_effective_role(
+      user_id, graph_id, session, allow_deprovisioned=allow_deprovisioned
+    )
     return role is not None
 
   @classmethod
@@ -265,9 +287,18 @@ class GraphUser(Model):
     return role is not None and role.at_least(GraphRole.MEMBER)
 
   @classmethod
-  def user_has_admin_access(cls, user_id: str, graph_id: str, session: Session) -> bool:
+  def user_has_admin_access(
+    cls,
+    user_id: str,
+    graph_id: str,
+    session: Session,
+    *,
+    allow_deprovisioned: bool = False,
+  ) -> bool:
     """Check if a user has admin access to a specific graph."""
-    role, _ = cls.get_effective_role(user_id, graph_id, session)
+    role, _ = cls.get_effective_role(
+      user_id, graph_id, session, allow_deprovisioned=allow_deprovisioned
+    )
     return role is not None and role.at_least(GraphRole.ADMIN)
 
   def update_role(self, role: str | GraphRole, session: Session) -> None:

--- a/robosystems/operations/graph/deprovision_service.py
+++ b/robosystems/operations/graph/deprovision_service.py
@@ -242,7 +242,7 @@ class GraphDeprovisionService:
     # --- 7. Update subscription metadata ---
     self._update_subscription_metadata(graph_id, session, result)
 
-    # --- 7. Transition status (soft-delete stamp landed in step 0) ---
+    # --- 8. Transition status (soft-delete stamp landed in step 0) ---
     graph.transition_status(GraphStatus.DEPROVISIONED, session)
 
     if result.errors:
@@ -654,6 +654,7 @@ class GraphDeprovisionService:
     try:
       from ...config import env
       from ...config.storage.graph import get_staging_prefix
+      from ...middleware.graph.types import parse_graph_id
       from ...models.core.graph.graph_user import GraphUser
       from ...operations.aws.s3 import S3Client
 
@@ -661,10 +662,16 @@ class GraphDeprovisionService:
       if not bucket:
         return
 
+      # Members are recorded on the PARENT graph — a subgraph carries no
+      # GraphUser row of its own (access to a subgraph is the parent's grant).
+      # So resolve the parent id for the membership lookup, but key the S3
+      # prefix on the graph_id we were handed: a file uploaded directly against
+      # a subgraph lives under user-staging/{user_id}/{subgraph_id}/.
+      parent_id, _ = parse_graph_id(graph_id)
       user_ids = [
         row[0]
         for row in session.query(GraphUser.user_id)
-        .filter(GraphUser.graph_id == graph_id)
+        .filter(GraphUser.graph_id == parent_id)
         .distinct()
         .all()
       ]

--- a/robosystems/operations/graph/deprovision_service.py
+++ b/robosystems/operations/graph/deprovision_service.py
@@ -37,6 +37,7 @@ class DeprovisionResult:
   connections_deleted: int = 0
   search_purged: bool = False
   report_bundles_deleted: int = 0
+  staged_objects_deleted: int = 0
   errors: list[str] = field(default_factory=list)
 
   @property
@@ -228,10 +229,17 @@ class GraphDeprovisionService:
     # --- 4. Deallocate DynamoDB registry ---
     await self._deallocate_registry(graph_id, result)
 
-    # --- 5. Clean PostgreSQL records ---
+    # --- 5. Purge staged uploads BEFORE the PG records that index them ---
+    # user-staging/{user_id}/{graph_id}/ is the last customer-data store, and
+    # the GraphUser rows are the only record of which users hold objects there.
+    # _clean_pg_records drops those rows, after which the platform can no longer
+    # enumerate what it still holds — so this must run first.
+    self._purge_staged_uploads(graph_id, session, result)
+
+    # --- 6. Clean PostgreSQL records ---
     self._clean_pg_records(graph_id, session, result)
 
-    # --- 6. Update subscription metadata ---
+    # --- 7. Update subscription metadata ---
     self._update_subscription_metadata(graph_id, session, result)
 
     # --- 7. Transition status (soft-delete stamp landed in step 0) ---
@@ -441,7 +449,9 @@ class GraphDeprovisionService:
         result.errors.append(error_msg)
         logger.warning(error_msg)
 
-      # Clean subgraph PG records (schemas, files) before marking deprovisioned
+      # Purge staged uploads before the PG records that index them (see the
+      # parent path), then clean subgraph PG records.
+      self._purge_staged_uploads(subgraph.graph_id, session, result)
       self._clean_pg_records(subgraph.graph_id, session, result)
       self._purge_search_index(subgraph.graph_id, result)
 
@@ -455,7 +465,17 @@ class GraphDeprovisionService:
         logger.warning(error_msg)
 
   async def _delete_database(self, graph_id: str, result: DeprovisionResult) -> None:
-    """Delete the parent graph database."""
+    """Delete the parent graph database.
+
+    A 404 (the .lbug is already absent) counts as success. The invariant that
+    gates the rest of teardown is *the file is not on the instance*, not *we
+    were the one who removed it*: run #1 can delete the file and the Dagster
+    daemon can restart before the status flip, and then every retry would get
+    the same 404 and strand the graph forever. Delete is idempotent on the
+    outcome that matters.
+    """
+    from ...graph_api.client.exceptions import GraphAPIError
+
     try:
       from ...graph_api.client.factory import get_graph_client
 
@@ -466,6 +486,18 @@ class GraphDeprovisionService:
         logger.info(f"Deleted database for graph {graph_id}")
       finally:
         await graph_client.close()
+    except GraphAPIError as e:
+      if getattr(e, "status_code", None) == 404:
+        result.database_deleted = True
+        logger.info(
+          f"Database for graph {graph_id} already absent; treating delete as "
+          "complete so teardown can converge",
+          extra={"graph_id": graph_id},
+        )
+      else:
+        error_msg = f"Database deletion failed: {e}"
+        result.errors.append(error_msg)
+        logger.warning(error_msg, extra={"graph_id": graph_id})
     except Exception as e:
       error_msg = f"Database deletion failed: {e}"
       result.errors.append(error_msg)
@@ -605,6 +637,54 @@ class GraphDeprovisionService:
     for user_id in member_ids:
       api_key_cache.invalidate_user_jwt_graph_access(user_id, graph_id)
     api_key_cache.invalidate_user_graph_access("*", graph_id)
+
+  def _purge_staged_uploads(
+    self, graph_id: str, session: Session, result: DeprovisionResult
+  ) -> None:
+    """Delete the graph's staged uploads from the user-data bucket.
+
+    The prefix is ``user-staging/{user_id}/{graph_id}/`` — raw source files a
+    customer uploaded before ingestion, held only by a bucket lifecycle rule.
+    Must run before ``_clean_pg_records`` drops the GraphUser rows: those rows
+    are the only record of which users have objects under this graph, so once
+    they are gone the objects can no longer be enumerated. Best-effort — a
+    failure records a warning without stranding teardown, and the lifecycle
+    rule remains the backstop.
+    """
+    try:
+      from ...config import env
+      from ...config.storage.graph import get_staging_prefix
+      from ...models.core.graph.graph_user import GraphUser
+      from ...operations.aws.s3 import S3Client
+
+      bucket = env.USER_DATA_BUCKET
+      if not bucket:
+        return
+
+      user_ids = [
+        row[0]
+        for row in session.query(GraphUser.user_id)
+        .filter(GraphUser.graph_id == graph_id)
+        .distinct()
+        .all()
+      ]
+      if not user_ids:
+        return
+
+      s3 = S3Client()
+      deleted = 0
+      for user_id in user_ids:
+        prefix = get_staging_prefix(user_id, graph_id)
+        for key in s3.iter_object_keys(bucket, prefix):
+          if s3.delete_object(bucket, key):
+            deleted += 1
+      result.staged_objects_deleted += deleted
+      if deleted:
+        logger.info(f"Purged {deleted} staged upload object(s) for graph {graph_id}")
+    except Exception as e:
+      error_msg = f"Staged upload purge failed: {e}"
+      result.errors.append(error_msg)
+      logger.warning(error_msg, extra={"graph_id": graph_id})
 
   def _clean_pg_records(
     self, graph_id: str, session: Session, result: DeprovisionResult

--- a/robosystems/routers/graphs/backups/backup.py
+++ b/robosystems/routers/graphs/backups/backup.py
@@ -85,7 +85,7 @@ async def list_backups(
       f"Starting list_backups for graph_id: {graph_id}, user: {current_user.id}"
     )
 
-    # Access validated by the require_graph_access dependency
+    # Access validated by the graph_access_dependency (deprovisioned-tolerant)
 
     # List backups from database instead of S3
     logger.info(f"Querying database for backups of graph: {graph_id}")

--- a/robosystems/routers/graphs/backups/backup.py
+++ b/robosystems/routers/graphs/backups/backup.py
@@ -29,7 +29,9 @@ from sqlalchemy.orm import Session
 from robosystems.config.storage.graph import get_download_extension
 from robosystems.database import get_async_db_session
 from robosystems.logger import logger
-from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+from robosystems.middleware.auth.dependencies import (
+  get_current_user_with_deprovisioned_graph,
+)
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
 from robosystems.middleware.graph.utils import MultiTenantUtils
 from robosystems.middleware.otel.metrics import (
@@ -72,7 +74,9 @@ async def list_backups(
     50, ge=1, le=100, description="Maximum number of backups to return"
   ),
   offset: int = Query(0, ge=0, description="Number of backups to skip"),
-  current_user: User = Depends(get_current_user_with_graph),
+  # Export grace period: a departing org's OWNER/ADMIN can still list a
+  # torn-down graph's backups (get_effective_role allow_deprovisioned).
+  current_user: User = Depends(get_current_user_with_deprovisioned_graph),
   db: Session = Depends(get_async_db_session),
   _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
 ) -> BackupListResponse:
@@ -81,7 +85,7 @@ async def list_backups(
       f"Starting list_backups for graph_id: {graph_id}, user: {current_user.id}"
     )
 
-    # Access validated by get_current_user_with_graph dependency
+    # Access validated by the require_graph_access dependency
 
     # List backups from database instead of S3
     logger.info(f"Querying database for backups of graph: {graph_id}")

--- a/robosystems/routers/graphs/backups/download.py
+++ b/robosystems/routers/graphs/backups/download.py
@@ -16,7 +16,9 @@ from sqlalchemy.orm import Session
 
 from robosystems.database import get_db_session
 from robosystems.logger import logger
-from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+from robosystems.middleware.auth.dependencies import (
+  get_current_user_with_deprovisioned_graph,
+)
 from robosystems.middleware.graph.types import GRAPH_OR_SUBGRAPH_ID_PATTERN
 from robosystems.middleware.graph.utils import MultiTenantUtils
 from robosystems.middleware.otel.metrics import (
@@ -75,7 +77,9 @@ async def get_backup_download_url(
   expires_in: int = Query(
     3600, ge=300, le=86400, description="URL expiration time in seconds"
   ),
-  current_user: User = Depends(get_current_user_with_graph),
+  # Export grace period: see list_backups. Both the dependency and the
+  # in-handler admin check below allow a torn-down graph for org OWNER/ADMIN.
+  current_user: User = Depends(get_current_user_with_deprovisioned_graph),
   session: Session = Depends(get_db_session),
   _: None = Depends(subscription_aware_rate_limit_dependency),
 ) -> BackupDownloadUrlResponse:
@@ -105,7 +109,7 @@ async def get_backup_download_url(
   minutes to 24 hours.
   """
   try:
-    # Access validated by get_current_user_with_graph dependency
+    # Access validated by the require_graph_access dependency
     is_shared = MultiTenantUtils.is_shared_repository_or_subgraph(graph_id)
     has_tier_limit = False
     # The single id the monthly counter is keyed on. Both the check and the
@@ -168,7 +172,7 @@ async def get_backup_download_url(
       # require admin on the graph; taking one out does too. Shared
       # repositories are gated by subscription plan above instead — there is
       # no per-graph role there.
-      verify_admin_access(current_user, graph_id, session)
+      verify_admin_access(current_user, graph_id, session, allow_deprovisioned=True)
 
       # Dedicated graph: check tier-based download limits.
       # Deprovisioned graphs are included deliberately. The final backup is

--- a/robosystems/routers/graphs/backups/download.py
+++ b/robosystems/routers/graphs/backups/download.py
@@ -109,7 +109,7 @@ async def get_backup_download_url(
   minutes to 24 hours.
   """
   try:
-    # Access validated by the require_graph_access dependency
+    # Access validated by the graph_access_dependency (deprovisioned-tolerant)
     is_shared = MultiTenantUtils.is_shared_repository_or_subgraph(graph_id)
     has_tier_limit = False
     # The single id the monthly counter is keyed on. Both the check and the

--- a/robosystems/routers/graphs/backups/utils.py
+++ b/robosystems/routers/graphs/backups/utils.py
@@ -20,17 +20,33 @@ def get_backup_manager():
   return _backup_manager
 
 
-def verify_graph_access(current_user: User, graph_id: str, db: Session) -> None:
-  """Verify the user has access to the graph, raising 403 otherwise."""
-  if not GraphUser.user_has_access(current_user.id, graph_id, db):
+def verify_graph_access(
+  current_user: User, graph_id: str, db: Session, *, allow_deprovisioned: bool = False
+) -> None:
+  """Verify the user has access to the graph, raising 403 otherwise.
+
+  ``allow_deprovisioned`` is set only by the backup export path, so a departing
+  org's OWNER/ADMIN can list/export a torn-down graph during the grace period.
+  """
+  if not GraphUser.user_has_access(
+    current_user.id, graph_id, db, allow_deprovisioned=allow_deprovisioned
+  ):
     raise HTTPException(
       status_code=status.HTTP_403_FORBIDDEN, detail="Access denied to this graph"
     )
 
 
-def verify_admin_access(current_user: User, graph_id: str, db: Session) -> None:
-  """Verify the user has admin access to the graph, raising 403 otherwise."""
-  if not GraphUser.user_has_admin_access(current_user.id, graph_id, db):
+def verify_admin_access(
+  current_user: User, graph_id: str, db: Session, *, allow_deprovisioned: bool = False
+) -> None:
+  """Verify the user has admin access to the graph, raising 403 otherwise.
+
+  ``allow_deprovisioned`` is set only by the backup download path (see
+  ``verify_graph_access``).
+  """
+  if not GraphUser.user_has_admin_access(
+    current_user.id, graph_id, db, allow_deprovisioned=allow_deprovisioned
+  ):
     raise HTTPException(
       status_code=status.HTTP_403_FORBIDDEN,
       detail="Admin access required for this operation",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,6 +195,7 @@ def client_with_mocked_auth(test_db, test_user):
   # Import the dependency directly
   from robosystems.middleware.auth.dependencies import (
     get_current_user,
+    get_current_user_with_deprovisioned_graph,
     get_current_user_with_graph,
   )
   from robosystems.middleware.rate_limits import (
@@ -223,6 +224,10 @@ def client_with_mocked_auth(test_db, test_user):
   # Override the dependencies
   app.dependency_overrides[get_current_user] = lambda: mock_user
   app.dependency_overrides[get_current_user_with_graph] = lambda: mock_user
+  # The backup list/download routes use the deprovisioned-tolerant variant.
+  app.dependency_overrides[get_current_user_with_deprovisioned_graph] = lambda: (
+    mock_user
+  )
   # Disable rate limiting during tests
   app.dependency_overrides[auth_rate_limit_dependency] = lambda: None
   app.dependency_overrides[rate_limit_dependency] = lambda: None
@@ -259,6 +264,7 @@ async def async_client(test_db, test_user):
   # Import the dependency directly
   from robosystems.middleware.auth.dependencies import (
     get_current_user,
+    get_current_user_with_deprovisioned_graph,
     get_current_user_with_graph,
   )
   from robosystems.middleware.rate_limits import (
@@ -291,6 +297,10 @@ async def async_client(test_db, test_user):
   # Override the dependencies
   app.dependency_overrides[get_current_user] = lambda: mock_user
   app.dependency_overrides[get_current_user_with_graph] = lambda: mock_user
+  # The backup list/download routes use the deprovisioned-tolerant variant.
+  app.dependency_overrides[get_current_user_with_deprovisioned_graph] = lambda: (
+    mock_user
+  )
 
   # Disable ALL rate limiting during tests
   app.dependency_overrides[auth_rate_limit_dependency] = lambda: None

--- a/tests/middleware/auth/test_dependencies.py
+++ b/tests/middleware/auth/test_dependencies.py
@@ -966,7 +966,9 @@ class TestGetCurrentUserWithGraph:
     )
 
     assert result == mock_user
-    mock_validate_api_key_with_graph.assert_called_once_with(api_key, self.graph_id)
+    mock_validate_api_key_with_graph.assert_called_once_with(
+      api_key, self.graph_id, allow_deprovisioned=False
+    )
     mock_audit_logger.log_auth_success.assert_called_once()
 
   @pytest.mark.asyncio

--- a/tests/models/core/graph/test_graph_role_access.py
+++ b/tests/models/core/graph/test_graph_role_access.py
@@ -264,3 +264,72 @@ class TestGoneGraphsGrantNoRole:
   def test_missing_graph_row_denies(self, test_db, test_user):
     role, _ = GraphUser.get_effective_role(test_user.id, _kg_id(), test_db)
     assert role is None
+
+
+class TestExportGracePeriod:
+  """``allow_deprovisioned=True`` — the one sanctioned relaxation of the
+  gone-graph denial, for the backup export path only. Org OWNER/ADMIN keep
+  implicit admin so a departing customer can export during the grace period;
+  everyone else, and every other caller, still resolves to no role.
+  """
+
+  def test_org_owner_keeps_implicit_admin_on_a_deprovisioned_graph(
+    self, test_db, test_user, test_org
+  ):
+    from robosystems.models.core import GraphStatus
+
+    graph = _create_org_graph(test_db, test_org.id)
+    graph.status = GraphStatus.DEPROVISIONED.value
+    test_db.commit()
+
+    # Default: denied.
+    assert GraphUser.get_effective_role(test_user.id, graph.graph_id, test_db) == (
+      None,
+      False,
+    )
+    # Grace period: implicit admin restored.
+    role, implicit = GraphUser.get_effective_role(
+      test_user.id, graph.graph_id, test_db, allow_deprovisioned=True
+    )
+    assert role == GraphRole.ADMIN
+    assert implicit is True
+    assert GraphUser.user_has_admin_access(
+      test_user.id, graph.graph_id, test_db, allow_deprovisioned=True
+    )
+
+  def test_grace_period_survives_the_deleted_at_stamp(
+    self, test_db, test_user, test_org
+  ):
+    from datetime import UTC, datetime
+
+    graph = _create_org_graph(test_db, test_org.id)
+    graph.deleted_at = datetime.now(UTC)
+    test_db.commit()
+
+    assert not GraphUser.user_has_access(test_user.id, graph.graph_id, test_db)
+    assert GraphUser.user_has_admin_access(
+      test_user.id, graph.graph_id, test_db, allow_deprovisioned=True
+    )
+
+  def test_a_non_member_stranger_still_gets_nothing(self, test_db, test_user, test_org):
+    """The relaxation is the org's implicit grant, not open access — a user
+    with no role and no org membership resolves to None even with the flag."""
+    from robosystems.models.core import GraphStatus
+
+    graph = _create_org_graph(test_db, test_org.id)
+    stranger = _create_user(test_db, test_user.password_hash)
+    graph.status = GraphStatus.DEPROVISIONED.value
+    test_db.commit()
+
+    role, _ = GraphUser.get_effective_role(
+      stranger.id, graph.graph_id, test_db, allow_deprovisioned=True
+    )
+    assert role is None
+
+  def test_a_missing_graph_denies_even_with_the_flag(self, test_db, test_user):
+    """The flag relaxes gone, not absent — a graph that never existed still
+    resolves to no role."""
+    role, _ = GraphUser.get_effective_role(
+      test_user.id, _kg_id(), test_db, allow_deprovisioned=True
+    )
+    assert role is None

--- a/tests/operations/graph/test_deprovision_service.py
+++ b/tests/operations/graph/test_deprovision_service.py
@@ -1156,6 +1156,49 @@ class TestStagedUploadPurge:
     remaining = db_session.query(GU).filter(GU.graph_id == test_graph.graph_id).count()
     assert remaining == 0
 
+  def test_subgraph_purge_resolves_members_from_the_parent(
+    self, service, db_session, test_org, test_user, stub_bundle_purge
+  ):
+    """A subgraph has no GraphUser row of its own — access is the parent's
+    grant. So the purge must resolve the parent for the member lookup while
+    keying the S3 prefix on the subgraph id, or it silently deletes nothing.
+    (Uses a realistic kg-hex parent id so subgraph parsing extracts the parent;
+    the shared test_graph fixture's kg_<uid> form has a stray underscore.)"""
+    from robosystems.config.graph_tier import GraphTier
+    from robosystems.models.core.graph.graph_user import GraphUser
+    from robosystems.operations.graph.deprovision_service import DeprovisionResult
+
+    parent = Graph.create(
+      graph_id=f"kg{uuid.uuid4().hex[:16]}",
+      graph_name="Parent",
+      graph_type="entity",
+      org_id=test_org.id,
+      session=db_session,
+      graph_tier=GraphTier.LADYBUG_STANDARD,
+    )
+    GraphUser.create(
+      user_id=test_user.id,
+      graph_id=parent.graph_id,  # parent only — subgraphs carry no row
+      role="admin",
+      session=db_session,
+    )
+    subgraph_id = f"{parent.graph_id}_dev"
+    staged_key = f"user-staging/{test_user.id}/{subgraph_id}/Entity/f1/data.parquet"
+
+    def iter_keys(bucket, prefix):
+      if prefix == f"user-staging/{test_user.id}/{subgraph_id}/":
+        return iter([staged_key])
+      return iter([])
+
+    stub_bundle_purge.iter_object_keys.side_effect = iter_keys
+
+    result = DeprovisionResult(graph_id=subgraph_id, status="success")
+    service._purge_staged_uploads(subgraph_id, db_session, result)
+
+    assert result.staged_objects_deleted == 1
+    deleted = [c.args[1] for c in stub_bundle_purge.delete_object.call_args_list]
+    assert staged_key in deleted
+
   @pytest.mark.asyncio
   async def test_purge_is_best_effort_and_never_strands_teardown(
     self, service, db_session, test_graph, test_user, stub_bundle_purge

--- a/tests/operations/graph/test_deprovision_service.py
+++ b/tests/operations/graph/test_deprovision_service.py
@@ -568,6 +568,82 @@ class TestDeprovisionService:
       assert test_graph.deleted_at is not None
 
   @pytest.mark.asyncio
+  async def test_deprovision_converges_when_the_database_is_already_gone(
+    self, service, db_session, test_graph
+  ):
+    """A 404 from delete_database (the .lbug is already absent) must count as
+    success so teardown converges.
+
+    The stranding case: run #1 deletes the file, the Dagster daemon restarts
+    before the status flip, and every retry then gets the same 404. Treating
+    it as a failure would re-select the graph every 5 minutes forever. The
+    invariant that gates the rest of teardown is *the file is not on the
+    instance*, not *we removed it*.
+    """
+    from robosystems.graph_api.client.exceptions import GraphClientError
+
+    with (
+      patch(
+        "robosystems.graph_api.client.factory.get_graph_client",
+        new_callable=AsyncMock,
+      ) as mock_get_client,
+      patch(
+        "robosystems.middleware.graph.allocation_manager.LadybugAllocationManager"
+      ) as mock_alloc_cls,
+    ):
+      mock_client = AsyncMock()
+      mock_client.delete_database.side_effect = GraphClientError(
+        "Database not found", status_code=404
+      )
+      mock_get_client.return_value = mock_client
+
+      mock_alloc = AsyncMock()
+      mock_alloc_cls.return_value = mock_alloc
+
+      result = await service.deprovision_graph(
+        test_graph.graph_id, db_session, create_backup=False
+      )
+
+      # Converged: the delete counted, the registry was freed, the status flipped.
+      assert result.database_deleted is True
+      assert not any("Database deletion failed" in e for e in result.errors)
+      db_session.refresh(test_graph)
+      assert test_graph.status == GraphStatus.DEPROVISIONED.value
+
+  @pytest.mark.asyncio
+  async def test_deprovision_still_strands_on_a_non_404_graph_api_error(
+    self, service, db_session, test_graph
+  ):
+    """A 500 (or any non-404 GraphAPIError) is a real failure — the file may
+    still be on the instance, so teardown must NOT converge."""
+    from robosystems.graph_api.client.exceptions import GraphServerError
+
+    with (
+      patch(
+        "robosystems.graph_api.client.factory.get_graph_client",
+        new_callable=AsyncMock,
+      ) as mock_get_client,
+      patch(
+        "robosystems.middleware.graph.allocation_manager.LadybugAllocationManager"
+      ) as mock_alloc_cls,
+    ):
+      mock_client = AsyncMock()
+      mock_client.delete_database.side_effect = GraphServerError(
+        "boom", status_code=500
+      )
+      mock_get_client.return_value = mock_client
+      mock_alloc_cls.return_value = AsyncMock()
+
+      result = await service.deprovision_graph(
+        test_graph.graph_id, db_session, create_backup=False
+      )
+
+      assert result.status == "partial"
+      assert result.database_deleted is False
+      db_session.refresh(test_graph)
+      assert test_graph.status != GraphStatus.DEPROVISIONED.value
+
+  @pytest.mark.asyncio
   async def test_deprovision_registry_deallocation_failure_continues(
     self, service, db_session, test_graph
   ):
@@ -1024,3 +1100,89 @@ class TestOrphanTenantSchemas:
     ):
       assert purge_orphan_tenant_schemas(db_session) == [ghost]
     drop.assert_called_once_with(ghost)
+
+
+class TestStagedUploadPurge:
+  """user-staging/{user_id}/{graph_id}/ is the last customer-data store, indexed
+  only by the GraphUser rows. It must be purged BEFORE _clean_pg_records drops
+  those rows, or the platform can no longer enumerate what it holds."""
+
+  @pytest.mark.asyncio
+  async def test_staged_uploads_are_deleted_before_the_rows_that_index_them(
+    self, service, db_session, test_graph, test_user, stub_bundle_purge
+  ):
+    from robosystems.models.core.graph.graph_user import GraphUser
+
+    GraphUser.create(
+      user_id=test_user.id,
+      graph_id=test_graph.graph_id,
+      role="admin",
+      session=db_session,
+    )
+
+    staged_key = (
+      f"user-staging/{test_user.id}/{test_graph.graph_id}/Entity/f1/data.parquet"
+    )
+
+    def iter_keys(bucket, prefix):
+      # Only the staging prefix for this (user, graph) yields an object.
+      if prefix == f"user-staging/{test_user.id}/{test_graph.graph_id}/":
+        return iter([staged_key])
+      return iter([])
+
+    stub_bundle_purge.iter_object_keys.side_effect = iter_keys
+
+    with (
+      patch(
+        "robosystems.graph_api.client.factory.get_graph_client",
+        new_callable=AsyncMock,
+      ) as mock_get_client,
+      patch("robosystems.middleware.graph.allocation_manager.LadybugAllocationManager"),
+    ):
+      mock_get_client.return_value = AsyncMock()
+      result = await service.deprovision_graph(
+        test_graph.graph_id, db_session, create_backup=False
+      )
+
+    # The staged object was found (via the GraphUser row) and deleted.
+    assert result.staged_objects_deleted >= 1
+    deleted_keys = [
+      call.args[1] for call in stub_bundle_purge.delete_object.call_args_list
+    ]
+    assert staged_key in deleted_keys
+    # And the rows that indexed it are gone afterward — the purge ran first.
+    from robosystems.models.core.graph.graph_user import GraphUser as GU
+
+    remaining = db_session.query(GU).filter(GU.graph_id == test_graph.graph_id).count()
+    assert remaining == 0
+
+  @pytest.mark.asyncio
+  async def test_purge_is_best_effort_and_never_strands_teardown(
+    self, service, db_session, test_graph, test_user, stub_bundle_purge
+  ):
+    from robosystems.models.core.graph.graph_user import GraphUser
+
+    GraphUser.create(
+      user_id=test_user.id,
+      graph_id=test_graph.graph_id,
+      role="admin",
+      session=db_session,
+    )
+    stub_bundle_purge.iter_object_keys.side_effect = RuntimeError("s3 down")
+
+    with (
+      patch(
+        "robosystems.graph_api.client.factory.get_graph_client",
+        new_callable=AsyncMock,
+      ) as mock_get_client,
+      patch("robosystems.middleware.graph.allocation_manager.LadybugAllocationManager"),
+    ):
+      mock_get_client.return_value = AsyncMock()
+      result = await service.deprovision_graph(
+        test_graph.graph_id, db_session, create_backup=False
+      )
+
+    # Teardown converged despite the purge failure; the failure was recorded.
+    db_session.refresh(test_graph)
+    assert test_graph.status == GraphStatus.DEPROVISIONED.value
+    assert any("Staged upload purge failed" in e for e in result.errors)

--- a/tests/routers/graphs/test_backup_download.py
+++ b/tests/routers/graphs/test_backup_download.py
@@ -102,10 +102,14 @@ class TestBackupDownloadEndpoint:
   ):
     """Test that download requires subscription for shared repositories."""
     from robosystems.database import get_db_session
-    from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+    from robosystems.middleware.auth.dependencies import (
+      get_current_user_with_deprovisioned_graph,
+    )
 
     mock_session = MagicMock()
-    app.dependency_overrides[get_current_user_with_graph] = lambda: mock_auth_user
+    app.dependency_overrides[get_current_user_with_deprovisioned_graph] = lambda: (
+      mock_auth_user
+    )
     app.dependency_overrides[get_db_session] = lambda: mock_session
 
     try:
@@ -128,8 +132,8 @@ class TestBackupDownloadEndpoint:
       assert response.status_code == 403
       assert "subscription required" in response.json()["detail"].lower()
     finally:
-      if get_current_user_with_graph in app.dependency_overrides:
-        del app.dependency_overrides[get_current_user_with_graph]
+      if get_current_user_with_deprovisioned_graph in app.dependency_overrides:
+        del app.dependency_overrides[get_current_user_with_deprovisioned_graph]
       if get_db_session in app.dependency_overrides:
         del app.dependency_overrides[get_db_session]
 
@@ -166,10 +170,14 @@ class TestBackupDownloadEndpoint:
   ):
     """Test that starter plan users get 403 (downloads not available)."""
     from robosystems.database import get_db_session
-    from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+    from robosystems.middleware.auth.dependencies import (
+      get_current_user_with_deprovisioned_graph,
+    )
 
     mock_session = MagicMock()
-    app.dependency_overrides[get_current_user_with_graph] = lambda: mock_auth_user
+    app.dependency_overrides[get_current_user_with_deprovisioned_graph] = lambda: (
+      mock_auth_user
+    )
     app.dependency_overrides[get_db_session] = lambda: mock_session
 
     try:
@@ -200,8 +208,8 @@ class TestBackupDownloadEndpoint:
       mock_check_limit.assert_not_called()
       mock_increment.assert_not_called()
     finally:
-      if get_current_user_with_graph in app.dependency_overrides:
-        del app.dependency_overrides[get_current_user_with_graph]
+      if get_current_user_with_deprovisioned_graph in app.dependency_overrides:
+        del app.dependency_overrides[get_current_user_with_deprovisioned_graph]
       if get_db_session in app.dependency_overrides:
         del app.dependency_overrides[get_db_session]
 
@@ -238,10 +246,14 @@ class TestBackupDownloadEndpoint:
   ):
     """Test that exceeding download rate limit returns 429."""
     from robosystems.database import get_db_session
-    from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+    from robosystems.middleware.auth.dependencies import (
+      get_current_user_with_deprovisioned_graph,
+    )
 
     mock_session = MagicMock()
-    app.dependency_overrides[get_current_user_with_graph] = lambda: mock_auth_user
+    app.dependency_overrides[get_current_user_with_deprovisioned_graph] = lambda: (
+      mock_auth_user
+    )
     app.dependency_overrides[get_db_session] = lambda: mock_session
 
     try:
@@ -274,8 +286,8 @@ class TestBackupDownloadEndpoint:
       assert "X-RateLimit-Remaining" in response.headers
       assert response.headers["X-RateLimit-Remaining"] == "0"
     finally:
-      if get_current_user_with_graph in app.dependency_overrides:
-        del app.dependency_overrides[get_current_user_with_graph]
+      if get_current_user_with_deprovisioned_graph in app.dependency_overrides:
+        del app.dependency_overrides[get_current_user_with_deprovisioned_graph]
       if get_db_session in app.dependency_overrides:
         del app.dependency_overrides[get_db_session]
 
@@ -312,10 +324,14 @@ class TestBackupDownloadEndpoint:
   ):
     """Test that download is allowed when under rate limit."""
     from robosystems.database import get_db_session
-    from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+    from robosystems.middleware.auth.dependencies import (
+      get_current_user_with_deprovisioned_graph,
+    )
 
     mock_session = MagicMock()
-    app.dependency_overrides[get_current_user_with_graph] = lambda: mock_auth_user
+    app.dependency_overrides[get_current_user_with_deprovisioned_graph] = lambda: (
+      mock_auth_user
+    )
     app.dependency_overrides[get_db_session] = lambda: mock_session
 
     try:
@@ -360,8 +376,8 @@ class TestBackupDownloadEndpoint:
         resource_id="sec",
       )
     finally:
-      if get_current_user_with_graph in app.dependency_overrides:
-        del app.dependency_overrides[get_current_user_with_graph]
+      if get_current_user_with_deprovisioned_graph in app.dependency_overrides:
+        del app.dependency_overrides[get_current_user_with_deprovisioned_graph]
       if get_db_session in app.dependency_overrides:
         del app.dependency_overrides[get_db_session]
 
@@ -393,10 +409,14 @@ class TestBackupDownloadEndpoint:
   ):
     """Test that user graph downloads are allowed when under tier limit."""
     from robosystems.database import get_db_session
-    from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+    from robosystems.middleware.auth.dependencies import (
+      get_current_user_with_deprovisioned_graph,
+    )
 
     mock_session = MagicMock()
-    app.dependency_overrides[get_current_user_with_graph] = lambda: mock_auth_user
+    app.dependency_overrides[get_current_user_with_deprovisioned_graph] = lambda: (
+      mock_auth_user
+    )
     app.dependency_overrides[get_db_session] = lambda: mock_session
 
     try:
@@ -428,8 +448,8 @@ class TestBackupDownloadEndpoint:
       # Verify download count was incremented (standard tier has limit > 0)
       mock_increment.assert_called_once()
     finally:
-      if get_current_user_with_graph in app.dependency_overrides:
-        del app.dependency_overrides[get_current_user_with_graph]
+      if get_current_user_with_deprovisioned_graph in app.dependency_overrides:
+        del app.dependency_overrides[get_current_user_with_deprovisioned_graph]
       if get_db_session in app.dependency_overrides:
         del app.dependency_overrides[get_db_session]
 
@@ -456,10 +476,14 @@ class TestBackupDownloadEndpoint:
   ):
     """Test that exceeding tier download limit returns 429 for user graphs."""
     from robosystems.database import get_db_session
-    from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+    from robosystems.middleware.auth.dependencies import (
+      get_current_user_with_deprovisioned_graph,
+    )
 
     mock_session = MagicMock()
-    app.dependency_overrides[get_current_user_with_graph] = lambda: mock_auth_user
+    app.dependency_overrides[get_current_user_with_deprovisioned_graph] = lambda: (
+      mock_auth_user
+    )
     app.dependency_overrides[get_db_session] = lambda: mock_session
 
     try:
@@ -482,8 +506,8 @@ class TestBackupDownloadEndpoint:
       assert "limit" in response.json()["detail"].lower()
       assert "X-RateLimit-Remaining" in response.headers
     finally:
-      if get_current_user_with_graph in app.dependency_overrides:
-        del app.dependency_overrides[get_current_user_with_graph]
+      if get_current_user_with_deprovisioned_graph in app.dependency_overrides:
+        del app.dependency_overrides[get_current_user_with_deprovisioned_graph]
       if get_db_session in app.dependency_overrides:
         del app.dependency_overrides[get_db_session]
 
@@ -515,10 +539,14 @@ class TestBackupDownloadEndpoint:
   ):
     """Test that xlarge tier downloads work and count is tracked."""
     from robosystems.database import get_db_session
-    from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+    from robosystems.middleware.auth.dependencies import (
+      get_current_user_with_deprovisioned_graph,
+    )
 
     mock_session = MagicMock()
-    app.dependency_overrides[get_current_user_with_graph] = lambda: mock_auth_user
+    app.dependency_overrides[get_current_user_with_deprovisioned_graph] = lambda: (
+      mock_auth_user
+    )
     app.dependency_overrides[get_db_session] = lambda: mock_session
 
     try:
@@ -548,8 +576,8 @@ class TestBackupDownloadEndpoint:
       # All tiers now track download count
       mock_increment.assert_called_once()
     finally:
-      if get_current_user_with_graph in app.dependency_overrides:
-        del app.dependency_overrides[get_current_user_with_graph]
+      if get_current_user_with_deprovisioned_graph in app.dependency_overrides:
+        del app.dependency_overrides[get_current_user_with_deprovisioned_graph]
       if get_db_session in app.dependency_overrides:
         del app.dependency_overrides[get_db_session]
 
@@ -576,10 +604,14 @@ class TestBackupDownloadEndpoint:
   ):
     """Test that 404 is returned when backup doesn't exist."""
     from robosystems.database import get_db_session
-    from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+    from robosystems.middleware.auth.dependencies import (
+      get_current_user_with_deprovisioned_graph,
+    )
 
     mock_session = MagicMock()
-    app.dependency_overrides[get_current_user_with_graph] = lambda: mock_auth_user
+    app.dependency_overrides[get_current_user_with_deprovisioned_graph] = lambda: (
+      mock_auth_user
+    )
     app.dependency_overrides[get_db_session] = lambda: mock_session
 
     try:
@@ -607,8 +639,8 @@ class TestBackupDownloadEndpoint:
       assert response.status_code == 404
       assert "not found" in response.json()["detail"].lower()
     finally:
-      if get_current_user_with_graph in app.dependency_overrides:
-        del app.dependency_overrides[get_current_user_with_graph]
+      if get_current_user_with_deprovisioned_graph in app.dependency_overrides:
+        del app.dependency_overrides[get_current_user_with_deprovisioned_graph]
       if get_db_session in app.dependency_overrides:
         del app.dependency_overrides[get_db_session]
 
@@ -654,10 +686,14 @@ class TestBackupDownloadEndpoint:
     resource.
     """
     from robosystems.database import get_db_session
-    from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+    from robosystems.middleware.auth.dependencies import (
+      get_current_user_with_deprovisioned_graph,
+    )
 
     mock_session = MagicMock()
-    app.dependency_overrides[get_current_user_with_graph] = lambda: mock_auth_user
+    app.dependency_overrides[get_current_user_with_deprovisioned_graph] = lambda: (
+      mock_auth_user
+    )
     app.dependency_overrides[get_db_session] = lambda: mock_session
 
     try:
@@ -696,7 +732,7 @@ class TestBackupDownloadEndpoint:
         resource_id="sec",
       )
     finally:
-      if get_current_user_with_graph in app.dependency_overrides:
-        del app.dependency_overrides[get_current_user_with_graph]
+      if get_current_user_with_deprovisioned_graph in app.dependency_overrides:
+        del app.dependency_overrides[get_current_user_with_deprovisioned_graph]
       if get_db_session in app.dependency_overrides:
         del app.dependency_overrides[get_db_session]

--- a/tests/routers/graphs/test_backups.py
+++ b/tests/routers/graphs/test_backups.py
@@ -105,13 +105,17 @@ class TestBackupEndpoints:
   ):
     """Test backup listing endpoint."""
     from robosystems.database import session
-    from robosystems.middleware.auth.dependencies import get_current_user_with_graph
+    from robosystems.middleware.auth.dependencies import (
+      get_current_user_with_deprovisioned_graph,
+    )
 
     # Create mock session
     mock_session = MagicMock()
 
     # Override the dependencies
-    app.dependency_overrides[get_current_user_with_graph] = lambda: mock_auth_user
+    app.dependency_overrides[get_current_user_with_deprovisioned_graph] = lambda: (
+      mock_auth_user
+    )
     app.dependency_overrides[session] = lambda: mock_session
 
     try:
@@ -146,8 +150,8 @@ class TestBackupEndpoints:
       assert "total_count" in data
     finally:
       # Reset only the specific overrides we added
-      if get_current_user_with_graph in app.dependency_overrides:
-        del app.dependency_overrides[get_current_user_with_graph]
+      if get_current_user_with_deprovisioned_graph in app.dependency_overrides:
+        del app.dependency_overrides[get_current_user_with_deprovisioned_graph]
       if session in app.dependency_overrides:
         del app.dependency_overrides[session]
 

--- a/tests/routers/graphs/test_graph_read_authorization.py
+++ b/tests/routers/graphs/test_graph_read_authorization.py
@@ -364,3 +364,54 @@ class TestBackupDownloadRequiresAdmin:
 
     assert response.status_code == 404
     manager.get_backup_download_url.assert_awaited_once()
+
+  async def test_admin_can_download_from_a_deprovisioned_graph(
+    self, async_client, test_db, test_user
+  ):
+    """The export grace period: after teardown, an org admin can still reach a
+    torn-down graph's backups. The real verify_admin_access(allow_deprovisioned)
+    runs here — the dependency override does not cover it."""
+    from robosystems.models.core import GraphStatus
+
+    graph = self._graph_with_grant(test_db, test_user, GraphRole.ADMIN)
+    graph.status = GraphStatus.DEPROVISIONED.value
+    test_db.commit()
+
+    manager = MagicMock()
+    manager.get_backup_download_url = AsyncMock(return_value=None)
+    with (
+      patch(
+        "robosystems.routers.graphs.backups.download.get_backup_manager",
+        return_value=manager,
+      ),
+      patch(
+        "robosystems.routers.graphs.backups.download.DownloadRateLimiter"
+        ".check_graph_download_limit",
+        new=AsyncMock(return_value=(True, 1, datetime.now(UTC))),
+      ),
+    ):
+      response = await async_client.get(
+        f"/v1/graphs/{graph.graph_id}/backups/bk_x/download"
+      )
+
+    # Past the gate (reaches the stubbed-missing backup), not 403'd out.
+    assert response.status_code == 404
+    manager.get_backup_download_url.assert_awaited_once()
+
+  async def test_viewer_still_denied_on_a_deprovisioned_graph(
+    self, async_client, test_db, test_user
+  ):
+    """The grace period is admin-only: allow_deprovisioned relaxes the gone-graph
+    denial, it does not grant a viewer admin."""
+    from robosystems.models.core import GraphStatus
+
+    graph = self._graph_with_grant(test_db, test_user, GraphRole.VIEWER)
+    graph.status = GraphStatus.DEPROVISIONED.value
+    test_db.commit()
+
+    response = await async_client.get(
+      f"/v1/graphs/{graph.graph_id}/backups/bk_x/download"
+    )
+
+    assert response.status_code == 403
+    assert "Admin access required" in response.json()["detail"]

--- a/tests/security/test_graph_access_control.py
+++ b/tests/security/test_graph_access_control.py
@@ -122,7 +122,9 @@ class TestGraphAccessControlDependency:
         mock_request, sample_graph.graph_id, test_api_key.key
       )
       assert user.id == test_user.id
-      mock_validate.assert_called_once_with(test_api_key.key, sample_graph.graph_id)
+      mock_validate.assert_called_once_with(
+        test_api_key.key, sample_graph.graph_id, allow_deprovisioned=False
+      )
 
   async def test_api_key_without_graph_access_raises_403(
     self, mock_request, test_user, sample_graph, test_api_key


### PR DESCRIPTION
Three offboarding fixes, two of them regressions a prior hardening pass introduced.

**Backup export after teardown.** A departing org's OWNER/ADMIN could no longer list or download a torn-down graph's backups: the effective-role resolver denies any gone graph before the handler runs, for everyone. This adds a scoped `allow_deprovisioned` relaxation to `get_effective_role`, threaded from exactly the backup **list** and **download** routes via a `require_graph_access` dependency factory (a named singleton variant) plus `verify_admin_access`. Every other authorizer keeps denying, and the flag bypasses — and never writes back — the JWT and API-key graph-access caches, so it can't leak to another route or persist.

**Teardown convergence.** A teardown whose database delete returned 404 (the file is already gone — e.g. a daemon restart between the delete and the status flip) re-selected the graph and failed the same way every cycle, forever. A 404 now counts as a completed delete so teardown converges; a non-404 error still strands for retry. The invariant that gates the rest of teardown is *the file is not on the instance*, not *we removed it*.

**Staged-upload purge.** `user-staging/{user_id}/{graph_id}/` objects are now deleted **before** the PG rows that index them (parent and subgraph paths). The convergence fix is what makes `_clean_pg_records` actually run in the 404 case, so this ordering had to ride along — once the rows are gone the platform can't enumerate what it still holds.

Tests: the real-auth grace-period route tests that do **not** override the auth dependency (admin passes on a deprovisioned graph, viewer still 403s), model-level `allow_deprovisioned` cases (org owner regains implicit admin; stranger and missing-graph still denied), a convergence test driving a real 404 vs a real 500, and a staged-purge ordering test. Full graphs/auth/models/deprovision suites green (1818 passed).

Remaining backlog (not in this PR): the subgraph search-index leak and the `user_orgs[0]` org resolution.