### PR TITLE
fix(sec): align the public SEC MCP copy with the subscription gate

### DIFF
--- a/robosystems/adapters/sec/manifest.py
+++ b/robosystems/adapters/sec/manifest.py
@@ -90,7 +90,7 @@ SEC_MANIFEST = SharedRepositoryManifest(
       "access_level": "READ",
       "description": "Full SEC data access for individuals",
       "features": [
-        "Unlimited MCP tool access",
+        "MCP access from Claude, Cursor, or any MCP client",
         "API access",
         "Standard rate limits",
         "1 backup download per month",

--- a/static/description.md
+++ b/static/description.md
@@ -107,7 +107,7 @@ Built on the blocks:
 
 ## Connect via MCP
 
-Every graph is an MCP server, and the graph's URL is the preferred way to connect — Claude, Claude Code, Cursor, or any MCP client that supports HTTP transports, no install required. The URL picks the graph (`sec` for the public SEC repository, your graph id for your own); your API key goes in the `X-API-Key` header:
+Every graph is an MCP server, and the graph's URL is the preferred way to connect — Claude, Claude Code, Cursor, or any MCP client that supports HTTP transports, no install required. The URL picks the graph (`sec` for the public SEC repository, your graph id for your own); your API key goes in the `X-API-Key` header. Access follows the graph: your own graphs need graph membership, and the public `sec` repository needs an **active repository subscription** (Starter or Advanced — plans and their MCP rate limits are published at `GET /v1/offering`). An API key alone does not open `sec`; the server answers `403` until the subscription exists, and tool calls count against the plan's MCP limits:
 
 ```
 https://api.robosystems.ai/v1/graphs/{graph_id}/mcp

--- a/tests/config/test_shared_repositories.py
+++ b/tests/config/test_shared_repositories.py
@@ -89,3 +89,43 @@ class TestResolveSharedRepositoryParent:
   def test_unknown_repo_raises(self):
     with pytest.raises(ValueError, match="Not a shared repository"):
       resolve_shared_repository_parent("nosuchrepo_sub")
+
+
+class TestPublishedPlanClaimsMatchEnforcedLimits:
+  """A plan's marketing bullets must not contradict the limits the same
+  manifest enforces.
+
+  The Starter plan advertised "Unlimited MCP tool access" while the manifest
+  set ``mcp_queries_per_hour: 100`` for it — copy a stranger reads on the
+  connector page and in ``GET /v1/offering``. Both are served from the
+  manifest, so the check lives against the manifest: any plan that carries a
+  per-window limit may not describe itself as unlimited.
+  """
+
+  def test_no_plan_with_rate_limits_claims_unlimited(self):
+    from robosystems.config.shared_repositories import (
+      get_all_manifests,
+      get_rate_limits,
+    )
+
+    offenders: list[str] = []
+    for repo_id, manifest in get_all_manifests().items():
+      for plan_key, plan in (manifest.plans or {}).items():
+        limits = get_rate_limits(repo_id, plan_key) or {}
+        if not any(v for k, v in limits.items() if "_per_" in k):
+          continue
+        for feature in plan.get("features", []):
+          if "unlimited" in feature.lower():
+            offenders.append(f"{repo_id}/{plan_key}: {feature!r}")
+
+    assert offenders == [], (
+      "A rate-limited plan advertises itself as unlimited; the enforced limit "
+      "and the published claim must agree — fix the copy, not the limit: "
+      + "; ".join(offenders)
+    )
+
+  def test_guard_sees_the_sec_plans(self):
+    from robosystems.config.shared_repositories import get_all_manifests
+
+    sec = get_all_manifests()["sec"]
+    assert set(sec.plans) >= {"starter", "advanced"}


### PR DESCRIPTION
## Summary

The public SEC MCP surface described access it does not grant. The Starter plan's feature list said "Unlimited MCP tool access" while the same manifest rate-limits MCP calls per plan, and the Swagger "Connect via MCP" section showed the `sec` connector URL with an API-key header and no mention that the public repository requires an active repository subscription — so a stranger following the snippet reaches a 403 with no explanation. This fixes the copy at its one writer and guards the manifest so a rate-limited plan cannot describe itself as unlimited again.

## Changes

**SEC manifest** (`robosystems/adapters/sec/manifest.py`)
- Starter plan feature "Unlimited MCP tool access" → "MCP access from Claude, Cursor, or any MCP client". The per-plan MCP rate limits are unchanged; the bullet now describes what the plan is rather than a quantity the manifest contradicts. This string is served verbatim by `GET /v1/offering`.

**API description** (`static/description.md`)
- The "Connect via MCP" section now states that access follows the graph: own graphs need graph membership, and the public `sec` repository needs an active repository subscription (Starter or Advanced), with plans and MCP limits published at `GET /v1/offering`. It says explicitly that an API key alone does not open `sec` and that the server answers 403 until the subscription exists.

**Guard test** (`tests/config/test_shared_repositories.py`)
- `TestPublishedPlanClaimsMatchEnforcedLimits`: for every shared-repository manifest, any plan carrying a per-window rate limit must not advertise itself as "unlimited". Verified to fail against the previous copy and pass against this one; a second test pins that the guard actually sees the `sec` plans.

Not in this PR: `robosystems-app`'s pricing page restates the same Starter bullet in its own markup — that is a separate app-side change.

## Breaking Changes

None. The changed manifest string reaches clients only as the value of an existing `features: string[]` field on `GET /v1/offering`; no schema, endpoint, or SDK facade changes. No SDK regen needed.

## Testing

- `uv run pytest tests/config/test_shared_repositories.py tests/routers/test_offering.py`: 31 passed.
- Mutation check: the new guard fails against the pre-change manifest (stashed and re-run), passes after.
- `just test-code`: ruff check, ruff format, basedpyright (0 errors, 0 warnings), cf-lint — all passed.
- `just test-all` was not run.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
