### PR TITLE
Schedule early termination + prepaid disposal NBV fix

### DIFF
--- a/robosystems/middleware/mcp/tools/playbook_tools.py
+++ b/robosystems/middleware/mcp/tools/playbook_tools.py
@@ -49,7 +49,19 @@ _RECURRING_SEQUENCE: list[str] = [
   "(reopen → re-close) when no external reporting binds them — the usual "
   "default inside the current fiscal year — or book a CATCH-UP entry in "
   "the open period when the reporting cadence has locked prior months. "
-  "Don't close over unreviewed reconciling items.",
+  "A catch-up/alignment JE that mirrors an edit ALREADY MADE in the source "
+  "system must post locally only — create it with source='system' "
+  "(source='manual' publishes to QB at close and would double-apply the "
+  "edit upstream). Don't close over unreviewed reconciling items.",
+  "Schedules ending this period? (an asset sold or transferred, a prepaid "
+  "cancelled or refunded): terminate BEFORE promoting obligations, or the "
+  "sweep drafts entries the termination says should not exist. "
+  "terminate-schedule ends a schedule at a month-end cutoff with no entry "
+  "(truncates forward facts + voids the remaining obligation chain) — use "
+  "it when the GL effect is already booked or none is wanted. "
+  "create-event-block(event_type='asset_disposed') additionally posts the "
+  "disposal/derecognition entry atomically — use it when that entry still "
+  "needs to be booked.",
   "get-period-close-status (period_start/period_end as YYYY-MM-DD) — see "
   "which schedules are pending / drafted / posted and their amounts.",
   "promote-obligations (dispatch_handlers=true) — draft every matured "
@@ -71,7 +83,11 @@ _RECURRING_SEQUENCE: list[str] = [
   "balance-sheet equation check, advances closed_through. Use "
   "allow_stale_sync=true only when the user has verified QB is complete "
   "despite a stale sync — normally run sync-connection instead (see the "
-  "sync_stale step above).",
+  "sync_stale step above). The call can outlive a client tool timeout "
+  "while the outbox publishes; the close is atomic server-side, so NEVER "
+  "retry on a timeout — verify with get-fiscal-calendar (period closed, "
+  "closed_through advanced) and reconstruct the receipt from "
+  "get-period-close-status.",
   "Post-close verification — read the receipt back to the user, don't "
   "assume: entries_posted should equal the reviewed draft count "
   "(entries_published_to_qb / entries_posted_locally carry the split); "
@@ -202,6 +218,19 @@ _KEY_RULES: list[str] = [
   "close would otherwise silently omit; promote-obligations with "
   "dispatch_handlers=true drafts them, or void the obligation). Resolve "
   "before close-period; get-fiscal-calendar reports them.",
+  "JE PUBLISH SEMANTICS: journal_entry_recorded events with source='manual' "
+  "publish to QuickBooks at close through the outbox; source='system' posts "
+  "locally only. Use 'system' for alignment/catch-up entries that mirror "
+  "edits already made in the source system — publishing those would "
+  "double-apply the edit upstream. list-period-drafts shows the split "
+  "(will_publish_to_qb per draft) before anything commits.",
+  "SCHEDULE TERMINATION: terminate-schedule ends a schedule early at a "
+  "month-end cutoff with no entry (truncates forward facts + voids the "
+  "remaining obligation chain past the cutoff); "
+  "create-event-block(event_type='asset_disposed') does the same void and "
+  "also posts the disposal/derecognition entry atomically. Terminate "
+  "BEFORE promote-obligations. delete-information-block is NOT a "
+  "termination — it erases the schedule's history.",
   "CHECK THE PER-TENANT PROCEDURES DOC FIRST: call search-documents for a "
   "'close procedures' / 'month-end' document before authoring or closing. It "
   "captures this company's specifics and should reference this playbook.",

--- a/robosystems/middleware/mcp/tools/schedule_tools.py
+++ b/robosystems/middleware/mcp/tools/schedule_tools.py
@@ -17,8 +17,12 @@ within one. Where the per-schedule operations live:
 - Closing-entry drafting → ``create-event-block``, with
   ``event_type='schedule_entry_due'`` for schedule-derived drafts and
   ``event_type='journal_entry_recorded'`` for free-form manual entries.
-- Schedule termination (truncate forward facts) → internal to the
-  ``asset_disposed`` event handler; there is no public op.
+- Schedule termination → ``terminate-schedule`` (no-entry: truncate
+  forward facts + void remaining obligations), or
+  ``create-event-block(event_type='asset_disposed')`` when the
+  derecognition entry still needs to be booked (the handler voids the
+  remaining obligations and posts the disposal entry atomically;
+  facts stay as history).
 """
 
 from datetime import date

--- a/robosystems/models/api/extensions/schedules.py
+++ b/robosystems/models/api/extensions/schedules.py
@@ -241,9 +241,11 @@ class UpdateScheduleRequest(BaseModel):
   Structure row / its metadata_ JSONB column).
 
   NOT editable via this op: period_start, period_end, monthly_amount.
-  Those require fact regeneration — fire an event block that terminates
-  the schedule (e.g., `asset_disposed`) and create a fresh schedule via
-  `create-information-block` (`block_type='schedule'`).
+  Those require fact regeneration — end the schedule early via
+  `terminate-schedule` (no entry) or
+  `create-event-block(event_type='asset_disposed')` (with a disposal
+  entry), then create a fresh schedule via `create-information-block`
+  (`block_type='schedule'`).
 
   Omitted fields are left unchanged.
   """
@@ -259,12 +261,56 @@ class DeleteScheduleRequest(BaseModel):
 
   Hard deletes the Structure, all Facts tied to it, and all
   Associations tied to it. This is a permanent, irreversible
-  operation. For ending a schedule early without removing history,
-  fire `create-event-block(event_type='asset_disposed')` instead — the
-  handler truncates the schedule + posts the disposal entry atomically.
+  operation. For ending a schedule early without removing history, use
+  `terminate-schedule` (no entry) or
+  `create-event-block(event_type='asset_disposed')` (the handler voids
+  the remaining obligation chain + posts the disposal entry atomically;
+  recognized facts stay as history).
   """
 
   structure_id: str
+
+
+class TerminateScheduleRequest(BaseModel):
+  """End a schedule early at a month-end cutoff — no entry is booked.
+
+  The no-entry half of schedule retirement, for terminations whose GL
+  effect is already booked (an asset transferred via a manual journal
+  entry, a prepaid refunded in the source system) or where none is
+  wanted. In one transaction: deletes forward facts past the cutoff,
+  voids the remaining obligation chain past it (pending and classified
+  rows), and rewrites the SumEquals rule to prove the truncated curve.
+  History at or before the cutoff is untouched.
+
+  When the derecognition entry still needs to be booked, use
+  `create-event-block(event_type='asset_disposed')` instead — the
+  disposal handler posts it atomically with the same obligation void.
+  """
+
+  structure_id: str = Field(..., description="The schedule structure to terminate.")
+  new_end_date: date = Field(
+    ...,
+    description=(
+      "Last date the schedule covers — must be the last day of a month "
+      "(schedule facts are whole-month). Facts and obligations for periods "
+      "starting after this date are removed/voided."
+    ),
+  )
+  reason: str = Field(
+    ...,
+    min_length=1,
+    description="Why the schedule is ending early — captured in the audit log.",
+  )
+
+
+class TerminateScheduleResponse(BaseModel):
+  structure_id: str
+  name: str
+  new_end_date: date
+  facts_deleted: int
+  obligations_voided: int
+  rule_updated: bool
+  reason: str
 
 
 class RebuildScheduleRequest(BaseModel):

--- a/robosystems/operations/event_block/python_handlers/_disposal_plan.py
+++ b/robosystems/operations/event_block/python_handlers/_disposal_plan.py
@@ -77,15 +77,25 @@ def compute_disposal_plan(
   if not asset_element_id:
     raise ValueError(
       "Disposal requires schedule_metadata.asset_element_id "
-      "(the balance-sheet asset element). Update the schedule first."
+      "(the balance-sheet asset element). Update the schedule first — "
+      "for prepaid-amortization schedules, this is the credited prepaid "
+      "element itself (the same element as entry_template.credit_element_id)."
     )
   if not credit_element_id:
     raise ValueError("Disposal requires entry_template.credit_element_id.")
 
-  # Accumulated depreciation = most recent cumulative in-scope instant fact
-  # up to disposal_date. fact_scope='in_scope' parity with schedule_entry_due:
+  # Most recent cumulative in-scope instant fact up to disposal_date on the
+  # credited element. fact_scope='in_scope' parity with schedule_entry_due:
   # post-truncation / amendment chains can leave out-of-scope instant facts
   # behind, and picking one would produce a wrong NBV silently.
+  #
+  # What that fact MEANS depends on the schedule shape:
+  # - Depreciation-style (credit element is a contra account, e.g.
+  #   Accumulated Depreciation): the instant fact is the RISING cumulative
+  #   accumulated balance.
+  # - Prepaid-style ("self-carried": the credited element IS the asset,
+  #   e.g. Prepaid Expenses): the instant fact is the DECLINING remaining
+  #   balance — reading it as "accumulated" inverts NBV.
   acc_row = session.execute(
     text(
       "SELECT value FROM facts "
@@ -96,10 +106,17 @@ def compute_disposal_plan(
     ),
     {"sid": structure_id, "eid": credit_element_id, "d": disposal_date},
   ).fetchone()
-  accumulated_dollars = float(acc_row.value) if acc_row else 0.0
-  accumulated_depreciation = round(accumulated_dollars * 100)
+  carried_dollars = float(acc_row.value) if acc_row else 0.0
+  carried_cents = round(carried_dollars * 100)
 
-  nbv = original_amount - accumulated_depreciation
+  self_carried = asset_element_id == credit_element_id
+  if self_carried:
+    # Prepaid-style: the instant fact is the remaining balance = NBV.
+    nbv = carried_cents
+    accumulated_depreciation = max(original_amount - nbv, 0)
+  else:
+    accumulated_depreciation = carried_cents
+    nbv = original_amount - accumulated_depreciation
   gain_loss = sale_proceeds - nbv
 
   if sale_proceeds > 0 and not proceeds_element_id:
@@ -110,22 +127,42 @@ def compute_disposal_plan(
       "the disposal produces a gain or loss."
     )
 
-  line_items: list[dict] = [
-    # DR accumulated depreciation (remove the contra account)
-    {
-      "element_id": credit_element_id,
-      "debit_amount": accumulated_depreciation,
-      "credit_amount": 0,
-      "description": "Remove accumulated depreciation",
-    },
-    # CR asset at cost
-    {
-      "element_id": asset_element_id,
-      "debit_amount": 0,
-      "credit_amount": original_amount,
-      "description": "Remove asset at cost",
-    },
-  ]
+  if self_carried:
+    if nbv == 0 and sale_proceeds == 0:
+      raise ValueError(
+        "Nothing to dispose: the schedule's remaining balance is zero "
+        "and no proceeds were supplied."
+      )
+    # One credit derecognizes the asset at its remaining balance — a
+    # DR-accumulated/CR-cost pair on the SAME element would net to the
+    # same amount while doubling the gross line traffic.
+    line_items: list[dict] = []
+    if nbv > 0:
+      line_items.append(
+        {
+          "element_id": asset_element_id,
+          "debit_amount": 0,
+          "credit_amount": nbv,
+          "description": "Derecognize asset at remaining balance",
+        }
+      )
+  else:
+    line_items = [
+      # DR accumulated depreciation (remove the contra account)
+      {
+        "element_id": credit_element_id,
+        "debit_amount": accumulated_depreciation,
+        "credit_amount": 0,
+        "description": "Remove accumulated depreciation",
+      },
+      # CR asset at cost
+      {
+        "element_id": asset_element_id,
+        "debit_amount": 0,
+        "credit_amount": original_amount,
+        "description": "Remove asset at cost",
+      },
+    ]
   if sale_proceeds > 0 and proceeds_element_id:
     line_items.append(
       {

--- a/robosystems/operations/roboledger/commands/schedules.py
+++ b/robosystems/operations/roboledger/commands/schedules.py
@@ -19,6 +19,8 @@ from robosystems.models.api.extensions.schedules import (
   PromoteObligationsResponse,
   RebuildScheduleRequest,
   ScheduleCreatedResponse,
+  TerminateScheduleRequest,
+  TerminateScheduleResponse,
   UpdateScheduleRequest,
 )
 from robosystems.models.extensions import (
@@ -521,6 +523,129 @@ def delete_schedule(session: Session, body: DeleteScheduleRequest) -> dict:
   session.commit()
 
   return {"deleted": True}
+
+
+def _rewrite_sum_equals_rule(session: Session, structure: Structure) -> bool:
+  """Re-anchor the schedule's native SumEquals rule to the truncated curve.
+
+  The rule proves sum(periodic facts) == the schedule's original amount;
+  truncation deletes forward facts, so the old total can never be
+  satisfied again. The remaining curve is still worth proving — the
+  expression is rewritten to its current sum, and verification results
+  proved against the old expression are cleared for re-evaluation.
+
+  Returns False (no-op) when the schedule has no native SumEquals rule
+  or its entry template carries no debit element to sum.
+  """
+  rule = (
+    session.execute(
+      select(Rule).where(
+        Rule.target_structure_id == structure.id,
+        Rule.rule_pattern == "SumEquals",
+        Rule.rule_origin == "native",
+      )
+    )
+    .scalars()
+    .first()
+  )
+  if rule is None:
+    return False
+
+  mechanics = structure.artifact_mechanics or {}
+  template = mechanics.get("entry_template") or {}
+  debit_element_id = template.get("debit_element_id")
+  if not debit_element_id:
+    return False
+
+  remaining = session.execute(
+    text(
+      "SELECT COALESCE(SUM(value), 0) FROM facts "
+      "WHERE structure_id = :sid AND element_id = :eid"
+    ),
+    {"sid": structure.id, "eid": debit_element_id},
+  ).scalar()
+  new_total = round(float(remaining or 0), 2)
+  rule.rule_expression = f"sum($periodic_amount) = {new_total}"
+  session.query(VerificationResult).filter(
+    VerificationResult.rule_id == rule.id
+  ).delete(synchronize_session=False)
+  return True
+
+
+def terminate_schedule(
+  session: Session,
+  body: TerminateScheduleRequest,
+  created_by: str = "system",
+) -> TerminateScheduleResponse:
+  """End a schedule early at a month-end cutoff — no entry is booked.
+
+  The no-entry half of schedule retirement, for terminations whose GL
+  effect is already booked (an asset transferred via a manual journal
+  entry, a prepaid refunded in the source system) or where none is
+  wanted. In one transaction:
+
+  1. ``truncate_schedule`` deletes facts with period_start past the
+     cutoff (guards: month-end cutoff only; refuses when posted entries
+     exist past it; deletes stale draft entries past it).
+  2. The remaining obligation chain past the cutoff is voided —
+     ``pending`` and ``classified`` rows both. A ``classified`` row here
+     can only be an undrafted stray: drafted entries past the cutoff
+     were deleted in step 1 and posted ones blocked it.
+  3. The schedule's SumEquals rule is rewritten to prove the truncated
+     curve.
+
+  Obligations and facts at or before the cutoff are untouched, so open
+  months the schedule still covers close normally.
+
+  When the derecognition entry still needs to be booked, use
+  ``create-event-block(event_type='asset_disposed')`` instead — the
+  disposal handler posts it atomically with the same obligation void.
+
+  Raises ``ScheduleNotFoundError`` if the schedule does not exist, and
+  ``ValueError`` on the truncation guards (mid-month cutoff, posted
+  entries past the cutoff, cutoff before the schedule's first fact).
+  """
+  structure = _load_schedule_or_404(session, body.structure_id)
+  service = ScheduleService()
+
+  truncation = service.truncate_schedule(
+    session,
+    structure_id=structure.id,
+    new_end_date=body.new_end_date,
+    reason=body.reason,
+    updated_by=created_by,
+  )
+
+  # The void locks the same pending rows the promotion sweep holds —
+  # bound the wait rather than hold this request for the length of a
+  # background tick (mirrors delete_schedule).
+  from robosystems.operations.locking import bounded_lock_wait
+
+  with bounded_lock_wait(
+    session,
+    "This schedule's pending obligations are being written by another "
+    "process. Retry in a moment.",
+  ):
+    obligations_voided = service.void_pending_obligations(
+      session,
+      structure=structure,
+      void_reason=f"schedule_terminated: {body.reason}",
+      period_start_after=body.new_end_date,
+      include_classified=True,
+    )
+
+  rule_updated = _rewrite_sum_equals_rule(session, structure)
+  session.commit()
+
+  return TerminateScheduleResponse(
+    structure_id=structure.id,
+    name=structure.name,
+    new_end_date=truncation["new_end_date"],
+    facts_deleted=truncation["facts_deleted"],
+    obligations_voided=obligations_voided,
+    rule_updated=rule_updated,
+    reason=body.reason,
+  )
 
 
 def _reconstruct_schedule_definition(

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -815,10 +815,12 @@ class ScheduleService:
     structure: Structure,
     void_reason: str,
     voided_by_event_id: str | None = None,
+    period_start_after: date | None = None,
+    include_classified: bool = False,
   ) -> int:
     """Void all `pending` schedule_entry_due events for a schedule.
 
-    Shared helper for the two lifecycle paths that retire a schedule's
+    Shared helper for the lifecycle paths that retire a schedule's
     remaining obligations:
 
     - **Disposal** (asset_disposed handler): pass ``voided_by_event_id``
@@ -830,6 +832,17 @@ class ScheduleService:
       event row is about to be deleted along with the schedule, so the
       pending children are voided pre-emptively to keep them from
       tripping the close-period gate after their parent disappears.
+    - **Termination** (cmd_terminate_schedule): pass
+      ``period_start_after`` = the truncation cutoff so obligations for
+      periods the schedule still covers are left alone, and
+      ``include_classified=True`` so matured-but-undrafted strays past
+      the cutoff are retired too (the terminate command deletes draft
+      entries past the cutoff first and is blocked by posted ones, so a
+      classified row it reaches can only be an undrafted stray).
+
+    ``period_start_after`` filters on the obligation's
+    ``metadata.period_start`` (ISO date string comparison): only rows
+    whose period starts strictly after the given date are voided.
 
     Returns the number of voided rows. Returns 0 (no-op) when the
     schedule has no ``schedule_created_event_id`` stamped (rows from
@@ -873,13 +886,23 @@ class ScheduleService:
     # surface at flush, outside any lock-wait translation. The status
     # predicate stays on the UPDATE: it is the invariant that a row this
     # call did not lock as `pending` is never voided.
+    voidable_statuses = (
+      ("pending", "classified") if include_classified else ("pending",)
+    )
+    select_filters = [
+      Event.obligated_by_event_id == schedule_created_event_id,
+      Event.status.in_(voidable_statuses),
+    ]
+    if period_start_after is not None:
+      # Obligation periods live in metadata as ISO date strings, so a
+      # lexicographic comparison IS a date comparison.
+      select_filters.append(
+        Event.metadata_["period_start"].astext > period_start_after.isoformat()
+      )
     pending_ids = list(
       session.execute(
         select(Event.id)
-        .where(
-          Event.obligated_by_event_id == schedule_created_event_id,
-          Event.status == "pending",
-        )
+        .where(*select_filters)
         .order_by(ordered_lock_column())
         .with_for_update()
       ).scalars()
@@ -893,7 +916,7 @@ class ScheduleService:
 
     result = session.execute(
       update(Event)
-      .where(Event.id.in_(pending_ids), Event.status == "pending")
+      .where(Event.id.in_(pending_ids), Event.status.in_(voidable_statuses))
       .values(**update_values)
     )
     voided_count = int(result.rowcount or 0)

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -28,8 +28,10 @@ Registered operations, in workflow order:
   dispatches on event type: `journal_entry_recorded` (manual entry, draft
   or posted), `journal_entry_reversed` (offsetting reversal of a posted
   entry), `schedule_entry_due` (a schedule period matured), and
-  `asset_disposed` (atomic disposal plus schedule termination and
-  truncate).
+  `asset_disposed` (books the disposal entry and voids the schedule's
+  remaining obligations atomically; recognized facts stay as history).
+  For a no-entry early ending — truncate forward facts + void the
+  remaining obligations — use the `terminate-schedule` operation.
 - Journal Entries: `update-journal-entry`, `delete-journal-entry`. These
   are the draft-correction CRUD surface; all GL-write origination goes
   through `create-event-block`.
@@ -163,6 +165,8 @@ from robosystems.models.api.extensions.schedules import (
   PromoteObligationsResponse,
   RebuildScheduleRequest,
   ScheduleCreatedResponse,
+  TerminateScheduleRequest,
+  TerminateScheduleResponse,
 )
 from robosystems.models.api.extensions.taxonomies import (
   AssociationResponse,
@@ -403,6 +407,9 @@ from robosystems.operations.roboledger.commands.schedules import (
 )
 from robosystems.operations.roboledger.commands.schedules import (
   rebuild_schedule as cmd_rebuild_schedule,
+)
+from robosystems.operations.roboledger.commands.schedules import (
+  terminate_schedule as cmd_terminate_schedule,
 )
 from robosystems.operations.roboledger.commands.taxonomies import (
   AssociationNotFoundError,
@@ -1842,6 +1849,42 @@ rebuild_schedule_op = _registrar.register(
       ValueError: 422,
     },
     mark_stale_reason="schedule_rebuilt",
+  )
+)
+
+
+terminate_schedule_op = _registrar.register(
+  OperationSpec(
+    name="terminate-schedule",
+    summary="Terminate Schedule Early (No Entry)",
+    description=(
+      "End a schedule early at a month-end cutoff without booking any "
+      "entry. In one transaction: deletes forward facts past the cutoff "
+      "(refusing when posted entries exist past it; stale drafts past it "
+      "are deleted), voids the remaining obligation chain past the cutoff "
+      "(pending and classified rows), and rewrites the SumEquals rule to "
+      "prove the truncated curve. History at or before the cutoff is "
+      "untouched, so open months the schedule still covers close "
+      "normally. Use this when the termination's GL effect is already "
+      "booked (an asset transferred via a manual entry, a prepaid "
+      "refunded in the source system) or none is wanted; when the "
+      "derecognition entry still needs to be booked, use "
+      "create-event-block(event_type='asset_disposed') instead — the "
+      "disposal handler posts it atomically with the same obligation "
+      "void. Run BEFORE promote-obligations at close so terminated "
+      "periods are never drafted."
+    ),
+    command=cmd_terminate_schedule,
+    request_model=TerminateScheduleRequest,
+    result_type=TerminateScheduleResponse,
+    error_map={
+      ScheduleNotFoundError: 404,
+      # The void locks the same pending rows the promotion sweep holds.
+      # Retryable.
+      RowLockedError: 409,
+      ValueError: 422,
+    },
+    mark_stale_reason="schedule_terminated",
   )
 )
 

--- a/tests/operations/event_block/python_handlers/test_asset_disposed.py
+++ b/tests/operations/event_block/python_handlers/test_asset_disposed.py
@@ -310,12 +310,12 @@ class TestVoidPendingObligationsForSchedule:
     lock_stmt = session.execute.call_args_list[0].args[0]
     lock_sql = str(lock_stmt.compile(compile_kwargs={"literal_binds": True}))
     assert "events.obligated_by_event_id = 'evt_schedule_created'" in lock_sql
-    assert "events.status = 'pending'" in lock_sql
+    assert "events.status IN ('pending')" in lock_sql
     assert "FOR UPDATE" in lock_sql and "ORDER BY events.id" in lock_sql
     update_stmt = session.execute.call_args_list[1].args[0]
     rendered = str(update_stmt.compile(compile_kwargs={"literal_binds": True}))
     assert "events.id IN (" in rendered
-    assert "events.status = 'pending'" in rendered
+    assert "events.status IN ('pending')" in rendered
     assert "status='voided'" in rendered.replace(" = ", "=")
     assert "replaced_by_event_id='evt_disposal'" in rendered.replace(" = ", "=")
 
@@ -359,3 +359,132 @@ class TestVoidPendingObligationsForSchedule:
     assert voided == 0
     # The fallback recovery select ran; no UPDATE followed.
     assert session.execute.call_count == 1
+
+
+class TestComputeDisposalPlanShapes:
+  """Direct compute_disposal_plan coverage for the two schedule shapes.
+
+  Depreciation-style schedules carry a RISING cumulative instant fact on
+  the contra credit element; prepaid-style ("self-carried") schedules
+  carry the DECLINING remaining balance on the credited asset itself.
+  Reading the latter as "accumulated" inverts NBV — the July 2026 close
+  regression this class pins down.
+  """
+
+  @staticmethod
+  def _structure(
+    asset_element_id: str, credit_element_id: str, original_amount: int
+  ) -> MagicMock:
+    structure = MagicMock()
+    structure.artifact_mechanics = {
+      "schedule_metadata": {
+        "asset_element_id": asset_element_id,
+        "original_amount": original_amount,
+      },
+      "entry_template": {"credit_element_id": credit_element_id},
+    }
+    return structure
+
+  @staticmethod
+  def _session(structure: MagicMock, instant_value: float | None) -> MagicMock:
+    structure_result = MagicMock()
+    structure_result.scalar_one_or_none.return_value = structure
+    fact_result = MagicMock()
+    if instant_value is None:
+      fact_result.fetchone.return_value = None
+    else:
+      row = MagicMock()
+      row.value = instant_value
+      fact_result.fetchone.return_value = row
+    session = MagicMock()
+    session.execute.side_effect = [structure_result, fact_result]
+    return session
+
+  def test_depreciation_shape_reads_instant_as_accumulated(self) -> None:
+    from datetime import date
+
+    from robosystems.operations.event_block.python_handlers._disposal_plan import (
+      compute_disposal_plan,
+    )
+
+    structure = self._structure("elem_ppe", "elem_accum", 120_000)
+    session = self._session(structure, 300.00)
+
+    plan = compute_disposal_plan(
+      session,
+      structure_id="struct_depr",
+      disposal_date=date(2026, 7, 1),
+      sale_proceeds=90_000,
+      proceeds_element_id="elem_cash",
+      gain_loss_element_id=None,
+    )
+
+    assert plan.accumulated_depreciation == 30_000
+    assert plan.nbv == 90_000
+    assert plan.gain_loss == 0
+    # DR accumulated / CR asset-at-cost / DR proceeds
+    assert [
+      (li["element_id"], li["debit_amount"], li["credit_amount"])
+      for li in plan.line_items
+    ] == [
+      ("elem_accum", 30_000, 0),
+      ("elem_ppe", 0, 120_000),
+      ("elem_cash", 90_000, 0),
+    ]
+
+  def test_self_carried_prepaid_reads_instant_as_remaining_balance(self) -> None:
+    from datetime import date
+
+    from robosystems.operations.event_block.python_handlers._disposal_plan import (
+      compute_disposal_plan,
+    )
+
+    # The July 2026 regression: AWS RI 2026-02, original 1,315.08, remaining
+    # 1,132.43 at 6/30. The old code computed NBV = 182.65 (inverted).
+    structure = self._structure("elem_prepaid", "elem_prepaid", 131_508)
+    session = self._session(structure, 1132.43)
+
+    plan = compute_disposal_plan(
+      session,
+      structure_id="struct_ri",
+      disposal_date=date(2026, 7, 1),
+      sale_proceeds=113_243,
+      proceeds_element_id="elem_other_services",
+      gain_loss_element_id=None,
+    )
+
+    assert plan.nbv == 113_243
+    assert plan.accumulated_depreciation == 18_265
+    assert plan.gain_loss == 0
+    # Single derecognition credit on the self-carried asset + proceeds.
+    assert [
+      (li["element_id"], li["debit_amount"], li["credit_amount"])
+      for li in plan.line_items
+    ] == [
+      ("elem_prepaid", 0, 113_243),
+      ("elem_other_services", 113_243, 0),
+    ]
+    # Balanced.
+    assert sum(li["debit_amount"] for li in plan.line_items) == sum(
+      li["credit_amount"] for li in plan.line_items
+    )
+
+  def test_self_carried_with_nothing_left_raises(self) -> None:
+    from datetime import date
+
+    from robosystems.operations.event_block.python_handlers._disposal_plan import (
+      compute_disposal_plan,
+    )
+
+    structure = self._structure("elem_prepaid", "elem_prepaid", 131_508)
+    session = self._session(structure, 0.0)
+
+    with pytest.raises(ValueError, match="Nothing to dispose"):
+      compute_disposal_plan(
+        session,
+        structure_id="struct_ri",
+        disposal_date=date(2026, 7, 1),
+        sale_proceeds=0,
+        proceeds_element_id=None,
+        gain_loss_element_id=None,
+      )

--- a/tests/operations/roboledger/commands/test_schedules.py
+++ b/tests/operations/roboledger/commands/test_schedules.py
@@ -808,3 +808,169 @@ def test_reinstate_reopened_schedule_scopes_handles_null_boundary() -> None:
   assert n == 5
   _stmt, params = session.execute.call_args[0]
   assert params == {"closed_through": None}
+
+
+# ── terminate_schedule ─────────────────────────────────────────────────────
+
+
+def _terminate_structure() -> MagicMock:
+  structure = MagicMock()
+  structure.id = "struct_term"
+  structure.name = "AWS RI 2026-02 Prepaid Amortization"
+  structure.artifact_mechanics = {
+    "entry_template": {
+      "debit_element_id": "elem_dr",
+      "credit_element_id": "elem_prepaid",
+    },
+    "schedule_metadata": {"original_amount": 131_508},
+  }
+  return structure
+
+
+def test_terminate_schedule_truncates_then_voids_scoped() -> None:
+  from datetime import date
+  from unittest.mock import patch
+
+  from robosystems.models.api.extensions.schedules import TerminateScheduleRequest
+  from robosystems.operations.roboledger.commands import schedules as sched_cmds
+
+  structure = _terminate_structure()
+  session = MagicMock()
+  session.execute.return_value.scalar_one_or_none.return_value = structure
+
+  call_order: list[str] = []
+
+  with (
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "ScheduleService.truncate_schedule",
+      side_effect=lambda *a, **k: (
+        call_order.append("truncate")
+        or {
+          "structure_id": "struct_term",
+          "new_end_date": date(2026, 6, 30),
+          "facts_deleted": 62,
+          "reason": k["reason"],
+        }
+      ),
+    ) as truncate,
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "ScheduleService.void_pending_obligations",
+      side_effect=lambda *a, **k: call_order.append("void") or 31,
+    ) as void,
+    patch.object(sched_cmds, "_rewrite_sum_equals_rule", return_value=True) as rewrite,
+  ):
+    resp = sched_cmds.terminate_schedule(
+      session,
+      TerminateScheduleRequest(
+        structure_id="struct_term",
+        new_end_date=date(2026, 6, 30),
+        reason="RI transferred to RFS LLC",
+      ),
+      created_by="usr_admin",
+    )
+
+  # Truncation (with its guards) runs BEFORE the obligation void.
+  assert call_order == ["truncate", "void"]
+  tkwargs = truncate.call_args.kwargs
+  assert tkwargs["structure_id"] == "struct_term"
+  assert tkwargs["new_end_date"] == date(2026, 6, 30)
+  assert tkwargs["updated_by"] == "usr_admin"
+
+  # The void is scoped past the cutoff and reaches classified strays.
+  vkwargs = void.call_args.kwargs
+  assert vkwargs["structure"] is structure
+  assert vkwargs["period_start_after"] == date(2026, 6, 30)
+  assert vkwargs["include_classified"] is True
+  assert vkwargs["void_reason"] == "schedule_terminated: RI transferred to RFS LLC"
+
+  rewrite.assert_called_once()
+  session.commit.assert_called_once()
+
+  assert resp.structure_id == "struct_term"
+  assert resp.new_end_date == date(2026, 6, 30)
+  assert resp.facts_deleted == 62
+  assert resp.obligations_voided == 31
+  assert resp.rule_updated is True
+
+
+def test_terminate_schedule_truncation_guard_stops_everything() -> None:
+  from datetime import date
+  from unittest.mock import patch
+
+  import pytest
+
+  from robosystems.models.api.extensions.schedules import TerminateScheduleRequest
+  from robosystems.operations.roboledger.commands import schedules as sched_cmds
+
+  structure = _terminate_structure()
+  session = MagicMock()
+  session.execute.return_value.scalar_one_or_none.return_value = structure
+
+  with (
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "ScheduleService.truncate_schedule",
+      side_effect=ValueError("Cannot truncate: 3 posted entries exist"),
+    ),
+    patch(
+      "robosystems.operations.roboledger.commands.schedules."
+      "ScheduleService.void_pending_obligations"
+    ) as void,
+  ):
+    with pytest.raises(ValueError, match="posted entries"):
+      sched_cmds.terminate_schedule(
+        session,
+        TerminateScheduleRequest(
+          structure_id="struct_term",
+          new_end_date=date(2026, 6, 30),
+          reason="early end",
+        ),
+      )
+
+  void.assert_not_called()
+  session.commit.assert_not_called()
+
+
+def test_rewrite_sum_equals_rule_reanchors_to_remaining_curve() -> None:
+  from decimal import Decimal
+
+  from robosystems.operations.roboledger.commands.schedules import (
+    _rewrite_sum_equals_rule,
+  )
+
+  structure = _terminate_structure()
+
+  rule = MagicMock()
+  rule.id = "rule_sum"
+  rule.rule_expression = "sum($periodic_amount) = 1315.08"
+
+  rule_result = MagicMock()
+  rule_result.scalars.return_value.first.return_value = rule
+  sum_result = MagicMock()
+  sum_result.scalar.return_value = Decimal("182.65")
+
+  session = MagicMock()
+  session.execute.side_effect = [rule_result, sum_result]
+  deleted_models: list[type] = []
+  session.query.side_effect = lambda model: _Query(model, deleted_models)
+
+  assert _rewrite_sum_equals_rule(session, structure) is True
+  assert rule.rule_expression == "sum($periodic_amount) = 182.65"
+  assert VerificationResult in deleted_models
+
+
+def test_rewrite_sum_equals_rule_noops_without_rule() -> None:
+  from robosystems.operations.roboledger.commands.schedules import (
+    _rewrite_sum_equals_rule,
+  )
+
+  structure = _terminate_structure()
+  rule_result = MagicMock()
+  rule_result.scalars.return_value.first.return_value = None
+  session = MagicMock()
+  session.execute.return_value = rule_result
+
+  assert _rewrite_sum_equals_rule(session, structure) is False
+  session.query.assert_not_called()

--- a/tests/operations/roboledger/schedules/test_service.py
+++ b/tests/operations/roboledger/schedules/test_service.py
@@ -1168,7 +1168,7 @@ class TestCreateScheduleMaterializesObligations:
     update_stmt = session.execute.call_args_list[1].args[0]
     update_sql = str(update_stmt.compile(compile_kwargs={"literal_binds": True}))
     assert "events.id IN (" in update_sql
-    assert "events.status = 'pending'" in update_sql
+    assert "events.status IN ('pending')" in update_sql
     assert originator.metadata_["pending_event_count"] == 0
     assert len(originator.metadata_["void_history"]) == 1
     assert originator.metadata_["void_history"][0]["voided_count"] == 12


### PR DESCRIPTION
## What

Closes the schedule-lifecycle gaps surfaced by the July 2026 dogfooding close (the pure-MCP acceptance run):

1. **`terminate-schedule` operation** (REST + MCP via the operation registrar) — ends a schedule early at a month-end cutoff **without booking an entry**, in one transaction:
   - `truncate_schedule` (previously fully implemented with zero callers) deletes facts past the cutoff, with its existing guards: month-end cutoffs only, refuses when posted entries exist past the cutoff, deletes stale drafts past it.
   - The remaining obligation chain past the cutoff is voided — `pending` and `classified` rows both (a `classified` row it reaches can only be an undrafted stray: drafts past the cutoff were deleted in step 1 and posted ones block it).
   - The schedule's native SumEquals rule is rewritten to prove the truncated curve instead of the now-unsatisfiable original total.
   - History at or before the cutoff is untouched, so open months the schedule still covers close normally.

2. **Prepaid-schedule NBV fix in `compute_disposal_plan`** — the disposal plan read the credited element's latest instant fact as *accumulated depreciation*. Correct for depreciation schedules (contra account, rising cumulative), inverted for prepaid schedules, where the credited element **is** the asset and the instant fact is the *declining remaining balance*. Self-carried schedules (asset element == credit element) now read NBV directly and derecognize in a single credit line. This makes `asset_disposed` usable on the entire prepaid-amortization class, as its docs always claimed.

3. **Docstring reconciliation** — three docstrings (operations router, MCP schedule-tools module, `DeleteScheduleRequest`) described `asset_disposed` as truncating facts; the handler deliberately voids obligations and keeps facts as history. All three now describe the actual behavior and route no-entry termination to the new op.

4. **Close playbook additions** (version-locked content): a schedule-termination step (terminate BEFORE `promote-obligations`), JE publish semantics (`source='system'` posts locally only — alignment entries mirroring edits already made upstream must not round-trip), and never-retry guidance when `close-period` outlives a client timeout (the close is atomic server-side).

## Why

At the July close, 7 prepaid schedules had to be terminated mid-life. The disposal handler's NBV inversion forced a manual JE + per-event void path, which could only practically reach the current month's obligations — leaving ~150 pre-materialized future obligations that would mature into `pending_obligations` close blockers every month. With this PR, terminating a schedule is one call and retires its whole remaining chain.

## Notes

- `void_pending_obligations` gains `period_start_after` / `include_classified`; existing callers unchanged (the two SQL-shape test assertions updated from `status = 'pending'` to `status IN ('pending')`).
- New surface is additive (generated SDK tier — rides a client minor).
- Deliberately skipped: the `get-period-close-status` display nit where a voided-obligation schedule shows as `pending` — after this op deletes the facts, that state is unreachable.
- Unit tests: terminate command (ordering, scoped void, guard propagation), SumEquals rewrite, and direct `compute_disposal_plan` coverage for both schedule shapes including the inversion regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)