### PR TITLE
fix(platform): bound event-loop occupancy and close the post-hoc credit band

### DIFF
--- a/robosystems/config/constants.py
+++ b/robosystems/config/constants.py
@@ -33,6 +33,13 @@ MAX_ERROR_MESSAGE_LENGTH = 1000  # characters
 PUBLIC_MAX_REQUEST_SIZE = 10 * 1024 * 1024  # 10 MB
 WEBHOOK_MAX_REQUEST_SIZE = 512 * 1024  # 512 KB
 
+# Per-request timeout for the Dagster GraphQL client (submit / status poll).
+# The library default is 300 s; a status poll that takes longer than a few
+# seconds is a hung webserver, and the call runs from the API's own event
+# loop (background tasks, SSE monitors), so the default would hold every
+# tenant on the task for five minutes per hang.
+DAGSTER_CLIENT_TIMEOUT_SECONDS = 15
+
 # Batch Processing
 DEFAULT_BATCH_SIZE = 5000  # Optimized for Graph API bulk ingestion
 MIN_BATCH_SIZE = 1

--- a/robosystems/config/defaults.py
+++ b/robosystems/config/defaults.py
@@ -32,6 +32,12 @@ class DatabaseDefaults:
   MAX_OVERFLOW = 10  # Additional connections above pool_size (burst)
   POOL_TIMEOUT = 30  # Seconds to wait for a connection from the pool
   POOL_RECYCLE = 3600  # Recycle connections after 1 hour (handles RDS drops)
+  # Per-statement ceiling for the platform engine, applied at connect time.
+  # The platform session is synchronous and called from async handlers, so a
+  # statement that runs unbounded holds the event loop — and every tenant on
+  # the task — for its whole duration. Migrations use their own engine and
+  # are unaffected. 0 disables.
+  STATEMENT_TIMEOUT_MS = 30_000
 
   # Extensions OLTP database — a separate engine/pool from the platform DB.
   # The per-graph OLTP write path (journal entries, etc.) is the hot path, so
@@ -280,6 +286,7 @@ SSM_TUNING_PATHS = {
   "database/MAX_OVERFLOW": DatabaseDefaults.MAX_OVERFLOW,
   "database/POOL_TIMEOUT": DatabaseDefaults.POOL_TIMEOUT,
   "database/POOL_RECYCLE": DatabaseDefaults.POOL_RECYCLE,
+  "database/STATEMENT_TIMEOUT_MS": DatabaseDefaults.STATEMENT_TIMEOUT_MS,
   "database/EXTENSIONS_POOL_SIZE": DatabaseDefaults.EXTENSIONS_POOL_SIZE,
   "database/EXTENSIONS_MAX_OVERFLOW": DatabaseDefaults.EXTENSIONS_MAX_OVERFLOW,
   "database/EXTENSIONS_STATEMENT_TIMEOUT_MS": (

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -69,6 +69,11 @@ try:
   # than silently run with permissive fallbacks. Always {} (→ False) outside
   # prod/staging by design; the validator only asserts on it when deployed.
   FEATURE_FLAGS_PRELOADED = bool(_preloaded_flags)
+  # The names that were actually present in SSM. `FEATURE_FLAGS_PRELOADED`
+  # is per-store (any flag came back); the validator also needs per-flag,
+  # because a flag individually absent from SSM resolves silently to its code
+  # default and the resolved bool cannot say which of "absent" or "false" it is.
+  PRELOADED_FEATURE_FLAG_NAMES = frozenset(_preloaded_flags or ())
   if _preloaded_flags:
     print(f"Preloaded {len(_preloaded_flags)} feature flags from SSM")
   elif os.getenv("ENVIRONMENT", "dev") in ("prod", "staging"):
@@ -78,6 +83,7 @@ except Exception as _e:
   # Catch all exceptions (not just ImportError) to handle transitive failures
   PARAMETER_STORE_AVAILABLE = False
   FEATURE_FLAGS_PRELOADED = False
+  PRELOADED_FEATURE_FLAG_NAMES = frozenset()
   print(
     f"WARNING: Parameter store unavailable ({type(_e).__name__}: {_e}). "
     "All feature flags will use defaults (false)."
@@ -374,6 +380,7 @@ class EnvConfig:
   # not read SSM would serve its whole life on code defaults.
   PARAMETER_STORE_AVAILABLE = PARAMETER_STORE_AVAILABLE
   FEATURE_FLAGS_PRELOADED = FEATURE_FLAGS_PRELOADED
+  PRELOADED_FEATURE_FLAG_NAMES = PRELOADED_FEATURE_FLAG_NAMES
 
   # Environment and debugging
   ENVIRONMENT = get_str_env("ENVIRONMENT", "dev")

--- a/robosystems/config/tuning.py
+++ b/robosystems/config/tuning.py
@@ -368,6 +368,13 @@ class TuningConfig:
     )
 
   @classmethod
+  def get_database_statement_timeout_ms(cls) -> int:
+    """Per-statement ceiling (ms) for the platform engine; 0 = none."""
+    return cls.get_int(
+      "database/STATEMENT_TIMEOUT_MS", DatabaseDefaults.STATEMENT_TIMEOUT_MS
+    )
+
+  @classmethod
   def get_database_pool_timeout(cls) -> int:
     """Get seconds to wait for a connection from the pool."""
     return cls.get_int("database/POOL_TIMEOUT", DatabaseDefaults.POOL_TIMEOUT)

--- a/robosystems/config/validation.py
+++ b/robosystems/config/validation.py
@@ -21,6 +21,17 @@ class ConfigValidationError(Exception):
 class EnvValidator:
   """Validates environment configuration at startup."""
 
+  # Flags whose code default is the permissive value, so an individual absence
+  # from SSM in a deployed environment is a silent control failure. Presence
+  # is asserted, not value: `false` is a legitimate setting for any of them.
+  SAFETY_CRITICAL_FEATURE_FLAGS: tuple[str, ...] = (
+    "RATE_LIMIT_ENABLED",
+    "BILLING_ENABLED",
+    "CAPTCHA_ENABLED",
+    "EMAIL_VERIFICATION_ENABLED",
+    "USER_REGISTRATION_ENABLED",
+  )
+
   @staticmethod
   def validate_required_vars(env_config) -> None:
     """
@@ -242,6 +253,23 @@ class EnvValidator:
         errors.append(
           "RATE_LIMIT_ENABLED is false in a deployed environment — this is the "
           "signature of an SSM read that fell back to defaults. Refusing to boot."
+        )
+      # Per-flag, not just per-store: the batched read returns only the
+      # parameters that exist, so a single safety-critical flag missing from
+      # SSM passes both checks above and resolves silently to its permissive
+      # code default (BILLING_ENABLED off is the expensive one). Presence is
+      # what is asserted — the value may legitimately be false.
+      preloaded = getattr(env_config, "PRELOADED_FEATURE_FLAG_NAMES", frozenset())
+      missing = [
+        name
+        for name in EnvValidator.SAFETY_CRITICAL_FEATURE_FLAGS
+        if name not in preloaded
+      ]
+      if missing:
+        errors.append(
+          "Safety-critical feature flag(s) absent from SSM in a deployed "
+          f"environment: {', '.join(missing)} — each would run on its code "
+          "default. Set the parameter(s) under /features/ and redeploy."
         )
 
     # Validate value ranges and formats

--- a/robosystems/db/platform.py
+++ b/robosystems/db/platform.py
@@ -84,6 +84,14 @@ def _connect_args() -> dict[str, str]:
   # A per-statement ceiling set on the connection, so no single platform query
   # can hold the (synchronous, loop-bound) session unboundedly. Mirrors the
   # extensions engine; migrations run on their own engine and are unaffected.
+  #
+  # Engine-wide (workers included) is intentional and safe: `statement_timeout`
+  # bounds a single statement, not a transaction, so a bulk job that issues
+  # many small statements under one commit (e.g. bulk_allocate_monthly_credits)
+  # is unaffected — only an individual query running longer than the ceiling is
+  # cut. The platform DB has no such single bulk statement (that shape lives on
+  # the extensions engine, which opts bulk paths out per-session). SSM-tunable;
+  # `database/STATEMENT_TIMEOUT_MS = 0` disables it without a deploy.
   timeout_ms = TuningConfig.get_database_statement_timeout_ms()
   # `options` is a libpq connection parameter; only PostgreSQL drivers accept it.
   if timeout_ms <= 0 or not (get_database_url() or "").startswith("postgresql"):

--- a/robosystems/db/platform.py
+++ b/robosystems/db/platform.py
@@ -80,6 +80,17 @@ def _session_scope():
   return threading.get_ident()
 
 
+def _connect_args() -> dict[str, str]:
+  # A per-statement ceiling set on the connection, so no single platform query
+  # can hold the (synchronous, loop-bound) session unboundedly. Mirrors the
+  # extensions engine; migrations run on their own engine and are unaffected.
+  timeout_ms = TuningConfig.get_database_statement_timeout_ms()
+  # `options` is a libpq connection parameter; only PostgreSQL drivers accept it.
+  if timeout_ms <= 0 or not (get_database_url() or "").startswith("postgresql"):
+    return {}
+  return {"options": f"-c statement_timeout={timeout_ms}"}
+
+
 engine = create_engine(
   get_database_url(),
   pool_size=TuningConfig.get_database_pool_size(),
@@ -87,6 +98,7 @@ engine = create_engine(
   pool_timeout=TuningConfig.get_database_pool_timeout(),
   pool_recycle=TuningConfig.get_database_pool_recycle(),
   pool_pre_ping=True,
+  connect_args=_connect_args(),
   echo=env.DATABASE_ECHO,
 )
 SessionFactory = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/robosystems/graph_api/core/duckdb/manager.py
+++ b/robosystems/graph_api/core/duckdb/manager.py
@@ -876,9 +876,17 @@ class DuckDBTableManager:
     """
     import time
 
+    from robosystems.security.error_handling import redact_connection_secrets
+
     start_time = time.time()
 
-    logger.info(f"Executing write for graph {request.graph_id}: {request.sql[:100]}...")
+    # postgres_scan() statements carry the extensions DSN in their leading
+    # characters; redact before the preview rather than relying on the
+    # truncation to happen to cut ahead of the password.
+    logger.info(
+      f"Executing write for graph {request.graph_id}: "
+      f"{redact_connection_secrets(request.sql)[:100]}..."
+    )
 
     pool = get_duckdb_pool()
 

--- a/robosystems/graph_api/routers/databases/query.py
+++ b/robosystems/graph_api/routers/databases/query.py
@@ -77,7 +77,7 @@ def track_connection(admission_controller, database_name):
 
 
 @router.post("/{graph_id}/query")
-async def execute_query(
+def execute_query(
   request: QueryRequest,
   graph_id: str = Path(..., description="Graph database identifier"),
   streaming: bool = False,
@@ -102,6 +102,11 @@ async def execute_query(
   Raises:
       HTTPException: 503 if server is overloaded (admission control)
       HTTPException: 503 if graph is rebuilding
+
+  Deliberately a plain ``def``: the body is entirely synchronous (the engine
+  call, and a Postgres read in ``_is_graph_rebuilding``), so Starlette runs it
+  on the threadpool. As ``async def`` it ran on the single event loop, where a
+  long query against the shared repository held every caller on the instance.
   """
   if _is_graph_rebuilding(graph_id):
     logger.warning(f"Query rejected for {graph_id}: graph is rebuilding")

--- a/robosystems/middleware/sse/dagster_monitor.py
+++ b/robosystems/middleware/sse/dagster_monitor.py
@@ -25,6 +25,7 @@ import logging
 from typing import Any
 
 from robosystems.config import env
+from robosystems.config.constants import DAGSTER_CLIENT_TIMEOUT_SECONDS
 from robosystems.middleware.sse.event_storage import EventType, SSEEventStorage
 
 logger = logging.getLogger(__name__)
@@ -66,9 +67,12 @@ class DagsterRunMonitor:
       try:
         from dagster_graphql import DagsterGraphQLClient
 
+        # Explicit timeout: the library default is 300 s, and these calls run
+        # on the API event loop — a hung webserver must not hold every tenant.
         self._client = DagsterGraphQLClient(
           hostname=self.dagster_host,
           port_number=self.dagster_port,
+          timeout=DAGSTER_CLIENT_TIMEOUT_SECONDS,
         )
       except ImportError:
         logger.error(
@@ -235,7 +239,8 @@ class DagsterRunMonitor:
         }
 
       try:
-        status_info = self.get_run_status(run_id)
+        # Sync HTTP under the hood; keep it off the event loop.
+        status_info = await asyncio.to_thread(self.get_run_status, run_id)
       except Exception as e:
         logger.error(f"Failed to get run status: {e}")
         await asyncio.sleep(self.poll_interval)
@@ -304,7 +309,8 @@ async def run_and_monitor_dagster_job(
   monitor = DagsterRunMonitor()
 
   try:
-    run_id = monitor.submit_job(job_name, run_config, tags)
+    # Sync HTTP submit; runs as a background task on the API loop, so offload.
+    run_id = await asyncio.to_thread(monitor.submit_job, job_name, run_config, tags)
 
     await monitor.emit_started(operation_id, job_name, run_id)
 

--- a/robosystems/middleware/sse/redis_subscriber.py
+++ b/robosystems/middleware/sse/redis_subscriber.py
@@ -108,8 +108,12 @@ class RedisEventSubscriber:
           await asyncio.sleep(1.0)
           continue
 
-        message = await asyncio.wait_for(
-          self.pubsub.get_message(ignore_subscribe_messages=True), timeout=1.0
+        # The timeout must be get_message's own: with redis-py's default
+        # (timeout=0.0) it returns immediately and the `continue` below spins
+        # the loop at full speed whenever any stream is open. wait_for around
+        # an instantly-returning call throttles nothing.
+        message = await self.pubsub.get_message(
+          ignore_subscribe_messages=True, timeout=1.0
         )
 
         if message is None:

--- a/robosystems/models/core/graph/graph_credits.py
+++ b/robosystems/models/core/graph/graph_credits.py
@@ -188,21 +188,25 @@ class GraphCredits(Base):
     request_id: str | None = None,
     user_id: str | None = None,
     metadata: dict[str, Any] | None = None,
+    drain_on_shortfall: bool = False,
   ) -> dict[str, Any]:
-    """Atomically deduct credits for a completed AI operation.
+    """Atomically deduct credits for a completed operation.
 
     The deduction and its balance check happen in one conditional UPDATE, so
     concurrent callers cannot drive the pool negative. Returns
     ``{"success": False, "error": "Insufficient credits", ...}`` rather than
     raising when the pool cannot cover ``amount``.
 
-    Billing is post-hoc — the model call has already been paid for by the
-    time this runs — so a pool that cannot cover the whole cost is **drained
-    to zero** rather than left untouched: what is there is debited, the
-    shortfall is recorded on the transaction, and the result still reports
-    ``success: False`` so the caller stops the run. Leaving the balance in
-    place would let the same request re-enter the band above the pre-flight
-    estimate and below one call's true cost indefinitely, billed nothing.
+    ``drain_on_shortfall`` selects what happens when the pool is short. By
+    default the balance is **left untouched** — the operation is simply
+    refused, and any remainder stays available for a cheaper one. Set it only
+    on a **post-hoc** charge (an AI call already paid for by the time this
+    runs), where instead the pool is **drained to zero**: what is there is
+    debited, the shortfall is recorded, and the result still reports
+    ``success: False`` so the caller stops. Draining there stops the same
+    request re-entering the band above the pre-flight estimate and below one
+    call's true cost, billed nothing; draining a *pre*-check would wrongly
+    destroy credits the user holds.
 
     ``metadata`` (token counts and the like) is merged into the transaction
     record; the built-in keys win on collision.
@@ -235,16 +239,30 @@ class GraphCredits(Base):
       consumption_result = result.fetchone()
 
       if not consumption_result:
-        return self._drain_for_shortfall(
-          actual_cost=actual_cost,
-          operation_type=operation_type,
-          operation_description=operation_description,
-          session=session,
-          request_id=request_id,
-          user_id=user_id,
-          metadata=metadata,
-          transaction_id=transaction_id,
+        if drain_on_shortfall:
+          return self._drain_for_shortfall(
+            actual_cost=actual_cost,
+            operation_type=operation_type,
+            operation_description=operation_description,
+            session=session,
+            request_id=request_id,
+            user_id=user_id,
+            metadata=metadata,
+            transaction_id=transaction_id,
+          )
+        # Pre-check semantics: refuse, leave the balance for a cheaper op.
+        current_result = session.execute(
+          text("SELECT current_balance FROM graph_credits WHERE id = :credits_id"),
+          {"credits_id": self.id},
         )
+        current_balance = current_result.fetchone()
+        available_balance = float(current_balance[0]) if current_balance else 0
+        return {
+          "success": False,
+          "error": "Insufficient credits",
+          "required_credits": float(actual_cost),
+          "available_credits": available_balance,
+        }
 
       GraphCreditTransaction.create_transaction(
         graph_credits_id=self.id,

--- a/robosystems/models/core/graph/graph_credits.py
+++ b/robosystems/models/core/graph/graph_credits.py
@@ -196,6 +196,14 @@ class GraphCredits(Base):
     ``{"success": False, "error": "Insufficient credits", ...}`` rather than
     raising when the pool cannot cover ``amount``.
 
+    Billing is post-hoc — the model call has already been paid for by the
+    time this runs — so a pool that cannot cover the whole cost is **drained
+    to zero** rather than left untouched: what is there is debited, the
+    shortfall is recorded on the transaction, and the result still reports
+    ``success: False`` so the caller stops the run. Leaving the balance in
+    place would let the same request re-enter the band above the pre-flight
+    estimate and below one call's true cost indefinitely, billed nothing.
+
     ``metadata`` (token counts and the like) is merged into the transaction
     record; the built-in keys win on collision.
     """
@@ -227,19 +235,16 @@ class GraphCredits(Base):
       consumption_result = result.fetchone()
 
       if not consumption_result:
-        current_result = session.execute(
-          text("SELECT current_balance FROM graph_credits WHERE id = :credits_id"),
-          {"credits_id": self.id},
+        return self._drain_for_shortfall(
+          actual_cost=actual_cost,
+          operation_type=operation_type,
+          operation_description=operation_description,
+          session=session,
+          request_id=request_id,
+          user_id=user_id,
+          metadata=metadata,
+          transaction_id=transaction_id,
         )
-        current_balance = current_result.fetchone()
-        available_balance = float(current_balance[0]) if current_balance else 0
-
-        return {
-          "success": False,
-          "error": "Insufficient credits",
-          "required_credits": float(actual_cost),
-          "available_credits": available_balance,
-        }
 
       GraphCreditTransaction.create_transaction(
         graph_credits_id=self.id,
@@ -281,6 +286,118 @@ class GraphCredits(Base):
         "success": False,
         "error": f"Credit consumption failed: {e!s}",
       }
+
+  def _drain_for_shortfall(
+    self,
+    *,
+    actual_cost: Decimal,
+    operation_type: str,
+    operation_description: str,
+    session: Session,
+    request_id: str | None,
+    user_id: str | None,
+    metadata: dict[str, Any] | None,
+    transaction_id: str,
+  ) -> dict[str, Any]:
+    """The insufficient-balance branch of :meth:`consume_credits_atomic`.
+
+    Debits whatever the pool still holds (to exactly zero) and records the
+    shortfall, so a completed call is never billed nothing and the next
+    pre-flight — which reads the now-empty balance — denies. A pool already
+    at zero records nothing. The ``FOR UPDATE`` read and the conditional
+    ``UPDATE`` run as one statement so a concurrent drain cannot double-take.
+    """
+    from sqlalchemy import text
+
+    drain = session.execute(
+      text("""
+        WITH prev AS (
+          SELECT current_balance AS old_balance
+          FROM graph_credits
+          WHERE id = :credits_id
+          FOR UPDATE
+        )
+        UPDATE graph_credits
+        SET current_balance = 0,
+            updated_at = :updated_at
+        FROM prev
+        WHERE graph_credits.id = :credits_id
+          AND prev.old_balance > 0
+          AND prev.old_balance < :actual_cost
+        RETURNING prev.old_balance AS drained
+      """),
+      {
+        "actual_cost": actual_cost,
+        "updated_at": datetime.now(UTC),
+        "credits_id": self.id,
+      },
+    )
+    drained_row = drain.fetchone()
+
+    if not drained_row:
+      # Nothing to take: the pool was already empty (or a concurrent caller
+      # drained it first). Report the balance as it stands.
+      current_result = session.execute(
+        text("SELECT current_balance FROM graph_credits WHERE id = :credits_id"),
+        {"credits_id": self.id},
+      )
+      current_balance = current_result.fetchone()
+      available_balance = float(current_balance[0]) if current_balance else 0
+
+      return {
+        "success": False,
+        "error": "Insufficient credits",
+        "required_credits": float(actual_cost),
+        "available_credits": available_balance,
+        "credits_consumed": 0.0,
+        "shortfall": float(actual_cost) - available_balance,
+      }
+
+    drained = Decimal(str(drained_row.drained))
+    shortfall = actual_cost - drained
+
+    GraphCreditTransaction.create_transaction(
+      graph_credits_id=self.id,
+      transaction_type=CreditTransactionType.CONSUMPTION,
+      amount=-drained,
+      description=operation_description,
+      metadata={
+        **(metadata or {}),
+        "operation_type": operation_type,
+        "base_cost": str(actual_cost),
+        "transaction_id": transaction_id,
+        "drained_to_zero": True,
+        "shortfall": str(shortfall),
+      },
+      session=session,
+      idempotency_key=f"consume_{transaction_id}",
+      request_id=request_id,
+      operation_id=transaction_id,
+      graph_id=self.graph_id,
+      user_id=user_id or self.user_id,
+    )
+
+    self.current_balance = Decimal("0")
+    self.updated_at = datetime.now(UTC)
+
+    session.commit()
+
+    logger.warning(
+      f"Credit pool for graph {self.graph_id} drained to zero: "
+      f"call cost {actual_cost}, billed {drained}, shortfall {shortfall}"
+    )
+
+    return {
+      "success": False,
+      "error": "Insufficient credits",
+      "required_credits": float(actual_cost),
+      "available_credits": 0.0,
+      "credits_consumed": float(drained),
+      "shortfall": float(shortfall),
+      "drained_to_zero": True,
+      "base_cost": float(actual_cost),
+      "transaction_id": transaction_id,
+    }
 
   def _expire_unspent(
     self,

--- a/robosystems/models/core/user/user_repository_credits.py
+++ b/robosystems/models/core/user/user_repository_credits.py
@@ -313,15 +313,19 @@ class UserRepositoryCredits(Base):
     drained = Decimal(str(drained_row.drained))
     shortfall = amount - drained
 
+    # Built-ins win on collision: these are the audit-critical fields the drain
+    # exists to record, so a caller-supplied `metadata` key must not overwrite
+    # them. Matches GraphCredits._drain_for_shortfall (the success path above
+    # spreads caller-last, but that record is not audit-critical the way this
+    # one is).
     transaction_metadata = {
+      **(metadata or {}),
       "repository": repository_name,
       "operation_type": operation_type,
       "drained_to_zero": True,
       "true_cost": str(amount),
       "shortfall": str(shortfall),
     }
-    if metadata:
-      transaction_metadata.update(metadata)
 
     UserRepositoryCreditTransaction.create_transaction(
       credit_pool_id=cast(str, self.id),

--- a/robosystems/models/core/user/user_repository_credits.py
+++ b/robosystems/models/core/user/user_repository_credits.py
@@ -181,6 +181,11 @@ class UserRepositoryCredits(Base):
     Returns False rather than raising when the pool is inactive or short. The
     balance check rides inside the UPDATE's WHERE clause, so concurrent callers
     cannot both pass it.
+
+    Billing here is post-hoc (the AI call has already happened), so a short
+    pool is drained to zero rather than left untouched — the shortfall is
+    recorded on the transaction and the call still returns False so the run
+    stops. See ``GraphCredits.consume_credits_atomic`` for the rationale.
     """
     if not self.is_active:
       logger.warning(f"Attempted to consume credits from inactive pool {self.id}")
@@ -208,10 +213,16 @@ class UserRepositoryCredits(Base):
       session.refresh(self)
       if not self.is_active:
         logger.warning(f"Attempted to consume credits from inactive pool {self.id}")
-      else:
-        logger.warning(
-          f"Insufficient credits in pool {self.id}: need {amount}, have {self.current_balance}"
-        )
+        return False
+
+      self._drain_for_shortfall(
+        amount=amount,
+        repository_name=repository_name,
+        operation_type=operation_type,
+        session=session,
+        metadata=metadata,
+        now=now,
+      )
       return False
 
     session.refresh(self)
@@ -249,6 +260,82 @@ class UserRepositoryCredits(Base):
     )
 
     return True
+
+  def _drain_for_shortfall(
+    self,
+    *,
+    amount: Decimal,
+    repository_name: str,
+    operation_type: str,
+    session: Session,
+    metadata: dict[str, Any] | None,
+    now: datetime,
+  ) -> None:
+    """Debit whatever an active-but-short pool still holds, down to zero.
+
+    Records the shortfall on the transaction so the call is billed for what
+    was there and the next pre-flight, reading an empty pool, denies. A pool
+    already at zero records nothing.
+    """
+    from sqlalchemy import text
+
+    drain = session.execute(
+      text("""
+        WITH prev AS (
+          SELECT current_balance AS old_balance
+          FROM user_repository_credits
+          WHERE id = :credit_id
+          FOR UPDATE
+        )
+        UPDATE user_repository_credits
+        SET current_balance = 0,
+            credits_consumed_this_month = credits_consumed_this_month + prev.old_balance,
+            last_consumption_at = :now,
+            updated_at = :now
+        FROM prev
+        WHERE user_repository_credits.id = :credit_id
+          AND user_repository_credits.is_active = true
+          AND prev.old_balance > 0
+          AND prev.old_balance < :amount
+        RETURNING prev.old_balance AS drained
+      """),
+      {"amount": float(amount), "now": now, "credit_id": self.id},
+    )
+    drained_row = drain.fetchone()
+    session.refresh(self)
+
+    if not drained_row:
+      logger.warning(
+        f"Insufficient credits in pool {self.id}: need {amount}, have {self.current_balance}"
+      )
+      return
+
+    drained = Decimal(str(drained_row.drained))
+    shortfall = amount - drained
+
+    transaction_metadata = {
+      "repository": repository_name,
+      "operation_type": operation_type,
+      "drained_to_zero": True,
+      "true_cost": str(amount),
+      "shortfall": str(shortfall),
+    }
+    if metadata:
+      transaction_metadata.update(metadata)
+
+    UserRepositoryCreditTransaction.create_transaction(
+      credit_pool_id=cast(str, self.id),
+      transaction_type=UserRepositoryCreditTransactionType.CONSUMPTION,
+      amount=-drained,
+      description=f"{repository_name} {operation_type} (pool drained; shortfall {shortfall})",
+      metadata=transaction_metadata,
+      session=session,
+    )
+
+    logger.warning(
+      f"Credit pool {self.id} drained to zero: call cost {amount}, "
+      f"billed {drained}, shortfall {shortfall}"
+    )
 
   def allocate_monthly_credits(self, session: Session) -> bool:
     """Allocate monthly credits if due. Credits do not roll over.

--- a/robosystems/models/core/user/user_repository_credits.py
+++ b/robosystems/models/core/user/user_repository_credits.py
@@ -175,6 +175,7 @@ class UserRepositoryCredits(Base):
     operation_type: str,
     session: Session,
     metadata: dict[str, Any] | None = None,
+    drain_on_shortfall: bool = False,
   ) -> bool:
     """Consume credits for a repository operation.
 
@@ -182,10 +183,11 @@ class UserRepositoryCredits(Base):
     balance check rides inside the UPDATE's WHERE clause, so concurrent callers
     cannot both pass it.
 
-    Billing here is post-hoc (the AI call has already happened), so a short
-    pool is drained to zero rather than left untouched — the shortfall is
-    recorded on the transaction and the call still returns False so the run
-    stops. See ``GraphCredits.consume_credits_atomic`` for the rationale.
+    ``drain_on_shortfall`` (see ``GraphCredits.consume_credits_atomic``):
+    default leaves a short pool untouched and just refuses; set it only on a
+    post-hoc AI charge, where the pool is instead drained to zero and the
+    shortfall recorded. Draining a pre-check would destroy credits the user
+    still holds.
     """
     if not self.is_active:
       logger.warning(f"Attempted to consume credits from inactive pool {self.id}")
@@ -215,14 +217,20 @@ class UserRepositoryCredits(Base):
         logger.warning(f"Attempted to consume credits from inactive pool {self.id}")
         return False
 
-      self._drain_for_shortfall(
-        amount=amount,
-        repository_name=repository_name,
-        operation_type=operation_type,
-        session=session,
-        metadata=metadata,
-        now=now,
-      )
+      if drain_on_shortfall:
+        self._drain_for_shortfall(
+          amount=amount,
+          repository_name=repository_name,
+          operation_type=operation_type,
+          session=session,
+          metadata=metadata,
+          now=now,
+        )
+      else:
+        # Pre-check semantics: refuse, leave the remainder for a cheaper op.
+        logger.warning(
+          f"Insufficient credits in pool {self.id}: need {amount}, have {self.current_balance}"
+        )
       return False
 
     session.refresh(self)

--- a/robosystems/operations/graph/credit_service.py
+++ b/robosystems/operations/graph/credit_service.py
@@ -124,6 +124,7 @@ class CreditService:
     idempotency_key: str | None = None,
     request_id: str | None = None,
     operation_id: str | None = None,
+    drain_on_shortfall: bool = False,
   ) -> dict[str, Any]:
     """Debit ``base_cost`` for an operation, returning the outcome as a dict.
 
@@ -160,15 +161,16 @@ class CreditService:
         metadata=metadata,
         cached=cached,
         base_cost=base_cost,
+        drain_on_shortfall=drain_on_shortfall,
       )
 
     parent_graph_id = self._get_parent_graph_id(graph_id)
 
-    # No cached pre-reject here, deliberately. This path is reached only after
-    # the billable call has completed, so there is always a real debit to make:
-    # a short pool is drained to zero by the atomic consume below, and an early
-    # return on a stale cached balance would skip exactly that. The cheap
-    # check belongs in the pre-flight (`check_credit_balance`), not here.
+    # No cached pre-reject here, deliberately. When called with
+    # drain_on_shortfall (the post-hoc AI path), an early return on a stale
+    # cached balance would skip the drain the atomic consume below performs.
+    # The cheap balance check belongs in the pre-flight (`check_credit_balance`),
+    # not on this post-charge path.
     credits = GraphCredits.get_by_graph_id(parent_graph_id, self.session)
     if not credits:
       return {
@@ -186,6 +188,7 @@ class CreditService:
       request_id=request_id,
       user_id=user_id,
       metadata=metadata,
+      drain_on_shortfall=drain_on_shortfall,
     )
 
     if consumption_result["success"]:
@@ -802,6 +805,7 @@ class CreditService:
     metadata: dict[str, Any] | None = None,
     cached: bool = False,
     base_cost: Decimal | None = None,
+    drain_on_shortfall: bool = False,
   ) -> dict[str, Any]:
     """Debit a user's repository pool. Missing add-on returns
     ``requires_addon``.
@@ -839,6 +843,7 @@ class CreditService:
       operation_type=operation_type,
       session=self.session,
       metadata=metadata,
+      drain_on_shortfall=drain_on_shortfall,
     )
 
     if success:
@@ -1041,6 +1046,9 @@ class CreditService:
       base_cost=total_cost,
       metadata=token_metadata,
       user_id=user_id,
+      # Post-hoc: the model call already happened, so a short pool drains to
+      # zero and records the shortfall rather than leaving a re-enterable band.
+      drain_on_shortfall=True,
     )
 
 

--- a/robosystems/operations/graph/credit_service.py
+++ b/robosystems/operations/graph/credit_service.py
@@ -164,24 +164,11 @@ class CreditService:
 
     parent_graph_id = self._get_parent_graph_id(graph_id)
 
-    from ...middleware.billing.cache import credit_cache
-
-    cached_data = credit_cache.get_cached_graph_credit_balance(parent_graph_id)
-
-    if cached_data:
-      # Cheap reject before touching the database; the authoritative check is
-      # inside the atomic consume below.
-      balance, graph_tier = cached_data
-
-      if balance < base_cost:
-        return {
-          "success": False,
-          "error": "Insufficient credits",
-          "credits_consumed": 0,
-          "required_credits": float(base_cost),
-          "available_credits": float(balance),
-        }
-
+    # No cached pre-reject here, deliberately. This path is reached only after
+    # the billable call has completed, so there is always a real debit to make:
+    # a short pool is drained to zero by the atomic consume below, and an early
+    # return on a stale cached balance would skip exactly that. The cheap
+    # check belongs in the pre-flight (`check_credit_balance`), not here.
     credits = GraphCredits.get_by_graph_id(parent_graph_id, self.session)
     if not credits:
       return {
@@ -276,18 +263,58 @@ class CreditService:
         "transaction_id": consumption_result["transaction_id"],
       }
     else:
-      # Drop the cached balance so the next check re-reads the database.
+      drained = Decimal(str(consumption_result.get("credits_consumed", 0) or 0))
+
+      # Drop the cached balance so the next check re-reads the database. On a
+      # drain-to-zero, pin the cache at zero as well: the pre-flight prefers
+      # the cached figure, and a stale positive balance there would re-admit
+      # the very request the drain exists to stop.
       try:
         from ...middleware.billing.cache import credit_cache
 
         credit_cache.invalidate_graph_credit_balance(parent_graph_id)
+        if consumption_result.get("drained_to_zero"):
+          credit_cache.cache_graph_credit_balance(
+            graph_id=parent_graph_id,
+            balance=Decimal("0"),
+            graph_tier=(
+              credits.graph_tier.value
+              if hasattr(credits.graph_tier, "value")
+              else str(credits.graph_tier)
+            ),
+          )
       except Exception as e:
-        logger.warning(f"Failed to invalidate credit cache: {e}")
+        logger.warning(f"Failed to update credit cache after shortfall: {e}")
+
+      # A drain is real spend, so the usage ledger records it like any other
+      # debit — otherwise the dashboards under-report exactly the calls that
+      # exhausted the pool.
+      if drained > 0 and user_id:
+        try:
+          GraphUsage.record_credit_consumption(
+            user_id=user_id,
+            graph_id=graph_id,
+            graph_tier=(
+              credits.graph_tier.value
+              if hasattr(credits.graph_tier, "value")
+              else str(credits.graph_tier)
+            ),
+            operation_type=operation_type,
+            credits_consumed=drained,
+            base_credit_cost=base_cost,
+            session=self.session,
+            cached_operation=cached,
+            metadata=metadata,
+          )
+        except Exception as e:
+          logger.warning(f"Failed to record drained credit usage for {graph_id}: {e}")
 
       return {
         "success": False,
         "error": consumption_result.get("error", "Credit consumption failed"),
-        "credits_consumed": 0,
+        "credits_consumed": float(drained),
+        "shortfall": consumption_result.get("shortfall"),
+        "drained_to_zero": bool(consumption_result.get("drained_to_zero", False)),
         "required_credits": consumption_result.get(
           "required_credits",
           float(base_cost),

--- a/robosystems/operations/graph/subgraph_service.py
+++ b/robosystems/operations/graph/subgraph_service.py
@@ -480,10 +480,13 @@ class SubgraphService:
       ]
       if database_name not in existing_database_ids:
         logger.warning(f"Database {database_name} does not exist on instance")
+        # The subgraph is still going away — its indexed documents go with it.
+        search_purged = await self._purge_subgraph_search_index(subgraph_id)
         return {
           "status": "not_found",
           "graph_id": subgraph_id,
           "message": "Subgraph database does not exist",
+          "search_purged": search_purged,
         }
 
       if is_local:
@@ -504,6 +507,8 @@ class SubgraphService:
 
       logger.info(f"Successfully deleted subgraph database {subgraph_id}")
 
+      search_purged = await self._purge_subgraph_search_index(subgraph_id)
+
       return {
         "status": "deleted",
         "graph_id": subgraph_id,
@@ -511,11 +516,42 @@ class SubgraphService:
         "parent_graph_id": parent_graph_id,
         "instance_id": instance_id,
         "deleted_at": datetime.now(UTC).isoformat(),
+        "search_purged": search_purged,
       }
 
     except Exception as e:
       logger.error(f"Failed to delete subgraph database {subgraph_id}: {e}")
       raise GraphAllocationError(f"Failed to delete subgraph: {e!s}")
+
+  async def _purge_subgraph_search_index(self, subgraph_id: str) -> bool:
+    """Drop a subgraph's documents from the shared OpenSearch index.
+
+    Documents are indexed under the subgraph id, and the index is shared
+    across tenants with only an application-level graph_id filter as the
+    boundary — so a subgraph deleted ahead of its parent's teardown would
+    otherwise leave its content indexed indefinitely, and a recreated subgraph
+    of the same (user-chosen, reusable) name would surface it. The parent's
+    teardown cannot catch it: it purges by iterating subgraph rows that this
+    path has already removed. Best-effort, guarded on the search flag, and
+    run off the event loop because the OpenSearch client is synchronous.
+    """
+    if not env.SEMANTIC_SEARCH_ENABLED:
+      return False
+    try:
+      import asyncio
+
+      from ...operations.search.client import OpenSearchClient
+
+      client = OpenSearchClient(env.OPENSEARCH_URL, env.OPENSEARCH_INDEX)
+      await asyncio.to_thread(client.delete_by_graph_id, subgraph_id)
+      logger.info(f"Purged search index for subgraph {subgraph_id}")
+      return True
+    except Exception as e:
+      logger.warning(
+        f"Search index purge failed for subgraph {subgraph_id}: {e}",
+        extra={"graph_id": subgraph_id},
+      )
+      return False
 
   async def list_subgraph_databases(
     self,

--- a/robosystems/operations/operators/adapters/api.py
+++ b/robosystems/operations/operators/adapters/api.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from robosystems.logger import logger
-from robosystems.operations.operators.ai_client import AIClient
+from robosystems.operations.operators.ai_client import get_ai_client
 from robosystems.operations.operators.base import (
   OperatorMode,
   OperatorResult,
@@ -68,7 +68,7 @@ async def run_operator_api(
   tools = HttpToolAccess(
     graph_id, read_only=operator.spec.read_only, user_id=str(user.id)
   )
-  ai_client = AIClient()
+  ai_client = get_ai_client()
 
   if db_session is None:
     logger.error(

--- a/robosystems/operations/operators/adapters/worker.py
+++ b/robosystems/operations/operators/adapters/worker.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 from robosystems.db.platform import SessionFactory
 from robosystems.logger import logger
-from robosystems.operations.operators.ai_client import AIClient
+from robosystems.operations.operators.ai_client import get_ai_client
 from robosystems.operations.operators.base import (
   OperatorMode,
   enforce_operator_graph_scope,
@@ -64,7 +64,7 @@ async def run_operator_worker(
     preflight_session.close()
 
   tools = DirectToolAccess(graph_id, user_id=user_id)
-  ai_client = AIClient()
+  ai_client = get_ai_client()
   credit_consumer = FactoryCreditConsumer()
 
   tracked_ai = TrackedAIClient(

--- a/robosystems/operations/operators/ai_client.py
+++ b/robosystems/operations/operators/ai_client.py
@@ -5,7 +5,9 @@ Explorer alongside everything else, emits CloudWatch token metrics, and lets
 IAM rather than a shared API key control who can call a model.
 """
 
+import asyncio
 import json
+import threading
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -131,6 +133,15 @@ class AIClient:
       messages, system, max_tokens, temperature, model_id, tools
     )
 
+  def _invoke_model_sync(
+    self, model: str, request_body: dict[str, Any]
+  ) -> dict[str, Any]:
+    response = self.client.invoke_model(
+      modelId=model,
+      body=json.dumps(request_body),
+    )
+    return json.loads(response["body"].read())
+
   async def _bedrock_create_message(
     self,
     messages: list[AIMessage],
@@ -154,12 +165,14 @@ class AIClient:
     if tools:
       request_body["tools"] = tools
 
-    response = self.client.invoke_model(
-      modelId=model,
-      body=json.dumps(request_body),
+    # botocore is synchronous and a model call can take minutes; run it on a
+    # worker thread so the event loop — shared by every tenant on this task —
+    # is not held for the duration. The default executor, not `run_off_loop`:
+    # that limiter fronts short OLTP work and must not be exhausted by
+    # minutes-long calls.
+    response_body = await asyncio.to_thread(
+      self._invoke_model_sync, model, request_body
     )
-
-    response_body = json.loads(response["body"].read())
 
     # A response may interleave text and tool_use blocks; the first block
     # is not guaranteed to be text (a pure tool_use turn has none). Join every
@@ -178,3 +191,23 @@ class AIClient:
       stop_reason=response_body.get("stop_reason"),
       content_blocks=blocks,
     )
+
+
+_shared_client: AIClient | None = None
+_shared_client_lock = threading.Lock()
+
+
+def get_ai_client() -> AIClient:
+  """Process-wide `AIClient`.
+
+  boto3 clients are thread-safe, and constructing one per request put a
+  synchronous client build plus an STS round-trip on the event loop every
+  time an operator ran. A failed construction is not cached, so the next
+  call retries.
+  """
+  global _shared_client
+  if _shared_client is None:
+    with _shared_client_lock:
+      if _shared_client is None:
+        _shared_client = AIClient()
+  return _shared_client

--- a/robosystems/worker/consumer.py
+++ b/robosystems/worker/consumer.py
@@ -92,9 +92,18 @@ async def run() -> None:
         await queue.lrem(inflight_key, 1, task_json)
         continue
 
-      await _process_task(
-        task_data, task_json, queue, inflight_key, manager, worker_id, protection
-      )
+      try:
+        await _process_task(
+          task_data, task_json, queue, inflight_key, manager, worker_id, protection
+        )
+      except Exception:
+        # A task must never take the worker down with it. `_process_task`
+        # handles its own failure reporting; anything that escapes it is
+        # logged and the loop moves on to the next task.
+        logger.exception(
+          f"Unhandled error processing task {task_data.get('task_id')}; "
+          f"worker continues"
+        )
   finally:
     logger.info(f"Worker shutting down: {worker_id}")
     depth_publisher.stop()
@@ -106,6 +115,22 @@ async def run() -> None:
       # server-side close will release any remaining resources.
       logger.debug(f"Connection error during queue close (expected on shutdown): {exc}")
     logger.info(f"Worker terminated: {worker_id}")
+
+
+async def _fail_quietly(manager: OperationManager, task_id: str, **kwargs: Any) -> None:
+  """Record a task failure without letting the recording itself raise.
+
+  `fail_operation` raises when the operation's metadata has already expired
+  (a task outliving its SSE TTL). Raising from inside an `except` handler
+  would escape `_process_task` and, with nothing above it, exit the worker —
+  so one expired long task would kill the process. Log and carry on instead.
+  """
+  try:
+    await manager.fail_operation(task_id, **kwargs)
+  except Exception as exc:
+    logger.error(
+      f"Could not record failure for task {task_id}: {type(exc).__name__}: {exc}"
+    )
 
 
 async def _process_task(
@@ -189,7 +214,8 @@ async def _process_task(
           "duration_ms": duration_ms,
         },
       )
-      await manager.fail_operation(
+      await _fail_quietly(
+        manager,
         task_id,
         error=f"Task timed out after {timeout}s",
         error_details={"error_type": "TimeoutError", "timeout_seconds": timeout},
@@ -205,7 +231,8 @@ async def _process_task(
           "graph_id": graph_id,
         },
       )
-      await manager.fail_operation(
+      await _fail_quietly(
+        manager,
         task_id,
         error=str(e),
         error_details={"error_type": type(e).__name__},

--- a/robosystems/worker/tasks/dagster_monitoring.py
+++ b/robosystems/worker/tasks/dagster_monitoring.py
@@ -40,7 +40,7 @@ class DagsterJobMonitorTask(BaseTask):
     monitor = DagsterRunMonitor()
 
     try:
-      run_id = monitor.submit_job(job_name, run_config, tags)
+      run_id = await asyncio.to_thread(monitor.submit_job, job_name, run_config, tags)
       await self.report_progress(f"Submitted {job_name}", percent=5)
 
       # Poll with cancellation checks between iterations.
@@ -52,7 +52,7 @@ class DagsterJobMonitorTask(BaseTask):
           logger.info(f"Dagster job monitor cancelled: {job_name} (run_id={run_id})")
           return {"status": "cancelled", "run_id": run_id, "job_name": job_name}
 
-        status_info = monitor.get_run_status(run_id)
+        status_info = await asyncio.to_thread(monitor.get_run_status, run_id)
         current_status = status_info["status"]
 
         if current_status == "completed":

--- a/tests/config/test_validation.py
+++ b/tests/config/test_validation.py
@@ -44,6 +44,11 @@ class MockEnvConfig:
     # in validation.py reads these.
     self.PARAMETER_STORE_AVAILABLE = True
     self.FEATURE_FLAGS_PRELOADED = True
+    # A healthy boot preloaded every safety-critical flag by name. The
+    # per-flag canary asserts membership, not value.
+    self.PRELOADED_FEATURE_FLAG_NAMES = frozenset(
+      EnvValidator.SAFETY_CRITICAL_FEATURE_FLAGS
+    )
 
 
 class TestParameterStoreReachability:
@@ -81,10 +86,35 @@ class TestParameterStoreReachability:
       with pytest.raises(ConfigValidationError):
         EnvValidator.validate_required_vars(cfg)
 
+  def test_one_safety_flag_absent_from_ssm_refuses_boot(self):
+    """The batched SSM read returns only the parameters that exist, so a single
+    safety-critical flag missing (here BILLING_ENABLED) passes the per-store
+    checks and resolves silently to its permissive code default. The per-flag
+    canary must catch it."""
+    cfg = self._prod()
+    cfg.PRELOADED_FEATURE_FLAG_NAMES = frozenset(
+      f for f in EnvValidator.SAFETY_CRITICAL_FEATURE_FLAGS if f != "BILLING_ENABLED"
+    )
+    with patch("os.getenv", return_value=None):
+      with pytest.raises(ConfigValidationError):
+        EnvValidator.validate_required_vars(cfg)
+
+  def test_a_safety_flag_present_but_false_is_accepted(self):
+    """Presence is asserted, not value: `false` is a legitimate setting (e.g.
+    USER_REGISTRATION_ENABLED off on staging). Membership is all that matters."""
+    cfg = self._prod()
+    # Every flag present; the canary must not fire on the values.
+    cfg.PRELOADED_FEATURE_FLAG_NAMES = frozenset(
+      EnvValidator.SAFETY_CRITICAL_FEATURE_FLAGS
+    )
+    with patch("os.getenv", return_value=None):
+      EnvValidator.validate_required_vars(cfg)  # does not raise
+
   def test_dev_is_never_subject_to_the_reachability_assertion(self):
     cfg = MockEnvConfig()  # ENVIRONMENT="dev"
     cfg.PARAMETER_STORE_AVAILABLE = False
     cfg.FEATURE_FLAGS_PRELOADED = False
+    cfg.PRELOADED_FEATURE_FLAG_NAMES = frozenset()
     cfg.RATE_LIMIT_ENABLED = False
     with patch("os.getenv", return_value=None):
       EnvValidator.validate_required_vars(cfg)  # does not raise

--- a/tests/graph_api/core/duckdb/test_execute_write_log_redaction.py
+++ b/tests/graph_api/core/duckdb/test_execute_write_log_redaction.py
@@ -1,0 +1,47 @@
+"""The pre-execution INFO log in execute_write must not leak the extensions DSN.
+
+`execute_write` runs postgres_scanner statements whose leading characters carry
+the libpq connstr — host, user, and password. #1213 redacted the *error* path;
+this covers the pre-execution log, which previously relied only on a `[:100]`
+truncation happening to cut ahead of the password.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from robosystems.graph_api.core.duckdb.manager import DuckDBTableManager
+from robosystems.graph_api.models.tables import TableQueryRequest
+
+MODULE = "robosystems.graph_api.core.duckdb.manager"
+
+
+@pytest.mark.unit
+def test_execute_write_info_log_redacts_the_dsn(monkeypatch):
+  # The INFO log fires before the pool is used; make the pool blow up so the
+  # test needs no real DuckDB — the line is already emitted by then.
+  def _boom():
+    raise RuntimeError("no pool in test")
+
+  monkeypatch.setattr(f"{MODULE}.get_duckdb_pool", _boom)
+  fake_logger = MagicMock()
+  monkeypatch.setattr(f"{MODULE}.logger", fake_logger)
+
+  secret_sql = (
+    "ATTACH 'dbname=extensions user=postgres password=hunter2 "
+    "host=rds.internal port=5432' AS ext (TYPE postgres); "
+    "INSERT INTO staging SELECT * FROM postgres_scan('...', 'kg1', 'line_items')"
+  )
+  request = TableQueryRequest(graph_id="kg1a2b3c4d5e6f7890ab", sql=secret_sql)
+
+  manager = DuckDBTableManager()
+  with pytest.raises((RuntimeError, HTTPException)):
+    manager.execute_write(request)
+
+  info_calls = " ".join(
+    str(c.args) + str(c.kwargs) for c in fake_logger.info.call_args_list
+  )
+  assert "Executing write" in info_calls, "pre-execution log line not emitted"
+  assert "hunter2" not in info_calls
+  assert "password=***" in info_calls

--- a/tests/graph_api/routers/databases/test_db_query.py
+++ b/tests/graph_api/routers/databases/test_db_query.py
@@ -362,3 +362,19 @@ class TestDatabaseQueryRouter:
       data = response.json()
       assert data["count"] == 10000
       assert data.get("truncated") is True
+
+
+@pytest.mark.unit
+def test_execute_query_handler_is_sync_for_threadpool_offload():
+  """The handler must be a plain `def`, not `async def`.
+
+  Its body is entirely synchronous (the engine call, plus a Postgres read in
+  `_is_graph_rebuilding`). As `async def` it ran on the single event loop, so a
+  long query against the shared `sec` repo held every caller on the instance.
+  A plain `def` is run on Starlette's threadpool instead.
+  """
+  import inspect
+
+  from robosystems.graph_api.routers.databases.query import execute_query
+
+  assert not inspect.iscoroutinefunction(execute_query)

--- a/tests/middleware/sse/test_dagster_monitor.py
+++ b/tests/middleware/sse/test_dagster_monitor.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from robosystems.config.constants import DAGSTER_CLIENT_TIMEOUT_SECONDS
 from robosystems.middleware.sse.dagster_monitor import (
   DAGSTER_STATUS_MAP,
   DagsterRunMonitor,
@@ -172,7 +173,15 @@ class TestGetClient:
       ):
         client = m._get_client()
         assert client is mock_client_instance
-        mock_client_cls.assert_called_once_with(hostname="localhost", port_number=3000)
+        # An explicit, short timeout: the library default is 300 s, and the
+        # call runs on the API event loop. A hung webserver must not hold
+        # every tenant on the task for five minutes per poll.
+        mock_client_cls.assert_called_once_with(
+          hostname="localhost",
+          port_number=3000,
+          timeout=DAGSTER_CLIENT_TIMEOUT_SECONDS,
+        )
+        assert DAGSTER_CLIENT_TIMEOUT_SECONDS < 60
 
   @pytest.mark.unit
   def test_reuses_client_on_subsequent_calls(self, monitor, mock_dagster_client):

--- a/tests/middleware/sse/test_redis_subscriber.py
+++ b/tests/middleware/sse/test_redis_subscriber.py
@@ -32,7 +32,7 @@ def mock_pubsub():
   pubsub.subscribe = AsyncMock()
   pubsub.unsubscribe = AsyncMock()
   pubsub.close = AsyncMock()
-  pubsub.get_message = AsyncMock(return_value=None)
+  pubsub.get_message = AsyncMock(return_value=None)  # accepts timeout= kwarg
   return pubsub
 
 
@@ -266,6 +266,30 @@ class TestUnsubscribeFromOperation:
 
 class TestListenForEvents:
   @pytest.mark.unit
+  async def test_get_message_carries_its_own_blocking_timeout(
+    self, started_subscriber, mock_pubsub
+  ):
+    """The timeout must be `get_message`'s own argument. With redis-py's default
+    (`timeout=0.0`) the call returns immediately, and the `continue` on a None
+    message spins the listener at full speed whenever any stream is open —
+    ~37% of a core, measured. Wrapping an instantly-returning call in
+    `wait_for` throttles nothing, which is how this ran for months."""
+    seen: list[dict] = []
+
+    async def mock_get_message(ignore_subscribe_messages=True, timeout=None):
+      seen.append({"ignore": ignore_subscribe_messages, "timeout": timeout})
+      started_subscriber._running = False
+      return None
+
+    mock_pubsub.get_message = mock_get_message
+    started_subscriber.subscriptions["sse:events:op-123"] = True
+
+    await started_subscriber._listen_for_events()
+
+    assert seen, "listener never polled"
+    assert seen[0]["timeout"] is not None and seen[0]["timeout"] > 0
+
+  @pytest.mark.unit
   async def test_processes_valid_message(self, started_subscriber, mock_pubsub):
     """Test that a valid Redis message is parsed and broadcast."""
     event_dict = _make_sse_event_dict()
@@ -277,7 +301,7 @@ class TestListenForEvents:
 
     call_count = 0
 
-    async def mock_get_message(ignore_subscribe_messages=True):
+    async def mock_get_message(ignore_subscribe_messages=True, timeout=None):
       nonlocal call_count
       call_count += 1
       if call_count == 1:
@@ -316,7 +340,7 @@ class TestListenForEvents:
 
     call_count = 0
 
-    async def mock_get_message(ignore_subscribe_messages=True):
+    async def mock_get_message(ignore_subscribe_messages=True, timeout=None):
       nonlocal call_count
       call_count += 1
       if call_count == 1:
@@ -348,7 +372,7 @@ class TestListenForEvents:
 
     call_count = 0
 
-    async def mock_get_message(ignore_subscribe_messages=True):
+    async def mock_get_message(ignore_subscribe_messages=True, timeout=None):
       nonlocal call_count
       call_count += 1
       if call_count == 1:
@@ -381,7 +405,7 @@ class TestListenForEvents:
 
     call_count = 0
 
-    async def mock_get_message(ignore_subscribe_messages=True):
+    async def mock_get_message(ignore_subscribe_messages=True, timeout=None):
       nonlocal call_count
       call_count += 1
       if call_count == 1:
@@ -410,7 +434,7 @@ class TestListenForEvents:
 
     call_count = 0
 
-    async def mock_get_message(ignore_subscribe_messages=True):
+    async def mock_get_message(ignore_subscribe_messages=True, timeout=None):
       # Should not be called since there are no subscriptions
       raise AssertionError("get_message should not be called with no subscriptions")
 
@@ -471,7 +495,7 @@ class TestListenForEvents:
     """Test that TimeoutError from get_message is handled gracefully."""
     call_count = 0
 
-    async def mock_get_message(ignore_subscribe_messages=True):
+    async def mock_get_message(ignore_subscribe_messages=True, timeout=None):
       nonlocal call_count
       call_count += 1
       if call_count <= 1:
@@ -495,7 +519,7 @@ class TestListenForEvents:
   async def test_handles_cancelled_error(self, started_subscriber, mock_pubsub):
     """Test that CancelledError exits the listener cleanly."""
 
-    async def mock_get_message(ignore_subscribe_messages=True):
+    async def mock_get_message(ignore_subscribe_messages=True, timeout=None):
       raise asyncio.CancelledError()
 
     mock_pubsub.get_message = mock_get_message
@@ -517,7 +541,7 @@ class TestListenForEvents:
     """Test that general exceptions cause a brief sleep and retry."""
     call_count = 0
 
-    async def mock_get_message(ignore_subscribe_messages=True):
+    async def mock_get_message(ignore_subscribe_messages=True, timeout=None):
       nonlocal call_count
       call_count += 1
       if call_count == 1:
@@ -544,7 +568,7 @@ class TestListenForEvents:
     """Test that None messages from get_message are skipped."""
     call_count = 0
 
-    async def mock_get_message(ignore_subscribe_messages=True):
+    async def mock_get_message(ignore_subscribe_messages=True, timeout=None):
       nonlocal call_count
       call_count += 1
       if call_count <= 2:
@@ -581,7 +605,7 @@ class TestListenForEvents:
 
     call_count = 0
 
-    async def mock_get_message(ignore_subscribe_messages=True):
+    async def mock_get_message(ignore_subscribe_messages=True, timeout=None):
       nonlocal call_count
       call_count += 1
       if call_count == 1:

--- a/tests/models/core/graph/test_graph_credits.py
+++ b/tests/models/core/graph/test_graph_credits.py
@@ -218,8 +218,14 @@ class TestGraphCredits:
     assert transaction is not None
     assert transaction.amount == Decimal("-100")
 
-  def test_consume_credits_atomic_insufficient(self):
-    """Test atomic credit consumption with insufficient balance."""
+  def test_consume_credits_atomic_insufficient_drains_to_zero(self):
+    """A completed call that costs more than the pool holds drains the pool.
+
+    Billing is post-hoc, so refusing the debit would leave the balance in
+    place for the next request to re-enter the band above the pre-flight
+    estimate and below one call's true cost — billed nothing, indefinitely.
+    The call still reports ``success: False`` so the run stops.
+    """
     credits = GraphCredits(
       graph_id=self.graph.graph_id,
       user_id=self.user.id,
@@ -234,12 +240,100 @@ class TestGraphCredits:
       operation_type="agent_call",
       operation_description="AI Agent API call",
       session=self.session,
+      user_id=self.user.id,
     )
 
     assert result["success"] is False
     assert result["error"] == "Insufficient credits"
     assert result["required_credits"] == 100.0
-    assert result["available_credits"] == 50.0
+    # What was there is taken, the shortfall is reported, the pool is empty.
+    assert result["drained_to_zero"] is True
+    assert result["credits_consumed"] == 50.0
+    assert result["shortfall"] == 50.0
+    assert result["available_credits"] == 0.0
+
+    self.session.refresh(credits)
+    assert credits.current_balance == Decimal("0")
+
+    # The partial debit is on the ledger, flagged so it can be reconciled.
+    transaction = (
+      self.session.query(GraphCreditTransaction)
+      .filter_by(
+        graph_credits_id=credits.id,
+        transaction_type=CreditTransactionType.CONSUMPTION.value,
+      )
+      .first()
+    )
+    assert transaction is not None
+    assert transaction.amount == Decimal("-50")
+    meta = transaction.get_metadata()
+    assert meta["drained_to_zero"] is True
+    assert Decimal(meta["shortfall"]) == Decimal("50")
+
+  def test_consume_credits_atomic_on_an_empty_pool_records_nothing(self):
+    """Nothing to take: no transaction row, balance stays at zero."""
+    credits = GraphCredits(
+      graph_id=self.graph.graph_id,
+      user_id=self.user.id,
+      billing_admin_id=self.billing_admin.id,
+      current_balance=Decimal("0"),
+    )
+    self.session.add(credits)
+    self.session.commit()
+
+    result = credits.consume_credits_atomic(
+      amount=Decimal("100"),
+      operation_type="agent_call",
+      operation_description="AI Agent API call",
+      session=self.session,
+    )
+
+    assert result["success"] is False
+    assert result["credits_consumed"] == 0.0
+    assert result["shortfall"] == 100.0
+    assert result.get("drained_to_zero") is not True
+
+    count = (
+      self.session.query(GraphCreditTransaction)
+      .filter_by(
+        graph_credits_id=credits.id,
+        transaction_type=CreditTransactionType.CONSUMPTION.value,
+      )
+      .count()
+    )
+    assert count == 0
+
+  def test_drain_closes_the_free_band_for_the_next_call(self):
+    """The reason the drain exists: a second call after a shortfall cannot
+    find a positive balance to sit under. Before, the balance survived every
+    over-budget call untouched and the band was re-enterable forever."""
+    credits = GraphCredits(
+      graph_id=self.graph.graph_id,
+      user_id=self.user.id,
+      billing_admin_id=self.billing_admin.id,
+      current_balance=Decimal("40"),
+    )
+    self.session.add(credits)
+    self.session.commit()
+
+    first = credits.consume_credits_atomic(
+      amount=Decimal("200"),
+      operation_type="agent_call",
+      operation_description="over-budget call #1",
+      session=self.session,
+    )
+    second = credits.consume_credits_atomic(
+      amount=Decimal("200"),
+      operation_type="agent_call",
+      operation_description="over-budget call #2",
+      session=self.session,
+    )
+
+    assert first["drained_to_zero"] is True and first["credits_consumed"] == 40.0
+    assert second["credits_consumed"] == 0.0
+    assert second["available_credits"] == 0.0
+    self.session.refresh(credits)
+    assert credits.current_balance == Decimal("0")
 
   def test_allocate_monthly_credits(self):
     """Test monthly credit allocation."""

--- a/tests/models/core/graph/test_graph_credits.py
+++ b/tests/models/core/graph/test_graph_credits.py
@@ -241,6 +241,7 @@ class TestGraphCredits:
       operation_description="AI Agent API call",
       session=self.session,
       user_id=self.user.id,
+      drain_on_shortfall=True,
     )
 
     assert result["success"] is False
@@ -270,6 +271,38 @@ class TestGraphCredits:
     assert meta["drained_to_zero"] is True
     assert Decimal(meta["shortfall"]) == Decimal("50")
 
+  def test_consume_credits_atomic_default_leaves_the_balance(self):
+    """Without drain_on_shortfall (the default / pre-check path), a shortfall
+    refuses and leaves the remainder — draining here would destroy credits the
+    user legitimately holds. This is the invariant the concurrency test relies
+    on."""
+    credits = GraphCredits(
+      graph_id=self.graph.graph_id,
+      user_id=self.user.id,
+      billing_admin_id=self.billing_admin.id,
+      current_balance=Decimal("10"),
+    )
+    self.session.add(credits)
+    self.session.commit()
+
+    result = credits.consume_credits_atomic(
+      amount=Decimal("15"),
+      operation_type="agent_call",
+      operation_description="cannot afford",
+      session=self.session,
+    )
+
+    assert result["success"] is False
+    assert result.get("drained_to_zero") is not True
+    self.session.refresh(credits)
+    assert credits.current_balance == Decimal("10")  # untouched
+    assert (
+      self.session.query(GraphCreditTransaction)
+      .filter_by(graph_credits_id=credits.id)
+      .count()
+      == 0
+    )
+
   def test_consume_credits_atomic_on_an_empty_pool_records_nothing(self):
     """Nothing to take: no transaction row, balance stays at zero."""
     credits = GraphCredits(
@@ -286,6 +319,7 @@ class TestGraphCredits:
       operation_type="agent_call",
       operation_description="AI Agent API call",
       session=self.session,
+      drain_on_shortfall=True,
     )
 
     assert result["success"] is False
@@ -321,12 +355,14 @@ class TestGraphCredits:
       operation_type="agent_call",
       operation_description="over-budget call #1",
       session=self.session,
+      drain_on_shortfall=True,
     )
     second = credits.consume_credits_atomic(
       amount=Decimal("200"),
       operation_type="agent_call",
       operation_description="over-budget call #2",
       session=self.session,
+      drain_on_shortfall=True,
     )
 
     assert first["drained_to_zero"] is True and first["credits_consumed"] == 40.0

--- a/tests/models/core/user/test_user_repository_credits.py
+++ b/tests/models/core/user/test_user_repository_credits.py
@@ -261,6 +261,7 @@ class TestUserRepositoryCredits:
         repository_name="sec",
         operation_type="query",
         session=self.session,
+        drain_on_shortfall=True,
         # Colliding caller keys must NOT overwrite the audit-critical fields.
         metadata={"shortfall": "0", "drained_to_zero": False, "note": "keep me"},
       )
@@ -304,11 +305,43 @@ class TestUserRepositoryCredits:
       repository_name="sec",
       operation_type="query",
       session=self.session,
+      drain_on_shortfall=True,
     )
 
     assert result is False
     self.session.refresh(credits)
     assert credits.current_balance == Decimal("0")
+    assert (
+      self.session.query(UserRepositoryCreditTransaction)
+      .filter_by(credit_pool_id=credits.id)
+      .count()
+      == 0
+    )
+
+  def test_consume_credits_default_leaves_the_remainder(self):
+    """Default (pre-check) path: a short pool refuses and keeps its balance —
+    the invariant the concurrency test in test_credit_race_conditions relies
+    on. Draining here would destroy credits the user still holds."""
+    credits = UserRepositoryCredits(
+      user_repository_id=self.repo_access.id,
+      current_balance=Decimal("10"),
+      monthly_allocation=Decimal("1000"),
+      is_active=True,
+    )
+    credits.user_repository = self.repo_access
+    self.session.add(credits)
+    self.session.commit()
+
+    result = credits.consume_credits(
+      amount=Decimal("15"),
+      repository_name="sec",
+      operation_type="query",
+      session=self.session,
+    )
+
+    assert result is False
+    self.session.refresh(credits)
+    assert credits.current_balance == Decimal("10")  # untouched
     assert (
       self.session.query(UserRepositoryCreditTransaction)
       .filter_by(credit_pool_id=credits.id)

--- a/tests/models/core/user/test_user_repository_credits.py
+++ b/tests/models/core/user/test_user_repository_credits.py
@@ -263,9 +263,54 @@ class TestUserRepositoryCredits:
         session=self.session,
       )
 
+    # Billing is post-hoc: the call already happened, so the short pool is
+    # drained to zero (what was there is billed, the shortfall recorded) and
+    # the call still returns False so the run stops.
     assert result is False
-    assert credits.current_balance == Decimal("50")  # Unchanged
+    self.session.refresh(credits)
+    assert credits.current_balance == Decimal("0")
+    assert credits.credits_consumed_this_month == Decimal("50")
     mock_logger.warning.assert_called()
+
+    drain_tx = (
+      self.session.query(UserRepositoryCreditTransaction)
+      .filter_by(credit_pool_id=credits.id)
+      .order_by(UserRepositoryCreditTransaction.created_at.desc())
+      .first()
+    )
+    assert drain_tx is not None
+    assert drain_tx.amount == Decimal("-50")
+    meta = drain_tx.get_metadata()
+    assert meta["drained_to_zero"] is True
+    assert Decimal(meta["shortfall"]) == Decimal("50")
+
+  def test_consume_credits_on_an_empty_pool_records_nothing(self):
+    credits = UserRepositoryCredits(
+      user_repository_id=self.repo_access.id,
+      current_balance=Decimal("0"),
+      monthly_allocation=Decimal("1000"),
+      is_active=True,
+    )
+    credits.user_repository = self.repo_access
+    self.session.add(credits)
+    self.session.commit()
+
+    result = credits.consume_credits(
+      amount=Decimal("100"),
+      repository_name="sec",
+      operation_type="query",
+      session=self.session,
+    )
+
+    assert result is False
+    self.session.refresh(credits)
+    assert credits.current_balance == Decimal("0")
+    assert (
+      self.session.query(UserRepositoryCreditTransaction)
+      .filter_by(credit_pool_id=credits.id)
+      .count()
+      == 0
+    )
 
   def test_consume_credits_inactive_pool(self):
     """Test credit consumption from inactive pool."""

--- a/tests/models/core/user/test_user_repository_credits.py
+++ b/tests/models/core/user/test_user_repository_credits.py
@@ -261,6 +261,8 @@ class TestUserRepositoryCredits:
         repository_name="sec",
         operation_type="query",
         session=self.session,
+        # Colliding caller keys must NOT overwrite the audit-critical fields.
+        metadata={"shortfall": "0", "drained_to_zero": False, "note": "keep me"},
       )
 
     # Billing is post-hoc: the call already happened, so the short pool is
@@ -281,8 +283,10 @@ class TestUserRepositoryCredits:
     assert drain_tx is not None
     assert drain_tx.amount == Decimal("-50")
     meta = drain_tx.get_metadata()
+    # Built-ins win over the colliding caller keys; non-colliding keys survive.
     assert meta["drained_to_zero"] is True
     assert Decimal(meta["shortfall"]) == Decimal("50")
+    assert meta["note"] == "keep me"
 
   def test_consume_credits_on_an_empty_pool_records_nothing(self):
     credits = UserRepositoryCredits(

--- a/tests/operations/graph/test_credit_integration.py
+++ b/tests/operations/graph/test_credit_integration.py
@@ -295,34 +295,52 @@ class TestCreditSystemIntegration:
         assert summary["usage_percentage"] == 25.0
 
   def test_credit_enforcement_prevents_overuse(self, credit_service, mock_session):
-    """Test that credit system prevents operations when balance is insufficient."""
+    """An over-budget spend reports insufficient credits — from the atomic
+    debit, not from a cached shortcut.
+
+    Billing is post-hoc, so the service must always reach the atomic consume
+    (which drains a short pool to zero); a stale cached balance must never
+    short-circuit it. This test pins the cache at a balance below the cost and
+    asserts the debit path still ran.
+    """
     graph_id = "kg1a2b3c"
 
-    # Create mock credits with low balance
     mock_credits = Mock(spec=GraphCredits)
     mock_credits.graph_id = graph_id
     mock_credits.current_balance = Decimal("5.0")  # Only 5 credits left
     mock_credits.graph_tier = GraphTier.LADYBUG_STANDARD.value
+    mock_credits.consume_credits_atomic = Mock(
+      return_value={
+        "success": False,
+        "error": "Insufficient credits",
+        "required_credits": 100.0,
+        "available_credits": 0.0,
+        "credits_consumed": 5.0,
+        "shortfall": 95.0,
+        "drained_to_zero": True,
+      }
+    )
 
-    # Mock cache
-    with patch("robosystems.middleware.billing.cache.credit_cache") as mock_cache:
+    with (
+      patch("robosystems.middleware.billing.cache.credit_cache") as mock_cache,
+      patch.object(GraphCredits, "get_by_graph_id", return_value=mock_credits),
+    ):
       mock_cache.get_cached_graph_credit_balance.return_value = (
         Decimal("5.0"),
         "standard",
       )
 
-      # Mock query
-      mock_session.query().filter_by().first.return_value = mock_credits
-
-      # Try to consume more AI credits than available
       result = credit_service.consume_credits(
         graph_id=graph_id,
         operation_type="agent_call",  # AI operation
         base_cost=Decimal("100.0"),
       )
 
-      # Verify operation was blocked
+      # The atomic debit ran despite the cache already showing a shortfall.
+      mock_credits.consume_credits_atomic.assert_called_once()
+
       assert result["success"] is False
       assert "Insufficient credits" in result["error"]
       assert result["required_credits"] == 100.0
-      assert result["available_credits"] == 5.0
+      assert result["drained_to_zero"] is True
+      assert result["credits_consumed"] == 5.0

--- a/tests/operations/graph/test_credit_service.py
+++ b/tests/operations/graph/test_credit_service.py
@@ -173,6 +173,7 @@ class TestCreditService:
           request_id=None,
           user_id=None,
           metadata={"test": "data"},
+          drain_on_shortfall=False,
         )
 
         # Verify cache invalidation was called
@@ -786,6 +787,7 @@ class TestCreditConsumptionWritesUsageLedger:
         operation_type="ai_tokens",
         base_cost=Decimal("200.0"),
         user_id="usr_abc",
+        drain_on_shortfall=True,
       )
 
       cache.invalidate_graph_credit_balance.assert_called_once_with("graph123")

--- a/tests/operations/graph/test_credit_service.py
+++ b/tests/operations/graph/test_credit_service.py
@@ -736,14 +736,73 @@ class TestCreditConsumptionWritesUsageLedger:
     assert kwargs["credits_consumed"] == Decimal("10.0")
 
   def test_failed_consumption_records_nothing(self, credit_service):
+    """A refusal that deducted nothing (empty pool) writes no usage row."""
     credits = self._credits(
-      {"success": False, "error": "Insufficient credits", "available_credits": 1.0}
+      {
+        "success": False,
+        "error": "Insufficient credits",
+        "available_credits": 0.0,
+        "credits_consumed": 0.0,
+      }
     )
 
     result, record = self._consume(credit_service, credits, user_id="usr_abc")
 
     assert result["success"] is False
     record.assert_not_called()
+
+  def test_drain_to_zero_records_the_partial_debit_and_pins_the_cache(
+    self, credit_service
+  ):
+    """A shortfall drain is real spend: the usage ledger records the drained
+    amount, the result reports it, and the cached balance is pinned at zero
+    rather than merely invalidated — the pre-flight prefers the cache, and a
+    stale positive figure there would re-admit the request the drain stops."""
+    credits = self._credits(
+      {
+        "success": False,
+        "error": "Insufficient credits",
+        "credits_consumed": 40.0,
+        "shortfall": 160.0,
+        "drained_to_zero": True,
+        "available_credits": 0.0,
+        "required_credits": 200.0,
+        "base_cost": 200.0,
+        "transaction_id": "t-drain",
+      }
+    )
+
+    with (
+      patch("robosystems.middleware.billing.cache.credit_cache") as cache,
+      patch.object(GraphCredits, "get_by_graph_id", return_value=credits),
+      patch.object(GraphUsage, "record_credit_consumption") as record,
+    ):
+      cache.get_cached_graph_credit_balance.return_value = (
+        Decimal("40.0"),
+        "ladybug-standard",
+      )
+      result = credit_service.consume_credits(
+        graph_id="graph123",
+        operation_type="ai_tokens",
+        base_cost=Decimal("200.0"),
+        user_id="usr_abc",
+      )
+
+      cache.invalidate_graph_credit_balance.assert_called_once_with("graph123")
+      cache.cache_graph_credit_balance.assert_called_once()
+      pinned = cache.cache_graph_credit_balance.call_args.kwargs
+      assert pinned["graph_id"] == "graph123"
+      assert pinned["balance"] == Decimal("0")
+
+    assert result["success"] is False
+    assert result["drained_to_zero"] is True
+    assert result["credits_consumed"] == 40.0
+    assert result["shortfall"] == 160.0
+
+    record.assert_called_once()
+    kwargs = record.call_args.kwargs
+    assert kwargs["credits_consumed"] == Decimal("40.0")
+    assert kwargs["operation_type"] == "ai_tokens"
 
   def test_unattributed_consumption_is_skipped_not_forged(self, credit_service):
     """`GraphUsage.user_id` is NOT NULL and usage is attributed per user, so a

--- a/tests/operations/graph/test_subgraph_service.py
+++ b/tests/operations/graph/test_subgraph_service.py
@@ -421,6 +421,78 @@ class TestSubgraphService:
   # was removed from subgraph_service.py as part of S3 bucket restructure
 
   @pytest.mark.asyncio
+  async def test_delete_purges_the_subgraph_from_the_shared_search_index(
+    self, service, mock_allocation_manager, mock_lbug_client, mock_parent_location
+  ):
+    """Documents are indexed under the subgraph id in a tenant-shared index.
+    A standalone delete-subgraph used to leave them there permanently (the
+    parent's teardown purges by iterating rows this path has already removed),
+    and a recreated subgraph of the same reusable name would resurface them.
+    The delete now purges the index, off the event loop."""
+    mock_allocation_manager.find_database_location.return_value = mock_parent_location
+    mock_lbug_client.list_databases.return_value = {
+      "databases": [{"graph_id": "kg5f2e5e0da65d45d69645_analysis"}]
+    }
+    mock_lbug_client.execute.return_value = [{"node_count": 0}]
+
+    mock_os_client = Mock()
+    with (
+      patch(
+        "robosystems.operations.graph.subgraph_service.get_graph_client_for_instance",
+        return_value=mock_lbug_client,
+      ),
+      patch("robosystems.graph_api.client.GraphClient", return_value=mock_lbug_client),
+      patch("robosystems.operations.graph.subgraph_service.env") as mock_env,
+      patch(
+        "robosystems.operations.search.client.OpenSearchClient",
+        return_value=mock_os_client,
+      ) as os_cls,
+    ):
+      mock_env.SEMANTIC_SEARCH_ENABLED = True
+      mock_env.OPENSEARCH_URL = "http://os:9200"
+      mock_env.OPENSEARCH_INDEX = "documents"
+      mock_env.GRAPH_API_URL = "http://localhost:8001"
+
+      result = await service.delete_subgraph_database(
+        "kg5f2e5e0da65d45d69645_analysis", force=True
+      )
+
+    assert result["status"] == "deleted"
+    assert result["search_purged"] is True
+    os_cls.assert_called_once_with("http://os:9200", "documents")
+    mock_os_client.delete_by_graph_id.assert_called_once_with(
+      "kg5f2e5e0da65d45d69645_analysis"
+    )
+
+  @pytest.mark.asyncio
+  async def test_delete_is_a_clean_noop_when_search_disabled(
+    self, service, mock_allocation_manager, mock_lbug_client, mock_parent_location
+  ):
+    mock_allocation_manager.find_database_location.return_value = mock_parent_location
+    mock_lbug_client.list_databases.return_value = {
+      "databases": [{"graph_id": "kg5f2e5e0da65d45d69645_analysis"}]
+    }
+    mock_lbug_client.execute.return_value = [{"node_count": 0}]
+
+    with (
+      patch(
+        "robosystems.operations.graph.subgraph_service.get_graph_client_for_instance",
+        return_value=mock_lbug_client,
+      ),
+      patch("robosystems.graph_api.client.GraphClient", return_value=mock_lbug_client),
+      patch("robosystems.operations.graph.subgraph_service.env") as mock_env,
+    ):
+      mock_env.SEMANTIC_SEARCH_ENABLED = False
+      mock_env.GRAPH_API_URL = "http://localhost:8001"
+
+      result = await service.delete_subgraph_database(
+        "kg5f2e5e0da65d45d69645_analysis", force=True
+      )
+
+    assert result["status"] == "deleted"
+    assert result["search_purged"] is False
+
+  @pytest.mark.asyncio
   async def test_delete_invalid_subgraph_id(self, service):
     """Test deletion with invalid subgraph ID."""
     with pytest.raises(ValueError) as exc_info:

--- a/tests/operations/operators/test_credit_preflight.py
+++ b/tests/operations/operators/test_credit_preflight.py
@@ -150,7 +150,7 @@ class TestAdaptersRunThePreflight:
         side_effect=InsufficientOperatorCreditsError("Test Operator", 10.0, 1.0),
       ),
       patch.object(api, "HttpToolAccess") as tool_access,
-      patch.object(api, "AIClient"),
+      patch.object(api, "get_ai_client"),
       patch.object(api, "TrackedAIClient"),
     ):
       with pytest.raises(InsufficientOperatorCreditsError):
@@ -172,7 +172,7 @@ class TestAdaptersRunThePreflight:
       ),
       patch.object(worker, "SessionFactory"),
       patch.object(worker, "DirectToolAccess") as tool_access,
-      patch.object(worker, "AIClient"),
+      patch.object(worker, "get_ai_client"),
       patch.object(worker, "TrackedAIClient"),
       patch.object(worker, "FactoryCreditConsumer"),
     ):

--- a/tests/operations/operators/test_write_role_gate.py
+++ b/tests/operations/operators/test_write_role_gate.py
@@ -102,7 +102,7 @@ class TestAdaptersEnforceBeforeToolAccess:
         side_effect=HTTPException(status_code=403, detail="read-only"),
       ),
       patch.object(api, "HttpToolAccess") as tool_access,
-      patch.object(api, "AIClient"),
+      patch.object(api, "get_ai_client"),
       patch.object(api, "TrackedAIClient"),
     ):
       with pytest.raises(HTTPException) as exc:
@@ -127,7 +127,7 @@ class TestAdaptersEnforceBeforeToolAccess:
         side_effect=HTTPException(status_code=403, detail="read-only"),
       ),
       patch.object(worker, "DirectToolAccess") as tool_access,
-      patch.object(worker, "AIClient"),
+      patch.object(worker, "get_ai_client"),
       patch.object(worker, "TrackedAIClient"),
       patch.object(worker, "FactoryCreditConsumer"),
     ):
@@ -186,7 +186,7 @@ class TestToolSurfaceMatchesSpec:
       patch.object(api, "enforce_operator_write_role"),
       patch.object(api, "enforce_operator_credits"),
       patch.object(api, "HttpToolAccess") as tool_access,
-      patch.object(api, "AIClient"),
+      patch.object(api, "get_ai_client"),
       patch.object(api, "TrackedAIClient"),
     ):
       tool_access.return_value = MagicMock(close=AsyncMock())
@@ -210,7 +210,7 @@ class TestToolSurfaceMatchesSpec:
       patch.object(api, "enforce_operator_write_role"),
       patch.object(api, "enforce_operator_credits"),
       patch.object(api, "HttpToolAccess") as tool_access,
-      patch.object(api, "AIClient"),
+      patch.object(api, "get_ai_client"),
       patch.object(api, "TrackedAIClient"),
     ):
       tool_access.return_value = MagicMock(close=AsyncMock())

--- a/tests/operations/test_ai_client.py
+++ b/tests/operations/test_ai_client.py
@@ -655,3 +655,79 @@ class TestAIClientBedrockEndpoint:
       call_args = mock_boto3_client.call_args
       assert call_args[1]["region_name"] == "ap-southeast-1"
       assert "ap-southeast-1" in call_args[1]["endpoint_url"]
+
+
+class TestAIClientOffloadsBedrock:
+  """The synchronous botocore call must run off the event loop.
+
+  `_bedrock_create_message` is `async def` and a model call can take minutes;
+  running `invoke_model` inline held the single-worker loop — and every tenant
+  on the task — for the whole call. It now goes through `asyncio.to_thread`.
+  """
+
+  @pytest.mark.unit
+  @pytest.mark.asyncio
+  async def test_invoke_model_runs_in_a_thread(self):
+    from robosystems.operations.operators.ai_client import AIMessage
+
+    client, mock_bedrock = _make_ai_client()
+
+    body = MagicMock()
+    body.read.return_value = json.dumps(
+      {
+        "content": [{"type": "text", "text": "hi"}],
+        "usage": {"input_tokens": 3, "output_tokens": 1},
+        "stop_reason": "end_turn",
+      }
+    )
+    mock_bedrock.invoke_model.return_value = {"body": body}
+
+    with patch(f"{AI_CLIENT_MODULE}.asyncio.to_thread") as mock_to_thread:
+
+      async def _fake_to_thread(fn, *args, **kwargs):
+        # Prove the blocking call is the one being offloaded, and run it.
+        assert fn == client._invoke_model_sync
+        return fn(*args, **kwargs)
+
+      mock_to_thread.side_effect = _fake_to_thread
+
+      resp = await client.create_message(
+        messages=[AIMessage(role="user", content="hi")]
+      )
+
+    mock_to_thread.assert_called_once()
+    assert resp.content == "hi"
+    assert resp.input_tokens == 3 and resp.output_tokens == 1
+
+
+class TestSharedAIClient:
+  """`get_ai_client` returns one process-wide instance, so operator requests do
+  not each rebuild a boto3 client + STS call on the loop."""
+
+  @pytest.mark.unit
+  def test_returns_a_singleton(self):
+    import robosystems.operations.operators.ai_client as mod
+
+    mod._shared_client = None
+    with patch.object(mod, "AIClient") as cls:
+      cls.side_effect = lambda: MagicMock()
+      a = mod.get_ai_client()
+      b = mod.get_ai_client()
+    assert a is b
+    cls.assert_called_once()
+    mod._shared_client = None
+
+  @pytest.mark.unit
+  def test_a_failed_build_is_not_cached(self):
+    import robosystems.operations.operators.ai_client as mod
+
+    mod._shared_client = None
+    with patch.object(mod, "AIClient", side_effect=ValueError("no creds")):
+      with pytest.raises(ValueError):
+        mod.get_ai_client()
+    # Next call retries rather than returning a broken/cached client.
+    with patch.object(mod, "AIClient") as cls:
+      cls.side_effect = lambda: MagicMock()
+      client = mod.get_ai_client()
+    assert client is not None
+    mod._shared_client = None

--- a/tests/worker/test_consumer.py
+++ b/tests/worker/test_consumer.py
@@ -159,6 +159,36 @@ async def test_error_path(mock_tracer, mock_cleanup, mock_manager, mock_queue):
 
 @pytest.mark.asyncio
 @patch("robosystems.worker.consumer.cleanup_connections")
+@patch("robosystems.worker.consumer.get_tracer")
+async def test_a_raising_fail_operation_does_not_escape(
+  mock_tracer, mock_cleanup, mock_manager, mock_queue
+):
+  """`fail_operation` raises when the operation's SSE metadata has expired
+  (a task outliving its TTL). Raising from inside the except handler used to
+  escape `_process_task` and, with nothing above it in the run loop, exit the
+  worker — so one long task could kill the process. It must be logged and
+  swallowed; cleanup and the inflight removal must still happen."""
+  mock_tracer.return_value = MagicMock()
+  mock_tracer.return_value.start_as_current_span.return_value.__enter__ = MagicMock()
+  mock_tracer.return_value.start_as_current_span.return_value.__exit__ = MagicMock()
+
+  # The real failure shape: the handler raises, then recording the failure
+  # raises too because the metadata key is gone.
+  mock_manager.fail_operation = AsyncMock(
+    side_effect=ValueError("Operation op_01TEST not found (metadata expired)")
+  )
+
+  task_data = _make_task_data(task_type="test_failure")
+  # Must not raise.
+  await _call_process_task(task_data, mock_queue, mock_manager)
+
+  mock_manager.fail_operation.assert_called_once()
+  mock_cleanup.assert_called_once()
+  mock_queue.lrem.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("robosystems.worker.consumer.cleanup_connections")
 async def test_unknown_task_type(mock_cleanup, mock_manager, mock_queue):
   task_data = _make_task_data(task_type="nonexistent_type")
   await _call_process_task(task_data, mock_queue, mock_manager)


### PR DESCRIPTION
Follow-up increment to the v1.9.8 hardening set — the availability, robustness, and defense-in-depth items surfaced by the round-3 onboarding-readiness review. None is a cross-tenant isolation issue; the isolation surfaces came back clean.

### Event-loop occupancy (noisy-neighbor)
Single-worker API tasks share one event loop, so synchronous work on it stalls every tenant on the task. Moved off the loop / bounded:

- Bedrock `invoke_model` → threadpool; `AIClient` hoisted to a process singleton (no per-request boto3 build + STS)
- Dagster submit/poll → threadpool, with an explicit short client timeout (was the library default)
- shared-repo query handler → plain `def` so Starlette threads it
- SSE subscriber poll timeout moved onto `get_message` (stops a busy-spin)
- platform DB engine gets a `statement_timeout`, matching the extensions engine

### Post-hoc credit band
An over-budget AI call is billed post-hoc; a short pool now drains to zero and records the shortfall instead of deducting nothing, so the band cannot be re-entered unbilled and the next pre-flight denies. Same shape fixed on the shared-repo pool.

### Robustness / defense-in-depth
- worker consumer survives a failure-recording that itself raises (was a process-exit path)
- boot asserts each safety-critical feature flag is *present* in SSM, not merely that some flag loaded
- `delete-subgraph` purges the subgraph's documents from the shared search index
- extensions DSN redacted in the pre-execution write log

Full context and the review that produced this list are in the vault.

### Tests
New/updated coverage for each item; broad regression sweep across billing, operators, SSE, worker, config, and graph_api green (2402 passed). One pre-existing cross-file ordering flake in `test_graph_table.py` (fails on clean main in the same order; passes in isolation) is unrelated.