### PR TITLE
Persist the close receipt; fix a second-libarrow collision that disabled PageRank weighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,10 @@ GEMINI.md
 robosystems/adapters/sec/arelle/EDGAR/
 # Arelle schema cache - downloaded during build
 robosystems/adapters/sec/arelle/cache/
+# Collateral of the line above: ArelleClient._setup_cache_directory sets the
+# process-global XDG_CACHE_HOME to robosystems/adapters/sec so Arelle resolves
+# its own cache, and every other XDG-respecting library in that process then
+# caches there too. huggingface_hub is the one that shows up locally
+# (.agent_harnesses.json + xet/logs). Ignore the whole tree, not one file —
+# the next such library will land here as well.
+robosystems/adapters/sec/huggingface/

--- a/migrations/extensions/versions/0034_close_receipt.py
+++ b/migrations/extensions/versions/0034_close_receipt.py
@@ -1,0 +1,55 @@
+"""close receipt — fiscal_periods carries the outcome of its own close
+
+The close result (entries posted, the QB/local split, statement stamping,
+rule summaries) existed only in the HTTP response. A close that SUCCEEDED
+but whose transport failed — the MCP surface's 25s client timeout is the
+live case — left no record on the books, so the operator reconstructed
+what happened from four separate state reads and had to know not to retry.
+
+``close_receipt`` is written by ``PeriodCloseService.close()`` in the same
+transaction as the ``status='closed'`` flip, so a committed close always
+carries its receipt and a rolled-back one carries none.
+
+Nullable with no backfill: periods closed before this shipped have no
+receipt to reconstruct, and inventing one would be worse than its absence
+(readers distinguish "closed, no receipt" from "closed, here is what
+happened"). Public schema AND every existing tenant schema get the column
+via the TenantOps fan-out; fresh tenants get it from the model at provision.
+
+Revision ID: 0034
+Revises: 0033
+Create Date: 2026-08-21
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+from migrations.extensions.helpers import TenantOps, for_each_tenant_schema
+
+# revision identifiers, used by Alembic.
+revision = "0034"
+down_revision = "0033"
+branch_labels = None
+depends_on = None
+
+
+def _apply(conn, schema: str) -> None:
+  TenantOps(conn, schema).add_column("fiscal_periods", "close_receipt", "JSONB")
+
+
+def _revert(conn, schema: str) -> None:
+  TenantOps(conn, schema).drop_column("fiscal_periods", "close_receipt")
+
+
+def upgrade() -> None:
+  conn = op.get_bind()
+  _apply(conn, "public")
+  for_each_tenant_schema(conn, _apply)
+
+
+def downgrade() -> None:
+  conn = op.get_bind()
+  _revert(conn, "public")
+  for_each_tenant_schema(conn, _revert)

--- a/robosystems/adapters/sec/knowledge/artifact.py
+++ b/robosystems/adapters/sec/knowledge/artifact.py
@@ -581,13 +581,24 @@ class DisclosureProfileBuilder:
       return {}
 
     try:
-      table = pq.read_table(path, columns=["qname", "pagerank"])
+      # Read through a handle. This module imports networkit at import time, and
+      # in a process that has done so `pq.read_table(path)` raises ArrowKeyError
+      # from the LocalFileSystem constructor (icebug bundles a second libarrow
+      # that collides with pyarrow's on Arrow's global filesystem registry — see
+      # this package's __init__). Passing a path here meant this function could
+      # never succeed: it raised on every call, the except below swallowed it at
+      # debug level, and disclosure profiles silently fell back to frequency-only
+      # weighting. The writers in this file already take the handle path.
+      with open(path, "rb") as f:
+        table = pq.read_table(f, columns=["qname", "pagerank"])
       cols = table.to_pydict()
       return {
         cols["qname"][i]: cols["pagerank"][i] or 0.0 for i in range(len(cols["qname"]))
       }
     except Exception as e:
-      logger.debug(f"Failed to load PageRank scores: {e}")
+      # Warning, not debug: the empty dict degrades weighting silently, so a
+      # recurring failure here has to be visible in logs to be noticed at all.
+      logger.warning(f"Failed to load PageRank scores from {path}: {e}")
       return {}
 
   def _compute_profiles(

--- a/robosystems/adapters/sec/pipeline/entity_sync/transform.py
+++ b/robosystems/adapters/sec/pipeline/entity_sync/transform.py
@@ -190,7 +190,15 @@ def sec_entity_transform(
     # key format: "nodes/Entity" or "relationships/ENTITY_HAS_REPORT"
     entity_type, table_name = key.split("/", 1)
     out_file = output_dir / f"sec_{table_name}.parquet"
-    pq.write_table(combined, str(out_file))
+    # Handle, not a path string: `write_table(t, str(p))` resolves the path by
+    # constructing `pyarrow.fs.LocalFileSystem()`, which raises ArrowKeyError in
+    # any process that has imported networkit (icebug bundles a second libarrow
+    # that collides with pyarrow's on Arrow's global filesystem registry — see
+    # `adapters/sec/knowledge/__init__.py`). Nothing pulls networkit into this
+    # asset's process today, but that rests on job layout and Dagster's default
+    # per-step subprocess rather than on anything enforced here.
+    with open(out_file, "wb") as f:
+      pq.write_table(combined, f)
     tables_output += 1
 
     context.log.info(f"Wrote {key}: {combined.num_rows} rows → {out_file.name}")

--- a/robosystems/graphql/types/ledger.py
+++ b/robosystems/graphql/types/ledger.py
@@ -133,6 +133,9 @@ from robosystems.models.api.extensions.reports import (
   ValidationCheckResponse as PydanticValidationCheckResponse,
 )
 from robosystems.models.api.extensions.schedules import (
+  CloseReceiptResponse as PydanticCloseReceiptResponse,
+)
+from robosystems.models.api.extensions.schedules import (
   PeriodCloseItemResponse as PydanticPeriodCloseItemResponse,
 )
 from robosystems.models.api.extensions.schedules import (
@@ -612,6 +615,18 @@ class PeriodDrafts:
 @pydantic_type(model=PydanticPeriodCloseItemResponse, all_fields=True)
 class PeriodCloseItem:
   """Single schedule's close state within a fiscal period."""
+
+
+@pydantic_type(model=PydanticCloseReceiptResponse, all_fields=True)
+class CloseReceipt:
+  """What a close did, stamped on the period it locked."""
+
+  # The three dict-typed fields need the JSON scalar — Strawberry's pydantic
+  # derivation can't map dict[str, ...] to a GraphQL type (same reason as
+  # Report.rule_summary below).
+  rule_summary: strawberry.scalars.JSON | None
+  stamped_statement_sets: strawberry.scalars.JSON
+  statement_rule_summary: strawberry.scalars.JSON | None
 
 
 @pydantic_type(model=PydanticPeriodCloseStatusResponse, all_fields=True)

--- a/robosystems/models/api/extensions/fiscal_calendar.py
+++ b/robosystems/models/api/extensions/fiscal_calendar.py
@@ -278,6 +278,15 @@ class FiscalPeriodSummary(BaseModel):
   end_date: date
   status: str = Field(..., description="'open' | 'closing' | 'closed'")
   closed_at: datetime | None = None
+  has_close_receipt: bool = Field(
+    False,
+    description=(
+      "Whether this period carries a close receipt. A flag rather than the "
+      "receipt itself keeps the calendar listing compact; fetch the receipt "
+      "from `get-period-close-status` for the period. False on open periods "
+      "and on periods closed before receipts shipped."
+    ),
+  )
 
 
 class PendingObligationDetailResponse(BaseModel):

--- a/robosystems/models/api/extensions/schedules.py
+++ b/robosystems/models/api/extensions/schedules.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -199,6 +199,54 @@ class PeriodCloseItemResponse(BaseModel):
   reversal_status: str | None = None
 
 
+class CloseReceiptResponse(BaseModel):
+  """What a close actually did, stamped on the period row that close locked.
+
+  The close result used to exist only in the HTTP response, so a close
+  that SUCCEEDED but whose transport failed left no record and the
+  operator reconstructed it from separate state reads. This is that
+  record. Written in the same transaction as the period's `status='closed'`
+  flip, so a closed period and its receipt can never disagree.
+
+  Typed rather than a free dict because it is a contract: the GraphQL
+  schema and both SDKs derive from it, and an opaque blob would push the
+  shape onto every reader to rediscover.
+  """
+
+  version: int = Field(
+    ..., description="Receipt schema version; 1 is the first shipped shape"
+  )
+  period: str = Field(..., description="Period this receipt is for (YYYY-MM)")
+  closed_at: datetime
+  closed_by: str = Field(..., description="Actor id that ran the close")
+  actor_type: str = Field(
+    ..., description="'user' for REST callers, 'agent' for MCP-driven closes"
+  )
+  was_reclose: bool = Field(
+    False, description="Whether this close re-closed a previously closed period"
+  )
+  entries_posted: int = Field(
+    0,
+    description=(
+      "Total entries the close transitioned to posted, across both post "
+      "paths — the sum of the two fields below"
+    ),
+  )
+  entries_published_to_qb: int = 0
+  entries_posted_locally: int = 0
+  target_auto_advanced: bool = False
+  rule_summary: dict[str, int] | None = Field(
+    None, description="Schedule rule outcomes: pass/fail/error/skipped counts"
+  )
+  evaluated_structure_ids: list[str] = Field(default_factory=list)
+  statements_stamped: bool = False
+  statement_stamp_note: str | None = None
+  stamped_statement_sets: dict[str, str] = Field(
+    default_factory=dict, description="structure_id -> minted fact_set_id"
+  )
+  statement_rule_summary: dict[str, int] | None = None
+
+
 class PeriodCloseStatusResponse(BaseModel):
   """Period-close dashboard view — every schedule in scope for the
   period plus drafted/posted entry totals.
@@ -214,6 +262,18 @@ class PeriodCloseStatusResponse(BaseModel):
   schedules: list[PeriodCloseItemResponse]
   total_draft: int
   total_posted: int
+  close_receipt: CloseReceiptResponse | None = Field(
+    None,
+    description=(
+      "Receipt stamped by the close that locked this period: entries_posted, "
+      "the entries_published_to_qb / entries_posted_locally split, statement "
+      "stamping and rule summaries, closed_at/closed_by. Null while the "
+      "period is open, and null for periods closed before receipts shipped "
+      "(a closed period without a receipt is not a failed close). This is "
+      "the authoritative record of what a close did — read it rather than "
+      "retrying when a close's response was lost in transport."
+    ),
+  )
 
 
 class ScheduleCreatedResponse(BaseModel):

--- a/robosystems/models/extensions/roboledger/fiscal_period.py
+++ b/robosystems/models/extensions/roboledger/fiscal_period.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
   String,
   UniqueConstraint,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 
 from robosystems.db.extensions import ExtensionsBase
 from robosystems.utils.ulid import generate_prefixed_ulid
@@ -52,6 +53,16 @@ class FiscalPeriod(ExtensionsBase):
   status = Column(String, nullable=False, default="open")
   closed_at = Column(DateTime, nullable=True)
   closed_by = Column(String, nullable=True)
+
+  # The close receipt, stamped in the same transaction as the status flip
+  # above. Without it the close result exists only in the HTTP response,
+  # so a transport failure on a close that SUCCEEDED leaves the operator
+  # reconstructing what happened from four separate state reads. Written
+  # by PeriodCloseService.close(); read back by get-period-close-status
+  # and the fiscal-calendar response. Nullable because periods closed
+  # before this shipped (and those seeded closed by initialize_ledger)
+  # have no receipt.
+  close_receipt = Column(JSONB, nullable=True)
 
   # Timestamps
   created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))

--- a/robosystems/operations/roboledger/fiscal_calendar/close_service.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_service.py
@@ -167,6 +167,45 @@ class PeriodCloseResult:
   statement_rule_summary: dict[str, int] | None = None
 
 
+# Bump when the receipt's shape changes so a reader can tell an old receipt
+# from a new one rather than inferring it from which keys are present.
+CLOSE_RECEIPT_VERSION = 1
+
+
+def _build_close_receipt(
+  result: PeriodCloseResult,
+  *,
+  actor_id: str,
+  actor_type: str,
+  closed_at: datetime,
+) -> dict:
+  """Render a `PeriodCloseResult` as the JSON receipt stored on the period.
+
+  Deliberately a projection, not a dump: `calendar` is a live ORM-backed
+  object whose state moves on with the ledger, and a receipt that changes
+  after the fact is not a receipt. Everything here is a scalar captured at
+  close time.
+  """
+  return {
+    "version": CLOSE_RECEIPT_VERSION,
+    "period": result.period,
+    "closed_at": closed_at.isoformat(),
+    "closed_by": actor_id,
+    "actor_type": actor_type,
+    "was_reclose": result.was_reclose,
+    "entries_posted": result.entries_posted,
+    "entries_published_to_qb": result.entries_published_to_qb,
+    "entries_posted_locally": result.entries_posted_locally,
+    "target_auto_advanced": result.target_auto_advanced,
+    "rule_summary": result.rule_summary,
+    "evaluated_structure_ids": list(result.evaluated_structure_ids),
+    "statements_stamped": result.statements_stamped,
+    "statement_stamp_note": result.statement_stamp_note,
+    "stamped_statement_sets": dict(result.stamped_statement_sets),
+    "statement_rule_summary": result.statement_rule_summary,
+  }
+
+
 # ────────────────────────────────────────────────────────────────────────────
 # Service
 # ────────────────────────────────────────────────────────────────────────────
@@ -420,7 +459,7 @@ class PeriodCloseService:
       f"rule_summary={rule_summary}"
     )
 
-    return PeriodCloseResult(
+    result = PeriodCloseResult(
       period=period,
       entries_posted=entries_posted,
       target_auto_advanced=target_auto_advanced,
@@ -435,6 +474,18 @@ class PeriodCloseService:
       stamped_statement_sets=stamp.fact_set_ids,
       statement_rule_summary=stamp.rule_summary,
     )
+
+    # 7. Stamp the receipt onto the period row. This assignment rides the
+    # SAME transaction as the `status='closed'` flip in step 5, so a
+    # committed close always carries its receipt and a rolled-back one
+    # carries none — the two can never disagree. Everything above is
+    # already computed; nothing here can fail the close.
+    fp.close_receipt = _build_close_receipt(
+      result, actor_id=actor_id, actor_type=actor_type, closed_at=now
+    )
+    session.flush()
+
+    return result
 
   # ── Private helpers ────────────────────────────────────────────────────
 

--- a/robosystems/operations/roboledger/reads/fiscal_calendar.py
+++ b/robosystems/operations/roboledger/reads/fiscal_calendar.py
@@ -154,6 +154,7 @@ def build_fiscal_calendar_response(
         end_date=p.end_date,
         status=p.status,
         closed_at=p.closed_at,
+        has_close_receipt=p.close_receipt is not None,
       )
       for p in periods
     ],

--- a/robosystems/operations/roboledger/reads/schedules.py
+++ b/robosystems/operations/roboledger/reads/schedules.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 from datetime import date
 
+from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
+from robosystems.logger import logger
 from robosystems.models.api.extensions.schedules import (
+  CloseReceiptResponse,
   PeriodCloseItemResponse,
   PeriodCloseStatusResponse,
 )
@@ -43,4 +46,27 @@ def get_period_close_status(
     ],
     total_draft=status.total_draft,
     total_posted=status.total_posted,
+    # The stored receipt is validated on the way out rather than trusted:
+    # rows written by an older shape (or hand-edited) surface as no receipt
+    # instead of failing the whole close-status read.
+    close_receipt=_parse_receipt(status.close_receipt),
   )
+
+
+def _parse_receipt(raw: dict | None) -> CloseReceiptResponse | None:
+  """Project a stored close receipt onto its typed response model.
+
+  Returns None for a missing or unreadable receipt. `get-period-close-status`
+  is the read an operator runs when a close's response was lost, so it must
+  not be the thing that breaks on a receipt it cannot parse.
+  """
+  if not raw:
+    return None
+  try:
+    return CloseReceiptResponse.model_validate(raw)
+  except ValidationError:
+    logger.warning(
+      "Stored close receipt failed validation; reporting no receipt",
+      extra={"period": raw.get("period"), "version": raw.get("version")},
+    )
+    return None

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -94,6 +94,11 @@ class PeriodCloseStatus:
   schedules: list[PeriodCloseItem]
   total_draft: int
   total_posted: int
+  # The receipt stamped by the close that locked this period, when there
+  # is one. None for an open period, and also for a period closed before
+  # receipts shipped — "closed with no receipt" is a real state, not an
+  # error, and callers must not read its absence as a failed close.
+  close_receipt: dict | None = None
 
 
 @dataclass
@@ -1126,7 +1131,7 @@ class ScheduleService:
 
     fp_result = session.execute(
       text("""
-        SELECT status FROM fiscal_periods
+        SELECT status, close_receipt FROM fiscal_periods
         WHERE start_date <= :period_start AND end_date >= :period_end
         LIMIT 1
       """),
@@ -1134,6 +1139,7 @@ class ScheduleService:
     )
     fp_row = fp_result.fetchone()
     period_status = fp_row.status if fp_row else "open"
+    close_receipt = fp_row.close_receipt if fp_row else None
 
     items: list[PeriodCloseItem] = []
     total_draft = 0
@@ -1168,6 +1174,7 @@ class ScheduleService:
       schedules=items,
       total_draft=total_draft,
       total_posted=total_posted,
+      close_receipt=close_receipt,
     )
 
   def create_closing_entry(

--- a/tests/adapters/sec/knowledge/test_disclosure_profiles.py
+++ b/tests/adapters/sec/knowledge/test_disclosure_profiles.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pyarrow as pa
 import pyarrow.parquet as pq
+import pytest
 
 from robosystems.adapters.sec.knowledge.artifact import DisclosureProfileBuilder
 from robosystems.adapters.sec.knowledge.extractors import ArcExtractor
@@ -150,11 +151,25 @@ class TestDisclosureProfileBuilder:
       table = pq.read_table(f)
     cols = table.to_pydict()
 
-    # Check that weighted_score >= frequency for elements with pagerank >= 0
-    for i in range(len(cols["qname"])):
-      freq = cols["frequency"][i]
-      ws = cols["weighted_score"][i]
-      assert ws >= freq - 0.001
+    # `weighted_score = freq * (1 + pagerank)`, so a loaded PageRank makes the
+    # score STRICTLY greater than frequency. The previous assertion here was
+    # `ws >= freq - 0.001`, which the degraded path (weighted == frequency)
+    # satisfies too — so this test and `test_weighted_score_degrades_without_
+    # pagerank` below were asserting the same output, and both passed for as
+    # long as `_load_pagerank_scores` was returning {} on every call.
+    scored = {
+      cols["qname"][i]: (cols["frequency"][i], cols["weighted_score"][i])
+      for i in range(len(cols["qname"]))
+    }
+    expected_pr = {"us-gaap:Liabilities": 0.8, "us-gaap:StockholdersEquity": 0.3}
+    matched = {q: v for q, v in scored.items() if q in expected_pr}
+    # Guard against a vacuous pass if the fixture stops emitting these elements.
+    assert matched, f"none of {sorted(expected_pr)} present in {sorted(scored)}"
+
+    for qname, (freq, ws) in matched.items():
+      pr = expected_pr[qname]
+      assert ws == pytest.approx(freq * (1.0 + pr), abs=1e-6)
+      assert ws > freq, f"{qname}: pagerank {pr} did not raise the weighted score"
 
   def test_weighted_score_degrades_without_pagerank(
     self, sec_duckdb, tmp_path, monkeypatch

--- a/tests/graph_api/core/duckdb/test_staging_identifiers.py
+++ b/tests/graph_api/core/duckdb/test_staging_identifiers.py
@@ -45,7 +45,18 @@ class _OneConnectionPool:
 
 
 def _write_parquet(path, columns: dict[str, list]) -> str:
-  pq.write_table(pa.table(columns), str(path))
+  # Write through an open handle, never a path string. `pq.write_table(t, str(p))`
+  # resolves the path by constructing `pyarrow.fs.LocalFileSystem()`, and once
+  # anything in the process has imported networkit that constructor raises
+  # ``ArrowKeyError: Attempted to register factory for scheme 'file'`` — icebug
+  # bundles its own libarrow alongside pyarrow's, and the second copy collides on
+  # Arrow's process-global filesystem registry. The whole test suite shares one
+  # process, so `tests/adapters/sec/knowledge/` (which imports networkit at module
+  # level) poisoned every test here that touched a local parquet file. Passing a
+  # file object skips filesystem resolution entirely. This is the same convention
+  # the production writers follow — see `adapters/sec/knowledge/__init__.py`.
+  with open(path, "wb") as f:
+    pq.write_table(pa.table(columns), f)
   return str(path)
 
 

--- a/tests/operations/roboledger/schedules/test_close_receipt_db.py
+++ b/tests/operations/roboledger/schedules/test_close_receipt_db.py
@@ -1,0 +1,225 @@
+"""The close receipt survives the round trip through Postgres — real DB,
+because the read is raw SQL.
+
+``get_period_close_status`` selects from ``fiscal_periods`` with hand-written
+SQL, and every mocked-session test in this suite drives ``session.execute``
+through a canned result list, so none of them executes it. That gap has
+already cost two defects on live books (PR #1228: a rule rewrite that missed
+the key the evaluator reads, and a close summary that counted phantom
+schedules) — both shipped green against tests that asserted what the author
+wrote rather than what the database returns.
+
+So these tests run the real statement against real tables.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date, datetime
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+import robosystems.models.extensions  # noqa: F401  (register models on ExtensionsBase)
+from robosystems.db.extensions import ExtensionsBase
+from robosystems.models.extensions.roboledger.fiscal_period import FiscalPeriod
+from robosystems.operations.roboledger.reads.schedules import get_period_close_status
+from robosystems.operations.roboledger.schedules.service import ScheduleService
+
+pytestmark = pytest.mark.unit
+
+PERIOD_START = date(2026, 7, 1)
+PERIOD_END = date(2026, 7, 31)
+
+RECEIPT = {
+  "version": 1,
+  "period": "2026-07",
+  "closed_at": "2026-08-20T03:35:00+00:00",
+  "closed_by": "user_abc",
+  "actor_type": "agent",
+  "was_reclose": False,
+  "entries_posted": 34,
+  "entries_published_to_qb": 31,
+  "entries_posted_locally": 3,
+  "target_auto_advanced": True,
+  "rule_summary": {"pass": 7, "fail": 0, "error": 0, "skipped": 0},
+  "evaluated_structure_ids": ["struct_1", "struct_2"],
+  "statements_stamped": True,
+  "statement_stamp_note": None,
+  "stamped_statement_sets": {"struct_bs": "fs_123"},
+  "statement_rule_summary": {"pass": 20, "fail": 0},
+}
+
+
+@pytest.fixture()
+def ext_session():
+  database_url = os.environ.get("TEST_DATABASE_URL")
+  if not database_url:
+    pytest.skip("TEST_DATABASE_URL not configured")
+
+  schema = f"ext_receipt_{uuid.uuid4().hex[:12]}"
+  engine = create_engine(database_url)
+  with engine.begin() as conn:
+    conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+
+  session = sessionmaker(bind=engine)()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+  ExtensionsBase.metadata.create_all(bind=session.connection())
+  session.commit()
+  session.execute(text(f'SET search_path TO "{schema}"'))
+  try:
+    yield session
+  finally:
+    session.rollback()
+    session.close()
+    with engine.begin() as conn:
+      conn.execute(text(f'DROP SCHEMA "{schema}" CASCADE'))
+    engine.dispose()
+
+
+def _period(session, *, status, receipt):
+  session.add(
+    FiscalPeriod(
+      graph_id="kg_test",
+      name="2026-07",
+      start_date=PERIOD_START,
+      end_date=PERIOD_END,
+      period_type="month",
+      status=status,
+      closed_at=datetime(2026, 8, 20, 3, 35) if status == "closed" else None,
+      closed_by="user_abc" if status == "closed" else None,
+      close_receipt=receipt,
+    )
+  )
+  session.flush()
+
+
+def _read(session):
+  return get_period_close_status(session, ScheduleService(), PERIOD_START, PERIOD_END)
+
+
+def test_receipt_round_trips_through_postgres(ext_session):
+  """A stamped receipt comes back off the row with its numbers intact."""
+  _period(ext_session, status="closed", receipt=RECEIPT)
+
+  result = _read(ext_session)
+
+  assert result.period_status == "closed"
+  assert result.close_receipt is not None
+  # The split must survive, not just the total — reconstructing which
+  # entries reached QuickBooks is the whole reason the receipt exists.
+  assert result.close_receipt.entries_posted == 34
+  assert result.close_receipt.entries_published_to_qb == 31
+  assert result.close_receipt.entries_posted_locally == 3
+  assert result.close_receipt.actor_type == "agent"
+  assert result.close_receipt.rule_summary == {
+    "pass": 7,
+    "fail": 0,
+    "error": 0,
+    "skipped": 0,
+  }
+  assert result.close_receipt.stamped_statement_sets == {"struct_bs": "fs_123"}
+
+
+def test_open_period_has_no_receipt(ext_session):
+  _period(ext_session, status="open", receipt=None)
+
+  result = _read(ext_session)
+
+  assert result.period_status == "open"
+  assert result.close_receipt is None
+
+
+def test_period_closed_before_receipts_shipped_reads_as_no_receipt(ext_session):
+  """A pre-existing closed period is not a failed close.
+
+  There is no backfill, so every period closed before this shipped has
+  `status='closed'` and a NULL receipt. That combination must read cleanly
+  rather than looking like a close that went wrong.
+  """
+  _period(ext_session, status="closed", receipt=None)
+
+  result = _read(ext_session)
+
+  assert result.period_status == "closed"
+  assert result.close_receipt is None
+
+
+def test_unreadable_receipt_degrades_to_none(ext_session):
+  """A receipt that fails validation must not break the status read.
+
+  `get-period-close-status` is exactly what an operator calls when a close's
+  response was lost in transport. If a malformed receipt made that read
+  raise, the failure mode the receipt exists to fix would take the recovery
+  path down with it.
+  """
+  _period(ext_session, status="closed", receipt={"version": 1, "nonsense": True})
+
+  result = _read(ext_session)
+
+  assert result.period_status == "closed"
+  assert result.close_receipt is None
+
+
+def test_writer_and_reader_agree_on_every_key():
+  """What `close()` stamps is exactly what the read model parses.
+
+  The #1228 defects were both a writer and a reader disagreeing about a key
+  while each side's own test passed. This asserts the seam itself: build a
+  receipt from a real `PeriodCloseResult`, then validate it with the model
+  the read path uses. A field renamed on one side and not the other fails
+  here rather than on a tenant's books.
+
+  No database needed — the contract is between two pure projections.
+  """
+  from datetime import UTC
+
+  from robosystems.models.api.extensions.schedules import CloseReceiptResponse
+  from robosystems.operations.roboledger.fiscal_calendar.close_service import (
+    PeriodCloseResult,
+    _build_close_receipt,
+  )
+
+  result = PeriodCloseResult(
+    period="2026-07",
+    entries_posted=34,
+    target_auto_advanced=True,
+    calendar=object(),  # never serialized — a live ORM object by design
+    was_reclose=False,
+    entries_published_to_qb=31,
+    entries_posted_locally=3,
+    rule_summary={"pass": 7, "fail": 0},
+    evaluated_structure_ids=("struct_1",),
+    statements_stamped=True,
+    statement_stamp_note=None,
+    stamped_statement_sets={"struct_bs": "fs_123"},
+    statement_rule_summary={"pass": 20, "fail": 0},
+  )
+
+  raw = _build_close_receipt(
+    result,
+    actor_id="user_abc",
+    actor_type="agent",
+    closed_at=datetime(2026, 8, 20, 3, 35, tzinfo=UTC),
+  )
+
+  # Must be JSON-serializable — it goes into a JSONB column, and a stray
+  # datetime or tuple would only fail at commit time, mid-close.
+  import json
+
+  json.dumps(raw)
+
+  parsed = CloseReceiptResponse.model_validate(raw)
+
+  assert parsed.entries_posted == 34
+  assert parsed.entries_published_to_qb == 31
+  assert parsed.entries_posted_locally == 3
+  assert parsed.period == "2026-07"
+  assert parsed.actor_type == "agent"
+  assert parsed.closed_by == "user_abc"
+  assert parsed.evaluated_structure_ids == ["struct_1"]
+  assert parsed.stamped_statement_sets == {"struct_bs": "fs_123"}
+  # The calendar object must not have leaked into the receipt.
+  assert "calendar" not in raw


### PR DESCRIPTION
## Summary

Two unrelated threads that landed together, both about a result that existed but was never recorded anywhere durable.

**The close receipt.** A period close's result — entries posted, the QuickBooks/local split, statement stamping, rule summaries — lived only in the HTTP response. A close that *succeeded* but whose transport failed left no record on the books, so the operator reconstructed what happened from four separate state reads and had to know not to retry. On the MCP surface that is routine rather than rare: a real close runs past the 25s client timeout. `fiscal_periods.close_receipt` is now written in the same transaction as the `status='closed'` flip, so a committed close always carries its receipt and a rolled-back one carries none.

**A second libarrow.** `icebug` bundles its own `libarrow` beside pyarrow's, and the two collide on Arrow's process-global filesystem registry. Once anything in a process has imported networkit, `pyarrow.fs.LocalFileSystem()` raises `ArrowKeyError` permanently — import order does not help. Chasing the staging-identifier test that has been failing in CI for days led to a live instance of the same thing: `_load_pagerank_scores` has never once succeeded in production.

## Changes

**Close receipt** (`c30fd3b`)
- `fiscal_periods.close_receipt` JSONB + extensions migration `0034` (public schema and every tenant schema via the `TenantOps` fan-out).
- Written by `PeriodCloseService.close()` alongside the status flip. It is a projection, not a dump — `calendar` is a live ORM object, and a receipt that changes after the fact is not a receipt.
- Typed `CloseReceiptResponse` rather than a free dict, surfaced on `get-period-close-status`, plus a `has_close_receipt` flag on the calendar's period rows so listings stay compact.
- No backfill. Periods closed before this read as closed with no receipt — a real state, not a failed close. A stored receipt that fails validation degrades to none rather than raising, since that read is exactly what an operator calls when a response was lost.

**PageRank weighting** (`7035e6c`) — the one to look at closely
- `_load_pagerank_scores` raised on every call, the surrounding `except` swallowed it at debug level, and it returned `{}`. `weighted_score = freq * (1 + pagerank)` collapsed to `freq * 1`, so disclosure profiles have been silently frequency-only.
- Both tests around it were asserting the broken output: `test_weighted_score_uses_pagerank` asserted `ws >= freq - 0.001`, which the degraded path (`ws == freq`) also satisfies, so it and `test_weighted_score_degrades_without_pagerank` were checking the same result. It now asserts the exact product and a strict increase, guarded against a vacuous pass.
- The `except` logs at warning now; the debug level is why this survived.

**Parquet path resolution** (`1fea2ca`, `20d07ee`)
- Staging-identifier test fixtures write through a handle. This is what has been red in CI — deterministic, not flaky, and `-x` in the addopts meant it aborted the run and masked everything after it.
- `entity_sync/transform.py` likewise. Not a live defect (separate job, separate step subprocess), but it was the last path-string write and an exception to a convention is what the next writer copies.

**Housekeeping** (`5958360`) — ignore the HuggingFace cache that `ArelleClient`'s process-global `XDG_CACHE_HOME` causes to be written into the source tree.

## Breaking Changes

None. The GraphQL and REST additions are purely additive — a new `CloseReceipt` type, an optional `closeReceipt` field, and an optional `has_close_receipt` flag.

Worth flagging for coordination rather than as a break: `robosystems-python-client` carries a checked-in `schema.graphql` with a regen-must-be-clean gate, so these additions will surface there on its next `just refresh-schema`.

## Testing

- Full suite green: 13,506 passed, ruff/format/basedpyright clean.
- The close-receipt tests run against **real Postgres**, deliberately. Every extensions test mocks `extensions_session`, so nothing in-suite executes the raw SQL this touches — the gap that let #1228 ship two defects onto live books. The writer/reader contract test was mutation-checked: renaming a key on the writer fails it.
- The strengthened PageRank test was mutation-checked the same way — reverting the fix fails it.
- Close receipt verified end to end on a local tenant: `2026-07` closed, the receipt landed on the row matching the response field-for-field, and read back through GraphQL. A period closed earlier correctly reports no receipt.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
