### PR TITLE
fix(security): emit the GraphiQL CSP only where the playground is served

### DIFF
--- a/main.py
+++ b/main.py
@@ -101,18 +101,22 @@ _SENSITIVE_PATH_PREFIXES = (
 )
 
 
-def csp_variant_for_path(path: str) -> str:
+def csp_variant_for_path(path: str, *, graphiql_enabled: bool = False) -> str:
   """Which CSP variant a path gets.
 
   - "docs": Swagger UI / ReDoc pages and their assets, self-hosted from
     /static — no third-party script origins and no 'unsafe-inline' script.
   - "graphiql": the GraphiQL playground, which loads React/GraphiQL from
-    CDNs and needs the historical relaxed policy.
+    CDNs and needs the historical relaxed policy. Returned only while the
+    playground is actually served (``graphiql_enabled`` — development
+    only); elsewhere the graph-scoped GraphQL path answers with JSON and
+    gets the strict policy like every other API route. The default is
+    closed so a caller that omits the flag can never relax production.
   - "api": everything else — strict policy.
   """
   if path in ("/", "/docs") or path.startswith("/static"):
     return "docs"
-  if path.startswith("/extensions/") and path.endswith("/graphql"):
+  if graphiql_enabled and path.startswith("/extensions/") and path.endswith("/graphql"):
     return "graphiql"
   return "api"
 
@@ -356,9 +360,10 @@ def create_app() -> FastAPI:
       )
 
     # Path-based CSP — strict for API, self-hosted policy for docs,
-    # relaxed (CDN) policy only for the GraphiQL playground.
+    # relaxed (CDN) policy only for the GraphiQL playground, and only
+    # where it is served (development — see the GraphQLRouter mount).
     path = request.url.path
-    csp_variant = csp_variant_for_path(path)
+    csp_variant = csp_variant_for_path(path, graphiql_enabled=env.is_development())
     if csp_variant == "docs":
       # Swagger UI / ReDoc served entirely from this origin (/static/vendor).
       # Both UIs inject inline <style> at runtime, so style-src keeps

--- a/tests/test_main_csp.py
+++ b/tests/test_main_csp.py
@@ -9,7 +9,9 @@ The matcher decides which Content-Security-Policy header a path gets:
   CDNs and needs the relaxed policy. The post-cutover URL change
   (graph-scoping the GraphQL endpoint) silently broke the original
   `startswith("/extensions/graphql")` check, so the URL shapes are pinned
-  here.
+  here. The playground is served in development only, so the variant is
+  too: the matcher returns it only when the caller says the playground is
+  enabled, and the default is closed.
 - "api": everything else — strict policy.
 
 These tests pin the matcher contract so future URL changes that move
@@ -42,15 +44,35 @@ class TestCspVariantForPath:
     (the pre-cutover shape) and would have served the strict API CSP
     on the new URL, blocking the CDN-hosted GraphiQL bundle.
     """
-    assert csp_variant_for_path("/extensions/kg01234567890abcdef/graphql") == (
-      "graphiql"
-    )
+    assert csp_variant_for_path(
+      "/extensions/kg01234567890abcdef/graphql", graphiql_enabled=True
+    ) == ("graphiql")
     # Subgraph IDs (with underscores) work too
-    assert csp_variant_for_path("/extensions/kg01a2b3c_dev/graphql") == "graphiql"
+    assert (
+      csp_variant_for_path("/extensions/kg01a2b3c_dev/graphql", graphiql_enabled=True)
+      == "graphiql"
+    )
 
   def test_legacy_graphql_path_still_relaxed(self) -> None:
     """The pre-cutover URL is kept defensively in case anything still hits it."""
-    assert csp_variant_for_path("/extensions/graphql") == "graphiql"
+    assert csp_variant_for_path("/extensions/graphql", graphiql_enabled=True) == (
+      "graphiql"
+    )
+
+  def test_graphql_paths_strict_when_playground_disabled(self) -> None:
+    """Where the playground is not served, neither is its policy.
+
+    Outside development the graph-scoped GraphQL path answers with JSON
+    only, so it must get the strict variant like every other API route.
+    The default is closed: a caller that omits the flag cannot relax it.
+    """
+    for path in (
+      "/extensions/kg01234567890abcdef/graphql",
+      "/extensions/kg01a2b3c_dev/graphql",
+      "/extensions/graphql",
+    ):
+      assert csp_variant_for_path(path, graphiql_enabled=False) == "api"
+      assert csp_variant_for_path(path) == "api"
 
   def test_api_routes_strict(self) -> None:
     """Core platform API routes use the strict CSP."""
@@ -65,20 +87,12 @@ class TestCspVariantForPath:
     They must NOT get a relaxed CSP — those routes never serve HTML
     and shouldn't be loading scripts from CDNs.
     """
-    assert (
-      csp_variant_for_path("/extensions/roboledger/kg01a2b3c/operations/update-entity")
-      == "api"
-    )
-    assert (
-      csp_variant_for_path("/extensions/roboledger/kg01a2b3c/operations/close-period")
-      == "api"
-    )
-    assert (
-      csp_variant_for_path(
-        "/extensions/roboinvestor/kg01a2b3c/operations/create-portfolio"
-      )
-      == "api"
-    )
+    for path in (
+      "/extensions/roboledger/kg01a2b3c/operations/update-entity",
+      "/extensions/roboledger/kg01a2b3c/operations/close-period",
+      "/extensions/roboinvestor/kg01a2b3c/operations/create-portfolio",
+    ):
+      assert csp_variant_for_path(path, graphiql_enabled=True) == "api"
 
   def test_arbitrary_paths_strict(self) -> None:
     assert csp_variant_for_path("/openapi.json") == "api"
@@ -87,8 +101,11 @@ class TestCspVariantForPath:
 
   def test_path_traversal_does_not_bypass(self) -> None:
     """Defense in depth: a `/graphql` suffix anywhere else shouldn't relax CSP."""
-    assert csp_variant_for_path("/v1/auth/graphql") == "api"
-    assert csp_variant_for_path("/extensions-evil/foo/graphql") == "api"
+    assert csp_variant_for_path("/v1/auth/graphql", graphiql_enabled=True) == "api"
+    assert (
+      csp_variant_for_path("/extensions-evil/foo/graphql", graphiql_enabled=True)
+      == "api"
+    )
 
 
 class TestDocsPagesSelfHosted:

--- a/tests/test_main_security_baseline.py
+++ b/tests/test_main_security_baseline.py
@@ -99,6 +99,30 @@ class TestResponseHeaderBaseline:
       "max-age=31536000; includeSubDomains"
     )
 
+  def test_graphql_path_strict_outside_development(self, client, monkeypatch):
+    """The GraphiQL playground is dev-only, so its relaxed CSP must be too.
+
+    Outside development the graph-scoped GraphQL path serves no page —
+    only JSON refusals — and nothing on it needs CDN, inline, or eval'd
+    script. The header on those responses must be the strict API policy;
+    the playground's policy carries exactly the directives the external
+    assessment flagged and would read as an unremediated finding.
+    """
+    monkeypatch.setattr(env, "is_development", lambda: False)
+    response = client.get("/extensions/kg0123456789abcdef0000/graphql")
+    csp = response.headers["content-security-policy"]
+    assert "'unsafe-inline'" not in csp
+    assert "'unsafe-eval'" not in csp
+    assert "https://" not in csp
+    assert "script-src 'self';" in csp
+
+  def test_graphql_path_relaxed_in_development(self, client, monkeypatch):
+    """The playground keeps its CDN policy where it is actually served."""
+    monkeypatch.setattr(env, "is_development", lambda: True)
+    response = client.get("/extensions/kg0123456789abcdef0000/graphql")
+    csp = response.headers["content-security-policy"]
+    assert "'unsafe-eval'" in csp
+
 
 class TestAuthenticationEnforcement:
   """Protected endpoints refuse unauthenticated requests with a clean 401."""


### PR DESCRIPTION
## Summary

The Content-Security-Policy middleware has three variants: strict for API routes, a self-hosted policy for the docs pages, and a relaxed (CDN + inline + eval) policy for the GraphiQL playground. The playground is mounted in development only, but the variant matcher chose its policy by URL shape alone — so outside development the graph-scoped GraphQL path, which only ever answers with JSON there, still carried the playground's header. This gates the variant on the same condition as the mount, so production emits the strict policy on every response except the two docs pages and their static assets.

## Changes

- **`main.py`** — `csp_variant_for_path` takes a keyword-only `graphiql_enabled` flag, **defaulting to `False`** so a caller that omits it can never relax production. The security-headers middleware passes `env.is_development()`, which is the condition the `GraphQLRouter` mount already uses for `graphql_ide`. Docstring and comment updated to say why.
- **`tests/test_main_csp.py`** — the pure-matcher pins for the relaxed variant now pass `graphiql_enabled=True`; a new test asserts all three GraphQL URL shapes return `"api"` when the flag is off *and* when it is omitted. The operations-route and path-traversal tests now run with the flag on so they still prove something non-trivial.
- **`tests/test_main_security_baseline.py`** — two end-to-end pins through the real middleware on the graph-scoped GraphQL path: with `is_development` false, the CSP contains no `'unsafe-inline'`, no `'unsafe-eval'`, and no `https://` origin; with it true, the playground keeps its CDN policy. (Patched `env.is_development` itself rather than `env.ENVIRONMENT`, since the latter doesn't reach a classmethod.)

No route, response body, or schema changes — header value only, on one path, outside development.

## Breaking Changes

None. No change to the GraphQL schema, the operations envelope, or any REST shape; nothing for the client SDKs to regenerate.

## Testing

- `uv run pytest tests/test_main_csp.py tests/test_main_security_baseline.py` — 33 passed.
- `just test-code` — ruff, format check, basedpyright, cf-lint all clean.
- Full `just test-all` not run in-session; the change is confined to the header middleware and its tests.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
