### PR TITLE
fix(operators): bound the tenant-controlled AI input length

### DIFF
--- a/robosystems/models/api/graphs/operator.py
+++ b/robosystems/models/api/graphs/operator.py
@@ -13,12 +13,23 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+# Bounds the tenant-controlled AI input. Without a cap, a single oversized
+# message (or a long history) can drive a Bedrock call whose true cost exceeds
+# the balance, which the post-hoc conditional debit then bills at zero — the
+# free-spend band. See specs/security/operation-lifecycle-budgets.md §3.1.
+MAX_OPERATOR_MESSAGE_CHARS = 100_000
+MAX_OPERATOR_HISTORY_MESSAGES = 100
+
 
 class OperatorMessage(BaseModel):
   """Message in conversation history."""
 
   role: str = Field(..., description="Message role (user/assistant)")
-  content: str = Field(..., description="Message content")
+  content: str = Field(
+    ...,
+    max_length=MAX_OPERATOR_MESSAGE_CHARS,
+    description="Message content",
+  )
   timestamp: datetime | None = Field(None, description="Message timestamp")
 
 
@@ -50,9 +61,16 @@ class SelectionCriteria(BaseModel):
 class OperatorRequest(BaseModel):
   """Request model for operator interactions."""
 
-  message: str = Field(..., description="The query or message to process")
+  message: str = Field(
+    ...,
+    min_length=1,
+    max_length=MAX_OPERATOR_MESSAGE_CHARS,
+    description="The query or message to process",
+  )
   history: list[OperatorMessage] = Field(
-    default_factory=list, description="Conversation history"
+    default_factory=list,
+    max_length=MAX_OPERATOR_HISTORY_MESSAGES,
+    description="Conversation history",
   )
   context: dict[str, Any] | None = Field(
     None,

--- a/tests/models/api/test_operator_models.py
+++ b/tests/models/api/test_operator_models.py
@@ -6,6 +6,8 @@ import pytest
 from pydantic import ValidationError
 
 from robosystems.models.api.graphs.operator import (
+  MAX_OPERATOR_HISTORY_MESSAGES,
+  MAX_OPERATOR_MESSAGE_CHARS,
   OperatorHealthResponse,
   OperatorHealthStatus,
   OperatorListResponse,
@@ -76,6 +78,28 @@ class TestOperatorRequest:
     assert model.enable_rag is True
     assert model.stream is False
     assert model.force_extended_analysis is False
+
+  def test_message_is_length_bounded(self):
+    """The tenant-controlled AI input is capped so a single oversized message
+    cannot drive a Bedrock call whose true cost the post-hoc debit bills at
+    zero (the free-spend band)."""
+    OperatorRequest(message="x" * MAX_OPERATOR_MESSAGE_CHARS)  # at the cap: ok
+    with pytest.raises(ValidationError):
+      OperatorRequest(message="x" * (MAX_OPERATOR_MESSAGE_CHARS + 1))
+
+  def test_empty_message_rejected(self):
+    with pytest.raises(ValidationError):
+      OperatorRequest(message="")
+
+  def test_history_is_bounded_in_size_and_content(self):
+    too_many = [
+      OperatorMessage(role="user", content="q")
+      for _ in range(MAX_OPERATOR_HISTORY_MESSAGES + 1)
+    ]
+    with pytest.raises(ValidationError):
+      OperatorRequest(message="ok", history=too_many)
+    with pytest.raises(ValidationError):
+      OperatorMessage(role="user", content="x" * (MAX_OPERATOR_MESSAGE_CHARS + 1))
 
   def test_with_history(self):
     history = [


### PR DESCRIPTION
Adds a `max_length` on the operator message (100k chars), the same cap on each history message, and a `max_length` (100) on the history list.

Without a bound on the tenant-controlled AI input, a single oversized message can drive a Bedrock call whose true cost exceeds the caller's credit balance. Because the credit debit is a post-hoc conditional `UPDATE ... WHERE balance >= cost`, an over-budget call matches no row and is billed **zero** — a free-spend band a tenant could sit in at the endpoint's rate limit. Capping the input closes the unbounded end of that band.

Tests: message at the cap passes, one over is rejected, empty is rejected, and an over-long history (by count or per-message length) is rejected.

Note for SDK consumers: this tightens validation on the operator request model (generated tier) — an empty or 100k+-char message now 422s. No facade or template path is affected; rides a client minor.