### PR TITLE
docs(release): curated notes for v1.10.0

### DIFF
--- a/.github/release-notes/v1.10.0.md
+++ b/.github/release-notes/v1.10.0.md
@@ -1,0 +1,196 @@
+v1.10.0 closes the 1.9 series. It is the release where the month-end close stopped needing the person
+who built it — where the last workflows that only worked if you knew a workaround became operations
+the product performs, and where the ledger's write paths were hardened against the concurrency a
+second tenant brings. Almost none of it was found by reading code. The series ran the company's own
+books through the product surface, month after month, and treated every reach outside that surface as
+a defect rather than a workaround.
+
+Covers everything since v1.9.0; the 1.9.x patches carried generated changelogs.
+
+## The close, finished
+
+A close that ran to completion through the operator surface was the standing acceptance test for this
+work, and each attempt returned a list of things the operator had to already know. That list is now
+empty.
+
+**Ending a schedule early.** Obligations are materialized for a schedule's whole life, which makes the
+close gate a simple question and makes *ending* a schedule different from skipping a month. Voiding
+one period's obligation retires one period; the rest keep maturing. Seven prepaid schedules ended by
+hand left 153 obligations stretching to 2029, seven a month becoming close blockers. `terminate-schedule`
+ends the chain instead of the period — deleting forward facts, voiding the remaining obligations, and
+re-anchoring the schedule's own verification rule, which can never again prove a total whose facts are
+gone. Its sibling, `asset_disposed`, does the same and books the derecognition entry; the choice
+between them is about the GL, not the schedule. Alongside it, a fix that made the second one usable at
+all: a prepaid schedule credits the asset itself rather than a contra account, so its stored balance is
+the *declining* remainder, and reading it as accumulated depreciation inverted net book value for the
+entire prepaid class.
+
+**A close that leaves a receipt.** A period close's result — entries posted, the QuickBooks/local
+split, statements stamped, rule outcomes — lived only in the HTTP response. A close that succeeded but
+whose transport did not left nothing on the books, and the operator reconstructed what happened from
+four separate reads. The receipt is now written to the period in the same transaction as the close
+itself, so a committed close always carries one and a rolled-back close carries none. Periods closed
+before this read as closed with no receipt, which is a real state rather than a failure.
+
+**A worklist that can be cleared.** When a transaction is edited in QuickBooks after it was synced, the
+ledger does not overwrite approved books — it flags the disagreement and keeps the incoming version.
+Nothing cleared that flag, so the queue only ever grew: items agreed with a customer in June were
+indistinguishable from unreviewed ones in August, and the ones QuickBooks kept re-sending came back
+every sync forever. `resolve-reconciling-item` gives the operator three dispositions, and which one is
+right is an accounting judgement about the period rather than a technical choice — **restate** the
+original months, post a **catch-up** entry in an open one, or **acknowledge** work already done by
+hand. A preview reads the difference per account first, because the treatment is agreed with the
+customer before anything is written.
+
+**An entry that knows not to travel back.** An alignment entry mirroring a change the source system
+already made must not publish back to it, or the change applies twice. That lane existed only as a
+side effect of one source name being absent from a list. It is now explicit on the entry itself, and
+the close refuses to stamp statements over an unresolved disagreement unless told otherwise — a rule
+the playbook had carried in prose for months, which is not the same as a gate.
+
+**A close that outlives its caller.** A real month takes about thirty seconds, most of it one
+QuickBooks round-trip per entry, against a twenty-five second budget on the operator surface. It always
+completed; the operator saw an error and had to know not to retry a write that had already landed. With
+the receipt on the period, nothing is lost when that happens — which made this a legibility fix rather
+than a durability one, and worth doing cheaply. The close now runs on the worker and the tool hands
+back where to look if it outlasts the wait, distinguishing a close that is running from one still
+queued. The REST surface is unchanged; its consumers do not have the timeout this insulates against.
+
+## Forecasting anchored to the books
+
+Forecast walks began from whichever period the caller asked for, so a scenario could quietly re-base
+the balance sheet at the actuals boundary and produce a cash-flow statement that could not explain its
+own jump. The walk is now anchored on the close seam, the anchor only ever advances onto a month the
+close actually stamped, and projections are kept out of the ledger they project from.
+
+## Writes that hold under a second writer
+
+The ledger's concurrency was designed for one writer and had never been tested with two. This series
+found and closed that class.
+
+Every path that decides an event's next status now locks the row it decided on. Three did not — an
+inbox approval, the sync's auto-commit pass, and the obligation sweep — and any two of them could leave
+one event carrying two sets of entries: books that still balance, still render, and no longer say what
+the event says. The wait policy is now stated in one place, and it is asymmetric on purpose: background
+jobs wait, because a batch should not fail behind one approval; request handlers bound the wait and
+return a retryable conflict.
+
+Related work through the series: the tenant session binding is re-applied on every transaction rather
+than once per session, so an operation that commits mid-flow cannot continue on a differently-bound
+connection; per-item loops inside a ledger transaction run under a savepoint and never swallow a lock
+error; the QuickBooks publish step isolates each entry, so one rejection cannot take a batch with it;
+and the deletes, calendar pointers and obligation voids that were still unordered now acquire in one
+direction.
+
+One exposure was deliberately left, documented rather than half-fixed: a sync writing into a period
+while it closes. A row lock cannot span the close's mid-flow commit, so the fix is a change to the
+close's concurrency model rather than a lock added to a read.
+
+## Multi-tenancy, hardened ahead of the first stranger
+
+Six review rounds ran against the shared plane before opening it to self-serve signup. The theme
+across them is that a control which has never been exercised is not yet a control.
+
+Tenant binding now fails closed: a session pointed at a schema that does not exist refuses on its first
+statement rather than resolving names somewhere else. Every graph carrying an OLTP extension gets its
+schema at creation. A soft-deleted graph reads as gone to every default lookup. Report shares and
+publish lists admit only live, provisioned recipients. Event connections are joined to the calling
+graph, so an operation cannot reach a connection registered elsewhere. Rate-limit budgets are charged
+only by callers authorized on the graph, and an unverified key is not yet an identity.
+
+The availability half followed: a per-statement ceiling on interactive tenant sessions with a typed
+answer on every surface, GraphQL resolvers moved off the event loop, row counting and ingest streaming
+taken off it too, and async operations made retryable — a failed background operation now releases its
+idempotency key instead of holding it against the retry. Denials on read paths emit the same audit
+event the write gates do, and every authenticated request now publishes its principal, so access-log
+lines carry the caller rather than `None`.
+
+Also in this class, and deliberately listed rather than described: input validation on the ingest path,
+bounded redaction, a cap on tenant-supplied AI input, event-loop occupancy limits, credit-ledger
+consistency, error-response sanitization on the query surface, and the playground's content-security
+policy emitted only where the playground is actually served.
+
+## Identity and the end of an account
+
+A withdrawn grant now stops authorizing at once. Every surface that revokes access clears the cached
+decisions derived from that grant in the same step, and the off-boarding sweep revokes every repository
+grant a member still holds — verified by a test that seeds the cache in production shape and asserts,
+across five different revocation paths, that nothing still authorizes.
+
+Graph-scoped reads resolve on the graph role rather than organization membership. Revoked API keys
+leave the listing and the sweep. Changing an email requires re-authentication and an interactive
+session.
+
+And an account whose last organization membership is removed is now closed out rather than left in a
+state nothing handled — able to authenticate, unable to reach anything, and invisible to the admin
+listing that support would use to find it, because that listing inner-joined the membership the account
+no longer had. Graph creation for such a caller answers 403 like every other organization-resolving
+surface, instead of the 500 that counted against the error rate.
+
+## Teardown that finishes
+
+Deleting a graph left residue in several places, each of which had to be found by deleting one and
+looking. Connections are removed and the final backup registered at teardown; published report
+artifacts are deleted with the graph that produced them; the purge paginates rather than assuming one
+page; the backup-export grace period is restored so teardown converges instead of racing an export; and
+shared repositories are exempt from the orphan-registration sweep that was never meant to reach them.
+
+## Surfaces that describe themselves accurately
+
+A recurring defect shape in this codebase is a surface that documents a capability it does not have.
+The series went looking for that class deliberately.
+
+An operation is now either exposed to the operator surface or recorded as deliberately held — before
+this, an unwired capability and an intentional omission were indistinguishable, and the whole codebase
+carried exactly one recorded exposure decision. A guard enforces it, and the sweep that added it found
+a complete, tested operation with no callers at all. Tool descriptions gained a shared, enforced
+skeleton. Declared configuration surface is compared against what actually resolves, as a set, so the
+two cannot drift apart again; feature flags that read as switches now behave as switches; and an
+inert kill switch, a retired connection provider, and a dead rate-limit knob were removed rather than
+left looking operational.
+
+The documentation sweep behind this deserves its own line, because it is the cautionary half: it
+introduced defects of its own, which a follow-up review found and fixed. Correcting prose against code
+is a change to the system, not a change to the description of it.
+
+## Audit and evidence
+
+Admin-surface actions are now recorded in the application-side audit trail. The practical effect is
+retention: those records ride the audit subscription to the audit bucket at 400 days, where they
+previously lived only in the API log group at 30 — shorter than a SOC 2 Type II observation window, so
+evidence aged out mid-window. The audit bucket's out-of-band object lock is now recorded in the
+template that owns it, and `SECURITY.md` was verified against the code rather than against memory.
+
+## Infrastructure
+
+Per-tier volume IOPS and throughput floors are authoritative on attach, so a volume that drifted below
+its tier is corrected rather than silently under-provisioned. The graph API enforces its body cap on
+streamed requests and derives capacity accounting from the graph id. A dependency conflict was resolved
+by overriding a transitive pin past its ceiling.
+
+One long-running defect closed here is worth naming for its shape: a second copy of a native library,
+bundled beside the one already in the process, collided on a process-global registry — with the result
+that a scoring path had never once succeeded in production. Both tests around it asserted the degraded
+output, so they passed. The failure was logged at debug, which is why it survived.
+
+## Upgrade notes
+
+- **Extensions database migrations.** Three: a uniqueness constraint on entry reversals, an index
+  backfill on external identifiers, and the close-receipt column, which fans out to every tenant
+  schema. The deploy carries a migration step. The platform database has none.
+- **CloudFormation.** Templates changed across the API, worker, Dagster, audit, security, WAF, S3,
+  Postgres and graph stacks; stack updates ride the deploy.
+- **New SSM tunable** — a per-statement ceiling for interactive extensions sessions, defaulting in code
+  and disabled by `0`.
+- **Materialization now fails closed** when its lock is unreachable, rather than proceeding unlocked;
+  the staleness sensor retries.
+- **S3 presigned uploads are SigV4**, which is same-region only — true of every bucket today.
+- **SDK.** Everything here is additive on the generated tier: `terminate-schedule`,
+  `preview-reconciling-item`, `resolve-reconciling-item`, the close receipt on the period-close read,
+  and a close-gate bypass field. No facade or integration-template symbol changed, so this rides a
+  client minor. Three surfaces were removed — an SSE kill switch, a retired connection provider, and a
+  rate-limit variable that enforced nothing — none of which had a consumer, and none of which ever
+  worked in a shipped configuration.
+- **The operator surface's close is now asynchronous.** A close that outlasts the wait returns an
+  in-progress handback with the operation id and where to poll; it must not be re-issued. REST is
+  unchanged.


### PR DESCRIPTION
The curated release body for **v1.10.0**, to be merged **before** dispatching `create-release.yml` — that workflow bumps the version on `main`, cuts the release branch and tags it in one run, so a file added afterwards is already too late.

## Scope

Covers everything since **v1.9.0** — 241 commits across 65 merged PRs — following the convention v1.9.0 set (*"Covers everything since v1.8.0; the 1.8.x patches carried generated changelogs"*). A minor memorializes the series; the patches keep their generated changelogs.

## The through-line

The series has one, and it isn't "assorted fixes": **the month-end close stopped needing the person who built it.** Each attempt to close real books through the operator surface came back with a list of things you had to already know, and that list is now empty — schedules that can be ended without hand-voiding a chain to 2029, a close that leaves a receipt, a reconciling-item worklist that can actually be cleared, an alignment entry that knows not to travel back to the system it mirrors, and a close that survives outliving its caller.

Sections, in order: the close arc · forecasting anchored to the seam · write isolation · multi-tenancy hardening ahead of self-serve · identity and the end of an account · teardown that finishes · surfaces that describe themselves accurately · audit and evidence · infrastructure · upgrade notes.

## Verified rather than asserted

- **Migrations**: three new on the extensions database (entry-reversal uniqueness, an external-id index backfill, the close-receipt column with its tenant fan-out); **none** on the platform database. Checked with `git cat-file` against `v1.9.0` rather than from the changed-files list, since that list includes modifications — `0002` was edited, not added.
- **CloudFormation**: templates changed across the API, worker, Dagster, audit, security, WAF, S3, Postgres and graph stacks — stack updates ride the deploy.
- **SDK**: everything additive on the generated tier (three new operations, the receipt on the period-close read, one close-gate bypass field), so it rides a **client minor**. Three surfaces removed — an SSE kill switch, a retired connection provider, a rate-limit variable enforcing nothing — each named in the notes because the notes are the only place a pinned integrator sees them; none had a consumer and none worked in a shipped configuration.
- **Disclosure**: the security-adjacent work is listed at PR-title neutrality — what area was hardened, never how or against what. The one paragraph that lists several is deliberately a list rather than a description.

## Format

Body only, per `.github/release-notes/README.md` — no `#` heading, no statistics, no links section, no generated-with footer; the workflow supplies all four. The archived `v1.0.0`–`v1.6.0` files keep their original headings and are records, not templates.

## After merge

Dispatch `create-release.yml` with a **minor** bump: `1.9.12` → `1.10.0`, which matches this filename exactly. A mismatch is silently ignored and the release falls back to the generated changelog.