### PR TITLE
feat(roboledger): run the MCP close on the worker

### DIFF
--- a/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
+++ b/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
@@ -363,24 +363,39 @@ The receipt:
         "message": "User context required to close a period.",
       }
 
-    dispatch = await enqueue_task(
-      task_type="period_close",
-      graph_id=graph_id,
-      user_id=str(user_id),
-      params={
+    try:
+      dispatch = await enqueue_task(
+        task_type="period_close",
+        graph_id=graph_id,
+        user_id=str(user_id),
+        params={
+          "period": period,
+          "actor_id": str(user_id),
+          "actor_type": "agent",
+          "allow_stale_sync": bool(arguments.get("allow_stale_sync", False)),
+          "allow_stranded_obligations": bool(
+            arguments.get("allow_stranded_obligations", False)
+          ),
+          "allow_reconciling_items": bool(
+            arguments.get("allow_reconciling_items", False)
+          ),
+          "note": arguments.get("note"),
+        },
+      )
+    except Exception as exc:
+      # Nothing was queued, which makes this the one failure here that is
+      # safe to retry — and worth saying so, because every other message
+      # this tool returns says the opposite.
+      logger.warning("close-period could not dispatch: %s", exc, exc_info=True)
+      return {
+        "error": "dispatch_failed",
         "period": period,
-        "actor_id": str(user_id),
-        "actor_type": "agent",
-        "allow_stale_sync": bool(arguments.get("allow_stale_sync", False)),
-        "allow_stranded_obligations": bool(
-          arguments.get("allow_stranded_obligations", False)
+        "message": (
+          "The close could not be handed to the worker, so it has NOT "
+          "started and nothing was written. Retry; if it keeps failing, "
+          "the task queue is unavailable."
         ),
-        "allow_reconciling_items": bool(
-          arguments.get("allow_reconciling_items", False)
-        ),
-        "note": arguments.get("note"),
-      },
-    )
+      }
     operation_id = dispatch["operation_id"]
 
     storage = get_event_storage()
@@ -392,7 +407,19 @@ The receipt:
     started_at = loop.time()
     status = None
     while loop.time() < deadline:
-      metadata = await storage.get_operation_metadata(operation_id)
+      try:
+        metadata = await storage.get_operation_metadata(operation_id)
+      except Exception as exc:
+        # The close is already running. Losing sight of it is a reporting
+        # problem, not a reason to suggest doing it again — fall through to
+        # the handback, which sends the operator to the period itself.
+        logger.warning(
+          "close-period lost track of operation %s: %s",
+          operation_id,
+          exc,
+          exc_info=True,
+        )
+        break
       status = metadata.status if metadata else None
       if metadata and status == OperationStatus.COMPLETED:
         # The task already shaped this — return it as it stands so the

--- a/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
+++ b/robosystems/middleware/mcp/tools/fiscal_calendar_tools.py
@@ -22,6 +22,7 @@ fiscal_calendar.py` so MCP, GraphQL, and the REST operation surface
 share one source of truth for both behavior and wire shape.
 """
 
+import asyncio
 from typing import Any
 
 from sqlalchemy.exc import SQLAlchemyError
@@ -47,18 +48,15 @@ from robosystems.operations.roboledger.commands.fiscal_calendar import (
   backfill_plan_history as ops_backfill_plan_history,
 )
 from robosystems.operations.roboledger.commands.fiscal_calendar import (
-  close_period as ops_close_period,
-)
-from robosystems.operations.roboledger.commands.fiscal_calendar import (
   reopen_period as ops_reopen_period,
 )
 from robosystems.operations.roboledger.fiscal_calendar import (
   CloseGateFailed,
   FiscalCalendarError,
   FiscalCalendarService,
-  PeriodAlreadyClosedError,
-  PeriodNotFoundError,
-  UnbalancedLedgerError,
+)
+from robosystems.operations.roboledger.fiscal_calendar.close_outcomes import (
+  close_error_payload,
 )
 from robosystems.operations.roboledger.fiscal_calendar.close_service import (
   PeriodCloseService,
@@ -66,9 +64,6 @@ from robosystems.operations.roboledger.fiscal_calendar.close_service import (
 from robosystems.operations.roboledger.reads.fiscal_calendar import (
   build_fiscal_calendar_response,
   qb_sync_state,
-)
-from robosystems.operations.roboledger.reports.statement_sets import (
-  StatementStampError,
 )
 
 from ._errors import database_failure
@@ -234,6 +229,13 @@ class ClosePeriodTool:
   Prefer resolve-reconciling-item on each first.
 
 **RETURNS:**
+Two shapes. Usually the receipt below, returned once the close lands. If the
+close is still running when this call's budget runs out, you instead get
+`status: "in_progress"` with an `operation_id`, `worker_started`, and
+instructions — see WORKFLOW. That is not a failure and not a timeout: the
+close is running on the worker and is atomic.
+
+The receipt:
 - period: the period that was closed
 - entries_posted: TOTAL drafts transitioned to posted, across both post
   paths; entries_published_to_qb / entries_posted_locally carry the
@@ -266,11 +268,28 @@ class ClosePeriodTool:
   preview-reconciling-item then resolve-reconciling-item on each first
 - Cannot close if BS equation doesn't balance for the period
 
+**WORKFLOW:**
+1. Call close-period once. It dispatches the close to the worker and waits
+   ~18s for it.
+2. If you get the receipt, you are done — read entries_published_to_qb and
+   statements_stamped to summarize for the user.
+3. If you get `status: "in_progress"`, do NOT call close-period again. The
+   close is already running and re-dispatching risks nothing useful. Poll
+   get-period-close-status (period_status flips to closed, close_receipt
+   fills in) or get-fiscal-calendar (has_close_receipt on the period row)
+   every ~10s until it lands, then summarize from the receipt.
+4. `worker_started: false` means the close is queued behind a busy worker
+   rather than running yet. Same instruction — it will run.
+
 **NOTES:**
 - Posted entries cannot be re-drafted — use reopen-period to undo
 - Manual entries (drafted via create-event-block event_type='journal_entry_recorded') are posted alongside schedule drafts
 - Which drafts write back to QuickBooks follows the event's source (schedule/manual publish; system posts locally), unless metadata.publish_to_source overrides it per entry. list-period-drafts previews the split before you close
-- After close, close_target auto-advances to the next period""",
+- After close, close_target auto-advances to the next period
+- The close runs on the worker, so a slow QuickBooks publish can outlast
+  this call. The work is unaffected by that — only who is waiting for it
+- An identical close re-dispatched within 30s returns the same operation
+  rather than starting a second one (`deduplicated: true`)""",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -313,145 +332,153 @@ class ClosePeriodTool:
       },
     }
 
+  # Polling budget for the dispatched close. The server cuts a tool call at
+  # 25s, so this has to land inside that with room for the dispatch itself;
+  # what is left over is the handback the operator reads.
+  POLL_INTERVAL_S = 1.0
+  POLL_BUDGET_S = 18.0
+
   async def execute(self, arguments: dict[str, Any]) -> Any:
-    return await run_off_loop(self._execute_sync, arguments)
+    from robosystems.middleware.sse.event_storage import (
+      OperationStatus,
+      get_event_storage,
+    )
+    from robosystems.worker.client import enqueue_task
 
-  def _execute_sync(self, arguments: dict[str, Any]) -> Any:
     graph_id = self.client.graph_id
+    period = arguments["period"]
 
+    gate = await run_off_loop(self._gate_check, arguments)
+    if gate is not None:
+      return gate
+
+    # A real user id, not the graph-scoped sentinel the synchronous path
+    # could fall back to: the operation is readable at
+    # /v1/operations/{id}/status only by the user it was created for, so a
+    # sentinel would enqueue work nobody could then look up.
+    user_id = getattr(self.client, "user_id", None)
+    if not user_id:
+      return {
+        "error": "authentication_required",
+        "message": "User context required to close a period.",
+      }
+
+    dispatch = await enqueue_task(
+      task_type="period_close",
+      graph_id=graph_id,
+      user_id=str(user_id),
+      params={
+        "period": period,
+        "actor_id": str(user_id),
+        "actor_type": "agent",
+        "allow_stale_sync": bool(arguments.get("allow_stale_sync", False)),
+        "allow_stranded_obligations": bool(
+          arguments.get("allow_stranded_obligations", False)
+        ),
+        "allow_reconciling_items": bool(
+          arguments.get("allow_reconciling_items", False)
+        ),
+        "note": arguments.get("note"),
+      },
+    )
+    operation_id = dispatch["operation_id"]
+
+    storage = get_event_storage()
+    # Measured against the clock rather than by summing the intended sleeps:
+    # the budget is "how long the caller has been waiting", and an interval
+    # that rounds to nothing must still exhaust it rather than spin.
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + self.POLL_BUDGET_S
+    started_at = loop.time()
+    status = None
+    while loop.time() < deadline:
+      metadata = await storage.get_operation_metadata(operation_id)
+      status = metadata.status if metadata else None
+      if metadata and status == OperationStatus.COMPLETED:
+        # The task already shaped this — return it as it stands so the
+        # receipt reads the same whether the worker was fast or slow.
+        return metadata.result_data or {}
+      if metadata and status == OperationStatus.FAILED:
+        return {
+          "error": "close_failed",
+          "operation_id": operation_id,
+          "period": period,
+          "message": (
+            f"{metadata.error_message or 'The close failed.'} If it ran out of "
+            "time rather than erroring, the close may still have landed — "
+            "check get-period-close-status before retrying."
+          ),
+        }
+      if metadata and status == OperationStatus.CANCELLED:
+        return {
+          "error": "cancelled",
+          "operation_id": operation_id,
+          "period": period,
+          "message": "The close was cancelled.",
+        }
+      await asyncio.sleep(self.POLL_INTERVAL_S)
+
+    started = status == OperationStatus.RUNNING
+    return {
+      "status": "in_progress",
+      "operation_id": operation_id,
+      "period": period,
+      "worker_started": started,
+      "deduplicated": bool(dispatch.get("deduplicated", False)),
+      "waited_seconds": round(loop.time() - started_at, 1),
+      "message": (
+        (
+          f"The close of {period} is running on the worker and is atomic — "
+          "NEVER call close-period again for this period. "
+        )
+        if started
+        else (
+          f"The close of {period} is queued and has not started yet (the "
+          "worker is busy or scaling). It will run — do not re-dispatch. "
+        )
+      )
+      + "Poll get-period-close-status (period_status and close_receipt) or "
+      "get-fiscal-calendar (has_close_receipt on the period) every ~10s "
+      "until it lands.",
+    }
+
+  def _gate_check(self, arguments: dict[str, Any]) -> Any:
+    """Answer an uncloseable period without burning a worker slot.
+
+    The task re-runs this gate under the period fence, which is the
+    authoritative check; this one only spares the operator a dispatch and a
+    poll to be told something already knowable. A period that becomes
+    uncloseable in between is caught there and comes back as a refusal.
+    """
+    graph_id = self.client.graph_id
     try:
       require_graph_extension_mcp("roboledger", graph_id)
     except MCPExtensionGateError as exc:
       return {"error": exc.code, "message": exc.message}
 
     period = arguments["period"]
-    allow_stale_sync = bool(arguments.get("allow_stale_sync", False))
-    allow_stranded_obligations = bool(
-      arguments.get("allow_stranded_obligations", False)
-    )
-    allow_reconciling_items = bool(arguments.get("allow_reconciling_items", False))
-    note = arguments.get("note")
-
-    # Best-effort user identity from the graph client context; fall back to
-    # a graph-scoped sentinel so audit logs stay traceable to the tenant.
-    actor_id = getattr(self.client, "user_id", None) or f"mcp:{graph_id}"
-
-    svc = FiscalCalendarService()
-    close_svc = PeriodCloseService()
-
     try:
       with extensions_session(graph_id) as session, _platform_session() as platform_db:
-        result = ops_close_period(
+        has_sync, last_sync_at = qb_sync_state(platform_db, graph_id)
+        gate = FiscalCalendarService().closeable_gate(
           session,
-          platform_db,
           graph_id,
           period,
-          actor_id=actor_id,
-          allow_stale_sync=allow_stale_sync,
-          note=note,
-          service=svc,
-          close_service=close_svc,
-          actor_type="agent",
-          allow_stranded_obligations=allow_stranded_obligations,
-          allow_reconciling_items=allow_reconciling_items,
+          has_sync_connection=has_sync,
+          last_sync_at=last_sync_at,
+          allow_stale_sync=bool(arguments.get("allow_stale_sync", False)),
+          allow_stranded_obligations=bool(
+            arguments.get("allow_stranded_obligations", False)
+          ),
+          allow_reconciling_items=bool(arguments.get("allow_reconciling_items", False)),
         )
-        # ops_close_period commits the session internally.
-        fc_payload = result.fiscal_calendar.model_dump(mode="json")
-        # Re-derive `has_sync_connection` so the MCP wire shape stays the
-        # same as before the refactor (the Pydantic response doesn't
-        # carry it).
-        has_sync, _ = qb_sync_state(platform_db, graph_id)
-        fc_payload["has_sync_connection"] = has_sync
-        return {
-          "period": result.period,
-          "entries_posted": result.entries_posted,
-          "entries_published_to_qb": result.entries_published_to_qb,
-          "entries_posted_locally": result.entries_posted_locally,
-          "target_auto_advanced": result.target_auto_advanced,
-          "fiscal_calendar": fc_payload,
-          # Rule eval outcomes from the auto-run on close. Pairs with
-          # the REST `ClosePeriodResponse` shape so agents and REST
-          # consumers see the same surface.
-          "rule_summary": result.rule_summary,
-          "evaluated_structure_ids": list(result.evaluated_structure_ids),
-          # Canonical statement stamping (the close-time pivot). Shaped
-          # by hand here — without these keys agents never see that the
-          # close persisted the month's statements.
-          "statements_stamped": result.statements_stamped,
-          "statement_stamp_note": result.statement_stamp_note,
-          "stamped_statement_sets": dict(result.stamped_statement_sets),
-          "statement_rule_summary": result.statement_rule_summary,
-        }
-    except CloseGateFailed as exc:
-      if exc.no_calendar:
-        return {
-          "error": "calendar_not_initialized",
-          "message": "Fiscal calendar not initialized for this graph.",
-        }
-      payload: dict = {
-        "error": "not_closeable",
-        "message": f"Cannot close period {period!r}.",
-        "blockers": exc.blockers,
-      }
-      if exc.gate.pending_obligation_count:
-        payload["pending_obligation_count"] = exc.gate.pending_obligation_count
-        payload["pending_obligation_sample"] = [
-          {
-            "event_id": d.event_id,
-            "schedule_id": d.schedule_id,
-            "schedule_name": d.schedule_name,
-            "period": d.period,
-          }
-          for d in exc.gate.pending_obligation_sample
-        ]
-        payload["earliest_pending_period"] = exc.gate.earliest_pending_period
-      if exc.gate.stranded_obligation_count:
-        payload["stranded_obligation_count"] = exc.gate.stranded_obligation_count
-        payload["stranded_obligation_sample"] = [
-          {
-            "event_id": d.event_id,
-            "schedule_id": d.schedule_id,
-            "schedule_name": d.schedule_name,
-            "period": d.period,
-          }
-          for d in exc.gate.stranded_obligation_sample
-        ]
-      if exc.gate.reconciling_item_count:
-        payload["reconciling_item_count"] = exc.gate.reconciling_item_count
-        payload["reconciling_item_sample"] = list(exc.gate.reconciling_item_sample)
-      if exc.gate.sync_stale_days is not None:
-        payload["sync_stale_days"] = exc.gate.sync_stale_days
-      return payload
-    except PeriodNotFoundError as exc:
-      return {"error": "period_not_found", "message": str(exc)}
-    except PeriodAlreadyClosedError as exc:
-      return {"error": "already_closed", "message": str(exc)}
-    except RowLockedError as exc:
-      return {"error": "row_locked", "message": str(exc)}
-    except UnbalancedLedgerError as exc:
-      return {
-        "error": "unbalanced",
-        "message": (
-          f"Balance sheet equation broken for period {period!r}: "
-          f"debits={exc.total_debit} credits={exc.total_credit}. "
-          "Review the ledger before closing."
-        ),
-      }
-    except StatementStampError as exc:
-      return {
-        "error": "statement_stamp_failed",
-        "message": (
-          f"{exc} The close rolled back — nothing was committed. Fix the "
-          "mapping/reporting configuration and re-run close-period."
-        ),
-      }
-    except FiscalCalendarError as exc:
-      return {"error": "calendar_error", "message": str(exc)}
+        if gate.is_closeable:
+          return None
+        return close_error_payload(CloseGateFailed(gate), period=period)
     except SQLAlchemyError as exc:
       return database_failure("close-period", exc)
-    except Exception as exc:
-      logger.warning(f"close-period failed: {exc}")
-      return {"error": str(exc)}
+    except FiscalCalendarError as exc:
+      return {"error": "calendar_error", "message": str(exc)}
 
 
 # ────────────────────────────────────────────────────────────────────────────

--- a/robosystems/middleware/mcp/tools/playbook_tools.py
+++ b/robosystems/middleware/mcp/tools/playbook_tools.py
@@ -91,11 +91,13 @@ _RECURRING_SEQUENCE: list[str] = [
   "balance-sheet equation check, advances closed_through. Use "
   "allow_stale_sync=true only when the user has verified QB is complete "
   "despite a stale sync — normally run sync-connection instead (see the "
-  "sync_stale step above). The call can outlive a client tool timeout "
-  "while the outbox publishes; the close is atomic server-side, so NEVER "
-  "retry on a timeout — verify with get-fiscal-calendar (period closed, "
-  "closed_through advanced) and reconstruct the receipt from "
-  "get-period-close-status.",
+  "sync_stale step above). The close runs on the worker, so a heavy month "
+  "can outlast the call: if you get status='in_progress' with an "
+  "operation_id, the close is already running and NEVER needs re-calling. "
+  "Poll get-period-close-status (period_status flips to closed and "
+  "close_receipt fills in) or get-fiscal-calendar (has_close_receipt) "
+  "every ~10s, then read the receipt. worker_started=false just means it "
+  "is queued behind a busy worker; the instruction is the same.",
   "Post-close verification — read the receipt back to the user, don't "
   "assume: entries_posted should equal the reviewed draft count "
   "(entries_published_to_qb / entries_posted_locally carry the split); "

--- a/robosystems/middleware/mcp/tools/schedule_tools.py
+++ b/robosystems/middleware/mcp/tools/schedule_tools.py
@@ -61,12 +61,17 @@ class GetPeriodCloseStatusTool:
 - At the start of a close session to see what's pending
 - After creating entries to verify progress
 - To generate a close summary for the user
+- To read the receipt after close-period — including when it handed back
+  `status: "in_progress"` and the close is still finishing on the worker
 
 **PARAMETERS:**
 - period_start / period_end (required): The fiscal period dates
 
 **RETURNS:**
 - Period status (open/closed)
+- close_receipt: what the close recorded about itself — entries posted, the
+  QuickBooks/local split, statements stamped, rule outcomes. Null while the
+  period is open, and for months closed before receipts were persisted
 - List of schedules with their status (pending/drafted/posted) and amounts
 - Count of draft and posted entries""",
       "inputSchema": {
@@ -102,6 +107,13 @@ class GetPeriodCloseStatusTool:
           "fiscal_period_start": response.fiscal_period_start.isoformat(),
           "fiscal_period_end": response.fiscal_period_end.isoformat(),
           "period_status": response.period_status,
+          # The record the close wrote about itself. Null while the period
+          # is open, and for months closed before receipts were persisted —
+          # both are real states, not failures. This is what an operator
+          # reads when the close outlived their client's patience.
+          "close_receipt": response.close_receipt.model_dump(mode="json")
+          if response.close_receipt
+          else None,
           "schedules": {
             "total": len(response.schedules),
             "pending": sum(1 for s in response.schedules if s.status == "pending"),

--- a/robosystems/operations/roboledger/fiscal_calendar/close_outcomes.py
+++ b/robosystems/operations/roboledger/fiscal_calendar/close_outcomes.py
@@ -1,0 +1,164 @@
+"""What a close says about itself, in one shape.
+
+The close has two callers that must describe it identically: the MCP tool,
+and the worker task the tool dispatches to. Their outcomes cannot be shaped
+independently — the tool returns whatever the task produced, so a divergence
+would mean the agent sees a different close depending on how fast the worker
+answered.
+
+It also settles a distinction the worker forces. A gate rejection ("this
+period has pending obligations") is an *outcome*, not a fault: it is the
+close correctly declining, and the operator needs the blockers to act on.
+The worker turns any raised exception into a plain string, so a rejection
+that propagated would arrive as `"CloseGateFailed(...)"` with the blockers
+gone. Everything a caller might reasonably act on is therefore shaped into a
+result here, and only genuine faults are left to raise.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from robosystems.models.api.extensions.fiscal_calendar import ClosePeriodResponse
+from robosystems.operations.locking import RowLockedError
+from robosystems.operations.roboledger.fiscal_calendar import (
+  CloseGateFailed,
+  FiscalCalendarError,
+  PeriodAlreadyClosedError,
+  PeriodNotFoundError,
+  UnbalancedLedgerError,
+)
+from robosystems.operations.roboledger.fiscal_calendar.close_service import (
+  WritebackFailed,
+)
+from robosystems.operations.roboledger.reports.statement_sets import StatementStampError
+
+# The exceptions that describe a close rather than a fault. Each maps to a
+# structured payload below; anything outside this tuple is a bug or an
+# infrastructure failure and should keep propagating.
+CLOSE_DOMAIN_ERRORS: tuple[type[Exception], ...] = (
+  CloseGateFailed,
+  PeriodNotFoundError,
+  PeriodAlreadyClosedError,
+  RowLockedError,
+  UnbalancedLedgerError,
+  WritebackFailed,
+  StatementStampError,
+  FiscalCalendarError,
+)
+
+
+def close_success_payload(
+  result: ClosePeriodResponse, *, has_sync_connection: bool
+) -> dict[str, Any]:
+  """The receipt an agent reads after a close lands."""
+  fiscal_calendar = result.fiscal_calendar.model_dump(mode="json")
+  # Not on the Pydantic response, but the agent needs it to reason about
+  # the sync gate on the next period.
+  fiscal_calendar["has_sync_connection"] = has_sync_connection
+  return {
+    "period": result.period,
+    "entries_posted": result.entries_posted,
+    "entries_published_to_qb": result.entries_published_to_qb,
+    "entries_posted_locally": result.entries_posted_locally,
+    "target_auto_advanced": result.target_auto_advanced,
+    "fiscal_calendar": fiscal_calendar,
+    # Rule outcomes from the auto-run on close, pairing with the REST
+    # response so agents and REST consumers see the same surface.
+    "rule_summary": result.rule_summary,
+    "evaluated_structure_ids": list(result.evaluated_structure_ids),
+    # Canonical statement stamping — without these keys an agent never
+    # learns that the close persisted the month's statements.
+    "statements_stamped": result.statements_stamped,
+    "statement_stamp_note": result.statement_stamp_note,
+    "stamped_statement_sets": dict(result.stamped_statement_sets),
+    "statement_rule_summary": result.statement_rule_summary,
+  }
+
+
+def close_error_payload(exc: Exception, *, period: str) -> dict[str, Any] | None:
+  """Describe a refused close, or return None if this is not one.
+
+  None means the exception is a fault rather than an outcome, and the
+  caller should let it propagate.
+  """
+  if isinstance(exc, CloseGateFailed):
+    return _gate_payload(exc, period=period)
+  if isinstance(exc, PeriodNotFoundError):
+    return {"error": "period_not_found", "message": str(exc)}
+  if isinstance(exc, PeriodAlreadyClosedError):
+    return {"error": "already_closed", "message": str(exc)}
+  if isinstance(exc, RowLockedError):
+    return {"error": "row_locked", "message": str(exc)}
+  if isinstance(exc, UnbalancedLedgerError):
+    return {
+      "error": "unbalanced",
+      "message": (
+        f"Balance sheet equation broken for period {period!r}: "
+        f"debits={exc.total_debit} credits={exc.total_credit}. "
+        "Review the ledger before closing."
+      ),
+    }
+  if isinstance(exc, WritebackFailed):
+    # The publish markers are committed before this raises, so a retry
+    # does not re-send what already reached QuickBooks.
+    return {
+      "error": "write_back_failed",
+      "message": (
+        f"{exc} The entries that did publish are recorded as published; "
+        "fix the rejected ones and re-run close-period."
+      ),
+      "failed_events": list(getattr(exc, "failed_events", []) or []),
+    }
+  if isinstance(exc, StatementStampError):
+    return {
+      "error": "statement_stamp_failed",
+      "message": (
+        f"{exc} The close rolled back — nothing was committed. Fix the "
+        "mapping/reporting configuration and re-run close-period."
+      ),
+    }
+  if isinstance(exc, FiscalCalendarError):
+    return {"error": "calendar_error", "message": str(exc)}
+  return None
+
+
+def _gate_payload(exc: CloseGateFailed, *, period: str) -> dict[str, Any]:
+  if exc.no_calendar:
+    return {
+      "error": "calendar_not_initialized",
+      "message": "Fiscal calendar not initialized for this graph.",
+    }
+  payload: dict[str, Any] = {
+    "error": "not_closeable",
+    "message": f"Cannot close period {period!r}.",
+    "blockers": exc.blockers,
+  }
+  # Each detail block rides only when its blocker fired, so the payload
+  # names what to go and fix rather than making the agent ask again.
+  if exc.gate.pending_obligation_count:
+    payload["pending_obligation_count"] = exc.gate.pending_obligation_count
+    payload["pending_obligation_sample"] = [
+      _obligation(detail) for detail in exc.gate.pending_obligation_sample
+    ]
+    payload["earliest_pending_period"] = exc.gate.earliest_pending_period
+  if exc.gate.stranded_obligation_count:
+    payload["stranded_obligation_count"] = exc.gate.stranded_obligation_count
+    payload["stranded_obligation_sample"] = [
+      _obligation(detail) for detail in exc.gate.stranded_obligation_sample
+    ]
+  if exc.gate.reconciling_item_count:
+    payload["reconciling_item_count"] = exc.gate.reconciling_item_count
+    payload["reconciling_item_sample"] = list(exc.gate.reconciling_item_sample)
+  if exc.gate.sync_stale_days is not None:
+    payload["sync_stale_days"] = exc.gate.sync_stale_days
+  return payload
+
+
+def _obligation(detail: Any) -> dict[str, Any]:
+  return {
+    "event_id": detail.event_id,
+    "schedule_id": detail.schedule_id,
+    "schedule_name": detail.schedule_name,
+    "period": detail.period,
+  }

--- a/robosystems/operations/roboledger/tasks/__init__.py
+++ b/robosystems/operations/roboledger/tasks/__init__.py
@@ -1,0 +1,19 @@
+"""Worker tasks for RoboLedger.
+
+Each task extends ``BaseTask`` and registers itself with ``@register_task`` so
+the worker consumer loop can dispatch it, mirroring
+:mod:`robosystems.operations.graph.tasks`. The business logic stays in
+``operations/``; the worker supplies only the infrastructure.
+"""
+
+# Imported for side effects: importing the module runs its @register_task.
+from robosystems.operations.roboledger.tasks import period_close as period_close
+
+
+def get_worker_components() -> dict[str, list[str]]:
+  """Return worker task types registered by this module."""
+  return {
+    "task_types": [
+      "period_close",
+    ],
+  }

--- a/robosystems/operations/roboledger/tasks/period_close.py
+++ b/robosystems/operations/roboledger/tasks/period_close.py
@@ -85,7 +85,11 @@ class PeriodCloseTask(BaseTask):
 
     period = self.params["period"]
     graph_id = self.graph_id
-    assert graph_id is not None  # every close is graph-scoped
+    if graph_id is None:
+      # BaseTask allows a graph-less task; a close is never one. Raising
+      # rather than asserting because `-O` strips asserts, and the failure
+      # this guards would otherwise be a confusing None in a session call.
+      raise ValueError("period_close requires a graph_id")
 
     service = FiscalCalendarService()
     with platform_session() as platform_db, extensions_session(graph_id) as session:

--- a/robosystems/operations/roboledger/tasks/period_close.py
+++ b/robosystems/operations/roboledger/tasks/period_close.py
@@ -1,0 +1,154 @@
+"""Worker task for period close.
+
+The close runs ~30 seconds on a real month — most of it one QuickBooks
+round-trip per draft — against a 25-second tool budget on the MCP surface.
+It always *completed*; the operator just stopped hearing about it, and then
+had to know not to retry a write that had already landed.
+
+Running it here decouples the work from the listener. The close itself is
+unchanged: same command, same exclusive period fence, same mid-flow commit
+of the publish markers. What changes is who waits.
+
+**A refused close is a result, not a failure.** The consumer reduces any
+raised exception to a plain string, so a gate rejection that propagated
+would reach the operator as text with its blockers stripped — the one part
+they need. Domain outcomes are therefore returned (shaped by
+``close_outcomes``), and only genuine faults are left to raise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from robosystems.logger import get_logger
+from robosystems.worker.tasks import register_task
+from robosystems.worker.tasks.base import BaseTask
+
+logger = get_logger(__name__)
+
+
+@register_task("period_close")
+class PeriodCloseTask(BaseTask):
+  """Close a fiscal period on the worker, reporting the outcome either way."""
+
+  async def execute(self) -> dict[str, Any]:
+    from robosystems.middleware.sse.event_storage import EventType
+
+    period = self.params["period"]
+
+    # Nothing else moves a worker operation off PENDING, and the tool's
+    # handback reads very differently for "queued behind a busy worker"
+    # than for "running now, do not retry".
+    await self.manager.event_storage.store_event(
+      self.task_id,
+      EventType.OPERATION_STARTED,
+      {
+        "operation_type": "period_close",
+        "graph_id": self.graph_id,
+        "period": period,
+      },
+    )
+    await self.report_progress(f"Closing {period}…", percent=5)
+
+    # The close is synchronous and blocks on QuickBooks, so it cannot run on
+    # the event loop the consumer uses to emit progress.
+    result = await asyncio.to_thread(self._run_close)
+
+    outcome = result.get("outcome")
+    await self.report_progress(
+      f"Close {'completed' if outcome == 'closed' else 'refused'} for {period}.",
+      percent=100,
+    )
+    return result
+
+  def _run_close(self) -> dict[str, Any]:
+    from robosystems.db.extensions import extensions_session
+    from robosystems.db.platform import platform_session
+    from robosystems.models.extensions.roboledger.fiscal_period import FiscalPeriod
+    from robosystems.operations.roboledger.commands.fiscal_calendar import (
+      close_period as cmd_close_period,
+    )
+    from robosystems.operations.roboledger.fiscal_calendar import (
+      FiscalCalendarService,
+      PeriodAlreadyClosedError,
+    )
+    from robosystems.operations.roboledger.fiscal_calendar.close_outcomes import (
+      CLOSE_DOMAIN_ERRORS,
+      close_error_payload,
+      close_success_payload,
+    )
+    from robosystems.operations.roboledger.fiscal_calendar.close_service import (
+      PeriodCloseService,
+    )
+    from robosystems.operations.roboledger.reads.fiscal_calendar import qb_sync_state
+
+    period = self.params["period"]
+    graph_id = self.graph_id
+    assert graph_id is not None  # every close is graph-scoped
+
+    service = FiscalCalendarService()
+    with platform_session() as platform_db, extensions_session(graph_id) as session:
+      try:
+        result = cmd_close_period(
+          session,
+          platform_db,
+          graph_id,
+          period,
+          actor_id=self.params.get("actor_id") or self.user_id,
+          allow_stale_sync=bool(self.params.get("allow_stale_sync", False)),
+          note=self.params.get("note"),
+          service=service,
+          close_service=PeriodCloseService(service),
+          actor_type=self.params.get("actor_type", "agent"),
+          allow_stranded_obligations=bool(
+            self.params.get("allow_stranded_obligations", False)
+          ),
+          allow_reconciling_items=bool(
+            self.params.get("allow_reconciling_items", False)
+          ),
+        )
+      except CLOSE_DOMAIN_ERRORS as exc:
+        payload = close_error_payload(exc, period=period)
+        if payload is None:  # pragma: no cover - CLOSE_DOMAIN_ERRORS covers these
+          raise
+        payload["outcome"] = "rejected"
+        payload["operation_id"] = self.task_id
+        # A close that already landed can be re-queued by the stalled-task
+        # reaper, which measures age from enqueue rather than from start.
+        # Reporting only "already closed" would describe a successful close
+        # as a refusal, so hand back the receipt it wrote.
+        if _is_already_closed(exc, PeriodAlreadyClosedError):
+          receipt = (
+            session.query(FiscalPeriod.close_receipt)
+            .filter(
+              FiscalPeriod.graph_id == graph_id,
+              FiscalPeriod.name == period,
+            )
+            .scalar()
+          )
+          if receipt:
+            payload["close_receipt"] = receipt
+        logger.info(
+          "period_close refused for %s %s: %s",
+          graph_id,
+          period,
+          payload.get("error"),
+        )
+        return payload
+
+      has_sync, _last_sync_at = qb_sync_state(platform_db, graph_id)
+
+    return {
+      **close_success_payload(result, has_sync_connection=has_sync),
+      "outcome": "closed",
+      "operation_id": self.task_id,
+    }
+
+
+def _is_already_closed(exc: Exception, already_closed_type: type[Exception]) -> bool:
+  """Whether this refusal means the period is closed rather than uncloseable."""
+  if isinstance(exc, already_closed_type):
+    return True
+  blockers = getattr(getattr(exc, "gate", None), "blockers", None) or []
+  return "period_already_closed" in blockers

--- a/robosystems/worker/__init__.py
+++ b/robosystems/worker/__init__.py
@@ -13,6 +13,7 @@ Task registration happens via side-effect imports at module load time:
 # These are imported for side effects only (registration).
 import robosystems.operations.graph.tasks as graph_tasks  # noqa: F401
 import robosystems.operations.operators.adapters.worker_task as worker_task  # noqa: F401
+import robosystems.operations.roboledger.tasks as roboledger_tasks  # noqa: F401
 import robosystems.worker.tasks.dagster_monitoring as dagster_monitoring  # noqa: F401
 from robosystems.worker.tasks import load_adapter_tasks
 

--- a/robosystems/worker/constants.py
+++ b/robosystems/worker/constants.py
@@ -47,6 +47,15 @@ TASK_TIMEOUTS: dict[str, int] = {
   # mid-flight. 900 covers those waits plus snapshot, ASG capacity, and
   # verification, with headroom.
   "graph_tier_upgrade": 900,  # 15 minutes
+  # The close publishes one QuickBooks entry per in-period draft, and the
+  # Intuit SDK sets no per-request timeout — a single call that hits the
+  # retry ladder backs off ~31s on its own. A 34-entry month runs ~30s;
+  # a heavier one, or one slow call, runs much longer. The failure mode
+  # decides the size: an under-budget close is cancelled mid-flight while
+  # its thread keeps running and can still commit, so the operation reports
+  # FAILED for a close that landed. Matching the operator's 600s leaves room
+  # for that rather than inviting it.
+  "period_close": 600,  # 10 minutes
 }
 DEFAULT_TASK_TIMEOUT = 120  # 2 minutes
 

--- a/tests/middleware/mcp/tools/test_fiscal_calendar_tools.py
+++ b/tests/middleware/mcp/tools/test_fiscal_calendar_tools.py
@@ -338,6 +338,45 @@ class TestClosePeriodToolHandback:
     assert "get-period-close-status" in result["message"]
 
   @pytest.mark.asyncio
+  async def test_a_dispatch_that_never_happened_is_the_one_safe_retry(self):
+    """Every other message this tool returns says not to re-run the close.
+    This one has to say the opposite, because nothing was queued and nothing
+    was written — and getting that backwards either strands the period or
+    invites a second close."""
+    tool = ClosePeriodTool(_client(user_id="usr_abc"))
+    enqueue = AsyncMock(side_effect=ConnectionError("queue unavailable"))
+
+    with (
+      patch.object(ClosePeriodTool, "_gate_check", return_value=None),
+      patch("robosystems.worker.client.enqueue_task", enqueue),
+    ):
+      result = await tool.execute({"period": "2026-01"})
+
+    assert result["error"] == "dispatch_failed"
+    assert "has NOT" in result["message"]
+    assert "Retry" in result["message"]
+    # No operation id, because there is no operation to look up.
+    assert "operation_id" not in result
+
+  @pytest.mark.asyncio
+  async def test_losing_sight_of_a_running_close_does_not_invite_a_retry(self):
+    """By the time polling fails the close is already running. A reporting
+    failure must not be reported as a reason to do it again."""
+    tool = ClosePeriodTool(_client(user_id="usr_abc"))
+
+    class _Broken:
+      async def get_operation_metadata(self, operation_id):
+        raise ConnectionError("event storage unavailable")
+
+    with _patch_dispatch(_Broken()):
+      result = await tool.execute({"period": "2026-01"})
+
+    assert result["status"] == "in_progress"
+    assert result["operation_id"] == "op_close_1"
+    assert "error" not in result
+    assert "get-period-close-status" in result["message"]
+
+  @pytest.mark.asyncio
   async def test_a_cancelled_operation_says_so(self):
     tool = ClosePeriodTool(_client(user_id="usr_abc"))
     storage = _Storage((OperationStatus.CANCELLED, None))

--- a/tests/middleware/mcp/tools/test_fiscal_calendar_tools.py
+++ b/tests/middleware/mcp/tools/test_fiscal_calendar_tools.py
@@ -1,23 +1,23 @@
 """Unit tests for the fiscal calendar MCP tools.
 
-Focus is on ClosePeriodTool — it's the thinnest wrapper over
-PeriodCloseService but the one most likely to drift from the REST path.
-We verify:
+Focus is on ClosePeriodTool, which no longer runs the close itself: it
+dispatches to the worker and waits inside the tool budget. So what is tested
+here is the dispatch and the handback — the arguments that reach the task,
+the receipt coming back untouched, and what the operator is told when the
+close outlives the call.
 
-- Happy path delegates to ops `close_period` with the expected arguments
-- All domain errors map to the right MCP error shape
-- actor_id falls back to "mcp:{graph_id}" when the client has no user identity
-
-Mocks live at the **operations layer boundary** (`ops_close_period`) — the
-MCP tool is now a thin shim that translates exceptions and re-shapes the
-response. Tests against mocked SQLAlchemy internals would only re-test what
-`tests/operations/roboledger/fiscal_calendar/` already covers.
+The outcome *shapes* moved with the shaping, to
+`tests/operations/roboledger/fiscal_calendar/test_close_outcomes.py`, and the
+task's own behaviour lives in `tests/operations/roboledger/tasks/`. Keeping
+them apart is what stops this file re-asserting a payload it no longer
+builds.
 """
 
 from __future__ import annotations
 
 from contextlib import contextmanager
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -27,6 +27,7 @@ from robosystems.middleware.mcp.tools.fiscal_calendar_tools import (
   ClosePeriodTool,
   ReopenPeriodTool,
 )
+from robosystems.middleware.sse.event_storage import OperationStatus
 from robosystems.models.api.extensions.fiscal_calendar import (
   BackfillPeriodOutcome,
   BackfillPlanHistoryResponse,
@@ -36,17 +37,6 @@ from robosystems.models.api.extensions.fiscal_calendar import (
 from robosystems.operations.roboledger.commands.fiscal_calendar import (
   BackfillPreconditionError,
   ReopenPeriodResult,
-)
-from robosystems.operations.roboledger.fiscal_calendar import (
-  CloseGateFailed,
-  PeriodNotFoundError,
-  UnbalancedLedgerError,
-)
-from robosystems.operations.roboledger.fiscal_calendar.service import (
-  CloseableGateResult,
-)
-from robosystems.operations.roboledger.reports.statement_sets import (
-  StatementStampError,
 )
 
 MODULE = "robosystems.middleware.mcp.tools.fiscal_calendar_tools"
@@ -122,271 +112,240 @@ def _close_response(**overrides) -> ClosePeriodResponse:
 
 
 # ────────────────────────────────────────────────────────────────────────────
-# Happy path
+# close-period — dispatch and poll
 # ────────────────────────────────────────────────────────────────────────────
 
 
-class TestClosePeriodToolHappyPath:
-  @pytest.mark.asyncio
-  async def test_delegates_to_ops_layer(self):
-    tool = ClosePeriodTool(_client(user_id="usr_abc"))
-    response = _close_response(entries_posted=5)
+class _Storage:
+  """Event storage returning a scripted sequence of operation states.
 
-    with (
-      _patch_sessions(),
-      patch(f"{MODULE}.ops_close_period", return_value=response) as ops,
-    ):
+  The last state repeats: an operation that is still running stays running
+  however many times it is polled, and a script that ran dry would otherwise
+  read as "no such operation".
+  """
+
+  def __init__(self, *states):
+    self._states = list(states)
+
+  async def get_operation_metadata(self, operation_id):
+    if not self._states:
+      return None
+    state = self._states.pop(0) if len(self._states) > 1 else self._states[0]
+    if state is None:
+      return None
+    status, payload = state
+    return SimpleNamespace(
+      operation_id=operation_id,
+      status=status,
+      result_data=payload if status is OperationStatus.COMPLETED else None,
+      error_message=payload if status is OperationStatus.FAILED else None,
+    )
+
+
+@contextmanager
+def _patch_dispatch(storage, *, deduplicated=False, gate=None):
+  """Patch the tool's dispatch path: gate check, enqueue, and polling."""
+  enqueue = AsyncMock(
+    return_value={"operation_id": "op_close_1", "deduplicated": deduplicated}
+  )
+  with (
+    patch.object(ClosePeriodTool, "_gate_check", return_value=gate),
+    patch("robosystems.worker.client.enqueue_task", enqueue),
+    patch(
+      "robosystems.middleware.sse.event_storage.get_event_storage",
+      return_value=storage,
+    ),
+  ):
+    yield enqueue
+
+
+def _receipt(**overrides) -> dict:
+  payload = {
+    "outcome": "closed",
+    "operation_id": "op_close_1",
+    "period": "2026-01",
+    "entries_posted": 5,
+    "entries_published_to_qb": 4,
+    "entries_posted_locally": 1,
+    "target_auto_advanced": False,
+    "fiscal_calendar": {"closed_through": "2026-01", "has_sync_connection": True},
+    "rule_summary": None,
+    "evaluated_structure_ids": [],
+    "statements_stamped": True,
+    "statement_stamp_note": None,
+    "stamped_statement_sets": {},
+    "statement_rule_summary": None,
+  }
+  payload.update(overrides)
+  return payload
+
+
+class TestClosePeriodToolDispatch:
+  @pytest.mark.asyncio
+  async def test_a_close_that_lands_in_budget_returns_its_receipt(self):
+    """The tool hands back what the task produced, untouched — the receipt
+    must not depend on how quickly the worker answered."""
+    tool = ClosePeriodTool(_client(user_id="usr_abc"))
+    storage = _Storage((OperationStatus.COMPLETED, _receipt()))
+
+    with _patch_dispatch(storage) as enqueue:
       result = await tool.execute({"period": "2026-01"})
 
     assert result["period"] == "2026-01"
     assert result["entries_posted"] == 5
-    assert result["target_auto_advanced"] is False
-    assert "fiscal_calendar" in result
-    assert "has_sync_connection" in result["fiscal_calendar"]
-    assert ops.call_count == 1
-    call = ops.call_args
-    assert call.kwargs["actor_id"] == "usr_abc"
-    assert call.kwargs["actor_type"] == "agent"
-    assert call.kwargs["allow_stale_sync"] is False
-
-  @pytest.mark.asyncio
-  async def test_response_includes_rule_summary_and_evaluated_structure_ids(self):
-    """The MCP close-period response must carry the same rule eval
-    fields the REST ClosePeriodResponse exposes so agents can report
-    which schedule rules passed / failed after a close."""
-    tool = ClosePeriodTool(_client(user_id="usr_abc"))
-    response = _close_response(
-      rule_summary={"pass": 3, "fail": 0, "error": 0, "skipped": 0},
-      evaluated_structure_ids=["struct_dep", "struct_amort"],
-    )
-
-    with (
-      _patch_sessions(),
-      patch(f"{MODULE}.ops_close_period", return_value=response),
-    ):
-      result = await tool.execute({"period": "2026-01"})
-
-    assert result["rule_summary"] == {
-      "pass": 3,
-      "fail": 0,
-      "error": 0,
-      "skipped": 0,
-    }
-    assert result["evaluated_structure_ids"] == ["struct_dep", "struct_amort"]
-
-  @pytest.mark.asyncio
-  async def test_response_handles_null_rule_summary(self):
-    """No schedules with facts in the period → rule_summary is None,
-    evaluated_structure_ids is an empty list. The MCP shape stays stable."""
-    tool = ClosePeriodTool(_client(user_id="usr_abc"))
-    response = _close_response()  # rule_summary defaults to None
-
-    with (
-      _patch_sessions(),
-      patch(f"{MODULE}.ops_close_period", return_value=response),
-    ):
-      result = await tool.execute({"period": "2026-01"})
-
-    assert result["rule_summary"] is None
-    assert result["evaluated_structure_ids"] == []
-
-  @pytest.mark.asyncio
-  async def test_response_includes_statement_stamp_fields(self):
-    """The close-time stamping outcome must reach agents — the MCP dict
-    is shaped by hand, so these keys are pinned explicitly."""
-    tool = ClosePeriodTool(_client(user_id="usr_abc"))
-    response = _close_response(
-      statements_stamped=True,
-      statement_stamp_note=None,
-      stamped_statement_sets={"struct_bs": "fs_bs", "struct_is": "fs_is"},
-      statement_rule_summary={"pass": 5, "fail": 0, "error": 0, "skipped": 1},
-    )
-
-    with (
-      _patch_sessions(),
-      patch(f"{MODULE}.ops_close_period", return_value=response),
-    ):
-      result = await tool.execute({"period": "2026-01"})
-
     assert result["statements_stamped"] is True
-    assert result["statement_stamp_note"] is None
-    assert result["stamped_statement_sets"] == {
-      "struct_bs": "fs_bs",
-      "struct_is": "fs_is",
-    }
-    assert result["statement_rule_summary"] == {
-      "pass": 5,
-      "fail": 0,
-      "error": 0,
-      "skipped": 1,
-    }
+    assert result["fiscal_calendar"]["has_sync_connection"] is True
+    assert enqueue.await_count == 1
 
   @pytest.mark.asyncio
-  async def test_response_soft_skip_note_surfaces(self):
+  async def test_the_close_is_dispatched_with_the_arguments_it_was_given(self):
     tool = ClosePeriodTool(_client(user_id="usr_abc"))
-    response = _close_response(
-      statements_stamped=False, statement_stamp_note="no_coa_mapping"
-    )
+    storage = _Storage((OperationStatus.COMPLETED, _receipt()))
 
-    with (
-      _patch_sessions(),
-      patch(f"{MODULE}.ops_close_period", return_value=response),
-    ):
+    with _patch_dispatch(storage) as enqueue:
+      await tool.execute(
+        {
+          "period": "2026-01",
+          "allow_stale_sync": True,
+          "allow_reconciling_items": True,
+          "note": "verified",
+        }
+      )
+
+    kwargs = enqueue.await_args.kwargs
+    assert kwargs["task_type"] == "period_close"
+    assert kwargs["graph_id"] == GRAPH_ID
+    # A real user id: the operation is readable only by the user it was
+    # created for, so a sentinel would enqueue work nobody could look up.
+    assert kwargs["user_id"] == "usr_abc"
+    params = kwargs["params"]
+    assert params["period"] == "2026-01"
+    assert params["actor_type"] == "agent"
+    assert params["actor_id"] == "usr_abc"
+    assert params["allow_stale_sync"] is True
+    assert params["allow_reconciling_items"] is True
+    assert params["allow_stranded_obligations"] is False
+    assert params["note"] == "verified"
+
+  @pytest.mark.asyncio
+  async def test_a_refused_close_reaches_the_caller_as_the_task_shaped_it(self):
+    """A gate rejection is a completed operation carrying a refusal, not a
+    failed one — the blockers have to survive the trip."""
+    tool = ClosePeriodTool(_client(user_id="usr_abc"))
+    refusal = {
+      "outcome": "rejected",
+      "error": "not_closeable",
+      "blockers": ["reconciling_items"],
+      "reconciling_item_count": 11,
+    }
+    storage = _Storage((OperationStatus.COMPLETED, refusal))
+
+    with _patch_dispatch(storage):
       result = await tool.execute({"period": "2026-01"})
 
-    assert result["statements_stamped"] is False
-    assert result["statement_stamp_note"] == "no_coa_mapping"
-    assert result["stamped_statement_sets"] == {}
+    assert result["error"] == "not_closeable"
+    assert result["reconciling_item_count"] == 11
 
   @pytest.mark.asyncio
-  async def test_actor_id_falls_back_to_graph_scoped_sentinel(self):
-    """When the MCP client has no user_id, fall back to mcp:{graph_id}
-    so audit logs stay traceable per tenant (matches ReopenPeriodTool)."""
+  async def test_without_a_user_nothing_is_dispatched(self):
     tool = ClosePeriodTool(_client(user_id=None))
+    storage = _Storage()
 
-    with (
-      _patch_sessions(),
-      patch(f"{MODULE}.ops_close_period", return_value=_close_response()) as ops,
-    ):
-      await tool.execute({"period": "2026-01"})
+    with _patch_dispatch(storage) as enqueue:
+      result = await tool.execute({"period": "2026-01"})
 
-    call = ops.call_args
-    assert call.kwargs["actor_id"] == f"mcp:{GRAPH_ID}"
+    assert result["error"] == "authentication_required"
+    assert enqueue.await_count == 0
 
   @pytest.mark.asyncio
-  async def test_allow_stale_sync_flag_propagates(self):
+  async def test_an_uncloseable_period_is_answered_without_a_worker(self):
+    """The task re-runs the gate authoritatively; this only spares the
+    operator a dispatch and a poll to learn something already knowable."""
     tool = ClosePeriodTool(_client(user_id="usr_abc"))
+    storage = _Storage()
+    gate_answer = {"error": "not_closeable", "blockers": ["sequence_violation"]}
 
-    with (
-      _patch_sessions(),
-      patch(f"{MODULE}.ops_close_period", return_value=_close_response()) as ops,
-    ):
-      await tool.execute({"period": "2026-01", "allow_stale_sync": True})
+    with _patch_dispatch(storage, gate=gate_answer) as enqueue:
+      result = await tool.execute({"period": "2026-05"})
 
-    call = ops.call_args
-    assert call.kwargs["allow_stale_sync"] is True
-
-
-# ────────────────────────────────────────────────────────────────────────────
-# Error translation
-# ────────────────────────────────────────────────────────────────────────────
+    assert result == gate_answer
+    assert enqueue.await_count == 0
 
 
-class TestClosePeriodToolErrors:
-  async def _run_with_side_effect(self, side_effect):
+class TestClosePeriodToolHandback:
+  """What the operator is told when the close outlives the call."""
+
+  @pytest.mark.asyncio
+  async def test_a_running_close_is_handed_back_with_where_to_look(self):
     tool = ClosePeriodTool(_client(user_id="usr_abc"))
-    with (
-      _patch_sessions(),
-      patch(f"{MODULE}.ops_close_period", side_effect=side_effect),
-    ):
-      return await tool.execute({"period": "2026-03"})
+    tool.POLL_INTERVAL_S = 0
+    tool.POLL_BUDGET_S = 0.01
+    storage = _Storage((OperationStatus.RUNNING, None))
+
+    with _patch_dispatch(storage):
+      result = await tool.execute({"period": "2026-01"})
+
+    assert result["status"] == "in_progress"
+    assert result["operation_id"] == "op_close_1"
+    assert result["worker_started"] is True
+    # The instruction that matters: the close is atomic and already running.
+    assert "NEVER call close-period again" in result["message"]
+    assert "get-period-close-status" in result["message"]
 
   @pytest.mark.asyncio
-  async def test_gate_failed_returns_not_closeable(self):
-    result = await self._run_with_side_effect(
-      CloseGateFailed(
-        CloseableGateResult(is_closeable=False, blockers=[CloseableGateResult.SEQUENCE])
-      )
-    )
-    assert result["error"] == "not_closeable"
-    assert CloseableGateResult.SEQUENCE in result["blockers"]
-
-  @pytest.mark.asyncio
-  async def test_no_calendar_returns_calendar_not_initialized(self):
-    result = await self._run_with_side_effect(
-      CloseGateFailed(
-        CloseableGateResult(
-          is_closeable=False, blockers=[CloseableGateResult.NO_CALENDAR]
-        )
-      )
-    )
-    assert result["error"] == "calendar_not_initialized"
-
-  @pytest.mark.asyncio
-  async def test_pending_obligations_enriches_detail(self):
-    """pending_obligations blocker surfaces count + sample +
-    earliest_pending_period on the close-period response."""
-    from robosystems.operations.roboledger.fiscal_calendar.service import (
-      PendingObligationDetail,
-    )
-
-    result = await self._run_with_side_effect(
-      CloseGateFailed(
-        CloseableGateResult(
-          is_closeable=False,
-          blockers=[CloseableGateResult.PENDING_OBLIGATIONS],
-          pending_obligation_count=3,
-          pending_obligation_sample=[
-            PendingObligationDetail(
-              event_id="evt_1",
-              schedule_id="struct_dep",
-              schedule_name="Computer Depreciation",
-              period="2026-04",
-            ),
-          ],
-          earliest_pending_period="2026-04",
-        )
-      )
-    )
-    assert result["error"] == "not_closeable"
-    assert result["pending_obligation_count"] == 3
-    assert result["pending_obligation_sample"][0]["schedule_name"] == (
-      "Computer Depreciation"
-    )
-    assert result["earliest_pending_period"] == "2026-04"
-    assert "sync_stale_days" not in result  # only populated when sync blocker active
-
-  @pytest.mark.asyncio
-  async def test_period_not_found_error(self):
-    result = await self._run_with_side_effect(PeriodNotFoundError("2026-03"))
-    assert result["error"] == "period_not_found"
-
-  @pytest.mark.asyncio
-  async def test_unbalanced_ledger_error(self):
-    result = await self._run_with_side_effect(
-      UnbalancedLedgerError(total_debit=1000, total_credit=900)
-    )
-    assert result["error"] == "unbalanced"
-    assert "1000" in result["message"]
-    assert "900" in result["message"]
-
-  @pytest.mark.asyncio
-  async def test_already_closed_error(self):
-    from robosystems.operations.roboledger.fiscal_calendar import (
-      PeriodAlreadyClosedError,
-    )
-
-    result = await self._run_with_side_effect(PeriodAlreadyClosedError("2026-03"))
-    assert result["error"] == "already_closed"
-
-  @pytest.mark.asyncio
-  async def test_row_locked_error(self):
-    from robosystems.operations.locking import RowLockedError
-
-    result = await self._run_with_side_effect(
-      RowLockedError("Period 2026-03 is being closed")
-    )
-    assert result["error"] == "row_locked"
-
-
-class TestStatementStampErrorTranslation:
-  @pytest.mark.asyncio
-  async def test_statement_stamp_failed_error_shape(self):
-    """A stamp hard-fail rolled the close back — the MCP error must say
-    so and encourage a retry after fixing the reporting config."""
+  async def test_a_queued_close_says_so_rather_than_claiming_to_be_running(self):
+    """'Queued behind a busy worker' and 'running now' need different
+    words — the operator's next question is whether anything is happening."""
     tool = ClosePeriodTool(_client(user_id="usr_abc"))
-    with (
-      _patch_sessions(),
-      patch(
-        f"{MODULE}.ops_close_period",
-        side_effect=StatementStampError("pivot failed for 2026-03"),
-      ),
-    ):
-      result = await tool.execute({"period": "2026-03"})
+    tool.POLL_INTERVAL_S = 0
+    tool.POLL_BUDGET_S = 0.01
+    storage = _Storage((OperationStatus.PENDING, None))
 
-    assert result["error"] == "statement_stamp_failed"
-    assert "rolled back" in result["message"]
-    assert "pivot failed for 2026-03" in result["message"]
+    with _patch_dispatch(storage):
+      result = await tool.execute({"period": "2026-01"})
+
+    assert result["status"] == "in_progress"
+    assert result["worker_started"] is False
+    assert "has not started yet" in result["message"]
+    assert "do not re-dispatch" in result["message"]
+
+  @pytest.mark.asyncio
+  async def test_a_deduplicated_dispatch_is_disclosed(self):
+    """Two identical calls inside the dedup window share one operation;
+    saying so stops the agent inferring a second close is running."""
+    tool = ClosePeriodTool(_client(user_id="usr_abc"))
+    tool.POLL_INTERVAL_S = 0
+    tool.POLL_BUDGET_S = 0.01
+    storage = _Storage((OperationStatus.RUNNING, None))
+
+    with _patch_dispatch(storage, deduplicated=True):
+      result = await tool.execute({"period": "2026-01"})
+
+    assert result["deduplicated"] is True
+
+  @pytest.mark.asyncio
+  async def test_a_failed_operation_warns_the_close_may_still_have_landed(self):
+    """The worker's timeout cancels the coroutine, not the thread doing the
+    QuickBooks publish — so a FAILED close can still commit afterwards."""
+    tool = ClosePeriodTool(_client(user_id="usr_abc"))
+    storage = _Storage((OperationStatus.FAILED, "Task timed out after 600s"))
+
+    with _patch_dispatch(storage):
+      result = await tool.execute({"period": "2026-01"})
+
+    assert result["error"] == "close_failed"
+    assert "may still have landed" in result["message"]
+    assert "get-period-close-status" in result["message"]
+
+  @pytest.mark.asyncio
+  async def test_a_cancelled_operation_says_so(self):
+    tool = ClosePeriodTool(_client(user_id="usr_abc"))
+    storage = _Storage((OperationStatus.CANCELLED, None))
+
+    with _patch_dispatch(storage):
+      result = await tool.execute({"period": "2026-01"})
+
+    assert result["error"] == "cancelled"
 
 
 class TestReopenPeriodToolResult:
@@ -408,31 +367,6 @@ class TestReopenPeriodToolResult:
 
 
 # ────────────────────────────────────────────────────────────────────────────
-# Re-close routing (end-to-end through the ops stub)
-# ────────────────────────────────────────────────────────────────────────────
-
-
-class TestClosePeriodToolRecloseRouting:
-  """The tool doesn't surface `was_reclose` directly, but a successful
-  re-close call must round-trip through the wrapper unchanged."""
-
-  @pytest.mark.asyncio
-  async def test_reclose_round_trips(self):
-    tool = ClosePeriodTool(_client(user_id="usr_abc"))
-    with (
-      _patch_sessions(),
-      patch(
-        f"{MODULE}.ops_close_period", return_value=_close_response(entries_posted=0)
-      ) as ops,
-    ):
-      result = await tool.execute({"period": "2026-01"})
-
-    ops.assert_called_once()
-    assert "period" in result
-    assert result["entries_posted"] == 0
-
-
-# ────────────────────────────────────────────────────────────────────────────
 # Extension gate — ClosePeriod / ReopenPeriod both reject pre-DB
 # ────────────────────────────────────────────────────────────────────────────
 
@@ -443,7 +377,10 @@ class TestFiscalCalendarGate:
 
   @pytest.mark.asyncio
   async def test_close_rejects_on_repo_graph(self):
+    """The refusal has to come before the dispatch, not after — otherwise a
+    forbidden close still occupies a worker slot to be told no."""
     tool = ClosePeriodTool(_client(user_id="usr_abc"))
+    enqueue = AsyncMock()
     with (
       patch(
         f"{MODULE}.require_graph_extension_mcp",
@@ -452,12 +389,14 @@ class TestFiscalCalendarGate:
           "roboledger commands are not available on repository graphs",
         ),
       ),
-      patch(f"{MODULE}.ops_close_period") as ops,
+      patch(f"{MODULE}.extensions_session"),
+      patch(f"{MODULE}._platform_session"),
+      patch("robosystems.worker.client.enqueue_task", enqueue),
     ):
       result = await tool.execute({"period": "2026-03"})
 
     assert result["error"] == "repository_write_forbidden"
-    ops.assert_not_called()
+    enqueue.assert_not_awaited()
 
   @pytest.mark.asyncio
   async def test_reopen_rejects_on_unprovisioned_graph(self):

--- a/tests/middleware/mcp/tools/test_schedule_tools.py
+++ b/tests/middleware/mcp/tools/test_schedule_tools.py
@@ -19,7 +19,7 @@ thin shims that build arguments, call into `operations/roboledger/reads/
 from __future__ import annotations
 
 from contextlib import contextmanager
-from datetime import date
+from datetime import UTC, date, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -109,6 +109,53 @@ class TestGetPeriodCloseStatusTool:
     assert result["period_status"] == "open"
     assert result["schedules"]["total"] == 1
     assert result["schedules"]["pending"] == 1
+    # An open period has no receipt, and saying so is the answer rather
+    # than an omission — this is the key an operator polls after a close
+    # hands back `in_progress`.
+    assert result["close_receipt"] is None
+
+  @pytest.mark.asyncio
+  async def test_the_close_receipt_reaches_the_wire(self, mock_graph_client):
+    """This tool is where the playbook sends an operator whose close
+    outlived their client. The receipt was on the ops response and absent
+    from the returned dict, so the instruction pointed at nothing."""
+    from robosystems.models.api.extensions.schedules import CloseReceiptResponse
+
+    receipt = CloseReceiptResponse(
+      version=1,
+      period="2026-01",
+      closed_at=datetime(2026, 2, 1, 3, 35, tzinfo=UTC),
+      closed_by="user_abc",
+      actor_type="agent",
+      was_reclose=False,
+      entries_posted=34,
+      entries_published_to_qb=31,
+      entries_posted_locally=3,
+      target_auto_advanced=True,
+      statements_stamped=True,
+    )
+    response = PeriodCloseStatusResponse(
+      fiscal_period_start=date(2026, 1, 1),
+      fiscal_period_end=date(2026, 1, 31),
+      period_status="closed",
+      schedules=[],
+      total_draft=0,
+      total_posted=34,
+      close_receipt=receipt,
+    )
+    tool = GetPeriodCloseStatusTool(mock_graph_client)
+    with (
+      _patch_session(),
+      patch(f"{MODULE}.ops_get_period_close_status", return_value=response),
+    ):
+      result = await tool.execute(
+        {"period_start": "2026-01-01", "period_end": "2026-01-31"}
+      )
+
+    assert result["period_status"] == "closed"
+    assert result["close_receipt"]["entries_posted"] == 34
+    assert result["close_receipt"]["entries_published_to_qb"] == 31
+    assert result["close_receipt"]["statements_stamped"] is True
 
   @pytest.mark.asyncio
   async def test_includes_reversal_fields(self, mock_graph_client):

--- a/tests/operations/roboledger/fiscal_calendar/test_close_outcomes.py
+++ b/tests/operations/roboledger/fiscal_calendar/test_close_outcomes.py
@@ -1,0 +1,263 @@
+"""How a close describes itself, refused or not.
+
+These assertions used to live against the MCP tool, which shaped its own
+outcomes inline. They moved when the close gained a second caller: the tool
+now returns whatever the worker task produced, so the shaping has one home
+and both paths describe the same close identically.
+
+What matters in each case is that the payload carries the part an operator
+can act on — the blockers, the entries that failed to publish, the amounts
+that did not balance — rather than a message they can only read.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robosystems.models.api.extensions.fiscal_calendar import (
+  ClosePeriodResponse,
+  FiscalCalendarResponse,
+)
+from robosystems.operations.locking import RowLockedError
+from robosystems.operations.roboledger.fiscal_calendar import (
+  CloseGateFailed,
+  FiscalCalendarError,
+  PeriodAlreadyClosedError,
+  PeriodNotFoundError,
+  UnbalancedLedgerError,
+)
+from robosystems.operations.roboledger.fiscal_calendar.close_outcomes import (
+  CLOSE_DOMAIN_ERRORS,
+  close_error_payload,
+  close_success_payload,
+)
+from robosystems.operations.roboledger.fiscal_calendar.close_service import (
+  WritebackFailed,
+)
+from robosystems.operations.roboledger.fiscal_calendar.service import (
+  CloseableGateResult,
+  PendingObligationDetail,
+)
+from robosystems.operations.roboledger.reports.statement_sets import StatementStampError
+
+pytestmark = pytest.mark.unit
+
+GRAPH_ID = "kg01234567890abcdef"
+
+
+def _response(**overrides) -> ClosePeriodResponse:
+  calendar = FiscalCalendarResponse(
+    graph_id=GRAPH_ID,
+    fiscal_year_start_month=1,
+    closed_through="2026-07",
+    close_target="2026-08",
+    gap_periods=1,
+    catch_up_sequence=["2026-08"],
+    closeable_now=True,
+    blockers=[],
+    last_close_at=None,
+    initialized_at=None,
+    last_sync_at=None,
+    periods=[],
+  )
+  defaults: dict = {
+    "fiscal_calendar": calendar,
+    "period": "2026-07",
+    "entries_posted": 34,
+    "target_auto_advanced": True,
+  }
+  defaults.update(overrides)
+  return ClosePeriodResponse(**defaults)
+
+
+class TestSuccessPayload:
+  def test_it_carries_the_numbers_an_operator_reports_back(self):
+    payload = close_success_payload(
+      _response(entries_published_to_qb=31, entries_posted_locally=3),
+      has_sync_connection=True,
+    )
+
+    assert payload["period"] == "2026-07"
+    assert payload["entries_posted"] == 34
+    assert payload["entries_published_to_qb"] == 31
+    assert payload["entries_posted_locally"] == 3
+    assert payload["target_auto_advanced"] is True
+
+  def test_the_calendar_says_whether_a_sync_gate_applies_next_time(self):
+    """Not on the Pydantic response, so it has to be added here or the
+    agent cannot reason about the next period's sync blocker."""
+    payload = close_success_payload(_response(), has_sync_connection=True)
+    assert payload["fiscal_calendar"]["has_sync_connection"] is True
+
+    payload = close_success_payload(_response(), has_sync_connection=False)
+    assert payload["fiscal_calendar"]["has_sync_connection"] is False
+
+  def test_statement_stamping_is_visible(self):
+    """Without these keys an agent never learns the close persisted the
+    month's statements, which is most of what the close is for."""
+    payload = close_success_payload(
+      _response(
+        statements_stamped=True,
+        stamped_statement_sets={"struct_bs": "fs_1"},
+        statement_rule_summary={"pass": 20, "fail": 0},
+      ),
+      has_sync_connection=False,
+    )
+
+    assert payload["statements_stamped"] is True
+    assert payload["stamped_statement_sets"] == {"struct_bs": "fs_1"}
+    assert payload["statement_rule_summary"] == {"pass": 20, "fail": 0}
+
+  def test_rule_outcomes_survive_being_empty(self):
+    payload = close_success_payload(
+      _response(rule_summary=None, evaluated_structure_ids=[]),
+      has_sync_connection=False,
+    )
+    assert payload["rule_summary"] is None
+    assert payload["evaluated_structure_ids"] == []
+
+
+class TestRefusals:
+  def test_a_sequence_violation_names_the_blocker(self):
+    payload = close_error_payload(
+      CloseGateFailed(
+        CloseableGateResult(is_closeable=False, blockers=[CloseableGateResult.SEQUENCE])
+      ),
+      period="2026-03",
+    )
+    assert payload is not None
+    assert payload["error"] == "not_closeable"
+    assert CloseableGateResult.SEQUENCE in payload["blockers"]
+
+  def test_an_uninitialized_calendar_is_its_own_answer(self):
+    payload = close_error_payload(
+      CloseGateFailed(
+        CloseableGateResult(
+          is_closeable=False, blockers=[CloseableGateResult.NO_CALENDAR]
+        )
+      ),
+      period="2026-03",
+    )
+    assert payload is not None
+    assert payload["error"] == "calendar_not_initialized"
+
+  def test_pending_obligations_name_the_schedules_to_go_and_promote(self):
+    payload = close_error_payload(
+      CloseGateFailed(
+        CloseableGateResult(
+          is_closeable=False,
+          blockers=[CloseableGateResult.PENDING_OBLIGATIONS],
+          pending_obligation_count=3,
+          pending_obligation_sample=[
+            PendingObligationDetail(
+              event_id="evt_1",
+              schedule_id="struct_dep",
+              schedule_name="Computer Depreciation",
+              period="2026-04",
+            ),
+          ],
+          earliest_pending_period="2026-04",
+        )
+      ),
+      period="2026-04",
+    )
+
+    assert payload is not None
+    assert payload["pending_obligation_count"] == 3
+    assert payload["pending_obligation_sample"][0]["schedule_name"] == (
+      "Computer Depreciation"
+    )
+    assert payload["earliest_pending_period"] == "2026-04"
+    # Detail rides only for the blockers that fired.
+    assert "sync_stale_days" not in payload
+    assert "reconciling_item_count" not in payload
+
+  def test_reconciling_items_name_the_transactions_holding_the_close(self):
+    payload = close_error_payload(
+      CloseGateFailed(
+        CloseableGateResult(
+          is_closeable=False,
+          blockers=[CloseableGateResult.RECONCILING_ITEMS],
+          reconciling_item_count=11,
+          reconciling_item_sample=["Expense_1721", "Expense_1727"],
+        )
+      ),
+      period="2026-08",
+    )
+
+    assert payload is not None
+    assert payload["reconciling_item_count"] == 11
+    assert payload["reconciling_item_sample"] == ["Expense_1721", "Expense_1727"]
+
+  def test_an_unbalanced_ledger_reports_both_sides(self):
+    payload = close_error_payload(
+      UnbalancedLedgerError(total_debit=1000, total_credit=900), period="2026-03"
+    )
+    assert payload is not None
+    assert payload["error"] == "unbalanced"
+    assert "1000" in payload["message"]
+    assert "900" in payload["message"]
+
+  def test_a_failed_writeback_names_the_entries_that_did_not_publish(self):
+    """The close commits its publish markers before raising, so the entries
+    that did reach QuickBooks are not re-sent on retry — the operator needs
+    to know which ones to fix, not to start over."""
+    payload = close_error_payload(
+      WritebackFailed(
+        [{"event_id": "evt_1", "memo": "AWS", "qb_error": {"code": "6000"}}]
+      ),
+      period="2026-07",
+    )
+
+    assert payload is not None
+    assert payload["error"] == "write_back_failed"
+    assert payload["failed_events"][0]["event_id"] == "evt_1"
+
+  def test_a_stamp_failure_says_the_close_rolled_back(self):
+    payload = close_error_payload(
+      StatementStampError("pivot failed for 2026-03"), period="2026-03"
+    )
+    assert payload is not None
+    assert payload["error"] == "statement_stamp_failed"
+    assert "rolled back" in payload["message"]
+    assert "pivot failed for 2026-03" in payload["message"]
+
+  @pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+      (PeriodNotFoundError("2026-03"), "period_not_found"),
+      (PeriodAlreadyClosedError("2026-03"), "already_closed"),
+      (RowLockedError("Period 2026-03 is being closed"), "row_locked"),
+      (FiscalCalendarError("bad target"), "calendar_error"),
+    ],
+  )
+  def test_the_remaining_domain_errors_keep_their_codes(self, error, expected):
+    payload = close_error_payload(error, period="2026-03")
+    assert payload is not None
+    assert payload["error"] == expected
+
+
+class TestFaultsAreNotOutcomes:
+  def test_an_unrecognized_exception_is_declined(self):
+    """None means "this is a fault" — the caller lets it propagate so the
+    operation is marked failed rather than described as a refusal."""
+    assert close_error_payload(RuntimeError("boom"), period="2026-03") is None
+
+  def test_every_declared_domain_error_has_a_payload(self):
+    """`CLOSE_DOMAIN_ERRORS` is what the worker catches. A type listed there
+    with no shaping would be swallowed and returned as an empty result."""
+    samples: dict[type, Exception] = {
+      CloseGateFailed: CloseGateFailed(
+        CloseableGateResult(is_closeable=False, blockers=["x"])
+      ),
+      PeriodNotFoundError: PeriodNotFoundError("2026-03"),
+      PeriodAlreadyClosedError: PeriodAlreadyClosedError("2026-03"),
+      RowLockedError: RowLockedError("busy"),
+      UnbalancedLedgerError: UnbalancedLedgerError(1, 2),
+      WritebackFailed: WritebackFailed([]),
+      StatementStampError: StatementStampError("x"),
+      FiscalCalendarError: FiscalCalendarError("x"),
+    }
+    assert set(samples) == set(CLOSE_DOMAIN_ERRORS)
+    for error_type, sample in samples.items():
+      assert close_error_payload(sample, period="2026-03") is not None, error_type

--- a/tests/operations/roboledger/tasks/test_period_close.py
+++ b/tests/operations/roboledger/tasks/test_period_close.py
@@ -1,0 +1,270 @@
+"""The close, run on the worker.
+
+The distinction under test is what counts as a *failure*. The consumer
+reduces any raised exception to a plain string, so a gate rejection that
+propagated would reach the operator as text with its blockers stripped —
+the one part they can act on. Every domain outcome must therefore come back
+as a result, and only genuine faults may raise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from robosystems.operations.locking import RowLockedError
+from robosystems.operations.roboledger.fiscal_calendar import (
+  CloseGateFailed,
+  PeriodAlreadyClosedError,
+  UnbalancedLedgerError,
+)
+from robosystems.operations.roboledger.fiscal_calendar.close_service import (
+  WritebackFailed,
+)
+from robosystems.operations.roboledger.fiscal_calendar.service import (
+  CloseableGateResult,
+)
+from robosystems.operations.roboledger.tasks.period_close import PeriodCloseTask
+
+GRAPH_ID = "kg01234567890abcdef"
+MODULE = "robosystems.operations.roboledger.tasks.period_close"
+
+
+def _task(**params) -> PeriodCloseTask:
+  manager = MagicMock()
+  manager.emit_progress = AsyncMock()
+  manager.event_storage = MagicMock()
+  manager.event_storage.store_event = AsyncMock()
+  return PeriodCloseTask(
+    task_id="op_close_1",
+    graph_id=GRAPH_ID,
+    user_id="user_1",
+    params={"period": "2026-07", **params},
+    manager=manager,
+  )
+
+
+def _close_response() -> SimpleNamespace:
+  """The shape `close_period` returns on success."""
+  return SimpleNamespace(
+    period="2026-07",
+    entries_posted=34,
+    entries_published_to_qb=31,
+    entries_posted_locally=3,
+    target_auto_advanced=True,
+    fiscal_calendar=SimpleNamespace(
+      model_dump=lambda mode="json": {"closed_through": "2026-07"}
+    ),
+    rule_summary={"pass": 7, "fail": 0},
+    evaluated_structure_ids=["struct_1"],
+    statements_stamped=True,
+    statement_stamp_note=None,
+    stamped_statement_sets={"struct_bs": "fs_1"},
+    statement_rule_summary={"pass": 20, "fail": 0},
+  )
+
+
+class _Ctx:
+  """Context manager yielding a session stand-in."""
+
+  def __init__(self, value):
+    self.value = value
+
+  def __enter__(self):
+    return self.value
+
+  def __exit__(self, *exc):
+    return False
+
+
+def _patched(close_result=None, close_error=None, session=None, close_spy=None):
+  """Patch the task's collaborators where it imports them from.
+
+  The task imports lazily inside `_run_close`, so each patch targets the
+  defining module rather than the task's namespace.
+  """
+  session = session or MagicMock()
+
+  def _close(*args, **kwargs):
+    if close_spy is not None:
+      close_spy(*args, **kwargs)
+    if close_error is not None:
+      raise close_error
+    return close_result
+
+  return (
+    patch(
+      "robosystems.operations.roboledger.commands.fiscal_calendar.close_period",
+      side_effect=_close,
+    ),
+    patch(
+      "robosystems.db.extensions.extensions_session",
+      return_value=_Ctx(session),
+    ),
+    patch(
+      "robosystems.db.platform.platform_session",
+      return_value=_Ctx(MagicMock()),
+    ),
+    patch(
+      "robosystems.operations.roboledger.reads.fiscal_calendar.qb_sync_state",
+      return_value=(True, None),
+    ),
+  )
+
+
+def _run(task, **kwargs):
+  patches = _patched(**kwargs)
+  for patcher in patches:
+    patcher.start()
+  try:
+    return asyncio.run(task.execute())
+  finally:
+    for patcher in patches:
+      patcher.stop()
+
+
+def _gate(*blockers, **detail) -> CloseGateFailed:
+  gate = CloseableGateResult(is_closeable=False, blockers=list(blockers), **detail)
+  return CloseGateFailed(gate)
+
+
+class TestSuccess:
+  def test_the_receipt_carries_the_close_and_names_the_operation(self):
+    result = _run(_task(), close_result=_close_response())
+
+    assert result["outcome"] == "closed"
+    assert result["operation_id"] == "op_close_1"
+    assert result["period"] == "2026-07"
+    assert result["entries_posted"] == 34
+    assert result["entries_published_to_qb"] == 31
+    assert result["statements_stamped"] is True
+    assert result["fiscal_calendar"]["has_sync_connection"] is True
+
+  def test_the_operation_is_moved_off_pending_before_the_work_starts(self):
+    """Nothing else does it, and the tool's handback depends on it: 'queued'
+    and 'running' are different things to tell an operator."""
+    task = _task()
+    _run(task, close_result=_close_response())
+
+    task.manager.event_storage.store_event.assert_awaited()
+    args = task.manager.event_storage.store_event.await_args
+    assert args.args[0] == "op_close_1"
+    assert args.args[1].value == "operation_started"
+    assert args.args[2]["period"] == "2026-07"
+
+  def test_the_overrides_and_actor_reach_the_close(self):
+    """The bypass flags an operator agreed to must survive the hop to the
+    worker — silently dropping one turns an approved close into a refusal."""
+    spy = MagicMock()
+    task = _task(
+      actor_id="user_9",
+      actor_type="agent",
+      allow_stale_sync=True,
+      allow_stranded_obligations=True,
+      allow_reconciling_items=True,
+      note="August close",
+    )
+
+    _run(task, close_result=_close_response(), close_spy=spy)
+
+    kwargs = spy.call_args.kwargs
+    assert kwargs["actor_id"] == "user_9"
+    assert kwargs["actor_type"] == "agent"
+    assert kwargs["allow_stale_sync"] is True
+    assert kwargs["allow_stranded_obligations"] is True
+    assert kwargs["allow_reconciling_items"] is True
+    assert kwargs["note"] == "August close"
+    assert spy.call_args.args[3] == "2026-07"
+
+
+class TestRefusals:
+  """A refused close is a result. None of these may raise."""
+
+  @pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+      (_gate("pending_obligations", pending_obligation_count=3), "not_closeable"),
+      (PeriodAlreadyClosedError("2026-07"), "already_closed"),
+      (RowLockedError("busy"), "row_locked"),
+      (UnbalancedLedgerError(100, 90), "unbalanced"),
+      (
+        WritebackFailed([{"event_id": "evt_1", "qb_error": {"code": "x"}}]),
+        "write_back_failed",
+      ),
+    ],
+  )
+  def test_domain_outcomes_come_back_as_results(self, error, expected):
+    result = _run(_task(), close_error=error)
+
+    assert result["outcome"] == "rejected"
+    assert result["error"] == expected
+    assert result["operation_id"] == "op_close_1"
+
+  def test_a_gate_rejection_keeps_the_blockers_the_operator_needs(self):
+    result = _run(
+      _task(),
+      close_error=_gate(
+        "reconciling_items",
+        reconciling_item_count=11,
+        reconciling_item_sample=["Expense_1721"],
+      ),
+    )
+
+    assert result["blockers"] == ["reconciling_items"]
+    assert result["reconciling_item_count"] == 11
+    assert result["reconciling_item_sample"] == ["Expense_1721"]
+
+  def test_write_back_failure_names_the_entries_that_did_not_publish(self):
+    result = _run(
+      _task(),
+      close_error=WritebackFailed(
+        [{"event_id": "evt_1", "memo": "AWS", "qb_error": {"code": "6000"}}]
+      ),
+    )
+
+    assert result["failed_events"][0]["event_id"] == "evt_1"
+
+  def test_an_already_closed_period_hands_back_the_receipt_it_wrote(self):
+    """The stalled-task reaper measures age from enqueue, so it can re-queue
+    a close that already landed. Reporting only 'already closed' would
+    describe a success as a refusal."""
+    session = MagicMock()
+    session.query.return_value.filter.return_value.scalar.return_value = {
+      "version": 1,
+      "entries_posted": 34,
+    }
+
+    result = _run(
+      _task(),
+      close_error=PeriodAlreadyClosedError("2026-07"),
+      session=session,
+    )
+
+    assert result["error"] == "already_closed"
+    assert result["close_receipt"]["entries_posted"] == 34
+
+  def test_an_unfinished_close_reports_no_receipt_rather_than_inventing_one(self):
+    session = MagicMock()
+    session.query.return_value.filter.return_value.scalar.return_value = None
+
+    result = _run(
+      _task(),
+      close_error=PeriodAlreadyClosedError("2026-07"),
+      session=session,
+    )
+
+    assert "close_receipt" not in result
+
+
+class TestFaults:
+  def test_a_database_fault_still_raises(self):
+    """Only outcomes are results. A fault must reach the consumer so the
+    operation is marked failed rather than reported as a refusal."""
+    fault = OperationalError("SELECT 1", {}, Exception("connection reset"))
+
+    with pytest.raises(OperationalError):
+      _run(_task(), close_error=fault)

--- a/tests/worker/test_task_timeout_coverage.py
+++ b/tests/worker/test_task_timeout_coverage.py
@@ -156,3 +156,36 @@ def test_tier_upgrade_budget_covers_its_internal_waits() -> None:
     f"its own drain + reattach waits ({internal_waits}s) with headroom for the "
     "snapshot, ASG capacity change, and health verification that follow them."
   )
+
+
+@pytest.mark.unit
+def test_period_close_budget_covers_one_slow_publish_and_the_locks() -> None:
+  """The close's own waits must fit inside its budget, with room to spare.
+
+  Sizing here is decided by the failure mode rather than by how long a close
+  usually takes. `asyncio.wait_for` cancels the coroutine but cannot cancel
+  the thread doing the QuickBooks publish, so an under-budget close is marked
+  FAILED while its thread runs on — and can still commit. Reporting a
+  landed close as a failure is far worse than waiting longer for a slow one.
+
+  Pinned against the constants that actually bound the run: one QuickBooks
+  call's retry ladder, the per-statement ceiling, and the period fence's
+  lock wait. Raising any of them without raising the budget fails here.
+  """
+  from robosystems.config.defaults import DatabaseDefaults
+  from robosystems.operations.locking import _LOCK_TIMEOUT_MS
+
+  # One QuickBooks call that exhausts its retry ladder: 5 attempts with
+  # exponential backoff capped at 60s. The floor below counts only the
+  # backoff between attempts, not the calls themselves.
+  qb_retry_backoff = 1 + 2 + 4 + 8
+  statement_ceiling = DatabaseDefaults.EXTENSIONS_STATEMENT_TIMEOUT_MS / 1000
+  fence_wait = _LOCK_TIMEOUT_MS / 1000
+
+  internal_waits = qb_retry_backoff + statement_ceiling + fence_wait
+  assert TASK_TIMEOUTS["period_close"] > internal_waits * 2, (
+    f"period_close budget ({TASK_TIMEOUTS['period_close']}s) must clear its own "
+    f"waits ({internal_waits}s) with wide headroom: a real month publishes one "
+    "QuickBooks entry per draft, any of which can hit that retry ladder, and a "
+    "cancelled close keeps running in its thread."
+  )


### PR DESCRIPTION
Closes gap 4(b) — the last of the three items on the 1.9 line. With #1251 merged, this completes the July-close reach list.

## The problem

A real month's close takes ~30s, most of it one QuickBooks round-trip per draft, against a 25s server-side tool budget. It always *completed*; the operator just stopped hearing about it, got an error, and then had to know not to retry a write that had already landed. Since PR #1233 persisted the receipt, nothing is lost when that happens — which is what makes this a legibility fix rather than a durability one.

## What changes

`close-period` dispatches to the worker and waits inside the budget:

- **Lands in time** → the receipt, exactly as before.
- **Doesn't** → `status: "in_progress"` with the operation id and where to look (`get-period-close-status` for the receipt, `get-fiscal-calendar` for `has_close_receipt`), and the instruction never to call `close-period` again — the close is atomic and already running.
- `worker_started` separates *running now* from *queued behind a busy worker*. Different things to tell someone who is waiting.

**REST is untouched.** The close panel and both SDK facades dereference the synchronous envelope's `result`, and the timeout they'd be insulated from isn't one they have.

## Three things that fell out of the move

**A refused close is a result, not a failure.** The consumer reduces any raised exception to a plain string, so a gate rejection that propagated would arrive as text with its blockers stripped — the one part an operator can act on. Outcome shaping moved to `close_outcomes.py`, shared by the task and the tool so both describe the same close identically; the task returns domain outcomes and lets genuine faults raise. It also picked up the `WritebackFailed` case the tool was previously dropping into a generic `except Exception`, losing `failed_events`.

**`get-period-close-status` never put `close_receipt` on the wire**, though the ops read returned it and the playbook told operators to reconstruct the receipt from there. The instruction pointed at nothing. Now it points at the receipt — which matters more here, since it is the poll target for an in-progress close.

**The tool needs a real user id.** An operation is readable at `/v1/operations/{id}/status` only by the user it was created for, so the `mcp:{graph_id}` sentinel the synchronous path could fall back on would have enqueued work nobody could look up. No user now means no dispatch.

## A defect the tests caught

The poll loop originally accumulated `waited += POLL_INTERVAL_S`. With a zero interval the accumulator never advances and it spins forever — which is exactly what the handback tests did. It now measures against the monotonic clock, which is the honest reading of "how long the caller has waited" regardless.

## Budget

`period_close` gets 600s, matching `operator`, pinned by a test against the constants that bound the run (the QuickBooks retry ladder, the statement ceiling, the fence's lock wait). The sizing is decided by the failure mode: `asyncio.wait_for` cancels the coroutine but cannot cancel the thread doing the publish, so an under-budget close is marked FAILED while its thread runs on and can still commit. Reporting a landed close as a failure is worse than waiting longer for a slow one — and the FAILED message says so.

## Testing

- `test_period_close.py` — the task: receipts, every domain refusal returned rather than raised, faults still raising, `OPERATION_STARTED` emitted first, and the already-closed case handing back the receipt (the stalled-task reaper measures age from enqueue, so it can re-queue a close that already landed).
- `test_close_outcomes.py` — the shapes, including a test that every type in `CLOSE_DOMAIN_ERRORS` actually has shaping, since one listed without it would be swallowed into an empty result.
- `test_fiscal_calendar_tools.py` — rewritten for dispatch and handback.
- Verified in the running worker container that `period_close` registers and resolves to `PeriodCloseTask`.

`just test-all` green: 13747 passed, 43 skipped.