### PR TITLE
docs: replace historical narration with present-tense statements

### DIFF
--- a/.github/actions/refresh-graph-asg/action.yml
+++ b/.github/actions/refresh-graph-asg/action.yml
@@ -53,8 +53,8 @@ inputs:
   completion-wait-minutes:
     description: >-
       How long to monitor for completion when wait-for-completion is true.
-      Ignored otherwise. The default of 20 preserves the previously hardcoded
-      1200s; raise it for a large fleet — Dagster's replica equivalent budgets
+      Ignored otherwise. Raise the default of 20 for a large fleet — Dagster's
+      replica equivalent budgets
       2 hours, sized for ~100 instances. Note the job timeout is derived from
       this, so raising it raises the cap rather than fighting it.
     required: false

--- a/.github/workflows/deploy-vpc.yml
+++ b/.github/workflows/deploy-vpc.yml
@@ -415,9 +415,8 @@ jobs:
             SECURITY_ENV="${{ inputs.environment }}"
           fi
 
-          # The API ALB alarms this job used to parameterize now live in api.yaml
-          # and reference the ALB and target group as CloudFormation resources,
-          # so there is nothing to resolve here any more.
+          # The API ALB alarms live in api.yaml and reference the ALB and target
+          # group as CloudFormation resources, so nothing is resolved here.
           SECURITY_PARAMS="ParameterKey=Environment,ParameterValue=$SECURITY_ENV \
                       ParameterKey=EnableConfig,ParameterValue=${{ inputs.security_config_enabled }}"
 

--- a/.github/workflows/service-refresh.yml
+++ b/.github/workflows/service-refresh.yml
@@ -160,11 +160,10 @@ jobs:
   # Graph Container Refresh (fleet-wide, via SSM)
   # ============================================
   # One job, one Lambda invocation, one tag-targeted SSM command per node-type
-  # group. This replaced a collector that enumerated every instance into a
-  # GitHub Actions matrix and gave each its own runner job. That design had a
-  # hard ceiling — a matrix caps at 256 jobs, and the fleet runs one database
-  # per instance — and it paid runner-minutes to sleep through a 30-minute
-  # busy-wait. Runner time here is now bounded and independent of fleet size.
+  # group. Do not fan the fleet into a job matrix: a matrix caps at 256 jobs,
+  # the fleet runs one database per instance, and per-instance jobs pay runner
+  # minutes to sit through the busy-wait. Runner time here is bounded and
+  # independent of fleet size.
   refresh-graph:
     needs: [graph-refresh-budget]
     if: ${{ inputs.graph_refresh_enabled == true || inputs.graph_refresh_enabled == 'true' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,7 +295,7 @@ robosystems/
 4. **Two-database split**: Platform (`robosystems`) for IAM/billing/metadata; extensions (`extensions`) for per-graph OLTP. Different `DeclarativeBase` classes, independent migration histories, same shared RDS instance
 5. **Credit-based AI billing**: Only AI operations (Anthropic/OpenAI) consume credits; database operations are free
 6. **Graph backend**: LadybugDB (`GRAPH_BACKEND_TYPE=ladybug`)
-7. **Two `Agent` concepts, disambiguated**: `Agent` (REA party — customer/vendor/employee counterparty) lives in `models/extensions/roboledger/agent.py` and is the canonical ontology term. The AI executor layer (Claude/MCP-driven, used to be called "AI agents") is named **Operator** throughout the codebase: `routers/graphs/operator/`, `operations/operators/`, classes like `CypherOperator` / `MappingOperator`, endpoint `/v1/graphs/{g}/operator`. Marketing-facing copy can still say "AI agent" / "AI assistant" — that's decoupled from internal naming.
+7. **Two `Agent` concepts, disambiguated**: `Agent` (REA party — customer/vendor/employee counterparty) lives in `models/extensions/roboledger/agent.py` and is the canonical ontology term. The AI executor layer (Claude/MCP-driven) is named **Operator** throughout the codebase: `routers/graphs/operator/`, `operations/operators/`, classes like `CypherOperator` / `MappingOperator`, endpoint `/v1/graphs/{g}/operator`. Marketing-facing copy can still say "AI agent" / "AI assistant" — that's decoupled from internal naming.
 
 ## Testing
 
@@ -373,8 +373,8 @@ ROBOINVESTOR_ENABLED=true          # gates roboinvestor ops + GraphQL investor f
 EXTENSIONS_GRAPHQL_ENABLED=true    # kill switch for the GraphQL endpoint
 EXTENSIONS_DATABASE_URL=postgresql://...  # extensions OLTP database
 # EXTENSIONS_ENABLED is a derived property (ROBOLEDGER_ENABLED OR ROBOINVESTOR_ENABLED)
-# — not a separate env var. Legacy LEDGER_ENABLED / INVESTOR_ENABLED names
-# have been retired; only ROBOLEDGER_ENABLED / ROBOINVESTOR_ENABLED are read.
+# — not a separate env var. Only ROBOLEDGER_ENABLED / ROBOINVESTOR_ENABLED
+# are read.
 ```
 
 ## Configuration System

--- a/bin/lambda/graph_volume_manager.py
+++ b/bin/lambda/graph_volume_manager.py
@@ -93,8 +93,8 @@ DEFAULT_THROUGHPUT = 125  # MB/s
 # ladybug-shared runs the SEC nightly full rebuild, whose relationship-table
 # COPYs are bound by small random reads (endpoint hash-index probes + CSR
 # rewrites) into this volume. At the 3000-IOPS baseline the volume sat 78-93%
-# busy moving ~20 MB/s and the rebuild took 6.4h; at 12000 IOPS / 500 MB/s the
-# same tables ran ~2.4x faster (2026-08-19). The other tiers stay at baseline.
+# busy at the 3000-IOPS baseline, so the shared tier is provisioned well above
+# it. The other tiers stay at baseline.
 TIER_VOLUME_SPEC: dict[str, dict[str, int]] = {
   "ladybug-standard": {"size": 20, "iops": 3000, "throughput": 125},
   "ladybug-large": {"size": 50, "iops": 3000, "throughput": 125},

--- a/bin/lambda/graph_volume_manager.py
+++ b/bin/lambda/graph_volume_manager.py
@@ -92,9 +92,10 @@ DEFAULT_THROUGHPUT = 125  # MB/s
 #
 # ladybug-shared runs the SEC nightly full rebuild, whose relationship-table
 # COPYs are bound by small random reads (endpoint hash-index probes + CSR
-# rewrites) into this volume. At the 3000-IOPS baseline the volume sat 78-93%
-# busy at the 3000-IOPS baseline, so the shared tier is provisioned well above
-# it. The other tiers stay at baseline.
+# rewrites) into this volume. At the 3000-IOPS baseline the volume sits 78-93%
+# busy moving ~20 MB/s; at 12000 IOPS / 500 MB/s the same tables run ~2.4x
+# faster, which is why the shared tier is provisioned there. The other tiers
+# stay at baseline.
 TIER_VOLUME_SPEC: dict[str, dict[str, int]] = {
   "ladybug-standard": {"size": 20, "iops": 3000, "throughput": 125},
   "ladybug-large": {"size": 50, "iops": 3000, "throughput": 125},

--- a/bin/lambda/graph_volume_monitor.py
+++ b/bin/lambda/graph_volume_monitor.py
@@ -231,9 +231,9 @@ def discover_lbug_instances() -> list[dict]:
 
   `writer` is the only value the writer launch template ever puts on
   `LadybugRole`, across every tier — the tier is carried separately on
-  `WriterTier`. This filter previously also listed `shared_master` and
-  `shared_replica`, which are `NODE_TYPE` values and never appear on
-  `LadybugRole`, so they matched nothing.
+  `WriterTier`. Do not add `shared_master` / `shared_replica` here: those are
+  `NODE_TYPE` values and never appear on `LadybugRole`, so they would match
+  nothing.
 
   Do not widen this to match any `LadybugRole` value. Replicas carry no
   `LadybugRole` today and are slated to get `replica` (deliberately not

--- a/bin/setup/gha.sh
+++ b/bin/setup/gha.sh
@@ -503,8 +503,8 @@ function setup_full_config() {
         gh variable set SHARED_REPLICAS_SPOT_WEIGHT_STAGING --body "0"
     fi
 
-    # Note: legacy graph backend variables were removed with the Ladybug-only deployment path
-    # If another backend is introduced in future, add its *_ENABLED_* variables here
+    # Ladybug is the only graph backend; a second one would add its
+    # *_ENABLED_* variables here.
 
     # Graph AMI: Auto-initialized by get-graph-ami action on first deploy
     # Stored in SSM: /robosystems/{env}/graph/ami-id

--- a/cloudformation/audit.yaml
+++ b/cloudformation/audit.yaml
@@ -63,7 +63,7 @@ Resources:
       # only calls the sub-APIs for properties present in the template, so
       # PutObjectLockConfiguration is never issued. Retention matches
       # RetentionDays below and the treatment already applied to the CloudTrail
-      # bucket; it applies to objects written after it was set (2026-08-17).
+      # bucket; it applies to objects written after it was set.
       LifecycleConfiguration:
         Rules:
           - Id: AuditRetention

--- a/cloudformation/graph-infra.yaml
+++ b/cloudformation/graph-infra.yaml
@@ -878,10 +878,9 @@ Resources:
   # AWS-RunShellScript, for three reasons that are one fact — the document name
   # is the only environment- or purpose-specific field an SSM invocation event
   # carries:
-  #   1. The failure rule below filters on it. Matching bare Failed/TimedOut
-  #      invocation events made every failed SSM command in the account page
-  #      BOTH environments' topics, each stamping its own environment name into
-  #      the message.
+  #   1. The failure rule below filters on it. Bare Failed/TimedOut invocation
+  #      events carry no such field, so every failed SSM command in the account
+  #      would page both environments' topics.
   #   2. The Lambda role's SendCommand collapses to this one document: the role
   #      can trigger a refresh on this environment's fleet, not run arbitrary
   #      shell on it.
@@ -900,10 +899,9 @@ Resources:
   # Output forwarding: the script's output is captured to an on-instance log
   # and only the REFRESH_RESULT line plus a bounded tail are echoed back. SSM
   # truncates a plugin's inline Output after 2500 characters keeping the head,
-  # and the script prints its marker last — after docker-pull progress — so on
-  # a real image refresh the marker fell outside the window and the Lambda
-  # classified nothing (empty refresh_results on this document's first
-  # fleet-wide prod run). Marker first + 2000-byte tail fits by construction.
+  # so a marker printed last — after docker-pull progress — falls outside the
+  # window and the Lambda classifies nothing. Marker first + 2000-byte tail
+  # fits by construction.
   GraphRefreshDocument:
     Type: AWS::SSM::Document
     Properties:
@@ -1054,16 +1052,14 @@ Resources:
         - Key: CreatedBy
           Value: CloudFormation
 
-  # Failure notification is push, not poll. Previously a failed refresh surfaced
-  # only as a red job in a workflow someone had to be watching; nothing paged.
-  # This fires regardless of whether anyone is looking at the run.
+  # Failure notification is push, not poll: it fires regardless of whether
+  # anyone is watching the run.
   #
   # Filtered to this stack's own document — the only environment- or
-  # purpose-specific field an SSM invocation event carries. Unfiltered, this
-  # pattern matched every failed SSM command in the account, so one prod
-  # failure paged BOTH environments' topics with each stamping its own
-  # environment name into the message, and unrelated commands (secrets
-  # rotation, maintenance sweeps) paged as "graph container refresh".
+  # purpose-specific field an SSM invocation event carries. Unfiltered, the
+  # pattern matches every failed SSM command in the account, so one failure
+  # pages both environments' topics and unrelated commands (secrets rotation,
+  # maintenance sweeps) page as "graph container refresh".
   GraphRefreshFailureRule:
     Type: AWS::Events::Rule
     Properties:

--- a/cloudformation/graph-ladybug-replicas.yaml
+++ b/cloudformation/graph-ladybug-replicas.yaml
@@ -845,8 +845,8 @@ Resources:
   # log group. Unlike a replica, the master is scaled 0->1 on purpose every
   # night (shared_master_wake), so one start per day is expected and cannot
   # page. What must page is a SECOND start while it is up — the container was
-  # killed and restarted under the nightly materialization (the 2026-08-12/13
-  # OOM kills, which nothing detected until a red Dagster run). A 12-hour
+  # killed and restarted under the nightly materialization, which nothing else
+  # detects until a job fails. A 12-hour
   # sliding window never holds two nightly wakes but covers the master's whole
   # waking life, so Sum > 1 is exactly "restarted while working". Homed here
   # with the other shared-repository serving alarms.

--- a/cloudformation/graph-ladybug-replicas.yaml
+++ b/cloudformation/graph-ladybug-replicas.yaml
@@ -846,9 +846,9 @@ Resources:
   # night (shared_master_wake), so one start per day is expected and cannot
   # page. What must page is a SECOND start while it is up — the container was
   # killed and restarted under the nightly materialization, which nothing else
-  # detects until a job fails. A 12-hour
-  # sliding window never holds two nightly wakes but covers the master's whole
-  # waking life, so Sum > 1 is exactly "restarted while working". Homed here
+  # detects until a job fails. A 12-hour sliding window never holds two nightly
+  # wakes but covers the master's whole waking life, so Sum > 1 is exactly
+  # "restarted while working". Homed here
   # with the other shared-repository serving alarms.
   SharedMasterContainerStartMetricFilter:
     Type: AWS::Logs::MetricFilter

--- a/cloudformation/graph-volumes.yaml
+++ b/cloudformation/graph-volumes.yaml
@@ -66,10 +66,8 @@ Resources:
   # ========================================
   # EBS SNAPSHOT LIFECYCLE
   # ========================================
-  # DLM (Data Lifecycle Manager) was removed because its TargetTags filtering
-  # proved unreliable — it snapshotted ALL volumes in the account regardless of
-  # tag filters, including shared replica root volumes and bastion volumes.
-  # This persisted across 4 fix attempts (Jan-Mar 2026).
+  # DLM (Data Lifecycle Manager) is deliberately not used: its TargetTags
+  # filtering snapshots every volume in the account regardless of tag filters.
   #
   # Snapshot strategy without DLM:
   # - Writer data volumes: Final snapshot on termination (graph-lifecycle.sh)
@@ -622,15 +620,14 @@ Resources:
       AlarmDescription: Disk usage exceeded 75% on any graph database data volume (/mnt/ladybug-data)
       # Metrics Insights, not a MetricStat with a partial dimension set. The CloudWatch
       # agent publishes DISK_USED_PERCENT with six dimensions (path, InstanceId,
-      # AutoScalingGroupName, InstanceType, device, fstype); a MetricStat must match the
-      # dimension set *exactly*, so the previous `Dimensions: [path=/mnt/ladybug-data]`
-      # matched nothing and sat OK on "no datapoints received" for the life of the
-      # stack. An Insights query aggregates across dimension sets while keeping the
-      # path filter, which is load-bearing: this ladder feeds VolumeMonitorFunction,
-      # and only attached data volumes are in the volume registry and expandable.
-      # Shared replicas keep the database on the root volume (DeleteOnTermination, no
-      # autoscaling) and are alarmed separately in graph-ladybug-replicas.yaml.
-      # Verified live against prod before commit.
+      # AutoScalingGroupName, InstanceType, device, fstype), and a MetricStat must
+      # match the dimension set *exactly* — a partial set matches nothing and reads
+      # as OK on no data. An Insights query aggregates across dimension sets while
+      # keeping the path filter, which is load-bearing: this ladder feeds
+      # VolumeMonitorFunction, and only attached data volumes are in the volume
+      # registry and expandable. Shared replicas keep the database on the root
+      # volume (DeleteOnTermination, no autoscaling) and are alarmed separately in
+      # graph-ladybug-replicas.yaml.
       Metrics:
         - Id: worst_disk
           Expression: !Sub 'SELECT MAX(DISK_USED_PERCENT) FROM "RoboSystems/Graph/${Environment}" WHERE path = ''/mnt/ladybug-data'''

--- a/cloudformation/security.yaml
+++ b/cloudformation/security.yaml
@@ -303,10 +303,9 @@ Resources:
   #
   # What belongs in this stack is the account-global detective baseline only.
   # Alarms on API-stack resources (ALB health, the security metric namespace,
-  # the rotation Lambda) used to live here because api.yaml had run out of
-  # inline-template room; api.yaml now deploys from S3, so they sit beside the
-  # resources they watch and reference them directly. Resist adding per-env
-  # application alarms back here — the size pressure that justified it is gone.
+  # the rotation Lambda) belong beside the resources they watch, in api.yaml,
+  # which deploys from S3 and has the room. Do not add per-env application
+  # alarms here.
   #
   # Precondition: the topic must already exist (api stack deployed with
   # SNSAlertEmail set), or the topic-policy attachment fails this stack.

--- a/cloudformation/worker.yaml
+++ b/cloudformation/worker.yaml
@@ -314,16 +314,8 @@ Resources:
               # allocation runs in the worker, and its failure metric publishes
               # to RoboSystems/Graph/${Environment} (allocation_manager.py's
               # _publish_failure_metric) because that is the namespace the
-              # AllocationFailures alarms in graph-ladybug.yaml watch. With only
-              # the Worker namespace allowed, every publish returned AccessDenied
-              # into a logger.error and the alarms sat OK on "no datapoints
-              # received" -- in BOTH environments -- since February.
-              #
-              # Proven 2026-08-15 by inducing a real no_capacity failure in
-              # staging: the allocation failed in 17s, the metric never
-              # published, and the worker log carried the AccessDenied. The
-              # 2026-08-09 dimension fix was correct and could never have taken
-              # effect underneath this.
+              # AllocationFailures alarms in graph-ladybug.yaml watch. Without
+              # it the publish is denied, and the alarms read no-data as OK.
               - Effect: Allow
                 Action:
                   - cloudwatch:PutMetricData

--- a/examples/custom_graph_demo/README.md
+++ b/examples/custom_graph_demo/README.md
@@ -221,14 +221,8 @@ The graph schema is defined in **`schema.json`** - a standalone JSON file that s
 - `PERSON_WORKS_ON_PROJECT`: Project participation relationships
 - `COMPANY_SPONSORS_PROJECT`: Sponsorship relationships between companies and projects
 
-**Customizing the Schema:**
-
-The `schema.json` file is the **official template** for creating custom graph schemas in RoboSystems. To create your own schema:
-
-1. Copy the schema file: `cp schema.json my_schema.json`
-2. Modify the nodes, properties, and relationships for your use case
-3. Update `create_graph.py` to load your custom schema file
-4. Generate data matching your schema structure
+`schema.json` is the template for custom graph schemas — see
+[Customize the Schema](#customize-the-schema) below for how to adapt it.
 
 **Schema Format:**
 

--- a/frameworks/README.md
+++ b/frameworks/README.md
@@ -104,7 +104,7 @@ frameworks/
 │   │   ├── rs-gaap-reporting-checklist/v1/
 │   │   ├── rs-gaap-reporting-styles/v1/   ★ vertical / filer-profile surface
 │   │   ├── rs-gaap-rollup-rules/v1/       L2 rollup-shaped consistency rules
-│   │   ├── rs-gaap-rules/v1/              L1 cross-tree consistency rules (rs-gaap-targeted; moved from fac)
+│   │   ├── rs-gaap-rules/v1/              L1 cross-tree consistency rules (rs-gaap-targeted)
 │   │   ├── rs-metric/v1/                  metric catalog + Derive rules (standing `metric` block)
 │   │   └── rs-driver/v1/                  forecast lever catalog + Derive rules (reference Structure)
 │   ├── bridges/

--- a/frameworks/fac/packages/README.md
+++ b/frameworks/fac/packages/README.md
@@ -81,8 +81,7 @@ metamodel publication, but the axes themselves are not us-gaap-specific
 — `elementsOfFinancialStatements`, `liquidity`, `activityType`,
 `recordedValue`, `realizationStatus`, `flowClassification`, etc.
 describe how *any* accounting element is classified, regardless of
-regulatory regime. Hoisted into `fac` so every dependent rs-* framework
-(rs-gaap today; rs-ifrs / rs-call-report / rs-statutory tomorrow)
+regulatory regime. They live in `fac` so every dependent rs-* framework
 inherits the same axes via `depends_on` and no rs-* framework has to
 re-author or duplicate the trait catalog.
 

--- a/frameworks/rs-gaap/packages/README.md
+++ b/frameworks/rs-gaap/packages/README.md
@@ -83,7 +83,7 @@ packages/
 ├── rs-gaap-reporting-styles/v1/      native  — vertical / filer-profile composition surface
 │                                               (v1 ships Default, Partnership, LLC)
 ├── rs-gaap-rollup-rules/v1/          native  — L2 rollup-shaped consistency rules
-├── rs-gaap-rules/v1/                 native  — L1 cross-tree consistency rules (moved from fac)
+├── rs-gaap-rules/v1/                 native  — L1 cross-tree consistency rules
 ├── rs-metric/v1/                     native  — metric catalog: one concept + one Derive rule per
 │                                               metric, plus the standing Key Financial Metrics
 │                                               block (block_type `metric`) compute-metrics fills

--- a/robosystems/adapters/sec/ixbrl_parser.py
+++ b/robosystems/adapters/sec/ixbrl_parser.py
@@ -124,9 +124,8 @@ def _find_nested_blocks(
 ) -> list[tuple[str, str]]:
   """Find matching open/close tag pairs with nesting-aware matching.
 
-  Uses str.find() instead of regex (.*?) to avoid catastrophic memory
-  usage on large files (the old regex approach caused 7GB+ allocation
-  on 5MB files).
+  Uses str.find() rather than a lazy regex (.*?), which allocates
+  catastrophically on large files — multiple GB on a 5 MB input.
 
   Args:
       html: Raw HTML string to search

--- a/robosystems/adapters/sec/pipeline/sensors.py
+++ b/robosystems/adapters/sec/pipeline/sensors.py
@@ -545,9 +545,9 @@ def sec_stage_to_materialize_sensor(context: RunStatusSensorContext):
   un-refreshed mutable Entity attributes), and its streaming COPY into an empty
   database has a far smaller memory working set than incremental mode, whose
   keyset-export + anti-join scales with the accumulated graph. Incremental
-  (per-table keyset anti-join, no rebuild) is parked as of 2026-08-13 — at
-  current corpus scale it exceeds the shared master's memory budget and
-  OOM-kills the Graph API mid-run — but remains available for manual runs via
+  (per-table keyset anti-join, no rebuild) is not used nightly — at current
+  corpus scale it exceeds the shared master's memory budget and OOM-kills the
+  Graph API mid-run — but remains available for manual runs via
   SECMaterializeConfig. The chain — wake → stage → materialize → publish →
   sleep — is unchanged. S3 publishes are handled by
   sec_post_materialize_publish_sensor (which keys off the mode:incremental tag,
@@ -579,7 +579,7 @@ def sec_stage_to_materialize_sensor(context: RunStatusSensorContext):
     )
     return
 
-  # Full rebuild every night. Incremental mode is parked (2026-08-13): at
+  # Full rebuild every night; incremental mode is manual-only. At
   # current corpus scale its keyset-export + anti-join phase runs DuckDB and
   # LadybugDB hot simultaneously and exceeds the shared master's memory budget,
   # OOM-killing the Graph API mid-run. The machinery remains available for

--- a/robosystems/config/deprovisioning.py
+++ b/robosystems/config/deprovisioning.py
@@ -15,18 +15,13 @@ class DeprovisioningConfig:
   retention_days: int = 7
   require_final_backup: bool = True
   backup_delay_hours: int = 24
-  # 90 days for every tier: the S3 lifecycle rule (cloudformation/s3.yaml,
-  # ExpireGraphBackups: 90) deletes the object then regardless of what is
-  # promised here. This table once promised 180/365 days to Large/XLarge —
-  # hosting the infrastructure could not deliver.
-  #
-  # The final backup is now tracked in GraphBackup (DeprovisionService's
-  # _register_final_backup), which is what makes it retrievable during the
-  # published export window and moves its expiry onto the tier-aware cleanup
-  # job. That job reads the value below, so differentiating this table by tier
-  # would now take effect — but only up to the lifecycle rule's 90-day
-  # ceiling, which still deletes the object regardless. Extending it for real
-  # means raising or exempting that rule too.
+  # 90 days for every tier, capped by the S3 lifecycle rule
+  # (cloudformation/s3.yaml, ExpireGraphBackups: 90), which deletes the object
+  # regardless of what is promised here. The final backup is tracked in
+  # GraphBackup (DeprovisionService's _register_final_backup), so its expiry
+  # runs through the tier-aware cleanup job, which reads the values below.
+  # Differentiating by tier therefore takes effect — but only up to that
+  # 90-day ceiling. Going beyond it means raising or exempting the rule too.
   backup_hosting_days: dict[str, int] = field(
     default_factory=lambda: {
       "ladybug-standard": 90,

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -779,11 +779,9 @@ class EnvConfig:
   #
   # Defaults to TRUE alongside the per-domain ROBOLEDGER/ROBOINVESTOR flags
   # so a fresh deployment with extensions on automatically gets the read
-  # surface (legacy /v1/ledger/* and /v1/investor/* routers are gone — this
-  # GraphQL endpoint is the only way to read extensions data). Kept as an
-  # independent kill switch for incident response (e.g. lock down
-  # introspection without disabling write operations). Prod/staging
-  # currently override to `false` via SSM during the staged rollout.
+  # surface — this GraphQL endpoint is the only way to read extensions data.
+  # Kept as an independent kill switch for incident response (e.g. lock down
+  # introspection without disabling write operations).
   EXTENSIONS_GRAPHQL_ENABLED = get_bool_env(
     "EXTENSIONS_GRAPHQL_ENABLED",
     get_parameter_value("EXTENSIONS_GRAPHQL_ENABLED", "true").lower() == "true",

--- a/robosystems/config/rate_limits.py
+++ b/robosystems/config/rate_limits.py
@@ -139,12 +139,11 @@ class RateLimitConfig:
     #                per user, so buying more graphs cannot multiply one
     #                customer's load on a resource others depend on.
     #
-    # An earlier version of this comment described LadybugDB as shared, which
-    # is what kept every tier on identical limits. It is not shared, and that
-    # is the whole reason the dedicated half can differentiate at all.
+    # LadybugDB is dedicated per graph, not shared, which is what lets the
+    # dedicated half differentiate by tier at all.
     #
-    # Admission control (85% of instance CPU/memory) remains the real overload
-    # backstop; these numbers are a product lever, not the safety mechanism.
+    # Admission control remains the real overload backstop; these numbers are a
+    # product lever, not the safety mechanism.
     # -----------------------------------------------------------------------
     "base": {
       # Anonymous / unrecognized tier — tightest limits

--- a/robosystems/config/valkey_registry.py
+++ b/robosystems/config/valkey_registry.py
@@ -386,7 +386,7 @@ manual_url = ValkeyURLBuilder.build_url(
     auth_token=auth_token
 )
 
-# LEGACY: Build URL without authentication (development only)
+# DEV: build a URL without authentication (development only)
 legacy_url = ValkeyURLBuilder.build_url(database=ValkeyDatabase.AUTH)
 """)
 

--- a/robosystems/config/valkey_registry.py
+++ b/robosystems/config/valkey_registry.py
@@ -387,7 +387,7 @@ manual_url = ValkeyURLBuilder.build_url(
 )
 
 # DEV: build a URL without authentication (development only)
-legacy_url = ValkeyURLBuilder.build_url(database=ValkeyDatabase.AUTH)
+dev_url = ValkeyURLBuilder.build_url(database=ValkeyDatabase.AUTH)
 """)
 
 

--- a/robosystems/dagster/jobs/backup_cleanup.py
+++ b/robosystems/dagster/jobs/backup_cleanup.py
@@ -45,12 +45,11 @@ def cleanup_tracked_backups(
   Covers both customer API backups and SEC pipeline backups,
   since both create GraphBackup records with expires_at.
 
-  Order matters, and it used to be the other way around. Marking the row
-  first drops it out of ``get_expired_backups`` forever, and the orphan sweep
-  skips every key a row still references — so a single transient S3 error
-  meant nothing ever retried the delete and the object rode the 90-day
-  lifecycle rule regardless of the graph's tier. A standard-tier backup
-  outlived its 7-day retention by twelve weeks on one failed API call.
+  Order matters: delete the object first, mark the row EXPIRED second. An
+  un-expired row is what drives the retry. Marking first drops the row out of
+  ``get_expired_backups`` for good, and the orphan sweep skips every key a row
+  still references, so one transient S3 error would leave the object to the
+  90-day lifecycle rule regardless of the graph's tier.
 
   Leaving the row un-expired is the retry: tomorrow's run picks it up again.
   Deleting an absent key is a success in S3, so a row whose object is already

--- a/robosystems/dagster/jobs/graph.py
+++ b/robosystems/dagster/jobs/graph.py
@@ -373,11 +373,10 @@ def restore_backup(
   context.log.info(f"Restoring graph {config.graph_id} from backup {config.backup_id}")
 
   with db.get_session() as session:
-    # Graph-type gate. This used to live on the REST operation; that surface was
-    # removed (restore is operator-run, not customer-facing), so the check moved
-    # here rather than leaving the only remaining path ungated. It fails closed
-    # on an unresolvable graph — a restore is destructive, so an unknown type is
-    # a refusal, not a default-allow.
+    # Graph-type gate. Restore is operator-run rather than customer-facing, so
+    # this job is the only path in and has to carry the check itself. It fails
+    # closed on an unresolvable graph — a restore is destructive, so an unknown
+    # type is a refusal, not a default-allow.
     unsupported = restore_unsupported_reason(config.graph_id, session)
     if unsupported:
       raise Failure(f"Restore refused for {config.graph_id}: {unsupported[1]}")

--- a/robosystems/db/platform.py
+++ b/robosystems/db/platform.py
@@ -163,8 +163,8 @@ def platform_session():
       with platform_session() as db:
           row = db.query(Connection).first()
 
-  This replaces ad-hoc `gen = get_db_session(); next(gen); ...; gen.close()`
-  patterns that used to live in the GraphQL resolvers and MCP tools.
+  Use this rather than driving `get_db_session()` by hand
+  (`gen = get_db_session(); next(gen); ...; gen.close()`).
   """
   db = SessionFactory()
   try:

--- a/robosystems/middleware/operations.py
+++ b/robosystems/middleware/operations.py
@@ -914,8 +914,7 @@ async def run_off_loop(func: Callable[..., Any], *args: Any) -> Any:
 
   This is what keeps ``/v1/status`` answering while a close posts to
   QuickBooks or a bounded lock wait sits on a busy row: the API runs one
-  uvicorn worker, and before this every operation's SQL and HTTP ran inline
-  on the loop.
+  uvicorn worker, so an operation's SQL and HTTP must not run on the loop.
 
   The worker-thread run is **shielded** from native asyncio cancellation.
   ``anyio.to_thread.run_sync`` shields only anyio-flavoured cancellation;

--- a/robosystems/models/core/graph/graph_backup.py
+++ b/robosystems/models/core/graph/graph_backup.py
@@ -37,11 +37,10 @@ class BackupStatus(str, Enum):
 class BackupType(str, Enum):
   """What shape the backup is.
 
-  ``SYSTEM`` is retained for historical rows only. It used to carry *who*
-  started a backup rather than what it is, which meant the shape axis could not
-  answer "is this a full dump?" for anything the platform produced. That axis
-  now lives on :class:`BackupInitiator`; new rows record shape here and
-  initiator there.
+  This axis is shape only — "is this a full dump?". Who started a backup is a
+  separate axis on :class:`BackupInitiator`; new rows record shape here and
+  initiator there. ``SYSTEM`` is retained for historical rows and is not a
+  shape; do not use it for new rows.
   """
 
   FULL = "full"

--- a/robosystems/models/extensions/element.py
+++ b/robosystems/models/extensions/element.py
@@ -33,8 +33,8 @@ from robosystems.db.extensions import ExtensionsBase
 from robosystems.utils.ulid import generate_prefixed_ulid
 
 # The `elements.source` vocabulary — the single source for the model CHECK and
-# for the tenant-provisioning widen step (`db.extensions._widen_library_checks`),
-# which used to carry its own copy that drifted from this one.
+# for the tenant-provisioning widen step (`db.extensions._widen_library_checks`).
+# Both read this; neither may keep its own copy.
 #
 # 'system' is reserved for internal FK-anchor elements created by the taxonomy
 # seed (e.g., struct_balance_sheet) and is intentionally NOT in COA_SOURCES so

--- a/robosystems/models/extensions/roboledger/fiscal_period.py
+++ b/robosystems/models/extensions/roboledger/fiscal_period.py
@@ -59,9 +59,8 @@ class FiscalPeriod(ExtensionsBase):
   # so a transport failure on a close that SUCCEEDED leaves the operator
   # reconstructing what happened from four separate state reads. Written
   # by PeriodCloseService.close(); read back by get-period-close-status
-  # and the fiscal-calendar response. Nullable because periods closed
-  # before this shipped (and those seeded closed by initialize_ledger)
-  # have no receipt.
+  # and the fiscal-calendar response. Nullable: a period can be closed
+  # without one (notably those seeded closed by initialize_ledger).
   close_receipt = Column(JSONB, nullable=True)
 
   # Timestamps

--- a/robosystems/operations/connection_service.py
+++ b/robosystems/operations/connection_service.py
@@ -718,8 +718,7 @@ async def dispatch_connection_sync(
     # The Dagster job releases the lock on run completion — but a failed
     # DISPATCH never starts a run, so without this release the leaked
     # lock 409s every sync attempt on this connection for its full
-    # 30-minute TTL (observed: a disabled-provider rejection locking the
-    # connection out). Best-effort, mirroring qb_load's release.
+    # 30-minute TTL. Best-effort, mirroring qb_load's release.
     if sync_lock_id:
       try:
         from robosystems.middleware.auth.distributed_lock import release_lock_by_id

--- a/robosystems/operations/event_block/__init__.py
+++ b/robosystems/operations/event_block/__init__.py
@@ -17,11 +17,9 @@ from .commands import (
   update_event_block,
 )
 
-# The lock policy moved to `operations/locking.py` and its error was renamed,
-# since it now guards entries, fiscal periods and reports as well as events.
-# This module's contract is a stable import path, so the old name keeps
-# resolving rather than breaking on the release that moved it. Deprecated —
-# import `RowLockedError` from `robosystems.operations.locking`.
+# Deprecated alias — import `RowLockedError` from
+# `robosystems.operations.locking`, which owns the lock policy for entries,
+# fiscal periods and reports as well as events.
 EventLockedError = RowLockedError
 
 __all__ = [

--- a/robosystems/operations/graph/commands/metadata.py
+++ b/robosystems/operations/graph/commands/metadata.py
@@ -1,9 +1,8 @@
 """Edit a graph's platform-level metadata — display name, description, tags.
 
-Backs the ``update-graph-metadata`` operation. Before this existed, every
-one of these fields was write-once at provisioning: ``graph_name`` was set
-by ``GraphCreationService`` and never touched again, and ``description`` /
-``tags`` were persisted into ``graph_metadata`` and read by nothing.
+Backs the ``update-graph-metadata`` operation — the only writer for these
+fields after provisioning, where ``GraphCreationService`` sets ``graph_name``
+and persists ``description`` / ``tags`` into ``graph_metadata``.
 
 Scope is deliberately the platform label only. The entity name that appears
 on financial statements lives in the extensions OLTP database and changes

--- a/robosystems/operations/graph/graph_creation_service.py
+++ b/robosystems/operations/graph/graph_creation_service.py
@@ -527,8 +527,8 @@ class GraphCreationService:
 
     Retried, because a graph without a pool has every AI run denied by the
     unconditional pre-flight, admin add-bonus/reset both 404 on the missing
-    row, and the monthly allocation iterates existing pools only — a single
-    transient failure here used to be a permanent, invisible gap.
+    row, and the monthly allocation iterates existing pools only, so a single
+    transient failure here would be a permanent, invisible gap.
     """
     import asyncio
 

--- a/robosystems/operations/information_block/forecast_compute.py
+++ b/robosystems/operations/information_block/forecast_compute.py
@@ -6,8 +6,7 @@ downstream, one forward month at a time from the walk's **anchor**.
 
 The anchor is not the block's ``base_period``. ``base_period`` is the origin
 of the authored window — every lever is keyed to a month inside it, so moving
-it means restating all of them, which is why advancing a scenario's base by
-hand meant deleting and rebuilding it. The anchor is derived instead: with
+it would mean restating all of them. The anchor is derived instead: with
 ``base_anchor='seam'`` (the default) it advances to the newest closed month
 inside the horizon, so a scenario survives a period close untouched and its
 first forward month opens on real balances rather than on a base several

--- a/robosystems/operations/information_block/rules/expressions.py
+++ b/robosystems/operations/information_block/rules/expressions.py
@@ -140,10 +140,10 @@ def require_single_equality(
 
   The whitelist walker permits ``ast.Compare`` and ``ast.Eq`` without
   bounding how many of each, so ``$A = $B = $C`` is structurally legal
-  while every consumer here requires exactly one operator. This was
-  open-coded in four places — parse, equality evaluation, derivation
-  evaluation, and LHS extraction — which is why the parser never grew the
-  check the other three all assumed. ``what`` keeps each caller's wording.
+  while every consumer here requires exactly one operator. All four call
+  sites — parse, equality evaluation, derivation evaluation, LHS extraction —
+  share this one check rather than open-coding it. ``what`` keeps each
+  caller's wording.
   """
   if (
     not isinstance(body, ast.Compare)
@@ -250,9 +250,9 @@ def _eval_arith(
   bound value, so the walk checks only whether the tree is *evaluable*.
   That is how :func:`parse_arithmetic_expression` validates at authoring
   time — by running this function rather than by maintaining a second
-  description of the same grammar. The two used to be separate, and every
-  shape one accepted and the other rejected produced a rule that saved
-  cleanly and then raised on every evaluation, forever.
+  description of the same grammar. Keep it that way: a second grammar would
+  drift, and any shape it accepted that this one rejects would save cleanly
+  and then raise on every evaluation.
   """
   if isinstance(node, ast.Constant):
     # bool first: isinstance(True, int) is True in Python, so without this

--- a/robosystems/operations/operators/operator_context.py
+++ b/robosystems/operations/operators/operator_context.py
@@ -60,11 +60,8 @@ class ToolAccess(Protocol):
 
     For operators that drive tools imperatively rather than through the
     model-driven loop (MappingOperator). Declared on the protocol because
-    both implementations provide it and an operator calling it must not
-    have to know which context it is running in — it was previously
-    implemented only on ``DirectToolAccess``, so every operator using it
-    raised ``AttributeError`` on the API path while working from the
-    worker.
+    both implementations provide it, so an operator calling it never has to
+    know which context it is running in. Both must keep implementing it.
     """
 
 

--- a/robosystems/operations/roboledger/commands/fiscal_calendar.py
+++ b/robosystems/operations/roboledger/commands/fiscal_calendar.py
@@ -127,7 +127,7 @@ def initialize_ledger(
     note=body.note,
   )
 
-  # Seed FiscalPeriod rows. Matches the old router's logic exactly.
+  # Seed FiscalPeriod rows.
   current = current_month_period()
   default_start = add_months(current, -23)
   start_period = body.earliest_data_period or default_start

--- a/robosystems/routers/__init__.py
+++ b/robosystems/routers/__init__.py
@@ -55,7 +55,7 @@ from .graphs import (
 )
 from .graphs import (
   main_router as graph_router,
-)  # Removed allocation_router - too dangerous for public API
+)
 from .graphs import (
   subscriptions_router as graph_subscriptions_router,
 )
@@ -71,8 +71,6 @@ from .offering import offering_router
 from .operations import router as operations_router
 from .orgs import router as orgs_router
 from .status import router as status_router
-
-# Removed entity router - using query endpoint for all Entity operations
 from .user import router as user_router
 
 # Graph-scoped routes that require an existing graph_id
@@ -186,11 +184,9 @@ admin_router_v1.include_router(admin_graphs_router)
 admin_router_v1.include_router(admin_users_router)
 admin_router_v1.include_router(admin_orgs_router)
 
-# NOTE: The old /v1/ledger/{graph_id} and /v1/investor/{graph_id} REST
-# surfaces were deleted in the extensions cutover. Reads now live at
-# /extensions/{graph_id}/graphql; writes live at
+# Extensions reads live at /extensions/{graph_id}/graphql; writes at
 # POST /extensions/{roboledger,roboinvestor}/{graph_id}/operations/{op_name}.
-# Both are mounted directly in main.py (no intermediate router_v1 wrapper).
+# Both mount directly in main.py, with no router_v1 wrapper.
 
 # Export routers for main application
 __all__ = [

--- a/robosystems/routers/auth/sso.py
+++ b/robosystems/routers/auth/sso.py
@@ -65,7 +65,7 @@ router = APIRouter()
 )
 async def generate_sso_token(
   request: Request,
-  auth_token: str | None = Cookie(None, alias="auth-token"),  # Backward compatibility
+  auth_token: str | None = Cookie(None, alias="auth-token"),
   session: Session = Depends(get_async_db_session),
   _rate_limit: None = Depends(sso_rate_limit_dependency),
 ) -> SSOTokenResponse:

--- a/robosystems/routers/graphs/__init__.py
+++ b/robosystems/routers/graphs/__init__.py
@@ -41,10 +41,8 @@ __all__ = [
   "usage_router",
 ]
 
-# NOTE: views_router was relocated to
-# routers/extensions/roboledger/views.py — the fact grid is roboledger
-# schema-specific and now lives on the extensions surface. See main.py
-# for the new mount.
+# The fact grid is roboledger schema-specific, so it lives on the extensions
+# surface: routers/extensions/roboledger/views.py, mounted in main.py.
 
 # Conditionally export search, documents, and memory routers based on flags.
 # The search router hosts both document search and memory `recall`, so it mounts

--- a/robosystems/routers/graphs/subgraphs/__init__.py
+++ b/robosystems/routers/graphs/subgraphs/__init__.py
@@ -32,7 +32,7 @@ for route in subgraph_router.routes:
   router.routes.append(route)
 
 # Include other sub-routers
-# Note: delete_router removed — delete lives at POST .../operations/delete-subgraph
+# Delete lives at POST .../operations/delete-subgraph
 router.include_router(info_router)
 
 __all__ = ["router"]

--- a/robosystems/routers/graphs/subscriptions.py
+++ b/robosystems/routers/graphs/subscriptions.py
@@ -235,7 +235,7 @@ async def create_repository_subscription(
     # subscriber — not the caller — is what determines who gets access. Owners
     # and admins may subscribe another member of their org; everyone else
     # resolves to themselves. Same rule (and same helper) as plan changes and
-    # cancellation, which have accepted a target user since Phase 3.
+    # cancellation, which also accept a target user.
     target_user_id, org_id = _resolve_subscription_target(
       current_user, request.user_id, db
     )

--- a/robosystems/routers/offering.py
+++ b/robosystems/routers/offering.py
@@ -218,7 +218,7 @@ async def get_service_offerings(
       repository_subscriptions={
         # Per USER, not per organization: access, credits, and volume limits
         # all key on the subscribing user (UserRepository / UserRepositoryCredits).
-        # This copy once claimed org-level sharing the implementation never had.
+        # There is no org-level sharing of repository access.
         "description": "Per-user shared repository access subscriptions",
         "pricing_model": "per_user",
         "repositories": repositories,

--- a/robosystems/security/auth_protection.py
+++ b/robosystems/security/auth_protection.py
@@ -54,8 +54,9 @@ class AdvancedAuthProtection:
 
   # Progressive delay configuration (seconds)
   PROGRESSIVE_DELAYS = {
-    0: 0,  # no failures: no delay (without this, min(0, 8) misses and falls
-    #       back to the 8th-failure value — a fresh IP charged 15 minutes)
+    0: 0,  # no failures: no delay. Explicit — the lookup floors to the
+    #       highest tier at or below the count, so a missing 0 charges a
+    #       fresh caller the 8th-failure delay.
     1: 1,  # 1st failure: 1 second
     2: 2,  # 2nd failure: 2 seconds
     3: 5,  # 3rd failure: 5 seconds

--- a/robosystems/security/password.py
+++ b/robosystems/security/password.py
@@ -272,9 +272,9 @@ class PasswordSecurity:
   def _bcrypt_bytes(cls, password: str) -> bytes:
     """Encode a password to bcrypt's 72-byte input, truncating if needed.
 
-    bcrypt 5.0 raises on inputs longer than 72 bytes rather than silently
-    truncating like 4.x. Truncating here reproduces the legacy behavior so
-    long passwords still work and hashes stored under 4.x keep verifying.
+    bcrypt raises on inputs longer than 72 bytes, so the truncation has to
+    happen here — and it must stay byte-exact, because stored hashes were
+    produced against the truncated input.
     """
     return password.encode("utf-8")[: cls.BCRYPT_MAX_BYTES]
 


### PR DESCRIPTION
## Summary

Comments across source, CloudFormation and workflows recorded what the codebase used to do, what an earlier approach was, or when a specific incident happened. Git history holds that; a comment should describe what is true now. Each rewrite keeps the constraint and drops the account of how it was learned.

Comments, docstrings and markdown only. No behavioural change.

## Changes

**Historical narration → present tense** (~45 sites)

- **CloudFormation** — `worker.yaml`, `graph-volumes.yaml`, `graph-infra.yaml`, `graph-ladybug-replicas.yaml`, `security.yaml`, `audit.yaml`. The load-bearing constraints all survive: why the second metric namespace is required, why the disk alarm needs a Metrics Insights query rather than a partial dimension set, why SSM skips must normalise to exit 0, why the failure rule filters on the document name. What goes is the dates, the incident retellings and the abandoned-approach postmortems around them.
- **Source** — `middleware/operations.py`, `db/platform.py`, `dagster/jobs/{backup_cleanup,graph}.py`, `models/core/graph/graph_backup.py`, `models/extensions/{element,roboledger/fiscal_period}.py`, `operations/{graph/commands/metadata,graph/graph_creation_service,connection_service,event_block/__init__,operators/operator_context,information_block/*}.py`, `adapters/sec/{ixbrl_parser,pipeline/sensors}.py`.
- **Config and security** — `config/{env,deprovisioning,valkey_registry,rate_limits}.py`, `security/{auth_protection,password}.py`.
- **Routers** — `routers/__init__.py` (three removed-surface tombstones, one of which named a removed router as "too dangerous for public API"), `routers/graphs/__init__.py`, `subgraphs/__init__.py`, `auth/sso.py`, `offering.py`, `subscriptions.py`.
- **Workflows, scripts and docs** — `service-refresh.yml`, `deploy-vpc.yml`, `refresh-graph-asg/action.yml`, `bin/setup/gha.sh`, `bin/lambda/graph_volume_{manager,monitor}.py`, `CLAUDE.md`, `frameworks/**`.

Also drops a roadmap aside naming unbuilt frameworks in `frameworks/fac/packages/README.md`. The framework names themselves stay throughout — `rs-ifrs`, `rs-call-report`, `rs-statutory` are public accounting standards, and they explain why the framework layout has a sibling slot per regulatory regime.

**Duplication** — `examples/custom_graph_demo/README.md` explained schema customization twice; the reference now points at the worked version under Advanced Usage.

## Two distillation targets checked and deliberately not changed

Both were flagged as redundant. Neither holds up:

- **The admission-control buffer-pool argument** was reported as "written out in full in five files". It is in three, each at a different altitude — the constants' home (`config/defaults.py`), the enforcing code (`graph_api/core/admission_control.py`), and the README whose point is *contrasting* the two controllers and which already cross-references the first. The other two are one-line summaries in bullet lists. Deduplicating would make each site worse.
- **`middleware/robustness/README.md`**'s "Putting it together" section was reported as restating the three preceding snippets. It shows the four helpers *composed* in one handler, which is the thing the individual sections cannot show.

## Breaking Changes

None.

## Testing

- `just test-code` — **passed** (ruff, format, basedpyright, cf-lint-all, lint-actions), re-run green by the pre-commit hook on both commits.
- **AST comparison** vs `main`: 30 of 31 changed Python files parse to an identical AST with docstrings stripped. The one difference is a comment inside a usage-example string in `config/valkey_registry.py`.
- **YAML comparison** vs `main` (CloudFormation-tag-aware loader): all six CF templates and `service-refresh.yml` parse identically. `deploy-vpc.yml` and `refresh-graph-asg/action.yml` differ only because the edited text sits inside a shell `run:` block and an input `description:` respectively — a `#` comment and a UI label.
- Full unit suite not re-run since the last green run on this base; leaving it to CI.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
