### PR TITLE
docs(identity): document enterprise SSO, SCIM, and passkeys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,7 +266,7 @@ robosystems/
 │   ├── operators/                # AI Operator operations (Claude/MCP executors — distinct from REA Agent counterparty model)
 │   └── providers/                # Provider registry and implementations
 ├── middleware/                   # Cross-cutting concerns
-│   ├── auth/                     # Authentication (JWT, API keys, SSO)
+│   ├── auth/                     # Authentication (JWT, API keys, cross-app SSO, passkeys/MFA, enterprise OIDC + SCIM)
 │   ├── billing/                  # Credit consumption tracking
 │   ├── graph/                    # Graph routing and multi-tenancy
 │   ├── rate_limits/              # Burst protection

--- a/README.md
+++ b/README.md
@@ -203,13 +203,9 @@ Because tenancy is enforced at the graph rather than in application predicates, 
 
 ### Identity & Access
 
-Credentials are `X-API-Key` for programmatic access and short-lived JWTs for the browser apps, both resolving to the same user and both revocable — deactivating a user bumps their session version *and* revokes their API keys, so there is no credential family that survives an offboarding.
+Programmatic access uses `X-API-Key`; the browser apps use short-lived JWTs. How a person *logs in* is a deployment decision — password, WebAuthn passkey, or an enterprise identity provider — published at `GET /v1/auth/providers`, so one frontend build renders whichever posture the backend is configured for.
 
-How a person authenticates is a deployment decision rather than a build-time one, published at `GET /v1/auth/providers` so a single frontend build renders whichever posture the backend is configured for:
-
-- **Passwords** — bcrypt cost 14, score-based strength policy, and a session-invalidating password change.
-- **Passkeys (WebAuthn)** — both a second factor after password login and a passwordless first factor, with optional enforcement for org owners and admins. Enrollment requires a fresh re-authentication proof and refuses API keys; challenge tokens are purpose-scoped and rejected as session bearers. The relying-party identity derives from the deployment's own domain, so each deployment is its own credential zone.
-- **Enterprise SSO (OIDC) + SCIM 2.0** — an identity-provider login paired with user provisioning, so the customer's IdP is the authoritative roster. Resolution is **link-only**: SCIM creates accounts, OIDC only resolves already-provisioned ones, and there is no just-in-time path where a valid token mints a local user. The SCIM bearer is its own credential class, accepted only at `/scim/v2` and never anywhere else. Off by default, not enabled on the managed platform, and — because the whole thing ships under Apache-2.0 — available to any fork without a license gate.
+Enterprise SSO (OIDC) and SCIM 2.0 provisioning ship in the repository, off by default — available to any fork without a license gate. Provisioning is link-only: SCIM creates accounts and OIDC only resolves already-provisioned ones, so the identity provider owns the account lifecycle in both directions.
 
 Details: [Enterprise SSO & SCIM](https://github.com/RoboFinSystems/robosystems/wiki/Enterprise-SSO-and-SCIM) · [Authentication & API Keys](https://github.com/RoboFinSystems/robosystems/wiki/Authentication-and-API-Keys) · [`SECURITY.md`](/SECURITY.md)
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,18 @@ One rule: **every isolation primitive keys on `graph_id`, never on an organizati
 
 Because tenancy is enforced at the graph rather than in application predicates, the same codebase serves managed SaaS, a dedicated single-tenant deployment, and a fully self-hosted install with no fork. Details: [Graphs & Multi-Tenancy](https://github.com/RoboFinSystems/robosystems/wiki/Graphs-and-Multi-Tenancy).
 
+### Identity & Access
+
+Credentials are `X-API-Key` for programmatic access and short-lived JWTs for the browser apps, both resolving to the same user and both revocable — deactivating a user bumps their session version *and* revokes their API keys, so there is no credential family that survives an offboarding.
+
+How a person authenticates is a deployment decision rather than a build-time one, published at `GET /v1/auth/providers` so a single frontend build renders whichever posture the backend is configured for:
+
+- **Passwords** — bcrypt cost 14, score-based strength policy, and a session-invalidating password change.
+- **Passkeys (WebAuthn)** — both a second factor after password login and a passwordless first factor, with optional enforcement for org owners and admins. Enrollment requires a fresh re-authentication proof and refuses API keys; challenge tokens are purpose-scoped and rejected as session bearers. The relying-party identity derives from the deployment's own domain, so each deployment is its own credential zone.
+- **Enterprise SSO (OIDC) + SCIM 2.0** — an identity-provider login paired with user provisioning, so the customer's IdP is the authoritative roster. Resolution is **link-only**: SCIM creates accounts, OIDC only resolves already-provisioned ones, and there is no just-in-time path where a valid token mints a local user. The SCIM bearer is its own credential class, accepted only at `/scim/v2` and never anywhere else. Off by default, not enabled on the managed platform, and — because the whole thing ships under Apache-2.0 — available to any fork without a license gate.
+
+Details: [Enterprise SSO & SCIM](https://github.com/RoboFinSystems/robosystems/wiki/Enterprise-SSO-and-SCIM) · [Authentication & API Keys](https://github.com/RoboFinSystems/robosystems/wiki/Authentication-and-API-Keys) · [`SECURITY.md`](/SECURITY.md)
+
 ### Components
 
 **Application Layer:**
@@ -330,7 +342,7 @@ pip install robosystems-client
 
 **Operations Layer:**
 
-- [Graphs & Multi-Tenancy](https://github.com/RoboFinSystems/robosystems/wiki/Graphs-and-Multi-Tenancy) · [Authentication & API Keys](https://github.com/RoboFinSystems/robosystems/wiki/Authentication-and-API-Keys) · [Querying the Analytical Graph](https://github.com/RoboFinSystems/robosystems/wiki/Querying-the-Analytical-Graph) · [Graph Operations](https://github.com/RoboFinSystems/robosystems/wiki/Graph-Operations) · [AI Operators & MCP](https://github.com/RoboFinSystems/robosystems/wiki/AI-Operators-and-MCP) · [Shared Repositories](https://github.com/RoboFinSystems/robosystems/wiki/Shared-Repositories) · [Credits & Billing](https://github.com/RoboFinSystems/robosystems/wiki/Credits-and-Billing) · [Pipeline Guide](https://github.com/RoboFinSystems/robosystems/wiki/Pipeline-Guide)
+- [Graphs & Multi-Tenancy](https://github.com/RoboFinSystems/robosystems/wiki/Graphs-and-Multi-Tenancy) · [Authentication & API Keys](https://github.com/RoboFinSystems/robosystems/wiki/Authentication-and-API-Keys) · [Enterprise SSO & SCIM](https://github.com/RoboFinSystems/robosystems/wiki/Enterprise-SSO-and-SCIM) · [Querying the Analytical Graph](https://github.com/RoboFinSystems/robosystems/wiki/Querying-the-Analytical-Graph) · [Graph Operations](https://github.com/RoboFinSystems/robosystems/wiki/Graph-Operations) · [AI Operators & MCP](https://github.com/RoboFinSystems/robosystems/wiki/AI-Operators-and-MCP) · [Shared Repositories](https://github.com/RoboFinSystems/robosystems/wiki/Shared-Repositories) · [Credits & Billing](https://github.com/RoboFinSystems/robosystems/wiki/Credits-and-Billing) · [Pipeline Guide](https://github.com/RoboFinSystems/robosystems/wiki/Pipeline-Guide)
 
 **Extensions Layer:**
 

--- a/robosystems/models/api/README.md
+++ b/robosystems/models/api/README.md
@@ -19,7 +19,9 @@ Prefer widening a model over replacing it.
 
 | Path | Contents |
 | ---- | -------- |
-| `auth.py` | Login, registration, JWT tokens, SSO flows |
+| `auth.py` | Login, registration, JWT tokens, the cross-app SSO bridge, auth-provider posture |
+| `passkeys.py` | WebAuthn passkey registration, passwordless login, and MFA challenge models |
+| `scim.py` | SCIM 2.0 resource, patch, list, and error-envelope models (RFC 7643/7644) |
 | `oauth.py` | OAuth provider integrations (QuickBooks, etc.) |
 | `common.py` | Error responses, pagination, health checks |
 | `user.py`, `orgs.py` | User profiles, API keys, usage analytics, organizations |

--- a/robosystems/operations/README.md
+++ b/robosystems/operations/README.md
@@ -46,6 +46,8 @@ Every operation on the platform is one of four shapes, and the shape determines 
 | `connection_service.py`, `document_service.py` | Connection and document lifecycle |
 | `oidc.py` | OIDC login kernel: connection config, flow state, ID-token validation, link-only user resolution |
 | `user_provisioning.py` | Account-creation kernel shared by registration and IdP-driven (SCIM) provisioning |
+| `passkeys.py` | WebAuthn kernel: registration and assertion challenges, credential storage, recovery codes |
+| `locking.py` | Distributed lock primitives for operations that must not run concurrently |
 
 Cross-domain block envelopes sit at the top level; domain kernels hold reads, commands, and services; cross-cutting infrastructure is top level too.
 

--- a/static/description.md
+++ b/static/description.md
@@ -98,7 +98,8 @@ Built on the blocks:
 
 ### User & Access
 
-- **Authentication**: JWT tokens and API key management
+- **Authentication**: JWT sessions and API keys, plus WebAuthn passkeys as a second factor or a passwordless first factor. A deployment publishes which login methods it offers at `GET /v1/auth/providers`
+- **Enterprise identity** *(off by default; dedicated and self-hosted deployments)*: OIDC single sign-on and SCIM 2.0 user provisioning at `/scim/v2`, so an identity provider owns the account lifecycle. Login resolves SCIM-provisioned users only — there is no just-in-time account creation
 - **User Management**: Manage user account settings and profile
 - **Subscriptions**: Shared repository subscription access & AI credits
 - **Limits**: Rate limiting and usage tracking for shared repositories


### PR DESCRIPTION
## Summary

Enterprise SSO (OIDC), SCIM provisioning, and passkeys were documented in `SECURITY.md` and nowhere else — absent from the README, the public OpenAPI landing description, the architecture tree, and the API/operations model layout tables. This PR is the docs-only half of closing that gap; the companion wiki changes (a new **Enterprise SSO & SCIM** page, plus passkeys/MFA coverage on the Authentication page) are already published.

Documentation only. No source, schema, or behavior changes.

## Changes

**`README.md`**
- Short **Identity & Access** subsection under Architecture: login method is a deployment decision published at `GET /v1/auth/providers`, and enterprise SSO/SCIM ship in the repository off by default with no license gate.
- States the link-only provisioning rule, since that is the design decision integrators most often assume the opposite of. Control-level detail (password policy, passkey enrollment mechanics) is deliberately left to `SECURITY.md` and the wiki rather than restated here.
- Adds the new wiki page to the Operations Layer link list.

**`static/description.md`** — *worth a closer look; this renders on the public API landing page.*
- Replaces `**Authentication**: JWT tokens and API key management`, which predated passkeys and enterprise identity entirely.
- Adds an **Enterprise identity** bullet marked off-by-default and scoped to dedicated/self-hosted deployments, so nobody reads it as available on the managed platform.

**`robosystems/models/api/README.md`**
- Adds the missing `passkeys.py` and `scim.py` rows.
- Corrects the `auth.py` row: it said "SSO flows", which reads as IdP federation but describes the internal cross-app bridge.

**`robosystems/operations/README.md`**
- Adds the missing `passkeys.py` and `locking.py` rows.

**`CLAUDE.md`**
- The architecture tree's `auth/` line named only "SSO"; now names all four mechanisms.

**Accuracy notes for the reviewer**
- Okta is described as validated; Entra deliberately is not. The deactivation path tolerates Entra's non-RFC payload shapes, but it has never been run against one.
- The supported surface is stated as users-only with a single filter — no Groups, bulk, sort, ETag, or password change — matching what `ServiceProviderConfig` declares.
- Nothing here discloses a vulnerability or a control that `SECURITY.md` did not already describe publicly, so there is no deploy-sequencing concern.

One item from the same finding was **not** actioned on purpose: seeding placeholder SSO keys into `bin/setup/aws.sh`. Boot validation refuses to start on `SSO_OIDC_ENABLED=true` with an unconfigured connection by testing those keys for truthiness, so placeholders would satisfy that check with garbage instead of failing loudly. The keys are documented in the Bootstrap Guide with that reasoning instead.

## Breaking Changes

None. No API surface, GraphQL schema, operations envelope, or REST shape changed, so there is no SDK impact in either the stable or generated tier.

## Testing

`just test-all` — **not run.** No Python changed; the diff is five markdown files.

The code-quality gate ran via the pre-commit hook on both commits (ruff, format, basedpyright): `All checks passed`, `1805 files already formatted`, `0 errors, 0 warnings, 0 notes`.

Wiki links and internal anchors on the changed pages were checked programmatically and resolve.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
