### PR TITLE
fix(graph-api): enforce the body cap on streamed requests

### DIFF
--- a/robosystems/graph_api/middleware/request_limits.py
+++ b/robosystems/graph_api/middleware/request_limits.py
@@ -1,18 +1,20 @@
-"""
-Request size limiting middleware for Graph API.
+"""Request size limiting for the Graph API.
 
-Prevents DoS attacks by limiting request body sizes.
+The body handling — header check, streamed byte count, buffer-and-replay — is
+:class:`~robosystems.middleware.request_size.BodySizeLimitMiddleware`. This
+module supplies only the limit, which varies by endpoint family.
 """
 
-from fastapi import Request, status
-from fastapi.responses import JSONResponse
-from starlette.middleware.base import BaseHTTPMiddleware
+from __future__ import annotations
+
+from starlette.types import ASGIApp
 
 from robosystems.config.constants import GRAPH_MAX_REQUEST_SIZE, MAX_QUERY_LENGTH
 from robosystems.logger import logger
+from robosystems.middleware.request_size import BodySizeLimitMiddleware
 
 
-class RequestSizeLimitMiddleware(BaseHTTPMiddleware):
+class RequestSizeLimitMiddleware(BodySizeLimitMiddleware):
   """Reject oversized request bodies before they are read into memory.
 
   The limit is chosen per endpoint family — queries, schema DDL, everything
@@ -22,14 +24,13 @@ class RequestSizeLimitMiddleware(BaseHTTPMiddleware):
 
   def __init__(
     self,
-    app,
+    app: ASGIApp,
     max_body_size: int | None = None,
     max_query_size: int | None = None,
     max_schema_size: int | None = None,
-  ):
-    super().__init__(app)
+  ) -> None:
     # All limits in bytes.
-    self.max_body_size = max_body_size or GRAPH_MAX_REQUEST_SIZE
+    super().__init__(app, max_body_size=max_body_size or GRAPH_MAX_REQUEST_SIZE)
     # MAX_QUERY_LENGTH counts characters; 10x leaves room for multi-byte ones.
     self.max_query_size = max_query_size or MAX_QUERY_LENGTH * 10
     self.max_schema_size = max_schema_size or 1 * 1024 * 1024
@@ -41,39 +42,9 @@ class RequestSizeLimitMiddleware(BaseHTTPMiddleware):
       f"Max schema: {self.max_schema_size:,} bytes"
     )
 
-  async def dispatch(self, request: Request, call_next):
-    """Reject the request with 413 if its Content-Length exceeds the limit."""
-    content_length_str = request.headers.get("content-length")
-    if content_length_str:
-      content_length = int(content_length_str)
-
-      path = request.url.path
-
-      if "/query" in path:
-        max_size = self.max_query_size
-        limit_type = "query"
-      elif "/schema" in path:
-        max_size = self.max_schema_size
-        limit_type = "schema"
-      else:
-        max_size = self.max_body_size
-        limit_type = "body"
-
-      if content_length > max_size:
-        logger.warning(
-          f"Request body too large: {content_length:,} bytes "
-          f"(max {limit_type}: {max_size:,} bytes) from {request.client.host if request.client else 'unknown'}"
-        )
-        return JSONResponse(
-          status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-          content={
-            "detail": f"Request {limit_type} too large. "
-            f"Size: {content_length:,} bytes, "
-            f"Max allowed: {max_size:,} bytes"
-          },
-        )
-
-    # Enforcement here is on the declared Content-Length. Bounding a streamed
-    # body requires counting it as it arrives, which the internet-facing edge
-    # middleware does before a request can reach this service.
-    return await call_next(request)
+  def _limit_for(self, path: str) -> tuple[int, str]:
+    if "/query" in path:
+      return self.max_query_size, "query"
+    if "/schema" in path:
+      return self.max_schema_size, "schema"
+    return self.max_body_size, "body"

--- a/robosystems/middleware/request_size.py
+++ b/robosystems/middleware/request_size.py
@@ -1,12 +1,12 @@
-"""Request-body size limiting for the public API.
+"""Request-body size limiting.
 
-The internet-facing app reads a request body into memory before authentication
-or rate limiting runs — FastAPI/Starlette resolve the body during dependency
-and model validation, and some routes (the Stripe webhook) call
-``await request.body()`` explicitly before any check. So an unbounded body is a
-pre-auth memory-allocation DoS that nothing downstream can bound.
+An app that reads a request body into memory before authentication or rate
+limiting runs has an unbounded body as a pre-auth memory-allocation DoS that
+nothing downstream can bound. FastAPI/Starlette resolve the body during
+dependency and model validation, and some routes (the Stripe webhook) call
+``await request.body()`` explicitly before any check.
 
-This ASGI middleware enforces the cap in two places:
+:class:`BodySizeLimitMiddleware` enforces the cap in two places:
 
 1. the ``Content-Length`` header (every conforming client sets it), rejected
    before the app is invoked; and
@@ -16,12 +16,21 @@ This ASGI middleware enforces the cap in two places:
 The body is buffered in the middleware and replayed to the app, so the cap is
 enforced without depending on how a downstream route or middleware handles a
 mid-read failure — an oversized request is answered with a 413 and the app is
-never invoked for it. The public API never stream-consumes a request body
-(uploads go straight to S3 via presigned PUT), so buffering up to the limit
+never invoked for it. Neither app stream-consumes a request body (public
+uploads go straight to S3 via presigned PUT), so buffering up to the limit
 costs nothing a body read would not have cost anyway.
 
-A per-path override lets one family (the webhook) carry a tighter limit than
-the default.
+Subclasses choose the limit per request by overriding
+:meth:`BodySizeLimitMiddleware._limit_for`. Two do:
+
+* :class:`RequestSizeLimitMiddleware` (here) resolves a longest-prefix path
+  override, letting one family — the webhook — carry a tighter limit than the
+  default.
+* The Graph API's variant resolves a limit per endpoint family, since a Cypher
+  query and a bulk body have very different reasonable sizes.
+
+Both inherit the body handling itself, so the limit is the only thing a
+subclass varies and the two services cannot enforce it differently.
 """
 
 from __future__ import annotations
@@ -34,33 +43,16 @@ from robosystems.config.constants import PUBLIC_MAX_REQUEST_SIZE
 from robosystems.logger import logger
 
 
-class RequestSizeLimitMiddleware:
-  """Reject request bodies larger than a per-path byte limit with a 413."""
+class BodySizeLimitMiddleware:
+  """Reject request bodies larger than a per-request byte limit with a 413."""
 
-  def __init__(
-    self,
-    app: ASGIApp,
-    *,
-    max_body_size: int = PUBLIC_MAX_REQUEST_SIZE,
-    path_limits: Sequence[tuple[str, int]] = (),
-  ) -> None:
+  def __init__(self, app: ASGIApp, *, max_body_size: int) -> None:
     self.app = app
     self.max_body_size = max_body_size
-    # Longest prefix first so a specific path wins over a broader one.
-    self.path_limits = tuple(
-      sorted(path_limits, key=lambda item: len(item[0]), reverse=True)
-    )
-    logger.info(
-      "Request Size Limit Middleware initialized - "
-      f"default {self.max_body_size:,} bytes"
-      + (f", {len(self.path_limits)} path override(s)" if self.path_limits else "")
-    )
 
-  def _limit_for(self, path: str) -> int:
-    for prefix, limit in self.path_limits:
-      if path.startswith(prefix):
-        return limit
-    return self.max_body_size
+  def _limit_for(self, path: str) -> tuple[int, str]:
+    """The byte limit for ``path``, and the noun to describe it in the 413."""
+    return self.max_body_size, "body"
 
   async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
     if scope["type"] != "http":
@@ -68,11 +60,13 @@ class RequestSizeLimitMiddleware:
       return
 
     path = scope.get("path", "")
-    limit = self._limit_for(path)
+    limit, label = self._limit_for(path)
 
     content_length = _content_length(scope)
     if content_length is not None and content_length > limit:
-      await self._reject(send, path, content_length, limit, source="content-length")
+      await self._reject(
+        send, path, content_length, limit, label, source="content-length"
+      )
       return
 
     # Buffer the body, enforcing the cap as it arrives. Reject before invoking
@@ -87,7 +81,7 @@ class RequestSizeLimitMiddleware:
         break
       received += len(message.get("body", b""))
       if received > limit:
-        await self._reject(send, path, received, limit, source="stream")
+        await self._reject(send, path, received, limit, label, source="stream")
         return
       buffered.append(message)
       if not message.get("more_body", False):
@@ -102,14 +96,18 @@ class RequestSizeLimitMiddleware:
     path: str,
     size: int,
     limit: int,
+    label: str,
     *,
     source: str,
   ) -> None:
     logger.warning(
-      f"Request body too large on {path}: {size:,} bytes exceeds {limit:,} ({source})"
+      f"Request {label} too large on {path}: {size:,} bytes "
+      f"exceeds {limit:,} ({source})"
     )
     body = (
-      b'{"detail":"Request body too large. Max allowed: '
+      b'{"detail":"Request '
+      + label.encode()
+      + b" too large. Max allowed: "
       + str(limit).encode()
       + b' bytes"}'
     )
@@ -129,6 +127,34 @@ class RequestSizeLimitMiddleware:
       }
     )
     await send({"type": "http.response.body", "body": body})
+
+
+class RequestSizeLimitMiddleware(BodySizeLimitMiddleware):
+  """The public app's limiter: a default cap plus per-path overrides."""
+
+  def __init__(
+    self,
+    app: ASGIApp,
+    *,
+    max_body_size: int = PUBLIC_MAX_REQUEST_SIZE,
+    path_limits: Sequence[tuple[str, int]] = (),
+  ) -> None:
+    super().__init__(app, max_body_size=max_body_size)
+    # Longest prefix first so a specific path wins over a broader one.
+    self.path_limits = tuple(
+      sorted(path_limits, key=lambda item: len(item[0]), reverse=True)
+    )
+    logger.info(
+      "Request Size Limit Middleware initialized - "
+      f"default {self.max_body_size:,} bytes"
+      + (f", {len(self.path_limits)} path override(s)" if self.path_limits else "")
+    )
+
+  def _limit_for(self, path: str) -> tuple[int, str]:
+    for prefix, limit in self.path_limits:
+      if path.startswith(prefix):
+        return limit, "body"
+    return self.max_body_size, "body"
 
 
 def _iter_messages(buffered: list[Message], receive: Receive) -> Receive:

--- a/tests/graph_api/test_request_limits.py
+++ b/tests/graph_api/test_request_limits.py
@@ -1,0 +1,150 @@
+"""The Graph API's body cap, and the per-family limit it layers on top.
+
+The interesting property is that the limit depends on the path while the
+enforcement does not: a query body and a bulk body get different ceilings, but
+both are bounded by the declared ``Content-Length`` *and* by the bytes actually
+streamed, so a chunked request with no ``Content-Length`` is not a way around
+either one.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+from fastapi.testclient import TestClient
+
+from robosystems.config.constants import GRAPH_MAX_REQUEST_SIZE, MAX_QUERY_LENGTH
+from robosystems.graph_api.middleware.request_limits import RequestSizeLimitMiddleware
+
+
+def _app(**kwargs) -> FastAPI:
+  app = FastAPI()
+
+  @app.post("/databases/{graph_id}/query")
+  async def query(graph_id: str, request: Request):
+    return {"len": len(await request.body())}
+
+  @app.post("/databases/{graph_id}/schema")
+  async def schema(graph_id: str, request: Request):
+    return {"len": len(await request.body())}
+
+  @app.post("/databases/{graph_id}/tables/rows")
+  async def rows(graph_id: str, request: Request):
+    return {"len": len(await request.body())}
+
+  @app.get("/health")
+  async def health():
+    return {"ok": True}
+
+  @app.post("/databases/{graph_id}/query/stream")
+  async def query_stream(graph_id: str, request: Request):
+    size = len(await request.body())
+
+    async def gen():
+      for _ in range(3):
+        yield b"chunk;"
+      yield str(size).encode()
+
+    return StreamingResponse(gen(), media_type="text/plain")
+
+  app.add_middleware(RequestSizeLimitMiddleware, **kwargs)
+  return app
+
+
+def _chunks(total: int, each: int = 100):
+  """A generator body, which makes httpx send it chunked with no length."""
+
+  def gen():
+    sent = 0
+    while sent < total:
+      n = min(each, total - sent)
+      sent += n
+      yield b"x" * n
+
+  return gen()
+
+
+@pytest.mark.unit
+class TestGraphApiRequestSizeLimit:
+  def test_body_within_limit_passes(self):
+    client = TestClient(_app(max_body_size=1000))
+    r = client.post("/databases/kg1/tables/rows", content=b"x" * 500)
+    assert r.status_code == 200
+    assert r.json() == {"len": 500}
+
+  def test_content_length_over_limit_is_413(self):
+    client = TestClient(_app(max_body_size=1000))
+    r = client.post("/databases/kg1/tables/rows", content=b"x" * 2000)
+    assert r.status_code == 413
+    assert "too large" in r.json()["detail"].lower()
+    # Answered without consuming the body → the connection must not be reused.
+    assert r.headers.get("connection", "").lower() == "close"
+
+  def test_chunked_body_over_limit_is_413(self):
+    """No Content-Length; the cap must hold on the streamed bytes."""
+    client = TestClient(_app(max_body_size=1000))
+    r = client.post("/databases/kg1/tables/rows", content=_chunks(3000))
+    assert r.status_code == 413
+
+  def test_chunked_body_within_limit_passes(self):
+    client = TestClient(_app(max_body_size=1000))
+    r = client.post("/databases/kg1/tables/rows", content=_chunks(300))
+    assert r.status_code == 200
+    assert r.json() == {"len": 300}
+
+  def test_empty_body_and_get_pass(self):
+    client = TestClient(_app(max_body_size=1000))
+    assert client.get("/health").status_code == 200
+    assert client.post("/databases/kg1/tables/rows", content=b"").json() == {"len": 0}
+
+
+@pytest.mark.unit
+class TestPerFamilyLimits:
+  """A path over its own family's limit is rejected even when the generous
+  default would have let it through — and the 413 names the family."""
+
+  def test_query_limit_is_independent_of_the_body_limit(self):
+    client = TestClient(_app(max_body_size=100_000, max_query_size=1000))
+    over = client.post("/databases/kg1/query", content=b"x" * 5000)
+    assert over.status_code == 413
+    assert "query" in over.json()["detail"].lower()
+    # The same body on a non-query path is under the default and passes.
+    assert (
+      client.post("/databases/kg1/tables/rows", content=b"x" * 5000).status_code == 200
+    )
+
+  def test_schema_limit_is_independent_of_the_body_limit(self):
+    client = TestClient(_app(max_body_size=100_000, max_schema_size=1000))
+    over = client.post("/databases/kg1/schema", content=b"x" * 5000)
+    assert over.status_code == 413
+    assert "schema" in over.json()["detail"].lower()
+
+  def test_chunked_query_body_is_bounded_by_the_query_limit(self):
+    """The family limit and the stream cap compose; neither is a way past the
+    other."""
+    client = TestClient(_app(max_body_size=100_000, max_query_size=1000))
+    r = client.post("/databases/kg1/query", content=_chunks(5000))
+    assert r.status_code == 413
+    assert "query" in r.json()["detail"].lower()
+
+  def test_defaults_come_from_the_shared_constants(self):
+    app = _app()
+    limiter = app.user_middleware[0].cls(app, **app.user_middleware[0].kwargs)
+    assert limiter.max_body_size == GRAPH_MAX_REQUEST_SIZE
+    assert limiter.max_query_size == MAX_QUERY_LENGTH * 10
+    assert limiter._limit_for("/databases/kg1/query")[0] == MAX_QUERY_LENGTH * 10
+    assert limiter._limit_for("/databases/kg1/tables/rows")[0] == GRAPH_MAX_REQUEST_SIZE
+
+
+@pytest.mark.unit
+def test_streaming_responses_pass_through():
+  """The Graph API streams query results, so the limiter must not buffer or
+  break a streamed response on the way back out."""
+  client = TestClient(_app(max_body_size=100_000, max_query_size=100_000))
+  with client.stream(
+    "POST", "/databases/kg1/query/stream", content=b"x" * 50
+  ) as response:
+    assert response.status_code == 200
+    body = b"".join(response.iter_bytes())
+  assert body == b"chunk;chunk;chunk;50"

--- a/tests/graph_api/test_request_limits.py
+++ b/tests/graph_api/test_request_limits.py
@@ -9,6 +9,8 @@ either one.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse
@@ -129,8 +131,7 @@ class TestPerFamilyLimits:
     assert "query" in r.json()["detail"].lower()
 
   def test_defaults_come_from_the_shared_constants(self):
-    app = _app()
-    limiter = app.user_middleware[0].cls(app, **app.user_middleware[0].kwargs)
+    limiter = RequestSizeLimitMiddleware(FastAPI())
     assert limiter.max_body_size == GRAPH_MAX_REQUEST_SIZE
     assert limiter.max_query_size == MAX_QUERY_LENGTH * 10
     assert limiter._limit_for("/databases/kg1/query")[0] == MAX_QUERY_LENGTH * 10
@@ -148,3 +149,52 @@ def test_streaming_responses_pass_through():
     assert response.status_code == 200
     body = b"".join(response.iter_bytes())
   assert body == b"chunk;chunk;chunk;50"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+  "messages,expected",
+  [
+    ([{"type": "http.disconnect"}], ["http.disconnect"]),
+    (
+      [
+        {"type": "http.request", "body": b"x" * 10, "more_body": True},
+        {"type": "http.disconnect"},
+      ],
+      ["http.request", "http.disconnect"],
+    ),
+  ],
+)
+async def test_a_disconnect_reaches_the_app_intact(messages, expected):
+  """Buffering must not swallow a disconnect or reorder it behind the body.
+
+  The app decides what a mid-body disconnect means — Starlette raises
+  ``ClientDisconnect`` — so the limiter's job is to replay what arrived, in
+  order, and not to hang waiting for a body that is never coming.
+  """
+  seen: list[str] = []
+
+  async def app(scope, receive, send):
+    while True:
+      message = await receive()
+      seen.append(message["type"])
+      if message["type"] != "http.request" or not message.get("more_body"):
+        break
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b""})
+
+  limiter = RequestSizeLimitMiddleware(app, max_body_size=1000)
+  pending = iter(messages)
+
+  async def receive():
+    return next(pending, {"type": "http.disconnect"})
+
+  async def send(message):
+    return None
+
+  await asyncio.wait_for(
+    limiter({"type": "http", "path": "/x", "headers": []}, receive, send),
+    timeout=5,
+  )
+  assert seen == expected

--- a/tests/middleware/test_request_size.py
+++ b/tests/middleware/test_request_size.py
@@ -1,8 +1,11 @@
 """The public-app request-body size limit rejects oversized bodies with a 413,
-by Content-Length and — the gap the graph-API version leaves open — by the
-streamed bytes of a chunked request with no Content-Length. It enforces the cap
-in the middleware, before the app is invoked, so it does not depend on how a
-downstream route handles a mid-read failure.
+by Content-Length and by the streamed bytes of a chunked request that declares
+none. It enforces the cap in the middleware, before the app is invoked, so it
+does not depend on how a downstream route handles a mid-read failure.
+
+The per-path override is this app's own; the body handling it inherits is
+covered against the Graph API's per-family limits in
+``tests/graph_api/test_request_limits.py``.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Harden the Graph API's request-body size limiting so it enforces at the same two
points the public API's limiter already does.

Rather than add the missing check in place, this lifts the body handling into a
shared `BodySizeLimitMiddleware` that both services subclass. A subclass supplies
only *the limit*; it inherits *the enforcement*. That is the part worth reviewing:
the two limiters are separate implementations of one control, and a shared base is
what keeps them from drifting.

## Changes

**`robosystems/middleware/request_size.py`**

- New `BodySizeLimitMiddleware`: header check, streamed byte count, buffer-and-replay,
  and the 413 (with `Connection: close`, since the over-limit body is never consumed).
- `_limit_for(path) -> (limit, label)` is the single extension point. The label names
  the family in the 413 and the log line.
- `RequestSizeLimitMiddleware` is now a subclass holding just the public app's
  longest-prefix path overrides. Its behaviour and response body are unchanged.

**`robosystems/graph_api/middleware/request_limits.py`**

- Now a subclass supplying the per-endpoint-family limits (query / schema / body).
  The limits themselves and the constants they derive from are unchanged.
- Drops `BaseHTTPMiddleware` for plain ASGI. The Graph API streams query results,
  so keeping it out of the response path is a small bonus rather than the point.
- 413 body shape changes from `Request query too large. Size: N, Max allowed: M` to
  the shared `Request query too large. Max allowed: M bytes`. Nothing parses it —
  the request size is in the warning log, where it is useful.

**`tests/graph_api/test_request_limits.py`** — new; this middleware had no coverage.
Covers both enforcement points, each family limit, a family limit under a chunked
body, the defaults resolving from the shared constants, a streamed response passing
through, and a client disconnect replaying to the app in order.

**`tests/middleware/test_request_size.py`** — module docstring only: it described the
two limiters as differing, and points at the new file for the shared behaviour.

## Breaking Changes

None. No published-SDK surface is touched — neither the stable tier (facades, the
integration template's emit path) nor the generated tier. The Graph API is
VPC-internal and has no OpenAPI-derived client. The only response-shape change is
the internal 413 detail string described above.

## Testing

- `tests/graph_api/test_request_limits.py` + `tests/middleware/test_request_size.py` — 20 passed.
- `tests/graph_api` — 1378 passed.
- `just lint` / `just format` / `just typecheck` — clean (0 errors, 0 warnings).
- The new tests were run against the previous implementation to confirm they fail on
  it: 4 of 10 fail. A test that passes either way would not have established anything.
- Verified against a real `create_app()` Graph API instance, not just a synthetic
  app: an under-limit body reaches the route, an over-limit body is rejected on both
  enforcement paths, and the limiter constructs with the real defaults.
- The disconnect assertions were confirmed to fail when deliberately broken, since
  `asyncio_mode = auto` makes a silently-unawaited async test easy to miss.
- Full `just test-all` not run locally; CI covers it.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
