### PR TITLE
feat(security): record admin-surface actions in the audit trail

### DIFF
--- a/robosystems/middleware/logging.py
+++ b/robosystems/middleware/logging.py
@@ -20,6 +20,7 @@ from robosystems.logger import (
   log_auth_event,
   security_logger,
 )
+from robosystems.security.audit_logger import SecurityAuditLogger
 from robosystems.security.request_context import bind_request_id, reset_request_id
 
 logger = api_logger
@@ -301,6 +302,22 @@ class SecurityLoggingMiddleware(BaseHTTPMiddleware):
           "method": request.method,
           "path": request.url.path,
         },
+      )
+
+    # Record every authenticated admin-surface action. `admin_key_id` is set on
+    # request.state by AdminAuthMiddleware once the key verifies, so its absence
+    # means authentication never succeeded — those are already recorded (and
+    # alarmed) by log_admin_auth_failure, and must not be double-logged here.
+    admin_key_id = getattr(request.state, "admin_key_id", None)
+    if admin_key_id and request.url.path.startswith("/admin/v1/"):
+      SecurityAuditLogger.log_admin_action(
+        admin_key_id=str(admin_key_id),
+        method=request.method,
+        endpoint=request.url.path,
+        status_code=response.status_code,
+        ip_address=client_ip,
+        user_agent=user_agent,
+        query=redact_sensitive_query_params(str(request.url.query)) or None,
       )
 
     # Log authorization failures (403 responses) using structured logging

--- a/robosystems/security/audit_logger.py
+++ b/robosystems/security/audit_logger.py
@@ -68,6 +68,13 @@ class SecurityEventType(Enum):
   GRAPH_MEMBER_ADDED = "graph_member_added"
   GRAPH_MEMBER_ROLE_CHANGED = "graph_member_role_changed"
   GRAPH_MEMBER_REMOVED = "graph_member_removed"
+  # Every authenticated request to the admin surface (SOC 2 CC6.1: privileged
+  # access is restricted AND what it did is recorded). Evidence, not alerts:
+  # no metric, like the membership and SCIM lifecycle events — the admin
+  # surface is unreachable from the internet, so volume here is not a signal.
+  # ``user_id`` is the admin credential that acted, which is what correlates
+  # this line to the CloudTrail ``GetSecretValue`` that fetched it.
+  ADMIN_ACTION = "admin_action"
   # Passkey MFA lifecycle (operational; only MFA_FAILED alarms — a spike is
   # the second-factor brute-force / phishing-relay signal)
   PASSKEY_ENROLLED = "passkey_enrolled"
@@ -282,6 +289,43 @@ class SecurityAuditLogger:
       endpoint=endpoint,
       details={"admin": True, "failure_reason": reason},
       risk_level="high",
+    )
+
+  @staticmethod
+  def log_admin_action(
+    admin_key_id: str,
+    method: str,
+    endpoint: str,
+    status_code: int,
+    ip_address: str | None = None,
+    user_agent: str | None = None,
+    query: str | None = None,
+  ):
+    """Record one authenticated action on the admin surface.
+
+    Emitted for every request that got past admin authentication, whatever it
+    returned — a 403 or a 500 on the admin surface is as much a part of the
+    trail as a 200. Authentication *failures* are not routed here; they go to
+    :meth:`log_admin_auth_failure`, which alarms.
+
+    ``endpoint`` is the literal path, identifiers included: which subscription
+    or user was acted on is the point of the record, not incidental detail.
+    """
+    SecurityAuditLogger.log_security_event(
+      event_type=SecurityEventType.ADMIN_ACTION,
+      user_id=admin_key_id,
+      ip_address=ip_address,
+      user_agent=user_agent,
+      endpoint=endpoint,
+      details={
+        "admin": True,
+        "admin_key_id": admin_key_id,
+        "method": method,
+        "status_code": status_code,
+        "success": 200 <= status_code < 400,
+        **({"query": query} if query else {}),
+      },
+      risk_level="low" if method in ("GET", "HEAD", "OPTIONS") else "medium",
     )
 
   @staticmethod

--- a/tests/middleware/test_admin_action_audit.py
+++ b/tests/middleware/test_admin_action_audit.py
@@ -1,0 +1,200 @@
+"""Tests for the admin-surface action audit trail.
+
+Covers both halves of the trail: ``SecurityAuditLogger.log_admin_action``,
+which shapes the record, and the ``SecurityLoggingMiddleware`` branch that
+decides which requests earn one.
+
+The middleware tests run through a real ASGI stack on purpose. The branch
+depends on ``request.state.admin_key_id`` — set inside the route by
+``AdminAuthMiddleware`` — being visible to middleware *after* ``call_next``
+returns. That works because Starlette backs ``request.state`` with
+``scope["state"]``, and it is exactly the kind of framework assumption that a
+mocked Request would assert away instead of verifying.
+"""
+
+import json
+from unittest.mock import patch
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from robosystems.middleware.logging import SecurityLoggingMiddleware
+from robosystems.security.audit_logger import (
+  _ADMIN_FLAGGABLE_EVENTS,
+  _METRIC_FOR_EVENT,
+  SecurityAuditLogger,
+  SecurityEventType,
+)
+
+
+def _build_app() -> FastAPI:
+  """An app whose routes stand in for the admin surface and the public API."""
+  app = FastAPI()
+  app.add_middleware(SecurityLoggingMiddleware)
+
+  @app.get("/admin/v1/subscriptions")
+  async def authenticated_admin_read(request: Request):
+    request.state.admin_key_id = "admin"
+    return {"ok": True}
+
+  @app.post("/admin/v1/invoices/inv_123/mark-paid")
+  async def authenticated_admin_write(request: Request):
+    request.state.admin_key_id = "admin"
+    return {"ok": True}
+
+  @app.get("/admin/v1/users/boom")
+  async def authenticated_admin_failure(request: Request):
+    request.state.admin_key_id = "admin"
+    from fastapi import HTTPException
+
+    raise HTTPException(status_code=403, detail="nope")
+
+  @app.get("/admin/v1/webhooks/stripe")
+  async def unauthenticated_admin_path():
+    """Stands in for the Stripe webhook: admin path, no admin credential."""
+    return {"ok": True}
+
+  @app.get("/v1/graphs")
+  async def public_route():
+    return {"ok": True}
+
+  return app
+
+
+class TestAdminActionRecordShape:
+  """``log_admin_action`` records the actor, the action and its outcome."""
+
+  def test_emits_admin_action_event_with_attribution(self):
+    with patch("robosystems.security.audit_logger.logger") as mock_logger:
+      SecurityAuditLogger.log_admin_action(
+        admin_key_id="admin",
+        method="POST",
+        endpoint="/admin/v1/invoices/inv_123/mark-paid",
+        status_code=200,
+        ip_address="10.0.0.4",
+        user_agent="robosystems-admin-cli",
+      )
+
+    payload = json.loads(
+      mock_logger.warning.call_args[0][0].removeprefix("SECURITY_AUDIT: ")
+    )
+
+    assert payload["event_type"] == "admin_action"
+    assert payload["user_id"] == "admin"
+    assert payload["endpoint"] == "/admin/v1/invoices/inv_123/mark-paid"
+    assert payload["ip_address"] == "10.0.0.4"
+    assert payload["details"]["method"] == "POST"
+    assert payload["details"]["status_code"] == 200
+    assert payload["details"]["success"] is True
+    assert payload["details"]["admin_key_id"] == "admin"
+
+  def test_failed_action_is_still_recorded(self):
+    """A 500 on the admin surface belongs in the trail as much as a 200."""
+    with patch("robosystems.security.audit_logger.logger") as mock_logger:
+      SecurityAuditLogger.log_admin_action(
+        admin_key_id="admin",
+        method="DELETE",
+        endpoint="/admin/v1/users/u_1",
+        status_code=500,
+      )
+
+    payload = json.loads(
+      mock_logger.warning.call_args[0][0].removeprefix("SECURITY_AUDIT: ")
+    )
+    assert payload["details"]["success"] is False
+    assert payload["details"]["status_code"] == 500
+
+  def test_reads_and_writes_carry_different_risk(self):
+    for method, expected in (("GET", "low"), ("POST", "medium"), ("DELETE", "medium")):
+      with patch("robosystems.security.audit_logger.logger") as mock_logger:
+        SecurityAuditLogger.log_admin_action(
+          admin_key_id="admin",
+          method=method,
+          endpoint="/admin/v1/users",
+          status_code=200,
+        )
+      payload = json.loads(
+        mock_logger.warning.call_args[0][0].removeprefix("SECURITY_AUDIT: ")
+      )
+      assert payload["risk_level"] == expected, method
+
+  @patch("robosystems.security.audit_logger._publish_security_metrics")
+  def test_publishes_no_metric(self, mock_publish):
+    """Evidence, not an alert — the admin surface is not internet-reachable,
+    so request volume here is not a detective-control signal."""
+    SecurityAuditLogger.log_admin_action(
+      admin_key_id="admin",
+      method="GET",
+      endpoint="/admin/v1/users",
+      status_code=200,
+    )
+    mock_publish.assert_called_once_with([])
+
+  def test_admin_action_is_not_flaggable_as_auth_failure(self):
+    """The ``details["admin"]`` flag must not drag ADMIN_ACTION into the
+    FailedAdminAuth alarm, which would fire on ordinary admin work."""
+    assert SecurityEventType.ADMIN_ACTION not in _ADMIN_FLAGGABLE_EVENTS
+    assert SecurityEventType.ADMIN_ACTION not in _METRIC_FOR_EVENT
+
+
+class TestAdminActionMiddlewareBranch:
+  """The middleware records authenticated admin requests, and only those."""
+
+  def test_authenticated_admin_request_is_recorded(self):
+    with patch.object(SecurityAuditLogger, "log_admin_action") as mock_log:
+      TestClient(_build_app()).get("/admin/v1/subscriptions")
+
+    mock_log.assert_called_once()
+    kwargs = mock_log.call_args.kwargs
+    assert kwargs["admin_key_id"] == "admin"
+    assert kwargs["method"] == "GET"
+    assert kwargs["endpoint"] == "/admin/v1/subscriptions"
+    assert kwargs["status_code"] == 200
+
+  def test_write_records_literal_path_including_identifiers(self):
+    """Which invoice was marked paid is the point of the record."""
+    with patch.object(SecurityAuditLogger, "log_admin_action") as mock_log:
+      TestClient(_build_app()).post("/admin/v1/invoices/inv_123/mark-paid")
+
+    kwargs = mock_log.call_args.kwargs
+    assert kwargs["endpoint"] == "/admin/v1/invoices/inv_123/mark-paid"
+    assert kwargs["method"] == "POST"
+
+  def test_authenticated_request_that_fails_is_recorded(self):
+    with patch.object(SecurityAuditLogger, "log_admin_action") as mock_log:
+      TestClient(_build_app()).get("/admin/v1/users/boom")
+
+    mock_log.assert_called_once()
+    assert mock_log.call_args.kwargs["status_code"] == 403
+
+  def test_admin_path_without_credential_is_not_recorded(self):
+    """Auth failures are recorded — and alarmed — by log_admin_auth_failure.
+    Logging them here too would double-count them in the audit stream."""
+    with patch.object(SecurityAuditLogger, "log_admin_action") as mock_log:
+      TestClient(_build_app()).get("/admin/v1/webhooks/stripe")
+
+    mock_log.assert_not_called()
+
+  def test_non_admin_path_is_not_recorded(self):
+    with patch.object(SecurityAuditLogger, "log_admin_action") as mock_log:
+      TestClient(_build_app()).get("/v1/graphs")
+
+    mock_log.assert_not_called()
+
+  def test_query_parameters_are_redacted(self):
+    with patch.object(SecurityAuditLogger, "log_admin_action") as mock_log:
+      TestClient(_build_app()).get(
+        "/admin/v1/subscriptions",
+        params={"api_key": "sk_live_secret", "status": "active"},
+      )
+
+    query = mock_log.call_args.kwargs["query"]
+    assert "sk_live_secret" not in query
+    assert "api_key=REDACTED" in query
+    assert "status=active" in query
+
+  def test_absent_query_is_none_not_empty_string(self):
+    with patch.object(SecurityAuditLogger, "log_admin_action") as mock_log:
+      TestClient(_build_app()).get("/admin/v1/subscriptions")
+
+    assert mock_log.call_args.kwargs["query"] is None


### PR DESCRIPTION
## Summary

Every request that passes admin authentication now emits an `ADMIN_ACTION` security audit event, so the application-side trail records *what* was done on the admin surface alongside the AWS-side record of *who* opened the session.

The practical effect is retention. These records go out as `SECURITY_AUDIT:` lines, which the existing `?SECURITY_AUDIT` subscription filter (`cloudformation/audit.yaml:207`) forwards to the audit bucket at 400 days. Admin activity previously lived only in the API log group, which rolls at 30 days — shorter than a SOC 2 Type II observation window, so evidence aged out mid-window.

## Changes

**`robosystems/security/audit_logger.py`**

- New `SecurityEventType.ADMIN_ACTION`, filed with the "evidence, not alerts" cohort (the membership and SCIM lifecycle events).
- New `SecurityAuditLogger.log_admin_action()` recording the acting key id, method, path, status code, success, and redacted query string. `risk_level` is `low` for safe methods and `medium` otherwise.

**`robosystems/middleware/logging.py`**

- New branch in `SecurityLoggingMiddleware.dispatch`, alongside the existing `/v1/auth/` and 403 branches, rather than a new middleware.

Three points worth a close look:

1. **No CloudWatch metric is published.** `ADMIN_ACTION` is deliberately absent from both `_METRIC_FOR_EVENT` and `_ADMIN_FLAGGABLE_EVENTS`. The event carries `details["admin"] = True` as a log dimension, and that flag only reaches the metric path for event types in the flaggable set — so routine admin work cannot trip `FailedAdminAuthAlarm`. Two tests pin this.
2. **The branch is guarded on `request.state.admin_key_id`, not on the path alone.** That attribute is set by `AdminAuthMiddleware` only after the key verifies, so unauthenticated requests are excluded structurally. Authentication failures keep their existing route through `log_admin_auth_failure` (which alarms) and are not double-logged here. This also correctly excludes the Stripe webhook, which shares the `/admin/v1/` prefix but is signature-verified rather than admin-authenticated.
3. **The recorded path is the literal one, identifiers included** — which invoice or subscription was acted on is the substance of the record. Query strings pass through the existing `redact_sensitive_query_params` first.

**`tests/middleware/test_admin_action_audit.py`** — 12 tests across the record shape and the middleware branch.

One test builds a real ASGI app rather than mocking `Request`. The branch reads state that the route sets, *after* `call_next` returns; that works because Starlette backs `request.state` with `scope["state"]`. A mocked `Request` would assert the assumption instead of exercising it, so this is verified end-to-end against the installed Starlette.

## Breaking Changes

None. The change is purely additive (261 insertions, 0 deletions) and touches no externally visible surface — no OpenAPI shape, GraphQL schema, or operations envelope changes, so neither client SDK is affected and no regen is required.

## Testing

- `just test-code` — passed (0 errors, 0 warnings, 0 notes). Ruff reformatted the new test file; the reformatted version is what's committed and tests were re-run after.
- `uv run pytest tests/middleware/ tests/security/ tests/routers/admin/ tests/admin/` — 3243 passed, 29 skipped. Chosen to cover the modified middleware, the modified audit logger, and every consumer of the admin auth path.
- `uv run pytest tests/middleware/test_admin_action_audit.py` — 12 passed.
- Full `just test-all` was **not** run; the suites above are a targeted subset.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
