### PR TITLE
fix(query): harden error responses on the query surface

### DIFF
--- a/robosystems/routers/graphs/query/execute.py
+++ b/robosystems/routers/graphs/query/execute.py
@@ -671,7 +671,7 @@ async def execute_cypher_query(
         )
         raise HTTPException(
           status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
-          detail=f"Failed to queue query: {queue_error!s}",
+          detail=safe_error_message(queue_error) or "Failed to queue query",
         )
 
     # Continue with the successfully queued query_id and status
@@ -895,7 +895,6 @@ async def execute_cypher_query(
         status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
         content={
           "error": "Query execution failed",
-          "error_type": type(e).__name__,
           "error_message": safe_error_message(e)
           or "An unexpected error occurred while processing your query",
           "suggestion": "Please check your query syntax and try again",


### PR DESCRIPTION
## Summary

Hardens two error responses on the query endpoint so they carry only the sanitized message, consistent with the rest of the surface. Closes CodeQL alert #742.

## Changes

- **`robosystems/routers/graphs/query/execute.py`**
  - The interactive-client 500 body no longer includes the exception class name; it keeps `error`, the sanitized `error_message`, and `suggestion`.
  - The queue-submission failure path now returns `safe_error_message(...)` with a generic fallback instead of interpolating the raw exception into `detail`, matching the other 500 paths in this module (same helper, same fallback pattern).

Nothing else changes: status codes, the non-interactive path, metrics events, and logging are untouched.

## Breaking Changes

None. The interactive 500 body loses one informational field; no SDK facade, generated model, or app reads it (checked the three apps and all three clients). Not an SDK-tier change.

## Testing

- `uv run pytest tests/routers/graphs/query tests/security`: **518 passed, 29 skipped**.
- `just test-code` (ruff, format, basedpyright, cf-lint): **all checks passed**.
- Full suite: CI. (The local full run halts early on a pre-existing, local-only pyarrow filesystem-registry error in `tests/graph_api/core/duckdb/test_staging_identifiers.py` that reproduces identically on `main`; tracked separately.)

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
