### PR TITLE
Harden error-response sanitization, credit-ledger consistency, and auth hashing

### DIFF
--- a/robosystems/middleware/graph/query_queue.py
+++ b/robosystems/middleware/graph/query_queue.py
@@ -20,6 +20,7 @@ from robosystems.middleware.graph.admission_control import (
   get_admission_controller,
 )
 from robosystems.middleware.otel.metrics import record_query_queue_metrics
+from robosystems.security.error_handling import safe_error_message
 
 
 class QueryStatus(str, Enum):
@@ -408,8 +409,9 @@ class QueryQueueManager:
 
     except Exception as e:
       query.status = QueryStatus.FAILED
-      query.error = str(e)
-      logger.error(f"Query {query.id} failed: {e}")
+      # query.error surfaces to the caller through status polls and SSE.
+      query.error = safe_error_message(e) or f"Query failed — reference {query.id}"
+      logger.error(f"Query {query.id} failed: {e}", exc_info=True)
 
     finally:
       # Clean up

--- a/robosystems/middleware/mcp/tools/document_tools.py
+++ b/robosystems/middleware/mcp/tools/document_tools.py
@@ -18,6 +18,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from robosystems.logger import logger
 from robosystems.middleware.operations import run_off_loop
+from robosystems.security.error_handling import safe_error_message
 
 from ._errors import database_failure
 
@@ -247,8 +248,14 @@ class CreateDocumentTool:
     except SQLAlchemyError as e:
       return database_failure("create-document", e, not_initialized_message=None)
     except Exception as e:
-      logger.error(f"create-document failed for graph_id={graph_id}: {e}")
-      return {"error": "create_failed", "message": str(e)}
+      logger.error(
+        f"create-document failed for graph_id={graph_id}: {e}", exc_info=True
+      )
+      return {
+        "error": "create_failed",
+        "message": safe_error_message(e)
+        or "create-document failed on a backend error; see server logs",
+      }
     finally:
       session.close()
 
@@ -354,8 +361,14 @@ Content changes are automatically re-indexed in OpenSearch.""",
     except SQLAlchemyError as e:
       return database_failure("update-document", e, not_initialized_message=None)
     except Exception as e:
-      logger.error(f"update-document failed for graph_id={graph_id}: {e}")
-      return {"error": "update_failed", "message": str(e)}
+      logger.error(
+        f"update-document failed for graph_id={graph_id}: {e}", exc_info=True
+      )
+      return {
+        "error": "update_failed",
+        "message": safe_error_message(e)
+        or "update-document failed on a backend error; see server logs",
+      }
     finally:
       session.close()
 
@@ -431,8 +444,12 @@ class GetDocumentTool:
     except SQLAlchemyError as e:
       return database_failure("get-document", e, not_initialized_message=None)
     except Exception as e:
-      logger.error(f"get-document failed for graph_id={graph_id}: {e}")
-      return {"error": "retrieval_failed", "message": str(e)}
+      logger.error(f"get-document failed for graph_id={graph_id}: {e}", exc_info=True)
+      return {
+        "error": "retrieval_failed",
+        "message": safe_error_message(e)
+        or "get-document failed on a backend error; see server logs",
+      }
     finally:
       session.close()
 
@@ -499,8 +516,14 @@ from OpenSearch. This is permanent — use get-document to review before deletin
     except SQLAlchemyError as e:
       return database_failure("delete-document", e, not_initialized_message=None)
     except Exception as e:
-      logger.error(f"delete-document failed for graph_id={graph_id}: {e}")
-      return {"error": "delete_failed", "message": str(e)}
+      logger.error(
+        f"delete-document failed for graph_id={graph_id}: {e}", exc_info=True
+      )
+      return {
+        "error": "delete_failed",
+        "message": safe_error_message(e)
+        or "delete-document failed on a backend error; see server logs",
+      }
     finally:
       session.close()
 
@@ -584,7 +607,11 @@ class ListDocumentsTool:
     except SQLAlchemyError as e:
       return database_failure("list-documents", e, not_initialized_message=None)
     except Exception as e:
-      logger.error(f"list-documents failed for graph_id={graph_id}: {e}")
-      return {"error": "list_failed", "message": str(e)}
+      logger.error(f"list-documents failed for graph_id={graph_id}: {e}", exc_info=True)
+      return {
+        "error": "list_failed",
+        "message": safe_error_message(e)
+        or "list-documents failed on a backend error; see server logs",
+      }
     finally:
       session.close()

--- a/robosystems/middleware/mcp/tools/search_tools.py
+++ b/robosystems/middleware/mcp/tools/search_tools.py
@@ -11,6 +11,7 @@ similarity (KNN) via a normalization pipeline for balanced scoring.
 from typing import Any
 
 from robosystems.logger import logger
+from robosystems.security.error_handling import safe_error_message
 
 
 class _SearchToolMixin:
@@ -151,8 +152,14 @@ class SearchDocumentsTool(_SearchToolMixin):
       response = service.search_documents(graph_id, request)
       return response.model_dump()
     except Exception as e:
-      logger.error(f"search-documents failed: {e}")
-      return {"error": f"Search failed: {e}"}
+      # opensearch-py exception text embeds the endpoint hostname and query
+      # internals — the LLM-facing result gets the fixed message instead.
+      logger.error(f"search-documents failed: {e}", exc_info=True)
+      return {
+        "error": "search_failed",
+        "message": safe_error_message(e)
+        or "search failed on a backend error; see server logs",
+      }
 
 
 class GetDocumentSectionTool(_SearchToolMixin):
@@ -206,5 +213,9 @@ class GetDocumentSectionTool(_SearchToolMixin):
         return {"error": f"Document {document_id} not found"}
       return result.model_dump()
     except Exception as e:
-      logger.error(f"get-document-section failed: {e}")
-      return {"error": f"Retrieval failed: {e}"}
+      logger.error(f"get-document-section failed: {e}", exc_info=True)
+      return {
+        "error": "retrieval_failed",
+        "message": safe_error_message(e)
+        or "retrieval failed on a backend error; see server logs",
+      }

--- a/robosystems/models/core/graph/graph_credits.py
+++ b/robosystems/models/core/graph/graph_credits.py
@@ -283,8 +283,15 @@ class GraphCredits(Base):
         user_id=user_id or self.user_id,
       )
 
-      self.current_balance = consumption_result.new_balance
-      self.updated_at = datetime.now(UTC)
+      # The conditional UPDATE above already persisted the debit. Never write
+      # the RETURNING value back through the ORM: create_transaction commits
+      # internally (releasing the row lock), so a concurrent debit can land
+      # before this method's final commit — an absolute
+      # `SET current_balance = <this session's view>` would then revert it
+      # (lost update: balance inflates while the ledger stays correct).
+      # Expire instead, so the next attribute access reloads from the DB.
+      if self in session:
+        session.expire(self, ["current_balance", "updated_at"])
 
       session.commit()
 
@@ -395,8 +402,12 @@ class GraphCredits(Base):
       user_id=user_id or self.user_id,
     )
 
-    self.current_balance = Decimal("0")
-    self.updated_at = datetime.now(UTC)
+    # The CTE UPDATE above already zeroed the row; an ORM write-back of the
+    # absolute value would clobber a concurrent allocation/bonus landing after
+    # create_transaction's internal commit (same lost-update as the consume
+    # path). Expire so the next access reloads.
+    if self in session:
+      session.expire(self, ["current_balance", "updated_at"])
 
     session.commit()
 

--- a/robosystems/models/core/user/user_api_key.py
+++ b/robosystems/models/core/user/user_api_key.py
@@ -22,6 +22,10 @@ class UserAPIKey(Model):
 
   __tablename__ = "user_api_keys"
 
+  # bcrypt cost for hashing API keys (~250ms at cost 12). A class constant so
+  # the test suite can patch it down, the way it patches PasswordSecurity.
+  BCRYPT_ROUNDS = 12
+
   id = Column(String, primary_key=True, default=lambda: generate_prefixed_ulid("uak"))
   user_id = Column(String, ForeignKey("users.id"), nullable=False, index=True)
   name = Column(String, nullable=False)  # User-friendly name for the key
@@ -315,9 +319,9 @@ class UserAPIKey(Model):
 
   @staticmethod
   def _hash_api_key(plain_key: str) -> str:
-    """Hash an API key with bcrypt at cost 12 (~250ms on current hardware)."""
+    """Hash an API key with bcrypt at cost ``BCRYPT_ROUNDS`` (~250ms at 12)."""
     try:
-      salt = bcrypt.gensalt(rounds=12)
+      salt = bcrypt.gensalt(rounds=UserAPIKey.BCRYPT_ROUNDS)
       hashed = bcrypt.hashpw(plain_key.encode("utf-8"), salt)
       return hashed.decode("utf-8")
     except Exception as e:

--- a/robosystems/models/core/user/user_repository_credits.py
+++ b/robosystems/models/core/user/user_repository_credits.py
@@ -30,6 +30,21 @@ from robosystems.utils.ulid import generate_prefixed_ulid
 logger = logging.getLogger(__name__)
 
 
+def _first_of_next_month(now: datetime) -> datetime:
+  """Midnight UTC on the 1st of the month after ``now``.
+
+  The allocation cron runs on the 1st; any other due date is one the cron
+  never lands on.
+  """
+  if now.month == 12:
+    return now.replace(
+      year=now.year + 1, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
+    )
+  return now.replace(
+    month=now.month + 1, day=1, hour=0, minute=0, second=0, microsecond=0
+  )
+
+
 def safe_float(value: Any) -> float:
   """Safely convert SQLAlchemy model attributes to float."""
   return float(value) if value is not None else 0.0
@@ -131,8 +146,6 @@ class UserRepositoryCredits(Base):
     session: Session,
   ) -> "UserRepositoryCredits":
     """Create credit pool for a new access record."""
-    from datetime import timedelta
-
     allows_rollover = False
     max_rollover = Decimal("0")
 
@@ -145,7 +158,10 @@ class UserRepositoryCredits(Base):
       allows_rollover=allows_rollover,
       max_rollover_credits=max_rollover,
       last_allocation_date=now,
-      next_allocation_date=now + timedelta(days=30),
+      # Aligned with the 1st-of-month allocation cron — a +30d seed lands
+      # mid-month, where the cron never fires, and the first refill silently
+      # skips a month.
+      next_allocation_date=_first_of_next_month(now),
     )
 
     session.add(credits)
@@ -355,12 +371,18 @@ class UserRepositoryCredits(Base):
     The balance is replaced by ``monthly_allocation``, matching ``GraphCredits``
     and the no-rollover promise on the offering page.
     """
-    from datetime import timedelta
-
     now = datetime.now(UTC)
 
-    if self.next_allocation_date and now < self.next_allocation_date:
-      return False
+    # One allocation per calendar month, matching the 1st-of-month cron that
+    # drives it (GraphCredits carries the same gate). The previous day-count
+    # gate (now < next_allocation_date, re-armed at +30 days) drifted off the
+    # 1st: a mid-month purchase re-armed to a mid-month date the cron never
+    # runs on, silently skipping that month's refill — and a 1-Feb allocation
+    # re-armed to 3-Mar, skipping March for every active pool, every year.
+    if self.last_allocation_date is not None:
+      last = self.last_allocation_date
+      if (last.year, last.month) == (now.year, now.month):
+        return False
 
     self.credits_consumed_this_month = Decimal("0")
 
@@ -378,7 +400,9 @@ class UserRepositoryCredits(Base):
     self.current_balance = new_balance
     self.rollover_credits = Decimal("0")
     self.last_allocation_date = now
-    self.next_allocation_date = now + timedelta(days=30)
+    # Kept for the Dagster op's due-pool filter and its index; pinned to the
+    # 1st so the date can never drift away from the cron again.
+    self.next_allocation_date = _first_of_next_month(now)
     self.updated_at = now
 
     UserRepositoryCreditTransaction.create_transaction(
@@ -591,8 +615,12 @@ class UserRepositoryCredits(Base):
         session=session,
       )
 
-      self.current_balance = reservation_result.new_balance
-      self.updated_at = datetime.now(UTC)
+      # The atomic UPDATE already persisted the reservation debit. Writing the
+      # RETURNING value back through the ORM would emit an absolute SET on
+      # commit and revert any concurrent movement (lost update) — expire so
+      # the next access reloads instead.
+      if self in session:
+        session.expire(self, ["current_balance", "updated_at"])
 
       session.commit()
 
@@ -748,7 +776,7 @@ class UserRepositoryCredits(Base):
         },
       )
 
-      refund_result = result.fetchone()
+      result.fetchone()
 
       UserRepositoryCreditTransaction.create_transaction(
         credit_pool_id=self.id,
@@ -777,9 +805,10 @@ class UserRepositoryCredits(Base):
 
         reservation_transaction.transaction_metadata = json.dumps(metadata)
 
-      if refund_result:
-        self.current_balance = refund_result.new_balance
-      self.updated_at = datetime.now(UTC)
+      # Refund already applied by the atomic UPDATE — expire, never write the
+      # absolute value back (same lost-update hazard as the reserve path).
+      if self in session:
+        session.expire(self, ["current_balance", "updated_at"])
 
       session.commit()
 

--- a/robosystems/operations/graph/credit_service.py
+++ b/robosystems/operations/graph/credit_service.py
@@ -436,7 +436,11 @@ class CreditService:
     if not credits:
       return {"error": "No credit pool found for graph"}
 
-    credits.current_balance += amount
+    # Server-side increment: `+= amount` in Python is a read-modify-write that
+    # flushes an absolute value, silently reverting any debit that lands
+    # concurrently. The SQL-expression assignment emits
+    # `SET current_balance = current_balance + :amount` instead.
+    credits.current_balance = GraphCredits.current_balance + amount
     credits.updated_at = datetime.now(UTC)
 
     import uuid

--- a/robosystems/operations/graph/graph_creation_service.py
+++ b/robosystems/operations/graph/graph_creation_service.py
@@ -171,7 +171,7 @@ class GraphCreationService:
           entity_dict = await self._provision_entity(graph_id, config)
 
       self._emit(config, "Creating credit pool...", 92)
-      self._create_credits(graph_id, config)
+      await self._create_credits(graph_id, config)
 
       result = GraphCreationResult(
         graph_id=graph_id,
@@ -517,32 +517,50 @@ class GraphCreationService:
       "database": graph_id,
     }
 
-  def _create_credits(self, graph_id: str, config: GraphCreationConfig) -> None:
-    """Create credit pool. Non-blocking — failures are logged, not raised."""
-    try:
-      from robosystems.database import get_db_session
+  async def _create_credits(self, graph_id: str, config: GraphCreationConfig) -> None:
+    """Create credit pool. Non-blocking — failures are logged, not raised.
 
-      from .credit_service import CreditService
+    Retried, because a graph without a pool has every AI run denied by the
+    unconditional pre-flight, admin add-bonus/reset both 404 on the missing
+    row, and the monthly allocation iterates existing pools only — a single
+    transient failure here used to be a permanent, invisible gap.
+    """
+    import asyncio
 
-      db_gen = get_db_session()
-      db = next(db_gen)
+    last_error: Exception | None = None
+    for attempt in range(3):
       try:
-        credit_service = CreditService(db)
-        credit_service.create_graph_credits(
-          graph_id=graph_id,
-          user_id=config.user_id,
-          billing_admin_id=config.user_id,
-          subscription_tier=config.tier.lower(),
-          graph_tier=config.graph_tier,
-        )
-        logger.info(f"Credit pool created for {graph_id}")
-      finally:
+        from robosystems.database import get_db_session
+
+        from .credit_service import CreditService
+
+        db_gen = get_db_session()
+        db = next(db_gen)
         try:
-          next(db_gen)
-        except StopIteration:
-          pass
-    except Exception as e:
-      logger.error(f"Failed to create credit pool for {graph_id}: {e}")
+          credit_service = CreditService(db)
+          credit_service.create_graph_credits(
+            graph_id=graph_id,
+            user_id=config.user_id,
+            billing_admin_id=config.user_id,
+            subscription_tier=config.tier.lower(),
+            graph_tier=config.graph_tier,
+          )
+          logger.info(f"Credit pool created for {graph_id}")
+          return
+        finally:
+          try:
+            next(db_gen)
+          except StopIteration:
+            pass
+      except Exception as e:
+        last_error = e
+        logger.warning(
+          f"Credit pool creation attempt {attempt + 1}/3 failed for {graph_id}: {e}"
+        )
+        await asyncio.sleep(attempt + 1)
+    logger.error(
+      f"Failed to create credit pool for {graph_id} after 3 attempts: {last_error}"
+    )
 
   async def _cleanup_within_budget(
     self,

--- a/robosystems/operations/graph/graph_creation_service.py
+++ b/robosystems/operations/graph/graph_creation_service.py
@@ -552,6 +552,11 @@ class GraphCreationService:
             next(db_gen)
           except StopIteration:
             pass
+      except ValueError as e:
+        # Deterministic config error (unknown tier, disallowed graph-tier combo)
+        # — retrying cannot help, so log and stop rather than burn the backoff.
+        logger.error(f"Failed to create credit pool for {graph_id}: {e}")
+        return
       except Exception as e:
         last_error = e
         logger.warning(

--- a/robosystems/operations/graph/graph_creation_service.py
+++ b/robosystems/operations/graph/graph_creation_service.py
@@ -30,6 +30,11 @@ logger = get_logger(__name__)
 # The worker's per-task budget must exceed the pipeline's waits *and* this.
 CLEANUP_TIMEOUT_SECONDS = 180
 
+# Base backoff between credit-pool creation retries (multiplied by the attempt).
+# A module constant so a test exercising the transient-retry path can zero it
+# instead of paying real wall-clock.
+CREDIT_POOL_RETRY_BACKOFF_SECONDS = 1.0
+
 
 # ---------------------------------------------------------------------------
 # Config / Result dataclasses
@@ -562,7 +567,7 @@ class GraphCreationService:
         logger.warning(
           f"Credit pool creation attempt {attempt + 1}/3 failed for {graph_id}: {e}"
         )
-        await asyncio.sleep(attempt + 1)
+        await asyncio.sleep(CREDIT_POOL_RETRY_BACKOFF_SECONDS * (attempt + 1))
     logger.error(
       f"Failed to create credit pool for {graph_id} after 3 attempts: {last_error}"
     )

--- a/robosystems/operations/graph/provisioning_service.py
+++ b/robosystems/operations/graph/provisioning_service.py
@@ -18,6 +18,7 @@ from typing import Any
 from robosystems.dagster.reporting import report_asset_materialization
 from robosystems.logger import logger
 from robosystems.middleware.sse.operation_manager import get_operation_manager
+from robosystems.security.error_handling import safe_error_message
 
 
 def _finalize_graph_provisioning(
@@ -251,11 +252,16 @@ async def run_graph_provisioning(
         pass
 
   except Exception as e:
-    logger.error(f"Graph provisioning failed for subscription {subscription_id}: {e}")
+    logger.error(
+      f"Graph provisioning failed for subscription {subscription_id}: {e}",
+      exc_info=True,
+    )
     if operation_id:
+      # Replays to the customer via SSE/status — sanitize at the write.
       await manager.fail_operation(
         operation_id,
-        error=str(e),
+        error=safe_error_message(e)
+        or f"Provisioning failed — reference {operation_id}",
         error_details={"error_type": type(e).__name__},
       )
 
@@ -437,12 +443,14 @@ async def run_user_repository_provisioning(
 
   except Exception as e:
     logger.error(
-      f"Repository provisioning failed for subscription {subscription_id}: {e}"
+      f"Repository provisioning failed for subscription {subscription_id}: {e}",
+      exc_info=True,
     )
     if operation_id:
       await manager.fail_operation(
         operation_id,
-        error=str(e),
+        error=safe_error_message(e)
+        or f"Provisioning failed — reference {operation_id}",
         error_details={"error_type": type(e).__name__},
       )
 

--- a/robosystems/routers/admin/credits.py
+++ b/robosystems/routers/admin/credits.py
@@ -425,7 +425,13 @@ async def add_bonus_credits_to_repository(
       }
     )
 
-    pool.current_balance += Decimal(str(data.amount))
+    # Server-side increment (not `+= amount`, a read-modify-write): the ORM
+    # read-modify-write flushes an absolute value that would revert a debit
+    # landing concurrently — the same lost-update this release closed on the
+    # graph pool's add_bonus_credits and the consume/reserve paths.
+    pool.current_balance = UserRepositoryCredits.current_balance + Decimal(
+      str(data.amount)
+    )
     pool.updated_at = datetime.now(UTC)
 
     UserRepositoryCreditTransaction.create_transaction(

--- a/robosystems/routers/admin/credits.py
+++ b/robosystems/routers/admin/credits.py
@@ -629,6 +629,26 @@ async def check_credit_health(request: Request):
     graph_pools = session.query(GraphCredits).all()
     repo_pools = session.query(UserRepositoryCredits).all()
 
+    # Active parent graphs with NO credit pool at all. Iterating pools can
+    # never see these — yet the AI pre-flight denies every run on them, and
+    # admin add-bonus/reset both 404 on the missing row. Subgraphs share the
+    # parent's pool and shared repositories have none by design, so both are
+    # excluded.
+    graph_missing_pools = [
+      {"graph_id": g.graph_id, "org_id": g.org_id, "tier": g.graph_tier}
+      for g in (
+        session.query(Graph)
+        .outerjoin(GraphCredits, GraphCredits.graph_id == Graph.graph_id)
+        .filter(
+          GraphCredits.id.is_(None),
+          Graph.parent_graph_id.is_(None),
+          Graph.graph_type != "repository",
+          Graph.status == "active",
+        )
+        .all()
+      )
+    ]
+
     graph_low_balance = []
     graph_negative_balance = []
     graph_allocation_issues = []
@@ -720,6 +740,7 @@ async def check_credit_health(request: Request):
       len(graph_low_balance)
       + len(graph_negative_balance)
       + len(graph_allocation_issues)
+      + len(graph_missing_pools)
     )
     repo_issues = (
       len(repo_low_balance)
@@ -732,7 +753,7 @@ async def check_credit_health(request: Request):
     total_pools = len(graph_pools) + len(repo_pools)
 
     status_value = "healthy"
-    if graph_negative_balance or repo_negative_balance:
+    if graph_negative_balance or repo_negative_balance or graph_missing_pools:
       status_value = "critical"
     elif total_issues > total_pools * 0.1:
       status_value = "warning"
@@ -756,6 +777,7 @@ async def check_credit_health(request: Request):
         "low_balance_pools": graph_low_balance,
         "negative_balance_pools": graph_negative_balance,
         "allocation_issues": graph_allocation_issues,
+        "missing_pools": graph_missing_pools,
       },
       repository_health={
         "total_pools": len(repo_pools),

--- a/robosystems/routers/auth/login.py
+++ b/robosystems/routers/auth/login.py
@@ -25,7 +25,8 @@ from ...security import SecurityAuditLogger, SecurityEventType
 from ...security.auth_protection import AdvancedAuthProtection
 from ...security.device_fingerprinting import extract_device_fingerprint
 from ...security.input_validation import sanitize_string, validate_email
-from .utils import require_password_auth, verify_password
+from ...security.password import PasswordSecurity
+from .utils import require_password_auth, verify_password_async
 
 # Create router for login endpoint
 router = APIRouter()
@@ -126,6 +127,12 @@ async def login(
   # Find user by email
   user = User.get_by_email(sanitized_email, session)
   if not user or not user.password_hash or not user.is_active:
+    # Burn one bcrypt verification so this branch costs the same wall-clock
+    # as a wrong password against a real account — otherwise the ~0.7 s
+    # difference is an account-enumeration oracle that defeats the generic
+    # message below.
+    await PasswordSecurity.equalize_verify_timing()
+
     # Record failed attempt for protection system
     if client_ip:
       AdvancedAuthProtection.record_auth_attempt(
@@ -147,7 +154,7 @@ async def login(
       status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid email or password"
     )
 
-  if not verify_password(request.password, user.password_hash):
+  if not await verify_password_async(request.password, user.password_hash):
     # Record failed attempt for protection system
     if client_ip:
       AdvancedAuthProtection.record_auth_attempt(

--- a/robosystems/routers/auth/password_reset.py
+++ b/robosystems/routers/auth/password_reset.py
@@ -40,7 +40,7 @@ from ...security.input_validation import (
   validate_email,
 )
 from ...security.password import PasswordSecurity
-from .utils import detect_app_source, hash_password, require_password_auth
+from .utils import detect_app_source, hash_password_async, require_password_auth
 
 # Create router for password reset endpoints
 router = APIRouter()
@@ -248,7 +248,7 @@ async def reset_password(
       detail=f"Password requirements not met: {', '.join(password_result.errors)}",
     )
 
-  password_hash = hash_password(request.new_password)
+  password_hash = await hash_password_async(request.new_password)
 
   # Update user's password
   user.update(session, password_hash=password_hash)

--- a/robosystems/routers/auth/register.py
+++ b/robosystems/routers/auth/register.py
@@ -38,7 +38,7 @@ from ...security.input_validation import (
   validate_email,
 )
 from ...security.password import PasswordSecurity
-from .utils import detect_app_source, hash_password, require_password_auth
+from .utils import detect_app_source, hash_password_async, require_password_auth
 
 # Create router for register endpoint
 router = APIRouter()
@@ -293,7 +293,7 @@ async def register(
         detail="This invitation was issued for a different email address.",
       )
 
-  password_hash = hash_password(request.password)
+  password_hash = await hash_password_async(request.password)
 
   # Verification policy: possession of the emailed invitation token proves
   # control of the invited mailbox, and dev environments skip verification

--- a/robosystems/routers/auth/utils.py
+++ b/robosystems/routers/auth/utils.py
@@ -91,6 +91,16 @@ def verify_password(password: str, hashed: str) -> bool:
   return PasswordSecurity.verify_password(password, hashed)
 
 
+async def hash_password_async(password: str) -> str:
+  """hash_password off the event loop — bcrypt at cost 14 blocks ~0.5-1 s."""
+  return await PasswordSecurity.hash_password_async(password)
+
+
+async def verify_password_async(password: str, hashed: str) -> bool:
+  """verify_password off the event loop; see hash_password_async."""
+  return await PasswordSecurity.verify_password_async(password, hashed)
+
+
 # JWT token functions are now imported from middleware.auth.jwt
 
 

--- a/robosystems/routers/graphs/query/execute.py
+++ b/robosystems/routers/graphs/query/execute.py
@@ -60,6 +60,7 @@ from robosystems.models.api.graphs.query import (
   CypherStatementResponse,
 )
 from robosystems.models.core import User
+from robosystems.security.error_handling import safe_error_message
 
 from .handlers import (
   get_query_operation_type,
@@ -840,9 +841,12 @@ async def execute_cypher_query(
       },
       user_id=current_user.id if current_user else None,
     )
+    # Transient-rejection text can name factory internals (pool state, the
+    # shared master) — the caller only needs "at capacity, back off".
     raise HTTPException(
       status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE,
-      detail=str(e),
+      detail=safe_error_message(e)
+      or "Graph API is temporarily unavailable; retry shortly",
       headers={"Retry-After": str(retry_after)},
     )
 
@@ -883,14 +887,17 @@ async def execute_cypher_query(
 
     logger.error(f"Unexpected error in query execution: {e}")
 
-    # Provide helpful error for testing tools
+    # Provide helpful error for testing tools. is_interactive is caller-
+    # controlled (test_mode / User-Agent), so it confers verbosity of shape
+    # only — the message itself is sanitized like every other sink.
     if client_info.get("is_interactive"):
       return JSONResponse(
         status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
         content={
           "error": "Query execution failed",
           "error_type": type(e).__name__,
-          "error_message": str(e),
+          "error_message": safe_error_message(e)
+          or "An unexpected error occurred while processing your query",
           "suggestion": "Please check your query syntax and try again",
         },
       )

--- a/robosystems/routers/graphs/query/sql.py
+++ b/robosystems/routers/graphs/query/sql.py
@@ -36,6 +36,7 @@ from robosystems.models.api.graphs.tables import (
   SqlStatementResponse,
 )
 from robosystems.models.core import User
+from robosystems.security.error_handling import safe_error_message
 
 router = APIRouter()
 
@@ -197,7 +198,11 @@ async def execute_sql(
       exc_info=True,
     )
 
+    # The caller's own statement errors keep their message; infrastructure
+    # exceptions (boto3/redis/driver text naming hosts and internals) collapse
+    # to a generic detail — the full text is in the log line above.
+    safe_message = safe_error_message(e)
     raise HTTPException(
       status_code=status.HTTP_400_BAD_REQUEST,
-      detail=f"Query failed: {e!s}",
+      detail=f"Query failed: {safe_message}" if safe_message else "Query failed",
     )

--- a/robosystems/routers/graphs/query/streaming.py
+++ b/robosystems/routers/graphs/query/streaming.py
@@ -23,6 +23,7 @@ from robosystems.models.api.graphs.query import (
   CypherStatementRequest,
 )
 from robosystems.models.core import User
+from robosystems.security.error_handling import safe_error_message
 
 # Initialize circuit breaker
 circuit_breaker = CircuitBreakerManager()
@@ -173,9 +174,11 @@ async def stream_ndjson_response(
       )
 
     except Exception as e:
-      # Stream error as NDJSON
+      # Stream error as NDJSON. Headers are already sent, so in-band is the
+      # only channel — sanitize at the yield: infrastructure exception text
+      # stays in server logs, the caller's own query errors pass through.
       error_chunk = {
-        "error": str(e),
+        "error": safe_error_message(e) or "Query streaming failed",
         "error_type": type(e).__name__,
         "graph_id": graph_id,
         "timestamp": datetime.now(UTC).isoformat(),
@@ -184,7 +187,7 @@ async def stream_ndjson_response(
 
       # Record failure metrics
       circuit_breaker.record_failure(graph_id, "cypher_query", error=e)
-      logger.error(f"NDJSON streaming failed: {e}")
+      logger.error(f"NDJSON streaming failed: {e}", exc_info=True)
 
   return StreamingResponse(
     generate_ndjson(),
@@ -385,13 +388,13 @@ async def stream_sse_response(
         "event": "error",
         "data": json.dumps(
           {
-            "error": str(e),
+            "error": safe_error_message(e) or "Query streaming failed",
             "error_type": type(e).__name__,
           }
         ),
       }
       circuit_breaker.record_failure(graph_id, "cypher_query", error=e)
-      logger.error(f"SSE streaming failed: {e}")
+      logger.error(f"SSE streaming failed: {e}", exc_info=True)
 
   return EventSourceResponse(
     sse_generator(),
@@ -595,12 +598,12 @@ async def stream_sse_with_queue(
           break
 
     except Exception as e:
-      logger.error(f"Queue SSE error: {e}")
+      logger.error(f"Queue SSE error: {e}", exc_info=True)
       yield {
         "event": "error",
         "data": json.dumps(
           {
-            "error": str(e),
+            "error": safe_error_message(e) or "Query streaming failed",
             "query_id": query_id,
           }
         ),

--- a/robosystems/routers/user/password.py
+++ b/robosystems/routers/user/password.py
@@ -70,7 +70,7 @@ async def update_user_password(
         code=ErrorCode.INVALID_INPUT,
       )
 
-    if not PasswordSecurity.verify_password(
+    if not await PasswordSecurity.verify_password_async(
       request.current_password, user_with_password.password_hash
     ):
       metrics_instance = get_endpoint_metrics()
@@ -114,7 +114,7 @@ async def update_user_password(
     # registration and reset both hash at the policy cost, and a bare
     # bcrypt.gensalt() defaults to cost 12, silently downgrading every account
     # that changes its password below the configured work factor.
-    new_password_hash = PasswordSecurity.hash_password(request.new_password)
+    new_password_hash = await PasswordSecurity.hash_password_async(request.new_password)
 
     user_in_session = User.get_by_id(user_id, db)
     if not user_in_session:

--- a/robosystems/security/error_handling.py
+++ b/robosystems/security/error_handling.py
@@ -290,3 +290,28 @@ def sanitize_error_detail(detail_message: str) -> str:
 
   # Return generic message for potentially sensitive errors
   return "An error occurred while processing your request"
+
+
+def safe_error_message(exc: BaseException) -> str | None:
+  """The exception's own message when it is safe to show the caller, else None.
+
+  Safe means the message is about the caller's own input — a query syntax
+  error, a client-side rejection from the graph API, or a domain validation
+  ``ValueError`` — scrubbed of connection secrets. Driver and infrastructure
+  exceptions (boto3, psycopg2, httpx, opensearch-py, redis, …) return None:
+  their text names hosts, indexes, SQL, and internals, and belongs in server
+  logs only. Callers substitute their sink's generic message on None.
+  """
+  from robosystems.graph_api.client.exceptions import (
+    GraphClientError,
+    GraphSyntaxError,
+  )
+
+  if isinstance(exc, GraphSyntaxError | GraphClientError):
+    return redact_connection_secrets(str(exc))
+  # Plain ValueError is domain-validation text throughout the operations
+  # kernel; subclasses from third-party libs are excluded so a driver that
+  # subclasses ValueError cannot ride the whitelist.
+  if type(exc) is ValueError:
+    return redact_connection_secrets(str(exc))
+  return None

--- a/robosystems/security/password.py
+++ b/robosystems/security/password.py
@@ -233,6 +233,42 @@ class PasswordSecurity:
       return False
 
   @classmethod
+  async def hash_password_async(cls, password: str) -> str:
+    """hash_password off the event loop — cost-14 bcrypt is ~0.5-1 s of CPU
+    that would otherwise stall every tenant sharing the loop."""
+    import asyncio
+
+    return await asyncio.to_thread(cls.hash_password, password)
+
+  @classmethod
+  async def verify_password_async(cls, password: str, hashed: str) -> bool:
+    """verify_password off the event loop; see hash_password_async."""
+    import asyncio
+
+    return await asyncio.to_thread(cls.verify_password, password, hashed)
+
+  # A fixed cost-14 hash whose only purpose is burning the same bcrypt work as
+  # a real verification. The candidate string below never matches it — the
+  # result is discarded; only the wall-clock parity matters.
+  _TIMING_EQUALIZER_HASH = (
+    "$2b$14$QZqnSEVBjqfiGXIKfN1osuDqkogiNCpSZW3UFxutpEGp1hB7VxkZe"
+  )
+
+  @classmethod
+  async def equalize_verify_timing(cls) -> None:
+    """Burn one bcrypt verification's worth of work, off the loop.
+
+    The login miss path (unknown email, inactive user, null hash) returns 401
+    having done zero bcrypt work, while a real account pays the full cost-14
+    hash — a ~0.7 s wall-clock difference that defeats the deliberately
+    generic "Invalid email or password". Calling this on the miss path makes
+    both branches cost the same.
+    """
+    await cls.verify_password_async(
+      "timing-equalizer-candidate", cls._TIMING_EQUALIZER_HASH
+    )
+
+  @classmethod
   def _bcrypt_bytes(cls, password: str) -> bytes:
     """Encode a password to bcrypt's 72-byte input, truncating if needed.
 

--- a/robosystems/worker/consumer.py
+++ b/robosystems/worker/consumer.py
@@ -27,6 +27,7 @@ from robosystems.middleware.sse.operation_manager import (
   OperationManager,
   get_operation_manager,
 )
+from robosystems.security.error_handling import safe_error_message
 from robosystems.worker.cleanup import cleanup_connections
 from robosystems.worker.constants import DEFAULT_TASK_TIMEOUT, TASK_TIMEOUTS
 from robosystems.worker.metrics import QueueDepthPublisher
@@ -231,10 +232,13 @@ async def _process_task(
           "graph_id": graph_id,
         },
       )
+      # The stored error replays to the customer via SSE and operation status;
+      # infrastructure exception text (boto3/psycopg2/httpx internals) stays in
+      # the server log above and the customer gets a reference id instead.
       await _fail_quietly(
         manager,
         task_id,
-        error=str(e),
+        error=safe_error_message(e) or f"Operation failed — reference {task_id}",
         error_details={"error_type": type(e).__name__},
       )
 

--- a/tests/config/test_parameter_store.py
+++ b/tests/config/test_parameter_store.py
@@ -4,7 +4,6 @@ Tests for the SSM Parameter Store integration for feature flags.
 These are pure unit tests that mock AWS SSM, requiring no database or external services.
 """
 
-import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -23,7 +22,7 @@ pytestmark = pytest.mark.unit
 class TestParameterStoreManagerCaching:
   """Test TTL-based caching functionality."""
 
-  def test_cache_ttl_respects_expiry(self):
+  def test_cache_ttl_respects_expiry(self, monkeypatch):
     """Test that cached parameters expire after TTL."""
     with patch("robosystems.config.parameter_store._get_ssm_client") as mock_get_client:
       mock_client = MagicMock()
@@ -45,8 +44,15 @@ class TestParameterStoreManagerCaching:
       assert result2 == "true"
       assert mock_client.get_parameter.call_count == 1
 
-      # Wait for TTL to expire
-      time.sleep(1.1)
+      # Advance the manager's clock past the TTL instead of sleeping.
+      import time as _t
+      from types import SimpleNamespace
+
+      future = _t.time() + manager.cache_ttl_seconds + 1
+      monkeypatch.setattr(
+        "robosystems.config.parameter_store.time",
+        SimpleNamespace(time=lambda: future),
+      )
 
       # Next call should hit AWS again
       result3 = manager.get_parameter("RATE_LIMIT_ENABLED")

--- a/tests/config/test_secrets_manager.py
+++ b/tests/config/test_secrets_manager.py
@@ -3,7 +3,6 @@ Tests for the improved secrets manager with TTL caching and better error handlin
 """
 
 import json
-import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,7 +18,7 @@ from robosystems.config.secrets_manager import (
 class TestSecretsManagerTTL:
   """Test TTL-based caching functionality."""
 
-  def test_cache_ttl_respects_expiry(self):
+  def test_cache_ttl_respects_expiry(self, monkeypatch):
     """Test that cached secrets expire after TTL."""
     with patch("boto3.client") as mock_boto:
       mock_client = MagicMock()
@@ -43,8 +42,15 @@ class TestSecretsManagerTTL:
       assert result2["TEST_KEY"] == "test_value"
       assert mock_client.get_secret_value.call_count == 1
 
-      # Wait for TTL to expire
-      time.sleep(1.1)
+      # Advance the manager's clock past the TTL instead of sleeping.
+      import time as _t
+      from types import SimpleNamespace
+
+      future = _t.time() + manager.cache_ttl_seconds + 1
+      monkeypatch.setattr(
+        "robosystems.config.secrets_manager.time",
+        SimpleNamespace(time=lambda: future),
+      )
 
       # Next call should hit AWS again
       result3 = manager.get_secret()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,11 +12,14 @@ from sqlalchemy.orm import sessionmaker
 from main import app
 from robosystems.database import Model as Base
 
-# Speed up password hashing for tests by reducing bcrypt rounds
-# Production uses 14 rounds, but that's too slow for tests
+# Speed up bcrypt hashing for tests by reducing rounds. Production uses cost 14
+# for passwords and cost 12 for API keys (~250ms each — API-key hashing alone is
+# paid by ~15 test files); both are too slow for the suite.
+from robosystems.models.core.user.user_api_key import UserAPIKey as _UserAPIKey
 from robosystems.security import password as password_module
 
 password_module.PasswordSecurity.BCRYPT_ROUNDS = 4  # Fast for tests
+_UserAPIKey.BCRYPT_ROUNDS = 4  # Fast for tests
 
 
 @pytest.fixture(autouse=True)
@@ -441,7 +444,7 @@ def test_user(test_db):
 
   unique_id = str(uuid.uuid4())[:8]
   password = "T3stP@ssw0rd!"
-  salt = bcrypt.gensalt()
+  salt = bcrypt.gensalt(rounds=4)  # fast for tests
   password_hash = bcrypt.hashpw(password.encode("utf-8"), salt).decode("utf-8")
 
   org = Org(
@@ -951,7 +954,7 @@ def other_user(test_db):
 
   unique_id = str(uuid.uuid4())[:8]
   password = "0th3rP@ssw0rd!"
-  salt = bcrypt.gensalt()
+  salt = bcrypt.gensalt(rounds=4)  # fast for tests
   password_hash = bcrypt.hashpw(password.encode("utf-8"), salt).decode("utf-8")
 
   user = User(

--- a/tests/middleware/billing/test_credit_cache.py
+++ b/tests/middleware/billing/test_credit_cache.py
@@ -193,8 +193,11 @@ class TestCreditCache:
     # Operation cost should still be there
     assert cache_instance.get_cached_operation_cost("query") == Decimal("1.0")
 
-  def test_ttl_expiry(self, cache_instance):
+  def test_ttl_expiry(self, cache_instance, monkeypatch):
     """Test that entries expire based on TTL."""
+    import time as _t
+    from types import SimpleNamespace
+
     cache_key = "test_key"
     # Set with 1-second TTL
     cache_instance._setex(cache_key, 1, "test_value")
@@ -202,8 +205,12 @@ class TestCreditCache:
     # Should exist immediately
     assert cache_instance._get(cache_key) == "test_value"
 
-    # Wait for expiry
-    time.sleep(1.1)
+    # Advance the cache's clock past expiry instead of sleeping.
+    future = _t.time() + 2
+    monkeypatch.setattr(
+      "robosystems.middleware.billing.cache.time",
+      SimpleNamespace(time=lambda: future),
+    )
 
     # Should be gone
     assert cache_instance._get(cache_key) is None

--- a/tests/middleware/graph/test_query_queue.py
+++ b/tests/middleware/graph/test_query_queue.py
@@ -629,7 +629,11 @@ class TestQueryQueueManager:
 
     assert query.status == QueryStatus.FAILED
     assert query.error is not None
-    assert "Query executor not configured" in query.error
+    # Internal config text ("executor not configured") is not a caller-safe
+    # message — it is withheld and replaced with a reference id, the full text
+    # going to the server log only.
+    assert "executor not configured" not in query.error
+    assert query.id in query.error
 
   def test_cleanup_completed_queries(self, queue_manager):
     """Test cleanup of completed queries cache."""

--- a/tests/middleware/mcp/tools/test_search_tools.py
+++ b/tests/middleware/mcp/tools/test_search_tools.py
@@ -161,3 +161,29 @@ class TestToolRegistration:
 
     assert search_tool.get_tool_definition()["name"] == "search-documents"
     assert section_tool.get_tool_definition()["name"] == "get-document-section"
+
+
+class TestSearchToolErrorSanitization:
+  """opensearch-py exception text (endpoint hostnames, index internals) must
+  not reach the LLM through a tool result."""
+
+  @pytest.mark.asyncio
+  async def test_backend_error_is_withheld_from_the_llm(self, mock_graph_client):
+    tool = SearchDocumentsTool(mock_graph_client)
+
+    class ConnectionTimeout(Exception):
+      pass
+
+    mock_service = MagicMock()
+    mock_service.search_documents.side_effect = ConnectionTimeout(
+      "ConnectionTimeout caused by vpc-os-abc.us-east-1.es.amazonaws.com:443"
+    )
+    with patch(
+      "robosystems.operations.search.get_search_service",
+      return_value=mock_service,
+    ):
+      result = await tool.execute({"query": "anything"})
+
+    assert result["error"] == "search_failed"
+    assert "amazonaws.com" not in result["message"]
+    assert "see server logs" in result["message"]

--- a/tests/models/core/graph/test_graph_credits.py
+++ b/tests/models/core/graph/test_graph_credits.py
@@ -1020,3 +1020,72 @@ class TestSingleBalanceDefinition:
     summary = self.credits.get_usage_summary(self.session)
     assert summary["current_balance"] == 700.0
     assert summary["consumed_this_month"] == 300.0
+
+  def test_consume_does_not_revert_a_concurrent_debit(self):
+    """Regression: the ORM write-back after the atomic UPDATE used to flush an
+    absolute balance, clobbering any debit that committed concurrently (the
+    lock is released by create_transaction's internal commit). A second debit
+    landing in that window must survive."""
+    from unittest.mock import patch
+
+    from sqlalchemy import text
+    from sqlalchemy.orm import Session
+
+    from robosystems.models.core.graph.graph_credits import GraphCreditTransaction
+
+    credits = self.credits
+    credits.current_balance = Decimal("100")
+    self.session.commit()
+    credits_id = credits.id
+
+    engine = self.session.get_bind()
+    real_create = GraphCreditTransaction.create_transaction.__func__
+    fired = {"done": False}
+
+    def create_then_inject_concurrent_debit(cls, *args, **kwargs):
+      # The real call commits the atomic debit and releases the row lock.
+      txn = real_create(cls, *args, **kwargs)
+      # Exactly here, a concurrent request debits the same pool in its own
+      # committed transaction — the interleaving the write-back used to lose.
+      if not fired["done"]:
+        fired["done"] = True
+        other = Session(bind=engine)
+        try:
+          other.execute(
+            text(
+              "UPDATE graph_credits SET current_balance = current_balance - 5 "
+              "WHERE id = :cid"
+            ),
+            {"cid": credits_id},
+          )
+          other.commit()
+        finally:
+          other.close()
+      return txn
+
+    with patch.object(
+      GraphCreditTransaction,
+      "create_transaction",
+      classmethod(create_then_inject_concurrent_debit),
+    ):
+      result = credits.consume_credits_atomic(
+        amount=Decimal("10"),
+        operation_type="agent_call",
+        operation_description="AI call",
+        session=self.session,
+        user_id=self.user.id,
+      )
+
+    assert result["success"] is True
+
+    # 100 - 10 (this consume) - 5 (concurrent) = 85. A revert-to-absolute bug
+    # would leave 90 (the concurrent -5 lost).
+    verify = Session(bind=engine)
+    try:
+      db_balance = verify.execute(
+        text("SELECT current_balance FROM graph_credits WHERE id = :cid"),
+        {"cid": credits_id},
+      ).scalar()
+    finally:
+      verify.close()
+    assert Decimal(str(db_balance)) == Decimal("85")

--- a/tests/models/core/user/test_user_repository_credits.py
+++ b/tests/models/core/user/test_user_repository_credits.py
@@ -411,14 +411,13 @@ class TestUserRepositoryCredits:
     assert transaction.amount == Decimal("1000")
 
   def test_allocate_monthly_credits_not_due(self):
-    """Test allocation when not due yet."""
-    future_date = datetime.now(UTC) + timedelta(days=15)
-
+    """Not due = already allocated this calendar month (the gate keys on
+    last_allocation_date, matching the 1st-of-month cron)."""
     credits = UserRepositoryCredits(
       user_repository_id=self.repo_access.id,
       current_balance=Decimal("500"),
       monthly_allocation=Decimal("1000"),
-      next_allocation_date=future_date,
+      last_allocation_date=datetime.now(UTC),  # allocated this month already
     )
     self.session.add(credits)
     self.session.commit()
@@ -427,6 +426,43 @@ class TestUserRepositoryCredits:
 
     assert result is False
     assert credits.current_balance == Decimal("500")  # Unchanged
+
+  def test_allocate_does_not_skip_the_next_calendar_month(self):
+    """Regression: a mid-month allocation used to re-arm next_allocation_date
+    to +30 days — a date the 1st-of-month cron never runs on — so the very
+    next month was silently skipped. With the calendar-month gate, a pool
+    allocated last month is due this month regardless of the day."""
+    last_month = datetime.now(UTC).replace(day=15) - timedelta(days=31)
+
+    credits = UserRepositoryCredits(
+      user_repository_id=self.repo_access.id,
+      current_balance=Decimal("100"),
+      monthly_allocation=Decimal("1000"),
+      last_allocation_date=last_month,
+    )
+    self.session.add(credits)
+    self.session.commit()
+
+    assert credits.allocate_monthly_credits(self.session) is True
+    assert credits.current_balance == Decimal("1000")
+
+  def test_next_allocation_date_is_pinned_to_the_first(self):
+    """The re-armed date must land on the 1st so it can never drift off the
+    cron again."""
+    last_month = datetime.now(UTC).replace(day=10) - timedelta(days=31)
+    credits = UserRepositoryCredits(
+      user_repository_id=self.repo_access.id,
+      current_balance=Decimal("100"),
+      monthly_allocation=Decimal("1000"),
+      last_allocation_date=last_month,
+    )
+    self.session.add(credits)
+    self.session.commit()
+
+    credits.allocate_monthly_credits(self.session)
+
+    assert credits.next_allocation_date.day == 1
+    assert credits.next_allocation_date > datetime.now(UTC)
 
   def test_allocate_monthly_credits_overflow_protection(self):
     """Test overflow protection during allocation."""

--- a/tests/operations/graph/test_create_credits_retry.py
+++ b/tests/operations/graph/test_create_credits_retry.py
@@ -1,0 +1,65 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robosystems.operations.graph.graph_creation_service import (
+  GraphCreationConfig,
+  GraphCreationService,
+)
+
+
+def _config():
+  return GraphCreationConfig(
+    user_id="u1", tier="ladybug-standard", graph_name="G", graph_type="generic"
+  )
+
+
+@pytest.mark.asyncio
+async def test_create_credits_does_not_retry_deterministic_valueerror():
+  """A config ValueError (unknown tier / disallowed combo) can never succeed on
+  retry — it must return immediately without burning the backoff sleeps."""
+  service = GraphCreationService()
+
+  fake_service = MagicMock()
+  fake_service.create_graph_credits.side_effect = ValueError("Unknown tier")
+
+  with (
+    patch(
+      "robosystems.operations.graph.credit_service.CreditService",
+      return_value=fake_service,
+    ),
+    patch(
+      "robosystems.database.get_db_session",
+      side_effect=lambda: iter([MagicMock()]),
+    ),
+    patch("asyncio.sleep", new_callable=AsyncMock) as sleep_mock,
+  ):
+    await service._create_credits("kg1", _config())
+
+  fake_service.create_graph_credits.assert_called_once()  # no retry
+  sleep_mock.assert_not_called()  # no backoff burned
+
+
+@pytest.mark.asyncio
+async def test_create_credits_retries_transient_error():
+  """A transient (non-ValueError) failure retries up to 3x with backoff."""
+  service = GraphCreationService()
+
+  fake_service = MagicMock()
+  fake_service.create_graph_credits.side_effect = RuntimeError("connection reset")
+
+  with (
+    patch(
+      "robosystems.operations.graph.credit_service.CreditService",
+      return_value=fake_service,
+    ),
+    patch(
+      "robosystems.database.get_db_session",
+      side_effect=lambda: iter([MagicMock()]),
+    ),
+    patch("asyncio.sleep", new_callable=AsyncMock) as sleep_mock,
+  ):
+    await service._create_credits("kg1", _config())
+
+  assert fake_service.create_graph_credits.call_count == 3
+  assert sleep_mock.await_count == 3

--- a/tests/routers/admin/test_credits.py
+++ b/tests/routers/admin/test_credits.py
@@ -652,6 +652,16 @@ class TestAddBonusCreditsToRepository:
     mock_query = mock_session.query.return_value
     mock_query.filter.return_value.first.return_value = pool
 
+    # refresh() reloads the server-computed balance from the DB — simulate that,
+    # capturing what was assigned before the reload.
+    captured = {}
+
+    def fake_refresh(obj):
+      captured["pre_reload"] = obj.current_balance
+      obj.current_balance = Decimal("900.0")
+
+    mock_session.refresh.side_effect = fake_refresh
+
     with (
       patch(f"{MODULE}.get_db_session", return_value=iter([mock_session])),
       patch(f"{MODULE}.UserRepositoryCreditTransaction") as MockTransaction,
@@ -662,8 +672,14 @@ class TestAddBonusCreditsToRepository:
         data=bonus_request,
       )
 
-    # Balance should have been incremented
-    assert pool.current_balance == Decimal("700.0") + Decimal("200.0")
+    # The fix: balance is incremented server-side (SET current_balance =
+    # current_balance + :amount), not by a Python read-modify-write that could
+    # revert a concurrent debit — so what was assigned before the reload is a
+    # SQLAlchemy expression, not a pre-computed Decimal. The arithmetic itself is
+    # exercised by the model tests against a real DB.
+    assert not isinstance(captured["pre_reload"], Decimal)
+    assert "current_balance" in str(captured["pre_reload"])
+    assert result.current_balance == 900.0
     MockTransaction.create_transaction.assert_called_once()
     call_kwargs = MockTransaction.create_transaction.call_args.kwargs
     assert call_kwargs["credit_pool_id"] == "crd_pool_001"

--- a/tests/routers/admin/test_credits.py
+++ b/tests/routers/admin/test_credits.py
@@ -807,6 +807,7 @@ class TestCheckCreditHealth:
     mock_session.query.return_value = query_mock
     # First .all() returns graph pools, second returns repo pools
     query_mock.all.side_effect = [[pool], []]
+    query_mock.outerjoin.return_value.filter.return_value.all.return_value = []
 
     with patch(f"{MODULE}.get_db_session", return_value=iter([mock_session])):
       result = await check_credit_health(request=mock_request)
@@ -818,6 +819,31 @@ class TestCheckCreditHealth:
     assert result.graph_health["negative_balance_pools"] == []
     assert result.graph_health["low_balance_pools"] == []
     mock_session.close.assert_called_once()
+
+  @pytest.mark.unit
+  async def test_missing_pool_triggers_critical(self, mock_request, mock_session):
+    """An active graph with no credit pool is invisible to per-pool scans yet
+    has every AI run denied — it must surface as a critical missing_pools row."""
+    from robosystems.routers.admin.credits import check_credit_health
+
+    orphan = MagicMock()
+    orphan.graph_id = "kg_orphan"
+    orphan.org_id = "org_1"
+    orphan.graph_tier = "ladybug-standard"
+
+    query_mock = MagicMock()
+    mock_session.query.return_value = query_mock
+    query_mock.all.side_effect = [[], []]  # no pools of either kind
+    query_mock.outerjoin.return_value.filter.return_value.all.return_value = [orphan]
+
+    with patch(f"{MODULE}.get_db_session", return_value=iter([mock_session])):
+      result = await check_credit_health(request=mock_request)
+
+    assert result.status == "critical"
+    assert result.graph_health["missing_pools"] == [
+      {"graph_id": "kg_orphan", "org_id": "org_1", "tier": "ladybug-standard"}
+    ]
+    assert result.pools_with_issues >= 1
 
   @pytest.mark.unit
   async def test_critical_with_negative_balance(self, mock_request, mock_session):
@@ -833,6 +859,7 @@ class TestCheckCreditHealth:
     query_mock = MagicMock()
     mock_session.query.return_value = query_mock
     query_mock.all.side_effect = [[negative_pool], []]
+    query_mock.outerjoin.return_value.filter.return_value.all.return_value = []
 
     with patch(f"{MODULE}.get_db_session", return_value=iter([mock_session])):
       result = await check_credit_health(request=mock_request)
@@ -858,6 +885,7 @@ class TestCheckCreditHealth:
     query_mock = MagicMock()
     mock_session.query.return_value = query_mock
     query_mock.all.side_effect = [[low_pool], []]
+    query_mock.outerjoin.return_value.filter.return_value.all.return_value = []
 
     with patch(f"{MODULE}.get_db_session", return_value=iter([mock_session])):
       result = await check_credit_health(request=mock_request)
@@ -879,6 +907,7 @@ class TestCheckCreditHealth:
     query_mock = MagicMock()
     mock_session.query.return_value = query_mock
     query_mock.all.side_effect = [[zero_pool], []]
+    query_mock.outerjoin.return_value.filter.return_value.all.return_value = []
 
     with patch(f"{MODULE}.get_db_session", return_value=iter([mock_session])):
       result = await check_credit_health(request=mock_request)
@@ -903,6 +932,7 @@ class TestCheckCreditHealth:
     query_mock = MagicMock()
     mock_session.query.return_value = query_mock
     query_mock.all.side_effect = [[], [repo_pool]]
+    query_mock.outerjoin.return_value.filter.return_value.all.return_value = []
 
     with patch(f"{MODULE}.get_db_session", return_value=iter([mock_session])):
       result = await check_credit_health(request=mock_request)
@@ -925,6 +955,7 @@ class TestCheckCreditHealth:
     query_mock = MagicMock()
     mock_session.query.return_value = query_mock
     query_mock.all.side_effect = [[], [inactive_pool]]
+    query_mock.outerjoin.return_value.filter.return_value.all.return_value = []
 
     with patch(f"{MODULE}.get_db_session", return_value=iter([mock_session])):
       result = await check_credit_health(request=mock_request)
@@ -943,6 +974,7 @@ class TestCheckCreditHealth:
     query_mock = MagicMock()
     mock_session.query.return_value = query_mock
     query_mock.all.side_effect = [[], []]
+    query_mock.outerjoin.return_value.filter.return_value.all.return_value = []
 
     before = datetime.now(UTC)
 

--- a/tests/routers/auth/test_auth.py
+++ b/tests/routers/auth/test_auth.py
@@ -228,6 +228,25 @@ class TestAuthLogin:
     data = response.json()
     assert data["detail"] == "Invalid email or password"
 
+  def test_login_unknown_email_burns_bcrypt_to_equalize_timing(
+    self, client: TestClient
+  ):
+    """The miss path must spend a verification's worth of work so it is
+    indistinguishable from a wrong password (no enumeration oracle)."""
+    from unittest.mock import AsyncMock
+
+    with patch(
+      "robosystems.security.password.PasswordSecurity.equalize_verify_timing",
+      new=AsyncMock(),
+    ) as equalizer:
+      response = client.post(
+        "/v1/auth/login",
+        json={"email": "no-such-user@example.com", "password": "whatever123"},
+      )
+
+    assert response.status_code == 401
+    equalizer.assert_awaited_once()
+
   @patch.object(
     __import__("robosystems.config", fromlist=["env"]).env,
     "USER_REGISTRATION_ENABLED",

--- a/tests/routers/auth/test_password_reset.py
+++ b/tests/routers/auth/test_password_reset.py
@@ -1,6 +1,6 @@
 """Tests for password reset endpoints."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -198,7 +198,10 @@ class TestPasswordResetEndpoints:
   @pytest.mark.asyncio
   @patch.object(UserToken, "verify_token")
   @patch.object(User, "get_by_id")
-  @patch("robosystems.routers.auth.password_reset.hash_password")
+  @patch(
+    "robosystems.routers.auth.password_reset.hash_password_async",
+    new_callable=AsyncMock,
+  )
   async def test_reset_password_success(
     self, mock_hash_password, mock_get_user, mock_verify_token, client, test_db
   ):

--- a/tests/routers/graphs/query/test_sql.py
+++ b/tests/routers/graphs/query/test_sql.py
@@ -71,3 +71,68 @@ async def test_execute_sql_shared_repo_blocked():
       )
   assert e.value.status_code == 403
   assert "Shared repositories do not allow direct SQL" in e.value.detail
+
+
+async def test_execute_sql_driver_error_is_sanitized():
+  """A backend/driver exception must not put its text (hostnames, internals)
+  in front of the caller — the detail collapses to a generic message."""
+  req = SqlStatementRequest(sql="SELECT 1")
+
+  class FakeDriverError(Exception):
+    pass
+
+  client = MagicMock()
+  client.query_table = AsyncMock(
+    side_effect=FakeDriverError(
+      "could not connect to db.internal:5432 password=hunter2"
+    )
+  )
+  with (
+    patch(f"{MOD}.get_universal_repository", new=AsyncMock(return_value=MagicMock())),
+    patch(
+      "robosystems.graph_api.client.factory.get_graph_client",
+      new=AsyncMock(return_value=client),
+    ),
+  ):
+    with pytest.raises(HTTPException) as e:
+      await sql_module.execute_sql(
+        full_request=MagicMock(),
+        graph_id="kg1234567890abcdef",
+        request=req,
+        current_user=_user(),
+        _rate_limit=None,
+        db=MagicMock(),
+      )
+  assert e.value.status_code == 400
+  assert e.value.detail == "Query failed"
+  assert "db.internal" not in e.value.detail
+  assert "hunter2" not in e.value.detail
+
+
+async def test_execute_sql_syntax_error_passes_through():
+  """A caller-facing query error (GraphSyntaxError) keeps its message."""
+  from robosystems.graph_api.client.exceptions import GraphSyntaxError
+
+  req = SqlStatementRequest(sql="SELECT bad")
+  client = MagicMock()
+  client.query_table = AsyncMock(
+    side_effect=GraphSyntaxError("Binder Error: column x not found")
+  )
+  with (
+    patch(f"{MOD}.get_universal_repository", new=AsyncMock(return_value=MagicMock())),
+    patch(
+      "robosystems.graph_api.client.factory.get_graph_client",
+      new=AsyncMock(return_value=client),
+    ),
+  ):
+    with pytest.raises(HTTPException) as e:
+      await sql_module.execute_sql(
+        full_request=MagicMock(),
+        graph_id="kg1234567890abcdef",
+        request=req,
+        current_user=_user(),
+        _rate_limit=None,
+        db=MagicMock(),
+      )
+  assert e.value.status_code == 400
+  assert "Binder Error: column x not found" in e.value.detail

--- a/tests/security/test_error_handling.py
+++ b/tests/security/test_error_handling.py
@@ -626,3 +626,64 @@ class TestIntegrationScenarios:
     with pytest.raises(HTTPException) as exc_info:
       raise_secure_error(ErrorType.VALIDATION_ERROR)
     assert exc_info.value.detail == "Invalid request data"
+
+
+class TestSafeErrorMessage:
+  """The whitelist that decides which exception text may reach a caller."""
+
+  def test_value_error_passes_through(self):
+    from robosystems.security.error_handling import safe_error_message
+
+    assert safe_error_message(ValueError("period must be YYYY-MM")) == (
+      "period must be YYYY-MM"
+    )
+
+  def test_graph_syntax_error_passes_through(self):
+    from robosystems.graph_api.client.exceptions import GraphSyntaxError
+    from robosystems.security.error_handling import safe_error_message
+
+    assert (
+      safe_error_message(GraphSyntaxError("Parser error at line 1"))
+      == "Parser error at line 1"
+    )
+
+  def test_graph_client_error_passes_through(self):
+    from robosystems.graph_api.client.exceptions import GraphClientError
+    from robosystems.security.error_handling import safe_error_message
+
+    assert safe_error_message(GraphClientError("not found")) == "not found"
+
+  def test_driver_exception_is_withheld(self):
+    """boto3/psycopg2/opensearch text names hosts and internals — None."""
+    from robosystems.security.error_handling import safe_error_message
+
+    class ConnectionTimeout(Exception):
+      pass
+
+    assert (
+      safe_error_message(
+        ConnectionTimeout(
+          "ConnectionTimeout: vpc-os-abc.us-east-1.es.amazonaws.com:443 timed out"
+        )
+      )
+      is None
+    )
+
+  def test_value_error_subclass_from_a_library_is_withheld(self):
+    """Only exact ValueError rides the whitelist; a lib subclass does not."""
+    from robosystems.security.error_handling import safe_error_message
+
+    class WeirdDriverError(ValueError):
+      pass
+
+    assert safe_error_message(WeirdDriverError("host=10.0.0.5 refused")) is None
+
+  def test_connection_secret_is_redacted_from_passed_through_text(self):
+    from robosystems.security.error_handling import safe_error_message
+
+    msg = safe_error_message(
+      ValueError("scan failed: postgresql://u:s3cr3t@db.internal:5432/x")
+    )
+    assert msg is not None
+    assert "s3cr3t" not in msg
+    assert "***" in msg

--- a/tests/security/test_password.py
+++ b/tests/security/test_password.py
@@ -737,3 +737,47 @@ class TestConfigurationValidation:
     obvious_weak = ["password123", "admin123"]
     for weak_pwd in obvious_weak:
       assert weak_pwd in PasswordSecurity.COMMON_PASSWORDS
+
+
+class TestAsyncBcryptOffload:
+  """The async wrappers and the login-miss timing equalizer."""
+
+  @pytest.mark.asyncio
+  async def test_hash_and_verify_async_roundtrip(self):
+    # (conftest patches BCRYPT_ROUNDS to 4 for speed, so the cost prefix is not
+    # asserted here — the roundtrip behavior is what matters.)
+    hashed = await PasswordSecurity.hash_password_async("MyStr0ng!P@ss2024")
+    assert hashed.startswith("$2b$")
+    assert await PasswordSecurity.verify_password_async("MyStr0ng!P@ss2024", hashed)
+    assert not await PasswordSecurity.verify_password_async("wrong", hashed)
+
+  @pytest.mark.asyncio
+  async def test_async_offload_uses_a_thread(self):
+    """The point of the wrapper is that bcrypt runs off the event loop."""
+    import asyncio
+
+    called = {}
+    real_to_thread = asyncio.to_thread
+
+    async def spy(fn, *a, **kw):
+      called["hit"] = True
+      return await real_to_thread(fn, *a, **kw)
+
+    with patch("asyncio.to_thread", spy):
+      await PasswordSecurity.hash_password_async("MyStr0ng!P@ss2024")
+    assert called.get("hit") is True
+
+  @pytest.mark.asyncio
+  async def test_timing_equalizer_runs_a_real_bcrypt(self):
+    """The equalizer must actually spend a verification's worth of work, so a
+    login miss is indistinguishable from a wrong password."""
+    import time
+
+    start = time.perf_counter()
+    await PasswordSecurity.equalize_verify_timing()
+    elapsed = time.perf_counter() - start
+    # cost-14 bcrypt is hundreds of ms; a no-op would be ~microseconds.
+    assert elapsed > 0.05
+
+  def test_timing_equalizer_hash_is_cost_14(self):
+    assert PasswordSecurity._TIMING_EQUALIZER_HASH.startswith("$2b$14$")


### PR DESCRIPTION
Round-6 pre-onboarding hardening — the two `building` items from the round-6 review, plus the auth-hashing offload folded in. No isolation/blast-radius findings; this is correctness, robustness, and defense-in-depth. Full write-ups live in the private vault (`specs/security/error-response-sanitization.md`, `credit-ledger-integrity.md`).

## What changed

**Error-response sanitization.** A shared whitelist (`safe_error_message`) decides which exception text may reach a caller: caller-facing query/validation errors pass through (connection secrets scrubbed); backend/driver exceptions collapse to a generic message with the full text logged server-side. Wired into the SQL endpoint, the three streaming generators, the Cypher interactive/transient paths, the async operation failure channel (worker consumer, provisioning, query queue), and the MCP search/document tools. Extends the redaction pattern already shipped for the DSN log path.

**Credit-ledger consistency.**
- Replace post-atomic ORM balance write-backs with `expire` / server-side expressions on both credit pools, so a concurrent movement can't be reverted by a stale absolute write.
- Move the shared-repository monthly refill to a calendar-month gate aligned with the 1st-of-month allocation cron (the day-count gate could drift off the cron and skip a month).
- Retry graph credit-pool creation on transient failure, and surface pool-less active graphs in the admin credit-health check.

**Auth hashing.** Run bcrypt hashing/verification off the event loop (login, register, reset, password change, re-auth), and equalize timing on the credential-check miss path.

## Tests
New coverage for the sanitization whitelist, the lost-update regression (verified it fails on the pre-fix code and passes after), the refill-gate behavior, the admin missing-pools surface, the async bcrypt offload + timing equalizer, and the query/MCP error sinks. Full affected-area regression: 1232 passing; lint / format / typecheck clean.