### PR TITLE
fix(config): make declared configuration surface match what resolves

### DIFF
--- a/robosystems/config/rate_limits.py
+++ b/robosystems/config/rate_limits.py
@@ -447,3 +447,42 @@ class RateLimitConfig:
         return EndpointCategory.GRAPH_READ
 
     return None
+
+
+# Per-endpoint burst limits, in requests per window. These bound how fast a
+# single caller can hit one endpoint family; the per-tier limits above bound
+# volume. They are constants on purpose — a limit that can be raised at runtime
+# is a limit an attacker benefits from raising, and the safe direction (down)
+# is already reachable by deploying. Nothing reads these from the environment.
+BURST_LIMITS: dict[str, int] = {
+  # Identity-based limits for the general API bucket, per minute.
+  "api_key": 1000,  # 60k/hour possible
+  "jwt": 500,  # 30k/hour possible
+  "anonymous": 10,  # 600/hour possible
+  # Authentication. Windows are seconds, not counts.
+  "auth_attempts": 10,
+  "auth_window": 300,
+  "login_window": 300,
+  "register_window": 3600,
+  "sensitive_auth": 60,
+  "auth_status": 600,  # 10/second — polled by the login screen
+  "logout": 300,
+  "sso": 100,
+  "oidc": 120,  # 2 per flow
+  "mfa": 120,  # 2 per handshake
+  "passkey_management": 60,
+  # SCIM provisioning, which bursts during a directory's initial sync.
+  "scim": 120,  # per token
+  "scim_ip": 300,  # per IP
+  # Ordinary API surfaces, per minute.
+  "general_api": 200,
+  "public_api": 600,  # divided by 10 for anonymous callers
+  "user_management": 600,  # 10/second
+  "tasks": 200,
+  "analytics": 100,
+  "connection_mgmt": 30,
+  "sync_ops": 50,
+  "backup_ops": 10,  # expensive operations
+  "billing": 60,  # checkout polls at ~20/min
+  "webhook": 1200,  # anonymous → 120/min per IP
+}

--- a/robosystems/middleware/rate_limits/rate_limiting.py
+++ b/robosystems/middleware/rate_limits/rate_limiting.py
@@ -13,6 +13,7 @@ from ...config.constants import (
   RATE_LIMIT_SSE_CONNECTIONS,
   RATE_LIMIT_SSE_CONNECTIONS_WINDOW,
 )
+from ...config.rate_limits import BURST_LIMITS
 from ...security import SecurityAuditLogger, SecurityEventType
 from .cache import rate_limit_cache
 from .subscription_rate_limits import (
@@ -20,14 +21,6 @@ from .subscription_rate_limits import (
   get_subscription_rate_limit,
   should_use_subscription_limits,
 )
-
-
-def get_int_env(key: str, default: str) -> int:
-  """Get integer environment variable, stripping any inline comments."""
-  value = str(getattr(env, key, default))
-  # Strip inline comments (anything after #)
-  value = value.split("#")[0].strip()
-  return int(value)
 
 
 def _verify_jwt_for_rate_limiting(token: str) -> str | None:
@@ -148,15 +141,15 @@ def get_rate_limit_config(identifier: str) -> tuple[int, int]:
   # Environment-based rate limits - BURST PROTECTION ONLY
   if identifier.startswith("apikey:"):
     # API key users get very high burst limits
-    limit = get_int_env("RATE_LIMIT_API_KEY", "1000")  # 1k/minute default
+    limit = BURST_LIMITS["api_key"]  # 1k/minute default
     window = 60  # 1 minute (60k/hour possible)
   elif identifier.startswith("jwt:"):
     # JWT users get high burst limits
-    limit = get_int_env("RATE_LIMIT_JWT", "500")  # 500/minute default
+    limit = BURST_LIMITS["jwt"]  # 500/minute default
     window = 60  # 1 minute (30k/hour possible)
   else:
     # IP-based (unauthenticated) users still get restricted
-    limit = get_int_env("RATE_LIMIT_ANONYMOUS", "10")  # 10/minute default
+    limit = BURST_LIMITS["anonymous"]  # 10/minute default
     window = 60  # 1 minute (600/hour possible)
 
   return limit, window
@@ -231,14 +224,14 @@ def auth_rate_limit_dependency(request: Request):
   path = request.url.path
   if "/login" in path:
     limit = AUTH_RATE_LIMIT_LOGIN_DEFAULT
-    window = get_int_env("RATE_LIMIT_LOGIN_WINDOW", "300")  # 5 minutes
+    window = BURST_LIMITS["login_window"]  # 5 minutes
   elif "/register" in path:
     limit = AUTH_RATE_LIMIT_REGISTER_DEFAULT
-    window = get_int_env("RATE_LIMIT_REGISTER_WINDOW", "3600")  # 1 hour
+    window = BURST_LIMITS["register_window"]  # 1 hour
   else:
     # Default auth endpoint limits
-    limit = get_int_env("RATE_LIMIT_AUTH", "10")  # 10 attempts
-    window = get_int_env("RATE_LIMIT_AUTH_WINDOW", "300")  # 5 minutes
+    limit = BURST_LIMITS["auth_attempts"]  # 10 attempts
+    window = BURST_LIMITS["auth_window"]  # 5 minutes
 
   # Auth endpoints fail CLOSED: if the limiter backend is down, deny rather
   # than silently disable brute-force protection on login/register.
@@ -412,62 +405,62 @@ def create_custom_rate_limit_dependency(
 
 def user_management_rate_limit_dependency(request: Request):
   """Rate limiting for user profile and settings endpoints."""
-  limit = get_int_env("RATE_LIMIT_USER_MANAGEMENT", "600")  # 600/minute (10/second)
+  limit = BURST_LIMITS["user_management"]  # 600/minute (10/second)
   return create_custom_rate_limit_dependency(limit, 60, "user_management")(request)
 
 
 def sync_operations_rate_limit_dependency(request: Request):
   """Rate limiting for external sync operations (QB, SEC)."""
-  limit = get_int_env("RATE_LIMIT_SYNC_OPS", "50")  # 50/minute
+  limit = BURST_LIMITS["sync_ops"]  # 50/minute
   return create_custom_rate_limit_dependency(limit, 60, "sync_operations")(request)
 
 
 def connection_management_rate_limit_dependency(request: Request):
   """Rate limiting for external connection setup/management."""
-  limit = get_int_env("RATE_LIMIT_CONNECTION_MGMT", "30")  # 30/minute
+  limit = BURST_LIMITS["connection_mgmt"]  # 30/minute
   return create_custom_rate_limit_dependency(limit, 60, "connection_mgmt")(request)
 
 
 def analytics_rate_limit_dependency(request: Request):
   """Rate limiting for graph analytics and metrics endpoints."""
-  limit = get_int_env("RATE_LIMIT_ANALYTICS", "100")  # 100/minute
+  limit = BURST_LIMITS["analytics"]  # 100/minute
   return create_custom_rate_limit_dependency(limit, 60, "analytics")(request)
 
 
 def backup_operations_rate_limit_dependency(request: Request):
   """Rate limiting for backup creation and export operations."""
-  limit = get_int_env("RATE_LIMIT_BACKUP_OPS", "10")  # 10/minute (expensive operations)
+  limit = BURST_LIMITS["backup_ops"]  # 10/minute (expensive operations)
   return create_custom_rate_limit_dependency(limit, 60, "backup_operations")(request)
 
 
 def sensitive_auth_rate_limit_dependency(request: Request):
   """Rate limiting for sensitive auth operations (refresh, SSO)."""
-  limit = get_int_env("RATE_LIMIT_SENSITIVE_AUTH", "60")  # 60/minute
+  limit = BURST_LIMITS["sensitive_auth"]  # 60/minute
   return create_custom_rate_limit_dependency(limit, 60, "sensitive_auth")(request)
 
 
 def logout_rate_limit_dependency(request: Request):
   """Rate limiting for logout endpoint - more generous to handle expired tokens."""
   # 300/minute for authenticated, 30/minute for anonymous (after division by 10)
-  limit = get_int_env("RATE_LIMIT_LOGOUT", "300")
+  limit = BURST_LIMITS["logout"]
   return create_custom_rate_limit_dependency(limit, 60, "logout")(request)
 
 
 def tasks_management_rate_limit_dependency(request: Request):
   """Rate limiting for task monitoring and management."""
-  limit = get_int_env("RATE_LIMIT_TASKS", "200")  # 200/minute
+  limit = BURST_LIMITS["tasks"]  # 200/minute
   return create_custom_rate_limit_dependency(limit, 60, "tasks")(request)
 
 
 def auth_status_rate_limit_dependency(request: Request):
   """Rate limiting for auth status check endpoints (like /auth/me)."""
-  limit = get_int_env("RATE_LIMIT_AUTH_STATUS", "600")  # 600/minute (10/second)
+  limit = BURST_LIMITS["auth_status"]  # 600/minute (10/second)
   return create_custom_rate_limit_dependency(limit, 60, "auth_status")(request)
 
 
 def sso_rate_limit_dependency(request: Request):
   """Rate limiting for SSO operations (token generation/exchange)."""
-  limit = get_int_env("RATE_LIMIT_SSO", "100")  # 100/minute
+  limit = BURST_LIMITS["sso"]  # 100/minute
   return create_custom_rate_limit_dependency(limit, 60, "sso")(request)
 
 
@@ -478,7 +471,7 @@ def oidc_rate_limit_dependency(request: Request):
   requests (login → callback). Anonymous callers get limit//10, so the
   default keeps ~12/min per IP — several complete flows plus retries.
   """
-  limit = get_int_env("RATE_LIMIT_OIDC", "120")  # 120/minute (2 per flow)
+  limit = BURST_LIMITS["oidc"]  # 120/minute (2 per flow)
   return create_custom_rate_limit_dependency(limit, 60, "oidc")(request)
 
 
@@ -493,7 +486,7 @@ def mfa_rate_limit_dependency(request: Request):
   Fails closed: this is an authentication surface, and its throttle must
   not silently vanish with the limiter backend (the SCIM precedent).
   """
-  limit = get_int_env("RATE_LIMIT_MFA", "120")  # 120/minute (2 per handshake)
+  limit = BURST_LIMITS["mfa"]  # 120/minute (2 per handshake)
   return create_custom_rate_limit_dependency(limit, 60, "mfa", fail_closed=True)(
     request
   )
@@ -502,7 +495,7 @@ def mfa_rate_limit_dependency(request: Request):
 def passkey_management_rate_limit_dependency(request: Request):
   """Rate limiting for authenticated passkey lifecycle endpoints
   (list/enroll/remove/recovery-codes)."""
-  limit = get_int_env("RATE_LIMIT_PASSKEY_MANAGEMENT", "60")  # 60/minute
+  limit = BURST_LIMITS["passkey_management"]  # 60/minute
   return create_custom_rate_limit_dependency(
     limit, 60, "passkey_management", fail_closed=True
   )(request)
@@ -533,7 +526,7 @@ def scim_rate_limit_dependency(request: Request):
   Fails closed: SCIM is an authentication surface, and its throttles must
   not silently vanish with the limiter backend. The IdP retries a denial.
   """
-  limit = get_int_env("RATE_LIMIT_SCIM", "120")  # 120/minute per token
+  limit = BURST_LIMITS["scim"]  # 120/minute per token
   return create_custom_rate_limit_dependency(
     limit, 60, "scim", identifier_fn=_scim_rate_limit_identifier, fail_closed=True
   )(request)
@@ -555,7 +548,7 @@ def scim_ip_rate_limit_dependency(request: Request):
   RATE_LIMIT_SCIM so a legitimate IdP burst exhausts its per-token budget
   first, never this one.
   """
-  limit = get_int_env("RATE_LIMIT_SCIM_IP", "300")  # 300/minute per IP
+  limit = BURST_LIMITS["scim_ip"]  # 300/minute per IP
   return create_custom_rate_limit_dependency(
     limit, 60, "scim_ip", identifier_fn=_scim_ip_identifier, fail_closed=True
   )(request)
@@ -563,7 +556,7 @@ def scim_ip_rate_limit_dependency(request: Request):
 
 def general_api_rate_limit_dependency(request: Request):
   """General rate limiting for standard API endpoints."""
-  limit = get_int_env("RATE_LIMIT_GENERAL_API", "200")  # 200/minute
+  limit = BURST_LIMITS["general_api"]  # 200/minute
   return create_custom_rate_limit_dependency(limit, 60, "general_api")(request)
 
 
@@ -574,9 +567,7 @@ def billing_rate_limit_dependency(request: Request):
   All user types (JWT, API key, IP) get the same generous limit
   because checkout redirects from Stripe may not carry auth cookies.
   """
-  limit = get_int_env(
-    "RATE_LIMIT_BILLING", "60"
-  )  # 60/minute (checkout polls at ~20/min)
+  limit = BURST_LIMITS["billing"]  # 60/minute (checkout polls at ~20/min)
   identifier = get_user_identifier(request)
   cache_key = f"{identifier}:billing"
 
@@ -614,7 +605,7 @@ def webhook_rate_limit_dependency(request: Request):
   security control, this is DoS defense in depth. Generous, because Stripe
   legitimately bursts redeliveries.
   """
-  limit = get_int_env("RATE_LIMIT_WEBHOOK", "1200")  # anonymous → 120/min per IP
+  limit = BURST_LIMITS["webhook"]  # anonymous → 120/min per IP
   return create_custom_rate_limit_dependency(limit, 60, "webhook")(request)
 
 
@@ -622,7 +613,7 @@ def public_api_rate_limit_dependency(request: Request):
   """Rate limiting for public API endpoints (no auth required)."""
   # More generous for anonymous users since these endpoints are meant to be public
   # 600/minute for authenticated, 60/minute for anonymous (after division by 10)
-  limit = get_int_env("RATE_LIMIT_PUBLIC_API", "600")
+  limit = BURST_LIMITS["public_api"]
   return create_custom_rate_limit_dependency(limit, 60, "public_api")(request)
 
 

--- a/robosystems/models/extensions/__init__.py
+++ b/robosystems/models/extensions/__init__.py
@@ -40,8 +40,11 @@ from .roboinvestor import (
 # RoboLedger extension (imports COA_SOURCES + ledger-specific models)
 from .roboledger import (
   COA_SOURCES,
+  Agent,
   BlockedSourceGraph,
   Entry,
+  Event,
+  EventHandler,
   Fact,
   FactSet,
   FiscalCalendar,
@@ -54,6 +57,7 @@ from .roboledger import (
   ReportShare,
   Transaction,
   entry_dimensions,
+  event_dimensions,
   line_item_dimensions,
   transaction_dimensions,
 )
@@ -65,10 +69,11 @@ from .trait import Trait
 from .verification_result import VerificationResult
 
 __all__ = [
-  # RoboLedger
   "COA_SOURCES",
   # Base ontology
   "Account",
+  # RoboLedger
+  "Agent",
   "Association",
   "AssociationClassification",
   "BlockedSourceGraph",
@@ -82,6 +87,8 @@ __all__ = [
   "Entity",
   "EntityTaxonomy",
   "Entry",
+  "Event",
+  "EventHandler",
   "Fact",
   "FactSet",
   "FiscalCalendar",
@@ -108,6 +115,7 @@ __all__ = [
   "Transaction",
   "VerificationResult",
   "entry_dimensions",
+  "event_dimensions",
   "line_item_dimensions",
   "transaction_dimensions",
 ]

--- a/tests/config/test_burst_limits.py
+++ b/tests/config/test_burst_limits.py
@@ -1,0 +1,72 @@
+"""The burst-limit table and its call sites must name the same things.
+
+These are constants, not tunables, so the risk is not that someone sets one and
+it does not take — it is that the table and the code that reads it drift apart.
+A key read but not defined is a ``KeyError`` on a rate-limited path; a key
+defined but never read is a number that looks authoritative and governs nothing.
+Both directions are asserted.
+
+The predecessor of this table resolved through ``getattr(env, name, default)``,
+which answered with the default for any name — so a value that governed nothing
+was indistinguishable from one that did. Reading the table by key means a wrong
+name fails loudly instead.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from robosystems.config.rate_limits import BURST_LIMITS
+
+RATE_LIMITING = (
+  Path(__file__).resolve().parents[2]
+  / "robosystems/middleware/rate_limits/rate_limiting.py"
+)
+
+
+def _keys_read() -> set[str]:
+  """Every ``BURST_LIMITS["..."]`` subscript in the rate-limiting middleware."""
+  tree = ast.parse(RATE_LIMITING.read_text(encoding="utf-8"))
+  keys: set[str] = set()
+  for node in ast.walk(tree):
+    if (
+      isinstance(node, ast.Subscript)
+      and isinstance(node.value, ast.Name)
+      and node.value.id == "BURST_LIMITS"
+      and isinstance(node.slice, ast.Constant)
+      and isinstance(node.slice.value, str)
+    ):
+      keys.add(node.slice.value)
+  return keys
+
+
+@pytest.mark.unit
+def test_the_call_sites_are_discoverable():
+  """A parse failure would make both assertions below vacuously pass."""
+  assert len(_keys_read()) >= 20
+
+
+@pytest.mark.unit
+def test_every_key_read_is_defined():
+  missing = sorted(_keys_read() - set(BURST_LIMITS))
+  assert not missing, (
+    f"rate_limiting.py reads BURST_LIMITS keys that are not defined: {missing}"
+  )
+
+
+@pytest.mark.unit
+def test_every_key_defined_is_read():
+  unused = sorted(set(BURST_LIMITS) - _keys_read())
+  assert not unused, (
+    f"BURST_LIMITS defines keys nothing reads: {unused}. Remove them, or find "
+    "the call site that was supposed to use them."
+  )
+
+
+@pytest.mark.unit
+def test_limits_are_positive_integers():
+  bad = {k: v for k, v in BURST_LIMITS.items() if not isinstance(v, int) or v <= 0}
+  assert not bad, f"non-positive or non-integer burst limits: {bad}"

--- a/tests/config/test_validation.py
+++ b/tests/config/test_validation.py
@@ -29,7 +29,6 @@ class MockEnvConfig:
     self.GRAPH_API_URL = "http://localhost:8001"
     self.GRAPH_API_KEY = None
     self.JWT_ACCESS_TOKEN_EXPIRE_MINUTES = 30
-    self.RATE_LIMIT_API_KEY = 10000
     self.LBUG_MAX_DATABASES_PER_NODE = 100
     self.VALKEY_URL = "redis://localhost:6379"
     self.LOG_FILE_PATH = "stdout"

--- a/tests/middleware/rate_limits/test_rate_limit_isolation.py
+++ b/tests/middleware/rate_limits/test_rate_limit_isolation.py
@@ -20,18 +20,6 @@ class TestRateLimitIsolation:
   def setup(self, monkeypatch):
     """Setup test environment."""
 
-    # Mock the get_int_env function to return our test values
-    def mock_get_int_env(key, default):
-      values = {
-        "RATE_LIMIT_LOGOUT": "300",
-        "RATE_LIMIT_SENSITIVE_AUTH": "60",
-      }
-      return int(values.get(key, default))
-
-    monkeypatch.setattr(
-      "robosystems.middleware.rate_limits.rate_limiting.get_int_env", mock_get_int_env
-    )
-
     # Mock JWT secret key
     monkeypatch.setattr("robosystems.config.env.JWT_SECRET_KEY", "test-secret-key")
 
@@ -276,18 +264,6 @@ class TestRateLimitIsolation:
     from robosystems.middleware.rate_limits.rate_limiting import (
       general_api_rate_limit_dependency,
       public_api_rate_limit_dependency,
-    )
-
-    # Mock the get_int_env function to return our test values
-    def mock_get_int_env(key, default):
-      values = {
-        "RATE_LIMIT_PUBLIC_API": "600",  # High limit for public endpoints
-        "RATE_LIMIT_GENERAL_API": "200",  # Lower limit for general endpoints
-      }
-      return int(values.get(key, default))
-
-    monkeypatch.setattr(
-      "robosystems.middleware.rate_limits.rate_limiting.get_int_env", mock_get_int_env
     )
 
     # Mock JWT verification for authenticated user

--- a/tests/middleware/rate_limits/test_rate_limiting.py
+++ b/tests/middleware/rate_limits/test_rate_limiting.py
@@ -9,7 +9,6 @@ from fastapi import HTTPException
 from robosystems.middleware.rate_limits.rate_limiting import (
   _verify_jwt_for_rate_limiting,
   create_custom_rate_limit_dependency,
-  get_int_env,
   get_rate_limit_config,
   get_user_from_request,
   get_user_identifier,
@@ -31,37 +30,6 @@ def _make_request(headers=None, cookies=None, host="127.0.0.1", path="/test"):
   mock_request.state = MagicMock()
   mock_request.state.current_time = None
   return mock_request
-
-
-@pytest.mark.unit
-class TestGetIntEnv:
-  """Tests for get_int_env helper."""
-
-  def test_returns_int_from_env(self):
-    from robosystems.config import env
-
-    try:
-      with patch.object(env, "RATE_LIMIT_API_KEY", "500"):
-        result = get_int_env("RATE_LIMIT_API_KEY", "1000")
-    except (AttributeError, TypeError):
-      with patch.object(env, "RATE_LIMIT_API_KEY", "500", create=True):
-        result = get_int_env("RATE_LIMIT_API_KEY", "1000")
-    assert result == 500
-
-  def test_strips_inline_comments(self):
-    from robosystems.config import env
-
-    try:
-      with patch.object(env, "RATE_LIMIT_API_KEY", "500 # some comment"):
-        result = get_int_env("RATE_LIMIT_API_KEY", "1000")
-    except (AttributeError, TypeError):
-      with patch.object(env, "RATE_LIMIT_API_KEY", "500 # some comment", create=True):
-        result = get_int_env("RATE_LIMIT_API_KEY", "1000")
-    assert result == 500
-
-  def test_uses_default_when_missing(self):
-    result = get_int_env("NONEXISTENT_RATE_LIMIT_KEY_XYZ", "100")
-    assert result == 100
 
 
 @pytest.mark.unit
@@ -158,20 +126,17 @@ class TestGetRateLimitConfig:
   """Tests for get_rate_limit_config."""
 
   def test_api_key_limits(self):
-    with patch(f"{MODULE}.get_int_env", return_value=1000):
-      limit, window = get_rate_limit_config("apikey:abc123")
+    limit, window = get_rate_limit_config("apikey:abc123")
     assert limit == 1000
     assert window == 60
 
   def test_jwt_limits(self):
-    with patch(f"{MODULE}.get_int_env", return_value=500):
-      limit, window = get_rate_limit_config("jwt:usr_123")
+    limit, window = get_rate_limit_config("jwt:usr_123")
     assert limit == 500
     assert window == 60
 
   def test_anonymous_limits(self):
-    with patch(f"{MODULE}.get_int_env", return_value=10):
-      limit, window = get_rate_limit_config("ip:1.2.3.4")
+    limit, window = get_rate_limit_config("ip:1.2.3.4")
     assert limit == 10
     assert window == 60
 
@@ -211,10 +176,7 @@ class TestRateLimitDependency:
 
   def test_allowed_sets_state(self):
     request = _make_request(headers={"X-API-Key": "test-key"})
-    with (
-      patch(f"{MODULE}.rate_limit_cache") as mock_cache,
-      patch(f"{MODULE}.get_int_env", return_value=1000),
-    ):
+    with patch(f"{MODULE}.rate_limit_cache") as mock_cache:
       mock_cache.check_rate_limit.return_value = (True, 99)
       rate_limit_dependency(request)
     assert request.state.rate_limit_remaining == 99
@@ -223,7 +185,6 @@ class TestRateLimitDependency:
     request = _make_request(headers={"X-API-Key": "test-key"})
     with (
       patch(f"{MODULE}.rate_limit_cache") as mock_cache,
-      patch(f"{MODULE}.get_int_env", return_value=1000),
       patch(f"{MODULE}.SecurityAuditLogger"),
     ):
       mock_cache.check_rate_limit.return_value = (False, 0)
@@ -286,10 +247,7 @@ class TestAuthRateLimitDependency:
     )
 
     request = _make_request(path="/v1/auth/login")
-    with (
-      patch(f"{MODULE}.rate_limit_cache") as mock_cache,
-      patch(f"{MODULE}.get_int_env", return_value=300),
-    ):
+    with patch(f"{MODULE}.rate_limit_cache") as mock_cache:
       mock_cache.check_rate_limit.return_value = (True, 4)
       auth_rate_limit_dependency(request)
       assert request.state.auth_rate_limit_remaining == 4
@@ -302,7 +260,6 @@ class TestAuthRateLimitDependency:
     request = _make_request(path="/v1/auth/login")
     with (
       patch(f"{MODULE}.rate_limit_cache") as mock_cache,
-      patch(f"{MODULE}.get_int_env", return_value=300),
       patch(f"{MODULE}.SecurityAuditLogger"),
     ):
       mock_cache.check_rate_limit.return_value = (False, 0)
@@ -317,10 +274,7 @@ class TestAuthRateLimitDependency:
     )
 
     request = _make_request(path="/v1/auth/register")
-    with (
-      patch(f"{MODULE}.rate_limit_cache") as mock_cache,
-      patch(f"{MODULE}.get_int_env", return_value=3600),
-    ):
+    with patch(f"{MODULE}.rate_limit_cache") as mock_cache:
       mock_cache.check_rate_limit.return_value = (True, 2)
       auth_rate_limit_dependency(request)
 
@@ -330,10 +284,7 @@ class TestAuthRateLimitDependency:
     )
 
     request = _make_request(path="/v1/auth/verify-email")
-    with (
-      patch(f"{MODULE}.rate_limit_cache") as mock_cache,
-      patch(f"{MODULE}.get_int_env", return_value=300),
-    ):
+    with patch(f"{MODULE}.rate_limit_cache") as mock_cache:
       mock_cache.check_rate_limit.return_value = (True, 8)
       auth_rate_limit_dependency(request)
 
@@ -350,10 +301,7 @@ class TestBillingRateLimitDependency:
     request = _make_request(
       headers={"X-API-Key": "test-key"}, path="/v1/billing/checkout"
     )
-    with (
-      patch(f"{MODULE}.rate_limit_cache") as mock_cache,
-      patch(f"{MODULE}.get_int_env", return_value=60),
-    ):
+    with patch(f"{MODULE}.rate_limit_cache") as mock_cache:
       mock_cache.check_rate_limit.return_value = (True, 55)
       billing_rate_limit_dependency(request)
       assert request.state.billing_rate_limit_remaining == 55
@@ -364,10 +312,7 @@ class TestBillingRateLimitDependency:
     )
 
     request = _make_request(path="/v1/billing/checkout")
-    with (
-      patch(f"{MODULE}.rate_limit_cache") as mock_cache,
-      patch(f"{MODULE}.get_int_env", return_value=60),
-    ):
+    with patch(f"{MODULE}.rate_limit_cache") as mock_cache:
       mock_cache.check_rate_limit.return_value = (False, 0)
       with pytest.raises(HTTPException) as exc_info:
         billing_rate_limit_dependency(request)
@@ -384,8 +329,7 @@ class TestScimRateLimitDependency:
   """
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=120)
-  def test_bearer_gets_full_limit_not_anonymous_tenth(self, mock_env, mock_cache):
+  def test_bearer_gets_full_limit_not_anonymous_tenth(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       scim_rate_limit_dependency,
     )
@@ -403,8 +347,7 @@ class TestScimRateLimitDependency:
     assert call_args[0][0].startswith("apikey:scim:")
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=120)
-  def test_two_tokens_same_ip_get_separate_buckets(self, mock_env, mock_cache):
+  def test_two_tokens_same_ip_get_separate_buckets(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       scim_rate_limit_dependency,
     )
@@ -426,8 +369,7 @@ class TestNamedRateLimitDependencies:
   """Tests for named rate limit dependency functions."""
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=600)
-  def test_user_management(self, mock_env, mock_cache):
+  def test_user_management(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       user_management_rate_limit_dependency,
     )
@@ -437,8 +379,7 @@ class TestNamedRateLimitDependencies:
     user_management_rate_limit_dependency(request)
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=50)
-  def test_sync_operations(self, mock_env, mock_cache):
+  def test_sync_operations(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       sync_operations_rate_limit_dependency,
     )
@@ -448,8 +389,7 @@ class TestNamedRateLimitDependencies:
     sync_operations_rate_limit_dependency(request)
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=30)
-  def test_connection_management(self, mock_env, mock_cache):
+  def test_connection_management(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       connection_management_rate_limit_dependency,
     )
@@ -459,8 +399,7 @@ class TestNamedRateLimitDependencies:
     connection_management_rate_limit_dependency(request)
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=100)
-  def test_analytics(self, mock_env, mock_cache):
+  def test_analytics(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       analytics_rate_limit_dependency,
     )
@@ -470,8 +409,7 @@ class TestNamedRateLimitDependencies:
     analytics_rate_limit_dependency(request)
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=10)
-  def test_backup_operations(self, mock_env, mock_cache):
+  def test_backup_operations(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       backup_operations_rate_limit_dependency,
     )
@@ -481,8 +419,7 @@ class TestNamedRateLimitDependencies:
     backup_operations_rate_limit_dependency(request)
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=60)
-  def test_sensitive_auth(self, mock_env, mock_cache):
+  def test_sensitive_auth(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       sensitive_auth_rate_limit_dependency,
     )
@@ -492,8 +429,7 @@ class TestNamedRateLimitDependencies:
     sensitive_auth_rate_limit_dependency(request)
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=300)
-  def test_logout(self, mock_env, mock_cache):
+  def test_logout(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       logout_rate_limit_dependency,
     )
@@ -503,8 +439,7 @@ class TestNamedRateLimitDependencies:
     logout_rate_limit_dependency(request)
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=200)
-  def test_tasks_management(self, mock_env, mock_cache):
+  def test_tasks_management(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       tasks_management_rate_limit_dependency,
     )
@@ -514,8 +449,7 @@ class TestNamedRateLimitDependencies:
     tasks_management_rate_limit_dependency(request)
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=600)
-  def test_auth_status(self, mock_env, mock_cache):
+  def test_auth_status(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       auth_status_rate_limit_dependency,
     )
@@ -525,8 +459,7 @@ class TestNamedRateLimitDependencies:
     auth_status_rate_limit_dependency(request)
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=100)
-  def test_sso(self, mock_env, mock_cache):
+  def test_sso(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       sso_rate_limit_dependency,
     )
@@ -536,8 +469,7 @@ class TestNamedRateLimitDependencies:
     sso_rate_limit_dependency(request)
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=200)
-  def test_general_api(self, mock_env, mock_cache):
+  def test_general_api(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       general_api_rate_limit_dependency,
     )
@@ -547,8 +479,7 @@ class TestNamedRateLimitDependencies:
     general_api_rate_limit_dependency(request)
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=600)
-  def test_public_api(self, mock_env, mock_cache):
+  def test_public_api(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       public_api_rate_limit_dependency,
     )
@@ -639,8 +570,7 @@ class TestScimIpRateLimitDependency:
   """
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=300)
-  def test_rotating_bearers_share_the_ip_bucket(self, mock_env, mock_cache):
+  def test_rotating_bearers_share_the_ip_bucket(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       scim_ip_rate_limit_dependency,
     )
@@ -658,8 +588,7 @@ class TestScimIpRateLimitDependency:
     assert keys[0].startswith("apikey:scim-ip:10.0.0.9")
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=300)
-  def test_ip_bucket_gets_the_full_limit(self, mock_env, mock_cache):
+  def test_ip_bucket_gets_the_full_limit(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       scim_ip_rate_limit_dependency,
     )
@@ -675,8 +604,7 @@ class TestScimBucketsFailClosed:
   """A limiter-backend outage must not silently disable SCIM's throttles."""
 
   @patch(f"{MODULE}.rate_limit_cache")
-  @patch(f"{MODULE}.get_int_env", return_value=120)
-  def test_both_scim_buckets_pass_fail_closed(self, mock_env, mock_cache):
+  def test_both_scim_buckets_pass_fail_closed(self, mock_cache):
     from robosystems.middleware.rate_limits.rate_limiting import (
       scim_ip_rate_limit_dependency,
       scim_rate_limit_dependency,

--- a/tests/models/extensions/test_reexports.py
+++ b/tests/models/extensions/test_reexports.py
@@ -1,0 +1,48 @@
+"""The extensions package must re-export everything its extension packages do.
+
+``robosystems.models.extensions`` exists so a caller does not have to know which
+extension a model belongs to. That only holds if the re-export list keeps pace,
+and it is the kind of list nobody rereads: four names had drifted out of it, and
+the omission stayed invisible because the sibling import path still worked.
+
+Asserted as a set comparison rather than a checklist, so a model added to
+``roboledger`` or ``roboinvestor`` tomorrow fails here instead of being quietly
+unreachable from the parent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import robosystems.models.extensions as extensions
+from robosystems.models.extensions import roboinvestor, roboledger
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+  "module", [roboledger, roboinvestor], ids=["roboledger", "roboinvestor"]
+)
+def test_extension_exports_are_reachable_from_the_parent(module):
+  declared = set(module.__all__)
+  assert declared, f"{module.__name__} declares no __all__"
+  missing = sorted(name for name in declared if not hasattr(extensions, name))
+  assert not missing, (
+    f"{module.__name__} exports {missing}, which do not resolve from "
+    "robosystems.models.extensions. Add them to its imports and __all__."
+  )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+  "module", [roboledger, roboinvestor], ids=["roboledger", "roboinvestor"]
+)
+def test_reexports_are_advertised_in_all(module):
+  """Reachable is not enough — an import the parent does not advertise in
+  ``__all__`` is absent from ``from ... import *`` and from tooling."""
+  undeclared = sorted(
+    name for name in module.__all__ if name not in set(extensions.__all__)
+  )
+  assert not undeclared, (
+    f"{module.__name__} exports {undeclared}, which resolve from the parent but "
+    "are missing from its __all__."
+  )


### PR DESCRIPTION
## Summary

Two places where a module's declared surface did not match what actually
resolves, each fixed with a guard that compares the two as sets so they cannot
drift apart again. Both were found by the documentation audit rather than by
anything failing.

Closes #1236. Closes #1237.

## Changes

**Burst rate limits (#1236)**

`rate_limiting.py` defined a local `get_int_env` that shadowed the one in
`config/env.py` and resolved values through `getattr(env, key, default)`. None of
the **26** `RATE_LIMIT_*` names it read are declared on `env`, so every one
answered with its default — a configuration surface that read as tunable and
governed nothing.

They are not meant to be tunable, so the fix is to stop them advertising
otherwise rather than to make them resolve:

- `config/rate_limits.py` — the documented home for rate limiting — gains a
  `BURST_LIMITS` mapping, keyed by what each limit *is* (`api_key`, `scim_ip`,
  `billing`) rather than by an environment variable name that never existed. The
  rationale comments move with the values, since that is where the numbers now live.
- `rate_limiting.py` drops the shadowing helper and reads the mapping. A wrong key
  is now a `KeyError` on the path, not a silent default.
- New `tests/config/test_burst_limits.py` asserts the keys read and the keys
  defined are the same set **in both directions**.

**Extensions model re-exports (#1237)**

`robosystems.models.extensions` omitted `Agent`, `Event`, `EventHandler` and
`event_dimensions` from its imports and `__all__`. The issue named three; the
fourth turned up on inspection, and settles it as oversight rather than curation —
`event_dimensions` sits alongside three other `*_dimensions` tables that are all
re-exported. New `tests/models/extensions/test_reexports.py` compares the parent's
surface to each extension package's `__all__` as a set, in both *reachable* and
*advertised in `__all__`* form.

## Breaking Changes

None, in either direction.

Every rate limit keeps its exact current value. `get_int_env` was module-private
to `rate_limiting.py` and is not published SDK surface; the four model re-exports
are additive. No OpenAPI or GraphQL shape changes, so neither SDK tier moves.

## Testing

- Every limit verified unchanged: captured the effective value at all 26 call
  sites before the change and compared after — identical, with no unused entries
  in the new mapping. This was the main risk, since the edit touched 26 sites in a
  security-relevant module.
- Both new guards were run against `main`'s code to confirm they fail on the
  defect they describe, then against the fix.
- `tests/middleware tests/config tests/models tests/routers/auth` — **4228 passed**.
- `just lint` / `just format` / `just typecheck` — clean.
- Full `just test-all` not run locally; CI covers it.

## Notes for the reviewer

- The rate-limit test suite patched `get_int_env` with fixed return values at 28
  sites, so it asserted against a mock rather than the real limit. Those patches
  are gone and the assertions now read the constants — the tests got stronger, but
  it is the largest part of the diff and worth a look.
- Not addressed here, to keep the diff scoped: `config/constants.py` still holds
  five burst limits of the same nature (`AUTH_RATE_LIMIT_LOGIN_DEFAULT`,
  `JWT_REFRESH_RATE_LIMIT_DEFAULT`, the two `RATE_LIMIT_SSE_CONNECTIONS*`). One of
  them is the *count* whose *window* is now in `BURST_LIMITS`, so the pair is split
  across two modules. Consolidating is a separate change.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
