### PR TITLE
docs(security): remove misplaced rotation bullet from API Key Management

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,7 +32,6 @@ Live compliance posture and audit artifacts are published in the [RoboSystems Tr
 - Bcrypt hashing with cost factor 12 for storage
 - Optional per-key expiration (`expires_at`)
 - Usage tracking via `last_used_at` timestamp
-- Monthly rotation via GitHub Actions (`secrets-rotation.yml`) using AWS Secrets Manager Lambda functions
 
 ### Authentication Protection
 


### PR DESCRIPTION
## Summary

Removes a stray bullet from the **API Key Management** section of `SECURITY.md` that described the infrastructure secret rotation run by `secrets-rotation.yml` — database, cache, and service credentials — rather than user API keys. That workflow is already documented accurately under **Data Security → Secrets Rotation**, so the bullet was a misplaced duplicate that read as a claim about a different key class. It dates from the initial open-source release.

## Changes

- `SECURITY.md` — drop the "Monthly rotation via GitHub Actions (`secrets-rotation.yml`)…" bullet from API Key Management. The remaining four bullets (generation, bcrypt storage, optional expiry, usage tracking) are unchanged and match `robosystems/models/core/user/user_api_key.py`. The Secrets Rotation section is untouched and remains the single description of that workflow.

## Breaking Changes

None. Documentation only — no code, API, or SDK surface touched.

## Testing

Not run — no code changed. Pre-commit hooks (ruff, format, cf-lint) passed on the commit.

## Certification

<!-- See CONTRIBUTING.md, "Licensing and Certification". Asserts provenance, not a transfer of rights. -->

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
