### PR TITLE
fix(security): bound the credential-redaction regex quantifiers

### DIFF
--- a/robosystems/security/error_handling.py
+++ b/robosystems/security/error_handling.py
@@ -251,8 +251,11 @@ def is_safe_to_expose(detail_message: str) -> bool:
   return not any(pattern in detail_lower for pattern in sensitive_patterns)
 
 
-_CONNSTR_PASSWORD_RE = re.compile(r"password=\S+")
-_URL_CRED_RE = re.compile(r"(postgres(?:ql)?://[^:/@\s]+:)[^@\s]+@")
+# Bounded quantifiers: the credential here is always our own RDS secret
+# (128 chars max), and unbounded runs let crafted error text drive the
+# scan quadratic (CodeQL py/polynomial-redos).
+_CONNSTR_PASSWORD_RE = re.compile(r"password=\S{1,256}")
+_URL_CRED_RE = re.compile(r"(postgres(?:ql)?://[^:/@\s]{1,256}:)[^@\s]{1,256}@")
 
 
 def redact_connection_secrets(text: str) -> str:

--- a/tests/security/test_redact_connection_secrets.py
+++ b/tests/security/test_redact_connection_secrets.py
@@ -45,3 +45,24 @@ class TestRedactConnectionSecrets:
     assert "password=a" not in out
     assert "password=b" not in out
     assert out.count("password=***") == 2
+
+  def test_max_length_rds_password_still_redacted(self):
+    # RDS master passwords max out at 128 chars; the bounded quantifiers
+    # (256) must keep redacting the longest credential we can hold.
+    secret = "x" * 128
+    raw = (
+      f"error in postgres_scan('user=postgres password={secret} host=h') "
+      f"and postgresql://postgres:{secret}@rds.aws:5432/extensions"
+    )
+    out = redact_connection_secrets(raw)
+    assert secret not in out
+    assert "password=***" in out
+    assert "postgresql://postgres:***@rds.aws" in out
+
+  @pytest.mark.timeout(10)
+  def test_adversarial_repetition_stays_fast(self):
+    # Many credential-shaped prefixes with no terminating '@' previously
+    # made the URL regex rescan to end-of-string from every prefix
+    # (quadratic). Bounded quantifiers keep this linear-ish.
+    raw = "postgres://!:" * 20_000
+    assert redact_connection_secrets(raw) == raw


### PR DESCRIPTION
## Summary

Bound the quantifiers in the two `redact_connection_secrets` regexes so pathological error text cannot make the redaction scan expensive (CodeQL `py/polynomial-redos`, alert #741). The credential these patterns redact is always our own RDS secret (128 chars max), so a 256-char bound changes no real redaction outcome.

## Changes

- **robosystems/security/error_handling.py** — `_CONNSTR_PASSWORD_RE` and `_URL_CRED_RE` now use bounded quantifiers (`{1,256}`) instead of unbounded `+`, with a comment recording the constraint that makes the bound safe.
- **tests/security/test_redact_connection_secrets.py** — two new regression tests: a 128-char (RDS-max) credential is still redacted in both the libpq and URL forms, and adversarial repeated credential-shaped prefixes pass through quickly (`@pytest.mark.timeout(10)`).

## Breaking Changes

None. Internal helper only; no API surface or SDK tier touched.

## Testing

- `uv run pytest tests/security/test_redact_connection_secrets.py` — 6 passed.
- `just test-code` — ruff, format, basedpyright, cf-lint all clean.
- Full `just test-all` not run this session.
