### PR TITLE
fix(roboledger): keep refused worker closes uncommitted

### DIFF
--- a/robosystems/middleware/auth/jwt.py
+++ b/robosystems/middleware/auth/jwt.py
@@ -152,6 +152,21 @@ def _get_user_session_version(user_id: str, session: Any = None) -> int | None:
     sess.close()
 
 
+def is_session_access_token(payload: dict[str, Any]) -> bool:
+  """Whether this JWT is a session bearer, not a purpose-scoped token.
+
+  Session tokens carry ``type: "access"``. Tokens with no ``type`` at all are
+  grandfathered (pre-type-claim sessions). SSO handoff tokens (``sso: true``)
+  and any other ``type`` (``mfa``, ``stream``, …) are not session bearers.
+  Shared by ``verify_jwt_claims`` and the ``/refresh`` grace path so a
+  purpose-scoped token cannot mint a session after it expires.
+  """
+  if payload.get("sso"):
+    return False
+  token_type = payload.get("type")
+  return token_type is None or token_type == "access"
+
+
 def verify_jwt_claims(
   token: str, device_fingerprint: dict[str, Any] | None = None
 ) -> tuple[str, int] | None:
@@ -186,8 +201,7 @@ def verify_jwt_claims(
     # through this function. Rejecting every non-`access` type also stops a
     # future purpose-scoped token (an SSE stream token, say) from being
     # replayed as a bearer. Tokens with no `type` claim at all are accepted.
-    token_type = payload.get("type")
-    if payload.get("sso") or (token_type is not None and token_type != "access"):
+    if not is_session_access_token(payload):
       logger.info("JWT token verification failed: non-access token presented as bearer")
       # A signature-valid but wrong-purpose token used as a bearer is a distinct
       # signal (possible replay of a leaked single-use SSO handoff) that the
@@ -199,7 +213,7 @@ def verify_jwt_claims(
         user_id=payload.get("user_id"),
         details={
           "reason": "non_access_token_as_bearer",
-          "token_type": "sso" if payload.get("sso") else token_type,
+          "token_type": "sso" if payload.get("sso") else payload.get("type"),
         },
         risk_level="high",
       )

--- a/robosystems/models/api/auth.py
+++ b/robosystems/models/api/auth.py
@@ -153,7 +153,12 @@ class AuthProvidersResponse(BaseModel):
 class PasswordCheckRequest(BaseModel):
   """Password strength check request model."""
 
-  password: str = Field(..., description="Password to check")
+  password: str = Field(
+    ...,
+    min_length=1,
+    max_length=128,
+    description="Password to check",
+  )
   email: str | None = Field(None, description="User email for personalization checks")
 
 

--- a/robosystems/operations/roboledger/tasks/period_close.py
+++ b/robosystems/operations/roboledger/tasks/period_close.py
@@ -133,6 +133,16 @@ class PeriodCloseTask(BaseTask):
           )
           if receipt:
             payload["close_receipt"] = receipt
+        # Domain refusals are results, so this `with` exits cleanly and
+        # `extensions_session` would COMMIT. Stamp/gate failures raise
+        # after the period has been marked closed in the same transaction;
+        # without a rollback the operator is told the close rolled back
+        # while OLTP disagrees. `WritebackFailed` already committed its
+        # publish markers in a prior transaction — rollback only discards
+        # uncommitted work after that. `PeriodAlreadyClosedError` has
+        # nothing dirty; the receipt SELECT above is against committed
+        # rows and survives this.
+        session.rollback()
         logger.info(
           "period_close refused for %s %s: %s",
           graph_id,

--- a/robosystems/routers/auth/password.py
+++ b/robosystems/routers/auth/password.py
@@ -1,7 +1,8 @@
 """Password policy and validation endpoints."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from ...middleware.rate_limits import auth_rate_limit_dependency
 from ...models.api.auth import (
   PasswordCheckRequest,
   PasswordCheckResponse,
@@ -31,7 +32,10 @@ async def get_password_policy():
   operation_id="checkPasswordStrength",
   responses={**COMMON_ERROR_RESPONSES},
 )
-async def check_password_strength(request: PasswordCheckRequest):
+async def check_password_strength(
+  request: PasswordCheckRequest,
+  _rate_limit: None = Depends(auth_rate_limit_dependency),
+):
   result = PasswordSecurity.validate_password(request.password, request.email)
 
   return PasswordCheckResponse(

--- a/robosystems/routers/auth/session.py
+++ b/robosystems/routers/auth/session.py
@@ -19,6 +19,7 @@ from ...database import get_async_db_session
 from ...logger import logger
 from ...middleware.auth.jwt import (
   create_jwt_token,
+  is_session_access_token,
   revoke_jwt_token,
   verify_jwt_claims,
 )
@@ -169,6 +170,16 @@ async def refresh_session(
           audience=env.JWT_AUDIENCE,
           options={"verify_exp": False},  # Allow expired tokens for grace period
         )
+
+        # Purpose-scoped tokens (SSO handoff, MFA challenge) fail
+        # `verify_jwt_claims` on type even while unexpired, and on `exp`
+        # once they age out. The grace path must re-apply the same gate or
+        # an expired MFA/SSO token mints a session JWT.
+        if not is_session_access_token(payload) or not payload.get("jti"):
+          raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+          )
 
         # Check if token expired recently (within reduced grace period)
         exp = payload.get("exp")

--- a/tests/models/api/test_auth_models.py
+++ b/tests/models/api/test_auth_models.py
@@ -232,6 +232,10 @@ class TestPasswordCheckModels:
     model = PasswordCheckRequest(password="test", email="user@example.com")
     assert model.email == "user@example.com"
 
+  def test_password_check_request_rejects_overlong_password(self):
+    with pytest.raises(ValidationError):
+      PasswordCheckRequest(password="x" * 129)
+
   def test_password_check_response(self):
     model = PasswordCheckResponse(
       is_valid=True,

--- a/tests/operations/roboledger/tasks/test_period_close.py
+++ b/tests/operations/roboledger/tasks/test_period_close.py
@@ -28,6 +28,7 @@ from robosystems.operations.roboledger.fiscal_calendar.close_service import (
 from robosystems.operations.roboledger.fiscal_calendar.service import (
   CloseableGateResult,
 )
+from robosystems.operations.roboledger.reports.statement_sets import StatementStampError
 from robosystems.operations.roboledger.tasks.period_close import PeriodCloseTask
 
 GRAPH_ID = "kg01234567890abcdef"
@@ -134,7 +135,9 @@ def _gate(*blockers, **detail) -> CloseGateFailed:
 
 class TestSuccess:
   def test_the_receipt_carries_the_close_and_names_the_operation(self):
-    result = _run(_task(), close_result=_close_response())
+    session = MagicMock()
+    result = _run(_task(), close_result=_close_response(), session=session)
+    session.rollback.assert_not_called()
 
     assert result["outcome"] == "closed"
     assert result["operation_id"] == "op_close_1"
@@ -195,14 +198,19 @@ class TestRefusals:
         WritebackFailed([{"event_id": "evt_1", "qb_error": {"code": "x"}}]),
         "write_back_failed",
       ),
+      (StatementStampError("pivot failed"), "statement_stamp_failed"),
     ],
   )
   def test_domain_outcomes_come_back_as_results(self, error, expected):
-    result = _run(_task(), close_error=error)
+    session = MagicMock()
+    result = _run(_task(), close_error=error, session=session)
 
     assert result["outcome"] == "rejected"
     assert result["error"] == expected
     assert result["operation_id"] == "op_close_1"
+    # Refusals are results, so extensions_session would commit on the way
+    # out. Rollback first or a stamp/gate failure leaves the period closed.
+    session.rollback.assert_called()
 
   def test_a_gate_rejection_keeps_the_blockers_the_operator_needs(self):
     result = _run(

--- a/tests/routers/auth/test_jwt_token_type.py
+++ b/tests/routers/auth/test_jwt_token_type.py
@@ -16,6 +16,7 @@ from robosystems.config import env
 from robosystems.middleware.auth.jwt import (
   create_jwt_token,
   create_sso_token,
+  is_session_access_token,
   verify_jwt_claims,
 )
 
@@ -95,6 +96,13 @@ class TestJWTTokenType:
     result = verify_jwt_claims(token)
     assert result is not None
     assert result[0] == "usr_1"
+
+  def test_is_session_access_token_matches_the_bearer_gate(self):
+    assert is_session_access_token({"type": "access"}) is True
+    assert is_session_access_token({}) is True  # grandfathered
+    assert is_session_access_token({"sso": True}) is False
+    assert is_session_access_token({"type": "mfa"}) is False
+    assert is_session_access_token({"type": "access", "sso": True}) is False
 
   def test_non_access_type_is_rejected(self):
     from datetime import UTC, datetime, timedelta

--- a/tests/routers/auth/test_password_check.py
+++ b/tests/routers/auth/test_password_check.py
@@ -1,0 +1,22 @@
+"""Public password-strength check mounts the same limiter as login."""
+
+from inspect import signature
+
+import pytest
+
+from robosystems.middleware.rate_limits import auth_rate_limit_dependency
+from robosystems.routers.auth.password import (
+  check_password_strength,
+  get_password_policy,
+)
+
+
+@pytest.mark.unit
+def test_password_check_mounts_the_auth_limiter():
+  dep = signature(check_password_strength).parameters["_rate_limit"].default
+  assert dep.dependency is auth_rate_limit_dependency
+
+
+@pytest.mark.unit
+def test_password_policy_stays_unlimited():
+  assert "_rate_limit" not in signature(get_password_policy).parameters

--- a/tests/routers/auth/test_session.py
+++ b/tests/routers/auth/test_session.py
@@ -597,6 +597,81 @@ class TestRefreshSession:
     assert exc_info.value.detail == "Session refresh failed"
 
 
+class TestRefreshPurposeGate:
+  """Expired purpose-scoped tokens must not mint a session on /refresh.
+
+  `verify_jwt_claims` already refuses them as bearers. The grace path is a
+  second decoder and has to re-apply the same gate.
+  """
+
+  def _expired(self, **claims) -> str:
+    from datetime import UTC, datetime, timedelta
+
+    import jwt
+
+    from robosystems.config import env
+
+    now = datetime.now(UTC)
+    payload = {
+      "user_id": "user_123",
+      "session_version": 0,
+      "iss": env.JWT_ISSUER,
+      "aud": env.JWT_AUDIENCE,
+      "exp": now - timedelta(minutes=1),
+      "iat": now - timedelta(minutes=6),
+    }
+    payload.update(claims)
+    return jwt.encode(payload, env.JWT_SECRET_KEY, algorithm="HS256")
+
+  def _request(self, token: str):
+    mock_request = Mock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.headers = {
+      "user-agent": "test-agent",
+      "authorization": f"Bearer {token}",
+    }
+    return mock_request
+
+  async def _refresh(self, token: str):
+    mock_redis = Mock()
+    mock_redis.hgetall.return_value = {}
+    with patch(
+      "robosystems.middleware.auth.jwt.get_redis_client", return_value=mock_redis
+    ):
+      return await refresh_session(
+        fastapi_request=self._request(token),
+        session=Mock(),
+        _rate_limit=None,
+      )
+
+  async def test_expired_mfa_token_cannot_refresh(self):
+    token = self._expired(type="mfa", purpose="login", jti="jti-mfa")
+    with pytest.raises(HTTPException) as exc_info:
+      await self._refresh(token)
+    assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert exc_info.value.detail == "Invalid or expired token"
+
+  async def test_expired_sso_token_cannot_refresh(self):
+    token = self._expired(sso=True)
+    with pytest.raises(HTTPException) as exc_info:
+      await self._refresh(token)
+    assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert exc_info.value.detail == "Invalid or expired token"
+
+  @patch("robosystems.routers.auth.session.User.get_by_id")
+  @patch("robosystems.routers.auth.session.revoke_jwt_token", return_value=True)
+  @patch(
+    "robosystems.routers.auth.session.create_jwt_token", return_value="new_jwt_token"
+  )
+  async def test_expired_access_token_within_grace_still_refreshes(
+    self, _create, _revoke, mock_get_by_id, mock_user
+  ):
+    mock_get_by_id.return_value = mock_user
+    token = self._expired(type="access", jti="jti-access")
+    result = await self._refresh(token)
+    assert result.token == "new_jwt_token"
+
+
 class TestCookieSettings:
   """Test cookie configuration in session refresh."""
 


### PR DESCRIPTION
## Summary

Two correctness fixes from the GTM readiness pass. A refused worker close no longer persists as a closed period, and session refresh plus the public password-strength check now share the same token-purpose and abuse bounds as the rest of login.

## Changes

**Worker close**
- Domain refusals on `period_close` roll back the extensions session before returning a result, so a failed statement stamp cannot commit a closed period.
- Tests now assert rollback on every refusal, including stamp failure, and that a successful close does not roll back.

**Auth**
- Session-token classification is one predicate, used by bearer verification and the refresh grace path.
- The public password-strength check uses the same rate limiter as login and rejects oversized input.
- Tests cover purpose-scoped tokens on refresh, the limiter mount, and the input bound.

## Breaking Changes

None. The password-strength request model now rejects passwords over 128 characters (the same ceiling registration already enforces). Additive otherwise; no SDK facade change.

## Testing

- `uv run pytest` on the close-task, JWT type, session refresh, password-check, auth-model, and MFA-token modules: 95 passed.
- Pre-commit ruff check/format: passed.
- `just test-all` was not run.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
