### PR TITLE
chore(deps): override sqlparse to 0.6.0 past dbt-core's ceiling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,14 @@ lambda = [
     "urllib3>=2.7.0,<3.0",          # HTTP client (graph-volume-monitor)
 ]
 
+[tool.uv]
+# sqlparse 0.6.0 (2026-08-13) fixes CVE-2026-59893 / CVE-2026-54284 /
+# CVE-2026-71491 (lexer and grouping DoS). dbt-core pins sqlparse<0.6.0 even
+# at its latest release, and it is the only consumer here (robosystems does not
+# import sqlparse; dbt parses only its own compiled SQL). Override until
+# dbt-core lifts the ceiling, then delete this block.
+override-dependencies = ["sqlparse>=0.6.0"]
+
 [tool.setuptools]
 packages = ["robosystems"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,9 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 
+[manifest]
+overrides = [{ name = "sqlparse", specifier = ">=0.6.0" }]
+
 [[package]]
 name = "actionlint-py"
 version = "1.7.12.24"
@@ -4089,11 +4092,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Takes sqlparse 0.6.0, which carries upstream's lexer and statement-grouping denial-of-service fixes (CVE-2026-59893, CVE-2026-54284, CVE-2026-71491). dbt-core still pins `sqlparse<0.6.0` — including its latest release — and is the only consumer in this tree, so a uv dependency override is the only way to take the release without forking the pin.

## Changes

- **`pyproject.toml`** — new `[tool.uv]` block with `override-dependencies = ["sqlparse>=0.6.0"]`. The comment records why the override exists and its removal condition: delete the block once dbt-core lifts its ceiling.
- **`uv.lock`** — `sqlparse 0.5.5 → 0.6.0`. No other package moved.

Context for reviewers: robosystems never imports `sqlparse` directly; dbt uses it on its own compiled SQL inside the QuickBooks and extensions pipelines, so there is no untrusted-input path either way — this is dependency hygiene, not an exposed-surface fix. sqlparse 0.6.0's non-security changes are a Python 3.8/3.9 drop (we run 3.13), two new recognized keywords, and escaping in the `python`/`php` output formats, none of which dbt exercises.

## Breaking Changes

None. No API surface changes; nothing reaches either SDK tier.

## Testing

- `uv run dbt --version` and a `dbt.version` / `sqlparse.__version__` import smoke against the re-locked environment — dbt-core 1.11.11 loads cleanly with sqlparse 0.6.0.
- The six dbt-touching test modules (`tests/operations/extensions/test_loader*.py`, `tests/adapters/qb/pipeline/test_transform.py`, `tests/adapters/qb/pipeline/test_event_action_mapping.py`, `tests/adapters/qb/processors/test_transactions.py`, `tests/middleware/mcp/tools/test_cypher_tool.py`): **117 passed**.
- `just test-code` (ruff, format, basedpyright, cf-lint): **all checks passed**.
- Full `just test` suite: running locally at time of opening; result will be posted before merge.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
