### PR TITLE
feat(mcp): give tool descriptions a shared, enforced skeleton

### DIFF
--- a/.claude/agents/ladybug-architect.md
+++ b/.claude/agents/ladybug-architect.md
@@ -90,6 +90,7 @@ Graph API (FastAPI on EC2:8001)
 - `databases/restore.py` - Restore operations
 - `databases/tables/` - DuckDB staging tables
 - `databases/tables/materialize.py` - Stage to graph ingestion
+- `metrics.py` - Prometheus metrics endpoint
 - `databases/vector_search.py` - LanceDB vector search
 - `databases/semantic_memory.py` - Semantic memory operations
 - `databases/schema.py` - Schema introspection
@@ -171,7 +172,7 @@ Confirm the set with `ls .github/workflows/ | grep graph` before acting on it �
 
 `.github/configs/graph.yml` is the source of truth — **read it rather than quoting sizes from memory**, since instance types and RAM have been resized more than once. Its `instance:` block per tier carries `instance_ram_gb` and `databases_per_instance`; ASG min/max counts come from GitHub variables (`just gha-list LBUG`).
 
-Shape as of this writing (verify before relying on it):
+Shape (read `.github/configs/graph.yml` for current values):
 
 ```
 ladybug-standard: dedicated instance, 3 subgraphs max
@@ -201,13 +202,9 @@ CLUSTER_TIER=ladybug-standard|ladybug-large|ladybug-xlarge|ladybug-shared
 LBUG_DATABASE_PATH=/data/lbug-dbs
 
 # Capacity Settings
-LBUG_MAX_DATABASES_PER_NODE=10
-LBUG_MAX_MEMORY_MB=2048
-LBUG_MAX_MEMORY_PER_DB_MB=0  # 0 = auto-calculate
-
-# Connection Management
-LBUG_MAX_CONNECTIONS_PER_DB=10
-LBUG_CONNECTION_TTL_MINUTES=30.0
+LBUG_MAX_DATABASES_PER_NODE
+LBUG_MAX_MEMORY_MB
+LBUG_MAX_MEMORY_PER_DB_MB  # 0 = auto-calculate
 
 # Admission Control
 LBUG_ADMISSION_MEMORY_THRESHOLD=0.85
@@ -303,7 +300,9 @@ curl http://{instance}:8001/metrics
 **Connection Pool Exhaustion:**
 
 - Check `/metrics` endpoint for pool stats
-- Increase `LBUG_MAX_CONNECTIONS_PER_DB` if needed
+- `LBUG_MAX_CONNECTIONS_PER_DB` and `LBUG_CONNECTION_TTL_MINUTES` are code
+  constants in `config/constants.py`, not environment variables — changing
+  either needs a deploy
 - Check for connection leaks in client code
 
 **Memory Pressure:**
@@ -356,7 +355,8 @@ async def get_graph_client(graph_id: str):
 ## Known Limitations
 
 1. **Sequential Ingestion**: One file at a time per database
-2. **Connection Limit**: Configurable, default 10 per database
+2. **Connection Limit**: per-database pool, capped at a small fixed size —
+   read `graph_api/core/ladybug/pool.py` for the current value
 3. **Single Writer**: One write operation per database at a time
 4. **No Cross-DB Queries**: Complete database isolation
 5. **Volume Attachment**: One EBS per database

--- a/robosystems/middleware/mcp/tools/cypher_tool.py
+++ b/robosystems/middleware/mcp/tools/cypher_tool.py
@@ -68,7 +68,7 @@ Query the graph using Cypher syntax. Use `get-graph-schema` first to discover av
 - No write operations (CREATE, SET, DELETE, etc.)
 - Query complexity is automatically monitored
 
-**EXAMPLES:**
+**NOTES:**
 ```cypher
 // Count nodes by type
 MATCH (n)
@@ -83,7 +83,7 @@ MATCH (a)-[r]->(b)
 RETURN DISTINCT labels(a)[0] AS from_type, type(r) AS rel_type, labels(b)[0] AS to_type
 ```
 
-**TIP:** Use `get-graph-schema` to understand what's in the graph before writing complex queries."""
+**NOTES:** Use `get-graph-schema` to understand what's in the graph before writing complex queries."""
 
     if self._has_ledger_spine():
       description += "\n\n" + LEDGER_STATUS_GUIDANCE

--- a/robosystems/middleware/mcp/tools/document_tools.py
+++ b/robosystems/middleware/mcp/tools/document_tools.py
@@ -140,21 +140,20 @@ class CreateDocumentTool:
 - To record observations, analysis notes, or research findings (use folder="memory")
 - To create any persistent document that should be searchable via search-documents
 
-**DOCUMENT TYPES:**
-- **Policy documents**: Accounting policies, close procedures, depreciation methods (folder="policies")
-- **Memory/notes**: Analysis, observations, key findings (folder="memory")
-- **General**: Any markdown document
+**PARAMETERS:**
+- `folder` groups the document: "policies" for accounting policies, close
+  procedures and depreciation methods; "memory" for analysis, observations and
+  findings; omit it for general documents
+- `content` is markdown. Use `## Section` headings — sections are split on them
+  and become individually searchable
+- YAML frontmatter sets title, tags and folder inline
 
-**FEATURES:**
-- Content is stored in PostgreSQL and automatically indexed in OpenSearch
-- Documents are searchable via the search-documents tool after creation
-- Supports markdown formatting with heading-based section splitting
-- Tags and folders help organize and filter documents
+**RETURNS:** The created document's id and metadata.
 
-**TIPS:**
-- Use markdown headings (## Section) to create searchable sections
-- Use YAML frontmatter for metadata (title, tags, folder)
-- Documents with folder="memory" replace the old remember-text pattern""",
+**NOTES:**
+- Stored in PostgreSQL and indexed in OpenSearch, so it is reachable via
+  search-documents once created
+- Tags and folders are the filters available to list-documents""",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -276,8 +275,10 @@ class UpdateDocumentTool:
 - To append notes to an existing memory document
 - To update tags or folder for organization
 
-Only provided fields are updated — omit fields you don't want to change.
-Content changes are automatically re-indexed in OpenSearch.""",
+**RETURNS:** The updated document's metadata.
+
+**NOTES:** Only provided fields are updated — omit fields you don't want to
+change. Content changes are re-indexed in OpenSearch.""",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -389,10 +390,12 @@ class GetDocumentTool:
 - To review a document before updating it
 - When you know the document ID (from list-documents or a previous interaction)
 
-**HOW IT DIFFERS FROM get-document-section:**
-- get-document returns the FULL document from PostgreSQL (the source of truth)
-- get-document-section returns a single search-indexed section from OpenSearch
-- Use get-document for reading/editing, use get-document-section for search drill-in""",
+**RETURNS:** The full document — content, title, tags, folder and metadata.
+
+**RELATED TOOLS:**
+- get-document-section returns one search-indexed section from OpenSearch; use
+  it to drill into a search hit. This tool reads the whole document from
+  PostgreSQL, which is the source of truth, so use it for reading and editing""",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -469,8 +472,10 @@ class DeleteDocumentTool:
 - To remove an outdated or incorrect policy/procedure document
 - To clean up a memory note that is no longer relevant
 
-Removes the document from PostgreSQL (source of truth) and its indexed sections
-from OpenSearch. This is permanent — use get-document to review before deleting.""",
+**RETURNS:** Confirmation of the deletion.
+
+**NOTES:** Removes the document from PostgreSQL and its indexed sections from
+OpenSearch. Permanent — read it with get-document first.""",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -544,10 +549,12 @@ class ListDocumentsTool:
 - To find a specific document by title when you don't have the ID
 - To see all policy documents (folder="policies") or memory notes (folder="memory")
 
-**HOW IT DIFFERS FROM search-documents:**
-- list-documents is a direct browse of PostgreSQL (no search ranking)
-- search-documents uses hybrid search (BM25 + KNN) for discovery by content
-- list-documents shows all docs including empty ones; search-documents only returns matches""",
+**RETURNS:** Document ids, titles, folders and tags — metadata, not content.
+
+**RELATED TOOLS:**
+- search-documents ranks by content using hybrid search (BM25 + KNN) and
+  returns only matches. This tool browses PostgreSQL directly with no ranking
+  and lists every document, including empty ones""",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/robosystems/middleware/mcp/tools/fact_grid_tool.py
+++ b/robosystems/middleware/mcp/tools/fact_grid_tool.py
@@ -53,7 +53,7 @@ class BuildFactGridTool:
 - live-financial-statement returns ALL line items for a standard statement from the tenant's live OLTP ledger
 - build-fact-grid returns SPECIFIC elements you choose, across any combination of periods and entities
 
-**INPUTS:**
+**PARAMETERS:**
 - elements: XBRL qnames (e.g., 'us-gaap:Assets'). Use resolve-element to find qnames.
 - canonical_concepts: Normalized concept names (e.g., 'revenue', 'net_income'). Matches ALL element qnames mapped to each concept across companies. Can be combined with elements.
 - periods: End dates in YYYY-MM-DD format
@@ -67,11 +67,10 @@ class BuildFactGridTool:
 - Only consolidated totals (dimensional breakdowns excluded)
 - `truncated: true` when more facts matched than `limit` allowed; the ones returned are the most recent by period
 
-**IMPORTANT:**
+**NOTES:**
 On shared repositories (e.g. SEC) entity or entities is REQUIRED — those graphs host thousands of filers, so an unscoped query returns an arbitrary slice of arbitrary companies. On a tenant graph the URL already scopes to one entity, so the filter is optional there.
-
-**TIP:**
-For income statement items (revenue, net income), always specify period_type='annual' or 'quarterly' to avoid mixing duration types. Use canonical_concepts for cross-company comparisons where companies may use different XBRL tags for the same concept.""",
+For income statement items (revenue, net income), always specify period_type='annual' or 'quarterly' to avoid mixing duration types. Use canonical_concepts for cross-company comparisons where companies may use different XBRL tags for the same concept.
+""",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/robosystems/middleware/mcp/tools/financial_statement_tools.py
+++ b/robosystems/middleware/mcp/tools/financial_statement_tools.py
@@ -50,20 +50,19 @@ class LiveFinancialStatementTool(BaseTool):
 - Live, up-to-the-minute data (no materialization required)
 - Only available on RoboLedger tenant entity graphs (not SEC shared repo)
 
-**STATEMENT TYPES:**
+**PARAMETERS:**
 - income_statement — Revenue, expenses, net income
 - balance_sheet — Assets, liabilities, equity (instant periods)
 - equity_statement — Equity components and changes
 - cash_flow_statement — Operating (indirect: net income + non-cash add-backs + working-capital deltas), investing, financing. Investing/financing leaves resolve from each line's explicit flow tag when present, else from the mapped rs-gaap element's default-flow derivation arc — so untagged QB data renders too, provided the relevant accounts are mapped at the grain the arcs key on (e.g. PP&E Gross for capex). Needs ≥2 periods (current + prior) for the indirect deltas.
-
-**INPUTS:**
 - Explicit `period_start` / `period_end` (YYYY-MM-DD) win over everything else
 - `period_type="annual"` + `fiscal_year=2025` → window anchored on the graph's FiscalCalendar
 - `period_type="quarterly"` → current calendar quarter
 - `period_type="instant"` / unset → current calendar month
 
 **RETURNS:**
-Facts with element qnames, names, classifications, values across current + prior periods (equal duration). Subtotal rows and all-zero rows are filtered out. Capped at `limit` rows.""",
+Facts with element qnames, names, classifications, values across current + prior periods (equal duration). Subtotal rows and all-zero rows are filtered out. Capped at `limit` rows.
+""",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -177,14 +176,12 @@ class FinancialStatementAnalysisTool(BaseTool):
 - RoboLedger tenant graph post-materialization: historical analytical queries against the materialized ledger
 - Use when you want cross-period or cross-entity analytical views rather than the current live books (use live-financial-statement for the latter)
 
-**ROUTING:**
+**NOTES:**
 - Shared-repo (SEC): `ticker` REQUIRED. If no `report_id`, auto-resolves the latest matching filing by form type (10-K/10-Q/20-F/40-F).
 - Tenant graph: `report_id` REQUIRED.
 
-**STATEMENT TYPES:**
+**PARAMETERS:**
 - income_statement, balance_sheet, cash_flow_statement, equity_statement
-
-**PERIOD TYPES:**
 - annual — 10-K/20-F/40-F forms, duration facts
 - quarterly — 10-Q + annuals (international filers), duration facts
 - instant — point-in-time facts (balance sheet default)
@@ -192,7 +189,8 @@ class FinancialStatementAnalysisTool(BaseTool):
 **RETURNS:**
 - Deduplicated facts (qname, name, value, end_date) ordered by end_date DESC
 - resolved_report info when auto-resolution was used
-- Dimensional/segment breakdowns are filtered out (consolidated totals only)""",
+- Dimensional/segment breakdowns are filtered out (consolidated totals only)
+""",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
+++ b/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
@@ -145,7 +145,7 @@ class GetFiscalCalendarTool:
    re-check
 6. If `gap_periods > 1`, the user is behind — acknowledge and plan a catch-up
 
-**READ-ONLY**: safe to call repeatedly, no side effects.""",
+**NOTES:** Read-only — safe to call repeatedly, no side effects.""",
       "inputSchema": {"type": "object", "properties": {}, "required": []},
     }
 
@@ -448,7 +448,7 @@ class ReopenPeriodTool:
 - A correcting entry is needed for a prior period adjustment
 - The user wants to re-run the close workflow for a closed period
 
-**WHAT IT DOES:**
+**NOTES:**
 1. Transitions FiscalPeriod from 'closed' → 'closing' (drafts may still exist)
 2. If this was the latest closed period, decrements closed_through
 3. Retracts the month's canonical statement FactSets (a reopened month is
@@ -456,6 +456,13 @@ class ReopenPeriodTool:
 4. Does NOT modify close_target — that's a separate user decision
 5. Does NOT modify existing posted entries — they stay posted
 6. Emits a period_reopened audit event with the required reason
+- Period must be in 'closed' status (422 otherwise)
+- Reason must be non-empty (422 otherwise)
+- Posted entries stay posted. To "undo" a posted entry, create a reversing
+  entry via create-event-block(event_type='journal_entry_recorded',
+  metadata.type='reversing'), or reopen + correct + re-close.
+- Reopening older periods (not the most recently closed) is allowed but
+  does not decrement closed_through.
 
 **PARAMETERS:**
 - period (required): YYYY-MM format
@@ -464,18 +471,8 @@ class ReopenPeriodTool:
 **RETURNS:**
 - Updated fiscal_calendar state
 - statement_sets_retracted: how many canonical statement FactSets the
-  reopen deleted (0 for months closed before close-time stamping existed)
-
-**GUARDS:**
-- Period must be in 'closed' status (422 otherwise)
-- Reason must be non-empty (422 otherwise)
-
-**NOTES:**
-- Posted entries stay posted. To "undo" a posted entry, create a reversing
-  entry via create-event-block(event_type='journal_entry_recorded',
-  metadata.type='reversing'), or reopen + correct + re-close.
-- Reopening older periods (not the most recently closed) is allowed but
-  does not decrement closed_through.""",
+  reopen deleted (0 for months whose statement sets were never stamped)
+""",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -586,7 +583,7 @@ class BackfillPlanHistoryTool:
 
 **WHEN TO USE:**
 - The Plan page shows only annual (or missing) columns because historical
-  months were closed before close-time statement stamping existed, or were
+  months have no stamped statement sets — either never stamped, or
   baseline-closed at calendar initialization and never really closed
 - A tenant with deep ledger history (QB sync) wants monthly statement
   columns further back than the calendar currently covers
@@ -605,7 +602,7 @@ class BackfillPlanHistoryTool:
 4. Stops after max_periods months and reports the rest in
    remaining_periods — call again to continue (chunked, resumable)
 
-**IDEMPOTENT / SAFE:**
+**NOTES:**
 - Months that already have canonical statement sets are never touched
   (unless restamp=true — the deliberate healing pass that re-derives them)
 - Months holding draft entries are SKIPPED, never posted — the backfill

--- a/robosystems/middleware/mcp/tools/graph_tools.py
+++ b/robosystems/middleware/mcp/tools/graph_tools.py
@@ -316,9 +316,13 @@ class DeleteSubgraphTool:
     return {
       "name": "delete-subgraph",
       "description": (
-        "Hard-delete a subgraph and all its data. Cannot target the parent "
-        "graph. Requires admin role on the parent. Use `backup_first=true` "
-        "to create a safety snapshot before deletion.\n\n"
+        "Hard-delete a subgraph and all its data.\n\n"
+        "**WHEN TO USE:**\n"
+        "- To permanently remove a subgraph that is no longer needed\n"
+        "- Requires admin role on the parent, and cannot target the parent "
+        "graph itself\n\n"
+        "**RETURNS:** Confirmation of the deletion, and the backup id when "
+        "`backup_first` is set.\n\n"
         "**PARAMETERS:**\n"
         "- subgraph_id: Full id like `{parent_id}_{name}`\n"
         "- force: Delete even if the subgraph contains data (default false)\n"
@@ -436,8 +440,14 @@ class ListSubgraphsTool:
       "name": "list-subgraphs",
       "description": (
         "List every subgraph under this parent graph, plus the parent itself "
-        "as the `primary` entry. Each row carries `connector_url` — the MCP "
-        "endpoint that serves that graph.\n\n"
+        "as the `primary` entry.\n\n"
+        "**WHEN TO USE:**\n"
+        "- To discover what subgraphs exist and how to reach each one\n"
+        "- Before working in a subgraph, to get its `connector_url`\n\n"
+        "**RETURNS:** One row per graph — the parent as `primary` plus each "
+        "subgraph — each carrying `connector_url`, the MCP endpoint that "
+        "serves that graph.\n\n"
+        "**NOTES:**\n"
         "A subgraph is a separate endpoint, not a mode of this one: this "
         "connector is anchored to its own graph by URL and cannot be "
         "retargeted. To work in a subgraph, add its `connector_url` as its "
@@ -620,7 +630,9 @@ class CreateBackupTool:
         "- On a scheduled basis for disaster-recovery hygiene\n"
         "- Before running large agent-driven workflows\n\n"
         "**PARAMETERS:**\n"
-        "- retention_days: How long to keep the backup (default 30, capped at tier max)."
+        "- retention_days: How long to keep the backup (default 30, capped at "
+        "tier max).\n\n"
+        "**RETURNS:** An `operation_id` to track the enqueued backup."
       ),
       "inputSchema": {
         "type": "object",
@@ -905,8 +917,9 @@ class SyncConnectionTool:
         "incremental refresh is the common case.\n"
         "- since_date: Bounded incremental window (YYYY-MM-DD); ignored "
         "when full_rebuild=true.\n\n"
-        "**COMPLETION:** returns `task_id` once dispatched; the sync runs "
-        "in the background. Poll `get-fiscal-calendar` until "
+        "**RETURNS:** A `task_id` once dispatched; the sync runs in the "
+        "background.\n\n"
+        "**NOTES:** Poll `get-fiscal-calendar` until "
         "`last_sync_at` advances past the dispatch time (and any "
         "`sync_stale` blocker clears) before proceeding with a close. A "
         "`sync_in_progress` error means a sync is already running — wait "
@@ -1036,7 +1049,7 @@ class SetWritePolicyTool:
       "description": (
         "Set whether a connection writes back to its source system — the "
         "explicit opt-in for outbound write-back.\n\n"
-        "**WHAT IT CONTROLS:**\n"
+        "**NOTES:**\n"
         "- `native`: RoboSystems is the source of truth. No write-back; "
         "RoboSystems-originated entries (manual JEs, schedule drafts) post "
         "locally only.\n"
@@ -1045,8 +1058,7 @@ class SetWritePolicyTool:
         "(`execute-event-block`) or at period close, then post locally.\n\n"
         "**WHEN TO USE:** Flip a QuickBooks connection to `qb_authoritative` "
         "before relying on write-back so drafts round-trip into QB; flip "
-        "back to `native` to disable write-back. (`hybrid` is not yet "
-        "supported.)\n\n"
+        "back to `native` to disable write-back.\n\n"
         "**RETURNS:** the updated connection (including `write_policy`)."
       ),
       "inputSchema": {

--- a/robosystems/middleware/mcp/tools/graphql_tool.py
+++ b/robosystems/middleware/mcp/tools/graphql_tool.py
@@ -186,15 +186,18 @@ class GraphqlSchemaTool(BaseTool):
     return {
       "name": "get-graphql-schema",
       "description": (
-        "Return the GraphQL schema for the extensions endpoint. "
-        "Call this before query-graphql to discover types, fields, and input "
-        "arguments. The schema is per-deployment — fields depend on which "
-        "extensions (roboledger, roboinvestor) are enabled.\n\n"
-        "**format options:**\n"
-        "- ``sdl`` (default) — human-readable Schema Definition Language; "
-        "best for scanning types and writing queries.\n"
-        "- ``introspection`` — full JSON introspection result; useful for "
-        "programmatic tooling that consumes the standard introspection format."
+        "Return the GraphQL schema for the extensions endpoint.\n\n"
+        "**WHEN TO USE:**\n"
+        "- Before query-graphql, to discover types, fields and input arguments\n"
+        "- When a query fails on an unknown field — the schema is "
+        "per-deployment and depends on which extensions (roboledger, "
+        "roboinvestor) are enabled\n\n"
+        "**PARAMETERS:**\n"
+        "- ``format``: ``sdl`` (default) is human-readable Schema Definition "
+        "Language, best for scanning types and writing queries; "
+        "``introspection`` is the full JSON introspection result, for tooling "
+        "that consumes the standard format.\n\n"
+        "**RETURNS:** The schema in the requested format."
       ),
       "inputSchema": {
         "type": "object",
@@ -261,19 +264,20 @@ class GraphqlQueryTool(BaseTool):
     return {
       "name": "query-graphql",
       "description": (
-        "Execute a read-only GraphQL query against the extensions endpoint. "
-        "Call get-graphql-schema first to discover types and fields. "
-        "Mutations and subscriptions are rejected.\n\n"
-        "**Usage pattern:**\n"
-        "1. Call get-graphql-schema to get the SDL.\n"
-        "2. Write a query against the SDL.\n"
-        "3. Call query-graphql with the query string.\n\n"
-        "**graph_id is always set from context** — do not pass it as a "
-        "query argument. The schema reflects the graph_id from the URL.\n\n"
-        "**Example:**\n"
-        "```graphql\n"
-        "{ fiscalCalendar { closedThrough closeTarget } }\n"
-        "```"
+        "Execute a read-only GraphQL query against the extensions "
+        "endpoint.\n\n"
+        "**WHEN TO USE:**\n"
+        "- For typed reads of extensions data (roboledger, roboinvestor)\n"
+        "- After get-graphql-schema, which gives the types and fields to "
+        "query against\n\n"
+        "**PARAMETERS:**\n"
+        "- ``query``: the GraphQL query string. Mutations and subscriptions "
+        "are rejected.\n"
+        "- **graph_id is set from context** — never pass it as a query "
+        "argument. The schema already reflects the graph_id from the URL.\n\n"
+        "**RETURNS:** The query result, shaped by the fields requested.\n\n"
+        "**NOTES:** A minimal query looks like "
+        "``{ fiscalCalendar { closedThrough closeTarget } }``."
       ),
       "inputSchema": {
         "type": "object",

--- a/robosystems/middleware/mcp/tools/information_block_tools.py
+++ b/robosystems/middleware/mcp/tools/information_block_tools.py
@@ -75,16 +75,15 @@ A typed envelope with:
 - information_model (concept + member arrangement)
 - artifact (topic, mechanics — typed per block_type)
 - elements, connections, facts (bundled atoms)
-- rules, dimensions, fact_set, verification_results (populated as
-  the rule engine + FactSet expand work progresses)
+- rules, dimensions, fact_set, verification_results (empty when the block
+  has none)
 
 **RELATED TOOLS:**
 - list-information-blocks — browse available blocks
 - create-information-block — build a new block
 
-Note: This is the generic reader for every block type; the old
-schedule-specific readers (list-schedule-structures, get-schedule-facts)
-were retired in favor of this pair.""",
+**NOTES:** This is the generic reader for every block type, schedules
+included.""",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/robosystems/middleware/mcp/tools/playbook_tools.py
+++ b/robosystems/middleware/mcp/tools/playbook_tools.py
@@ -299,7 +299,7 @@ class GetClosePlaybookTool:
 - Before running a monthly close → mode="recurring"
 - Any time the close workflow is unclear → mode="overview" (default)
 
-**ALSO READ:** call `search-documents` for this company's own "close procedures" document — it captures tenant-specific accounts/quirks and references this generic playbook.
+**RELATED TOOLS:** call `search-documents` for this company's own "close procedures" document — it captures tenant-specific accounts/quirks and references this generic playbook.
 
 **RETURNS:** the close overview, the ordered tool sequence for the chosen mode, schedule-authoring rules (incl. one-schedule-per-debit/credit-pair), and key gotchas (period-identifier shapes, amounts-in-cents, which block types 501, close blockers).""",
       "inputSchema": {

--- a/robosystems/middleware/mcp/tools/resolve_element_tool.py
+++ b/robosystems/middleware/mcp/tools/resolve_element_tool.py
@@ -35,12 +35,11 @@ class ResolveElementTool(BaseTool):
 - Top matching XBRL elements with qnames, labels, and fact counts
 - A ready-to-use Cypher query hint
 
-**EXAMPLES:**
+**NOTES:**
 - concept: "revenue" → finds us-gaap:Revenues, us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax, etc.
 - concept: "total debt" → finds us-gaap:LongTermDebt, us-gaap:DebtAndCapitalLeaseObligations, etc.
-
-**TIP:**
-Use the returned query_hint directly in read-graph-cypher for immediate results.""",
+Use the returned query_hint directly in read-graph-cypher for immediate results.
+""",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/robosystems/middleware/mcp/tools/schema_tool.py
+++ b/robosystems/middleware/mcp/tools/schema_tool.py
@@ -47,23 +47,7 @@ class SchemaTool(BaseTool):
 - **Property Details**: Name, data type (STRING, INT64, DOUBLE, etc.), nullable flags
 - **Metadata**: Descriptions and additional context when available
 
-**SCHEMA TYPES:**
-The database may use different schema configurations:
-1. **Base Schema**: Standard RoboSystems entities (Entity, User, etc.)
-2. **Extended Schema**: Base + domain-specific extensions
-3. **Custom Schema**: Custom entities and relationships
-4. **Hybrid Schema**: Custom schema extending the base
-
-**DATA TYPES:**
-Common property types you'll encounter:
-- STRING: Text values
-- INT64/INT32: Integer numbers
-- DOUBLE/FLOAT: Decimal numbers
-- BOOLEAN: True/false values
-- TIMESTAMP: Date/time values
-- JSON: Complex nested data
-
-**USAGE TIPS:**
+**NOTES:**
 - Look for node labels ending in specific patterns (Entity, Fact, etc.)
 - Check relationship direction: ->() vs <-()
 - Property names are case-sensitive

--- a/robosystems/middleware/mcp/tools/search_tools.py
+++ b/robosystems/middleware/mcp/tools/search_tools.py
@@ -55,7 +55,7 @@ class SearchDocumentsTool(_SearchToolMixin):
 - To discover any document content by topic or keyword
 - For cross-company topic search on shared repositories (e.g., "which companies mention tariff risk?")
 
-**DOCUMENT TYPES SEARCHED:**
+**PARAMETERS:**
 - User-uploaded documents (policies, procedures, notes) — created via create-document
 - SEC filing text blocks and narrative sections
 - iXBRL disclosure sections with embedded XBRL facts
@@ -76,7 +76,7 @@ class SearchDocumentsTool(_SearchToolMixin):
 - Use resolve-element to look up details, then read-graph-cypher for structured values
 - Bridges unstructured narrative context ↔ structured financial facts
 
-**TIPS:**
+**NOTES:**
 - Natural language queries work well ("depreciation policy", "month end close procedures")
 - Use entity filter to focus on one company's filings
 - Use section filter (item_1a, item_7) to target specific filing sections""",

--- a/robosystems/middleware/mcp/tools/semantic_memory_tools.py
+++ b/robosystems/middleware/mcp/tools/semantic_memory_tools.py
@@ -73,11 +73,17 @@ class SemanticRememberTool(_SemanticMemoryToolMixin, BaseTool):
     return {
       "name": "remember",
       "description": (
-        "Store a durable semantic memory for the active graph. The text is "
-        "embedded and can be recalled later with the `recall` tool. Use for "
-        "facts, decisions, preferences, and context worth persisting across "
-        "sessions. This is vector memory — distinct from write-graph-cypher, "
-        "which builds structural graph data on subgraphs."
+        "Store a durable semantic memory for the active graph.\n\n"
+        "**WHEN TO USE:**\n"
+        "- For facts, decisions, preferences and context worth persisting "
+        "across sessions\n"
+        "- When something learned in this session should survive it\n\n"
+        "**RETURNS:** The stored memory's id, for later `update-memory` or "
+        "`forget`.\n\n"
+        "**RELATED TOOLS:**\n"
+        "- `recall` retrieves what this stores\n"
+        "- write-graph-cypher builds structural graph data on subgraphs; this "
+        "is vector memory and does not put anything in the graph"
       ),
       "inputSchema": {
         "type": "object",
@@ -134,9 +140,14 @@ class SemanticRecallTool(_SemanticMemoryToolMixin, BaseTool):
     return {
       "name": "recall",
       "description": (
-        "Recall previously stored semantic memories for the active graph by "
-        "meaning (not keywords). Returns the top-k most relevant memories with "
-        "similarity scores. Use before answering to retrieve remembered context."
+        "Recall stored semantic memories for the active graph by meaning "
+        "rather than keywords.\n\n"
+        "**WHEN TO USE:**\n"
+        "- Before answering, to retrieve remembered context\n"
+        "- When the user refers to something established in an earlier "
+        "session\n\n"
+        "**RETURNS:** The top-k most relevant memories with their ids and "
+        "similarity scores."
       ),
       "inputSchema": {
         "type": "object",
@@ -198,11 +209,15 @@ class SemanticUpdateMemoryTool(_SemanticMemoryToolMixin, BaseTool):
     return {
       "name": "update-memory",
       "description": (
-        "Update a previously stored semantic memory in place by its id (from a "
-        "prior `remember`/`recall`). Only the fields you supply change; the "
-        "memory is re-embedded when `text` changes. Use to correct or refine a "
-        "memory instead of forgetting and re-remembering (which would mint a new "
-        "id and drop its history)."
+        "Update a stored semantic memory in place by its id.\n\n"
+        "**WHEN TO USE:**\n"
+        "- To correct or refine a memory — prefer this over forget plus "
+        "remember, which mints a new id and drops the memory's history\n\n"
+        "**PARAMETERS:**\n"
+        "- memory_id: from a prior `remember` or `recall`\n"
+        "- Only the fields supplied change; the memory is re-embedded when "
+        "`text` changes\n\n"
+        "**RETURNS:** The updated memory."
       ),
       "inputSchema": {
         "type": "object",
@@ -270,8 +285,14 @@ class SemanticForgetTool(_SemanticMemoryToolMixin, BaseTool):
     return {
       "name": "forget",
       "description": (
-        "Delete a semantic memory by its id (from a prior `remember`/`recall`). "
-        "Use to remove outdated or incorrect memories."
+        "Delete a semantic memory by its id.\n\n"
+        "**WHEN TO USE:**\n"
+        "- To remove an outdated or incorrect memory\n"
+        "- To correct one instead, prefer `update-memory`, which keeps the id "
+        "and its history\n\n"
+        "**PARAMETERS:**\n"
+        "- memory_id: from a prior `remember` or `recall`\n\n"
+        "**RETURNS:** Confirmation of the deletion."
       ),
       "inputSchema": {
         "type": "object",

--- a/robosystems/middleware/mcp/tools/subgraph_write_tools.py
+++ b/robosystems/middleware/mcp/tools/subgraph_write_tools.py
@@ -112,10 +112,13 @@ class WriteCypherTool(BaseTool):
     return {
       "name": "write-graph-cypher",
       "description": (
-        "Execute a write Cypher query on the active subgraph. "
-        "Creates, updates, or deletes data in the subgraph. "
-        "Only works on subgraphs, not the parent graph.\n\n"
-        "**Allowed operations:** CREATE, MERGE, SET, DELETE, REMOVE\n\n"
+        "Execute a write Cypher query on the active subgraph.\n\n"
+        "**WHEN TO USE:**\n"
+        "- To create, update or delete data in a subgraph\n"
+        "- Only on subgraphs — the parent graph is not writable here\n\n"
+        "**PARAMETERS:**\n"
+        "- ``query``: Cypher limited to CREATE, MERGE, SET, DELETE, REMOVE\n\n"
+        "**RETURNS:** The write result, including rows affected.\n\n"
         "**Examples:**\n"
         "```cypher\n"
         "// Create a node\n"
@@ -185,10 +188,13 @@ class AddNodeTableTool(BaseTool):
     return {
       "name": "add-node-table",
       "description": (
-        "Add a new node type to the subgraph schema. "
-        "Only works on subgraphs, not the parent graph. "
-        "Uses IF NOT EXISTS so it's safe to call multiple times.\n\n"
-        "**Example:** Add a CompanyProfile node type:\n"
+        "Add a new node type to the subgraph schema.\n\n"
+        "**WHEN TO USE:**\n"
+        "- To extend a subgraph's schema with a new node table\n"
+        "- Only on subgraphs — the parent graph's schema is fixed\n\n"
+        "**RETURNS:** Confirmation that the node table exists.\n\n"
+        "**NOTES:** Uses IF NOT EXISTS, so repeat calls are safe. Example — "
+        "add a CompanyProfile node type:\n"
         "```json\n"
         '{"table_name": "CompanyProfile", "properties": [\n'
         '  {"name": "identifier", "type": "STRING", "is_primary_key": true},\n'
@@ -322,10 +328,13 @@ class AddRelationshipTableTool(BaseTool):
     return {
       "name": "add-relationship-table",
       "description": (
-        "Add a new relationship type to the subgraph schema. "
-        "Only works on subgraphs, not the parent graph. "
-        "Uses IF NOT EXISTS so it's safe to call multiple times.\n\n"
-        "**Example:** Add a FINDING_SUPPORTS relationship:\n"
+        "Add a new relationship type to the subgraph schema.\n\n"
+        "**WHEN TO USE:**\n"
+        "- To extend a subgraph's schema with a new relationship table\n"
+        "- Only on subgraphs — the parent graph's schema is fixed\n\n"
+        "**RETURNS:** Confirmation that the relationship table exists.\n\n"
+        "**NOTES:** Uses IF NOT EXISTS, so repeat calls are safe. Example — "
+        "add a FINDING_SUPPORTS relationship:\n"
         "```json\n"
         '{"table_name": "FINDING_SUPPORTS", "from_node": "ResearchFinding", '
         '"to_node": "Concept", "properties": [\n'

--- a/robosystems/middleware/mcp/tools/taxonomy_tools.py
+++ b/robosystems/middleware/mcp/tools/taxonomy_tools.py
@@ -198,24 +198,20 @@ class SuggestMappingTool:
 - When deciding which reporting concept a CoA account should map to
 - Narrows by classification (asset→Assets subtree, revenue→Revenues subtree, etc.)
 
-**HOW IT WORKS:**
-- Queries rs-gaap elements filtered by the EFS trait (FASB
-  elementsOfFinancialStatements) matching the source element's
-  classification.
-- Restricts to concepts that appear in at least one rs-gaap-presentation
-  Network — any picked target is guaranteed to render on the standard
-  BS / IS / CF / SE reports under the active Reporting Style.
-- Excludes statement-level subtotals whose value comes from rendering
-  (e.g., rs-gaap:Assets, rs-gaap:LiabilitiesCurrent) — those are
-  computed by the calc DAG, not by a leaf fact.
+**RETURNS:** Candidate rs-gaap concepts with element id, qname, label and
+depth. Every candidate appears in at least one rs-gaap-presentation Network,
+so any target picked from here is guaranteed to render on the standard
+BS / IS / CF / SE reports under the active Reporting Style.
 
-**TIPS:**
-- The classification filter (asset / liability / equity / revenue /
-  expense / gain / loss) narrows candidates by ~80%.
-- Depth 1 = high-level line items; depth 2+ = detail items.
-- rs-gaap is the canonical render target (per the active Reporting
-  Style); there is no target_taxonomy parameter — only one taxonomy
-  renders.""",
+**NOTES:**
+- Candidates are filtered by the EFS trait (FASB
+  elementsOfFinancialStatements) matching the source element's
+  classification, which narrows by roughly 80%.
+- Statement-level subtotals are excluded (e.g. rs-gaap:Assets,
+  rs-gaap:LiabilitiesCurrent) — the calc DAG computes those, not a leaf fact.
+- Depth 1 is high-level line items; depth 2+ is detail.
+- rs-gaap is the only render target, so there is no target_taxonomy
+  parameter.""",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -428,12 +424,14 @@ class CreateMappingAssociationTool:
 - After choosing the best rs-gaap candidate for a CoA element (`association_type='mapping'` — the canonical arc the renderer follows)
 - Confidence ≥ 0.70 is required; skip below that threshold
 
-**INPUTS:**
+**PARAMETERS:**
 - mapping_id: The coa_mapping structure ID (from get-unmapped-elements)
 - from_element_id: CoA element ID (source)
 - to_element_id: rs-gaap element ID (the reporting concept)
 - confidence: Float 0.0–1.0 (AI confidence in the match)
-- association_type: 'mapping' (CoA→rs-gaap, the primary arc the renderer follows) or 'equivalence' (alternate cross-taxonomy arc). Defaults to 'mapping'.""",
+- association_type: 'mapping' (CoA→rs-gaap, the primary arc the renderer follows) or 'equivalence' (alternate cross-taxonomy arc). Defaults to 'mapping'.
+
+**RETURNS:** The written association's id, and the resulting mapping coverage.""",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/robosystems/middleware/mcp/tools/text_block_tools.py
+++ b/robosystems/middleware/mcp/tools/text_block_tools.py
@@ -38,15 +38,17 @@ class BindTextBlockTool:
 - To attach an accounting-policy or footnote narrative (stored as a document via create-document) to a disclosure structure so it renders in reports
 - After authoring a text-block disclosure structure via create-taxonomy-block (block_type='regulatory_disclosure', concept_arrangement='text_block')
 
-**HOW IT WORKS:**
+**NOTES:**
 - The document stays the editable source of truth; the bind snapshots its text into a standing 'disclosure' FactSet with document provenance (document_id + section + content_hash)
 - Reports generated afterward snapshot the standing set, so filed reports stay immutable even if the document is later edited
 - Re-binding the same element + period replaces the fact and refreshes the content hash (the drift signal)
-
-**TIPS:**
 - Use section_id (the slugified heading ids search-documents returns) to bind one section of a larger document; omit it to bind the whole document
 - The element must be a concrete (non-abstract) concept on the disclosure structure; provide element_qname or element_id
-- period_start/period_end should span the reporting period the narrative covers""",
+- period_start/period_end should span the reporting period the narrative covers
+
+**RETURNS:** The bound fact's id, the element it was bound to, and the content
+hash used as the drift signal.
+""",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/tests/middleware/mcp/test_tool_description_contract.py
+++ b/tests/middleware/mcp/test_tool_description_contract.py
@@ -1,0 +1,150 @@
+"""A tool description is a prompt, so its shape is part of the contract.
+
+Every string in a tool's ``description`` reaches the model that decides
+whether to call the tool and how. Unlike a docstring, it is read at
+selection time by something that cannot ask a follow-up question, so the
+cost of an inconsistent one is not readability — it is the model picking
+the wrong tool, or the right tool with the wrong arguments.
+
+These tests pin the shape rather than the wording. The wording is a
+judgement call per tool; the shape is what lets a model compare fifty of
+them. Two rules:
+
+1. **A tool says when to use it and what it returns.** Those two answer the
+   selection question. A description that only says what the tool *is*
+   leaves the model inferring applicability from the name.
+2. **Section headers come from a fixed vocabulary.** ``PARAMETERS`` and
+   ``INPUTS`` mean the same thing to a human and are two different tokens to
+   a model comparing tools. Divergence here is invisible in review — nobody
+   reads fifty descriptions side by side — which is exactly why it needs a
+   test rather than a convention.
+
+Deliberately not asserted: length. ``close-period`` is long because a close
+has real preconditions and a caller that improvises one corrupts a ledger.
+Brevity is not the goal; a shared skeleton is.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+TOOLS_DIR = Path(__file__).resolve().parents[3] / "robosystems/middleware/mcp/tools"
+
+# The canonical section vocabulary. A header outside this set is either a
+# synonym of one in it (use the canonical spelling) or a sign the description
+# is carrying something that belongs in the tool's own docstring.
+CANONICAL_SECTIONS = frozenset(
+  {
+    "WHEN TO USE",
+    "PARAMETERS",
+    "RETURNS",
+    "NOTES",
+    "RELATED TOOLS",
+    "WORKFLOW",
+  }
+)
+
+REQUIRED_SECTIONS = ("WHEN TO USE", "RETURNS")
+
+# Tools whose description is a single declarative line and needs no skeleton:
+# the name plus one sentence already answers both selection questions.
+_SINGLE_LINE_EXEMPT = frozenset({"forget", "update-memory"})
+
+
+def _tool_descriptions() -> dict[str, tuple[str, str]]:
+  """Every ``{"name": ..., "description": ...}`` literal under ``tools/``.
+
+  Parsed rather than imported: a tool definition can require a live graph
+  client to construct, and the shape of the string does not depend on it.
+  """
+  found: dict[str, tuple[str, str]] = {}
+  for path in sorted(TOOLS_DIR.glob("*.py")):
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+      if not isinstance(node, ast.Dict):
+        continue
+      keys = {
+        k.value: v
+        for k, v in zip(node.keys, node.values, strict=False)
+        if isinstance(k, ast.Constant) and isinstance(k.value, str)
+      }
+      name_node, desc_node = keys.get("name"), keys.get("description")
+      if name_node is None or desc_node is None:
+        continue
+      if not (isinstance(name_node, ast.Constant) and isinstance(name_node.value, str)):
+        continue
+      try:
+        description = ast.literal_eval(desc_node)
+      except ValueError:
+        continue  # an f-string or a computed value; not a static contract
+      if isinstance(description, str) and "\n" in description.strip():
+        found[name_node.value] = (description, path.name)
+  return found
+
+
+def _sections(description: str) -> list[str]:
+  """The ``**HEADER:**`` sections a description declares, in order."""
+  import re
+
+  return [
+    m.group(1).strip()
+    for m in re.finditer(r"\*\*([A-Z][A-Z0-9 /'&-]{2,}):?\*\*", description)
+  ]
+
+
+DESCRIPTIONS = _tool_descriptions()
+
+
+@pytest.mark.unit
+def test_the_registry_is_discoverable():
+  """A parse failure here would make every test below vacuously pass."""
+  assert len(DESCRIPTIONS) >= 40, (
+    f"only found {len(DESCRIPTIONS)} tool descriptions — the parser probably "
+    "stopped matching the definition shape"
+  )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("tool", sorted(DESCRIPTIONS))
+def test_sections_come_from_the_canonical_vocabulary(tool):
+  description, filename = DESCRIPTIONS[tool]
+  unknown = [s for s in _sections(description) if s not in CANONICAL_SECTIONS]
+  assert not unknown, (
+    f"{tool} ({filename}) uses non-canonical section header(s) {unknown}. "
+    f"Use one of {sorted(CANONICAL_SECTIONS)}, or move the content into the "
+    "tool class's docstring if it is for a maintainer rather than the model."
+  )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("tool", sorted(DESCRIPTIONS))
+def test_each_section_appears_once(tool):
+  """Two ``**NOTES:**`` blocks in one description is a merge nobody finished.
+
+  It reads as two unrelated lists to a model and hides the second from anyone
+  skimming for the first.
+  """
+  import collections
+
+  counts = collections.Counter(_sections(DESCRIPTIONS[tool][0]))
+  repeated = {k: v for k, v in counts.items() if v > 1}
+  assert not repeated, (
+    f"{tool} ({DESCRIPTIONS[tool][1]}) repeats {repeated}. Merge them into one section."
+  )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("tool", sorted(DESCRIPTIONS))
+def test_description_answers_the_selection_questions(tool):
+  if tool in _SINGLE_LINE_EXEMPT:
+    pytest.skip("single-line description; the name and sentence suffice")
+  description, filename = DESCRIPTIONS[tool]
+  present = set(_sections(description))
+  missing = [s for s in REQUIRED_SECTIONS if s not in present]
+  assert not missing, (
+    f"{tool} ({filename}) is missing {missing}. A model choosing between "
+    "tools needs to know when this one applies and what it hands back."
+  )

--- a/tests/middleware/mcp/test_tool_description_contract.py
+++ b/tests/middleware/mcp/test_tool_description_contract.py
@@ -51,7 +51,7 @@ REQUIRED_SECTIONS = ("WHEN TO USE", "RETURNS")
 
 # Tools whose description is a single declarative line and needs no skeleton:
 # the name plus one sentence already answers both selection questions.
-_SINGLE_LINE_EXEMPT = frozenset({"forget", "update-memory"})
+_SINGLE_LINE_EXEMPT: frozenset[str] = frozenset()
 
 
 def _tool_descriptions() -> dict[str, tuple[str, str]]:
@@ -72,7 +72,12 @@ def _tool_descriptions() -> dict[str, tuple[str, str]]:
         if isinstance(k, ast.Constant) and isinstance(k.value, str)
       }
       name_node, desc_node = keys.get("name"), keys.get("description")
-      if name_node is None or desc_node is None:
+      # ``inputSchema`` is what distinguishes a tool definition from a
+      # parameter definition — both carry name/description, and keying off
+      # anything else (length, whether the string is multi-line) silently
+      # drops the short tool descriptions, which are the ones most likely to
+      # be missing a section in the first place.
+      if name_node is None or desc_node is None or "inputSchema" not in keys:
         continue
       if not (isinstance(name_node, ast.Constant) and isinstance(name_node.value, str)):
         continue
@@ -80,7 +85,7 @@ def _tool_descriptions() -> dict[str, tuple[str, str]]:
         description = ast.literal_eval(desc_node)
       except ValueError:
         continue  # an f-string or a computed value; not a static contract
-      if isinstance(description, str) and "\n" in description.strip():
+      if isinstance(description, str):
         found[name_node.value] = (description, path.name)
   return found
 


### PR DESCRIPTION
## Summary

A tool `description` is not a comment — it is the prompt the model reads to decide whether to call the tool and with what arguments, at selection time, with no chance to ask a follow-up. Across 51 of them the vocabulary had drifted into **29 different section headers**, and **14 tools had no sections at all**, so a model comparing tools was comparing different shapes.

This adds a test that makes the shape a contract, then brings every description to it.

**This PR changes functional text.** Unlike the preceding documentation PRs, "no behavioural change" is not a claim I can make here — changing a prompt changes tool selection. That is the point of the change, and the reason it is separated from the inert prose work in #1240.

## Changes

**The contract** — `tests/middleware/mcp/test_tool_description_contract.py` parses every description out of `tools/*.py` (AST, so no live graph client is needed) and enforces:

1. Section headers come from a fixed vocabulary: `WHEN TO USE`, `PARAMETERS`, `RETURNS`, `NOTES`, `RELATED TOOLS`, `WORKFLOW`.
2. No section repeats — two `**NOTES:**` blocks read as two unrelated lists.
3. Every tool says **when to use it** and **what it returns**. Those are the two selection questions; a description that only says what a tool *is* leaves the model inferring applicability from the name.

Length is deliberately **not** asserted. `close-period` is 3.7k characters because a close has real preconditions and a caller who improvises one corrupts a ledger.

**Bringing all 51 descriptions to the contract** — mostly mechanical: `INPUTS`→`PARAMETERS`, `TIP`/`TIPS`/`USAGE TIPS`→`NOTES`, `ALSO READ`→`RELATED TOOLS`, and so on, with content-bearing sections (`STATEMENT TYPES`, `DOCUMENT TYPES SEARCHED`) folded into `PARAMETERS` where they describe an argument's allowed values. Fourteen tools gained the sections they lacked, including every `semantic_memory` and `subgraph_write` tool.

**A hole in the contract, found in review** — the parser keyed "is this a tool description" off the string being multi-line, which is a property of how a description happens to be written rather than of what it is. Four descriptions are a single line, so the contract silently skipped them — and they were four of the ones with no sections at all, the exact case it exists to catch. It now keys off `inputSchema`, which is what actually distinguishes a tool definition from a parameter definition. Coverage went from 47 tools to 51.

**Client-visible text corrected** — two tool names that exist nowhere in the repo (`list-schedule-structures`, `get-schedule-facts`), a roadmap aside advertising an unimplemented `hybrid` write policy, two references to when a feature was introduced, and a schema-type/data-type glossary in `get-graph-schema` that taught the model what `STRING` means.

**`.claude/agents/ladybug-architect.md`** — four state claims corrected: a capacity value that disagreed with `.env.example`/`pytest.ini`, two code constants (`LBUG_MAX_CONNECTIONS_PER_DB`, `LBUG_CONNECTION_TTL_MINUTES`) documented as environment variables with a debugging step telling the agent to change one, a connection limit that disagreed with `pool.py`, and a router inventory missing `metrics.py`. Values now point at the config rather than restating it.

## One thing left alone, deliberately

`constants.py`, `example_queries_tool.py` and `manager.py` use emoji (`✅ GOOD` / `❌ BAD`, `⚠️`) inside prompt text. `CLAUDE.md` bans emoji in "production code or logs" — but these are contrast markers in text a model reads, which is a category that rule predates, and stripping them from a prompt has a plausible downside. Flagging rather than deciding it inside a PR about prompt quality.

## Breaking Changes

None to any API, model or SDK surface. No operation names, arguments or response shapes change.

## Testing

- `just test-code` — **passed** (ruff, format, basedpyright, cf-lint-all, lint-actions), re-run green by the pre-commit hook.
- `tests/middleware/mcp` — **855 passed**, including the 154 new contract assertions.
- The contract test was written before the fixes and initially failed on 33 of them, so it is known to catch what it claims to. After the coverage fix it failed on a further 4, which is how those were found.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
