### PR TITLE
fix(deprovision): revoke provider grants at teardown; make delete-subgraph's backup real

### DIFF
--- a/robosystems/middleware/mcp/tools/graph_tools.py
+++ b/robosystems/middleware/mcp/tools/graph_tools.py
@@ -321,15 +321,18 @@ class DeleteSubgraphTool:
         "- To permanently remove a subgraph that is no longer needed\n"
         "- Requires admin role on the parent, and cannot target the parent "
         "graph itself\n\n"
-        "**RETURNS:** Confirmation of the deletion, echoing back the "
-        "`backup_first` flag. No backup is taken — see NOTES.\n\n"
+        "**RETURNS:** Confirmation of the deletion with `backup_created`, and "
+        "when a backup was taken its `backup_location` and `backup_id`.\n\n"
         "**PARAMETERS:**\n"
         "- subgraph_id: Full id like `{parent_id}_{name}`\n"
         "- force: Delete even if the subgraph contains data (default false)\n"
-        "- backup_first: Accepted but NOT implemented; it takes no backup\n\n"
-        "**NOTES:** This is irreversible. `backup_first` does not protect the "
-        "data and never has — to keep a copy, run `create-backup` on the "
-        "parent graph first and confirm it succeeded."
+        "- backup_first: Take a full backup of the subgraph first (default "
+        "true). It is registered on the parent graph's backup list, so it "
+        "stays listable and downloadable after the subgraph is gone. If the "
+        "backup fails, nothing is deleted.\n\n"
+        "**NOTES:** The deletion itself is irreversible; only a backup taken "
+        "here (or earlier via `create-backup` on the subgraph id) preserves "
+        "the data."
       ),
       "inputSchema": {
         "type": "object",
@@ -400,7 +403,7 @@ class DeleteSubgraphTool:
 
       service = SubgraphService()
       try:
-        await service.delete_subgraph_database(
+        deletion_result = await service.delete_subgraph_database(
           subgraph_id=subgraph_id,
           force=force,
           create_backup=backup_first,
@@ -421,7 +424,10 @@ class DeleteSubgraphTool:
       return {
         "deleted": True,
         "subgraph_id": subgraph_id,
-        "backup_created": backup_first,
+        # What happened, not what was asked.
+        "backup_created": bool(deletion_result.get("backup_created")),
+        "backup_location": deletion_result.get("backup_location"),
+        "backup_id": deletion_result.get("backup_id"),
       }
     finally:
       close()

--- a/robosystems/models/api/graphs/operations.py
+++ b/robosystems/models/api/graphs/operations.py
@@ -21,7 +21,12 @@ class DeleteSubgraphOp(BaseModel):
   )
   backup_first: bool = Field(
     default=True,
-    description="Create a backup before deleting",
+    description=(
+      "Take a full backup of the subgraph before deleting it. The backup is "
+      "registered on the parent graph's backup list, where it can be listed and "
+      "downloaded after the subgraph is gone. If the backup fails the subgraph "
+      "is not deleted."
+    ),
   )
 
 

--- a/robosystems/models/core/graph/graph_backup.py
+++ b/robosystems/models/core/graph/graph_backup.py
@@ -1,7 +1,7 @@
 """Graph backup tracking model for PostgreSQL."""
 
 from collections.abc import Sequence
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import Any, Optional
 
@@ -190,6 +190,67 @@ class GraphBackup(Model):
     session.commit()
     session.refresh(backup)
     return backup
+
+  @classmethod
+  def from_completed_export(
+    cls,
+    *,
+    graph_id: str,
+    database_name: str,
+    metadata: Any,
+    s3_bucket: str,
+    retention_days: int,
+    initiated_by: str,
+    now: datetime | None = None,
+  ) -> "GraphBackup":
+    """Build — but do not persist — a COMPLETED row from a BackupManager export.
+
+    The manager's metadata describes the archive; this maps it onto the row the
+    listing and download surfaces resolve through. The caller owns ``add`` and
+    the transaction: a graph's final backup at teardown is added under a
+    SAVEPOINT inside a batch that must not commit early, while a subgraph's
+    pre-delete backup commits at once. Neither can use ``create`` /
+    ``complete_backup``, which commit.
+
+    ``database_name`` is the LadybugDB database the archive holds. It differs
+    from ``graph_id`` when a subgraph's backup is registered on its parent —
+    the row the customer still has once the subgraph itself is gone.
+    """
+    now = now or datetime.now(UTC)
+    backup_metadata: dict[str, Any] = {
+      "backup_format": metadata.backup_format,
+      "compression_ratio": metadata.compression_ratio,
+    }
+    if metadata.memory:
+      backup_metadata["memory"] = metadata.memory
+    if metadata.payload_delta:
+      backup_metadata["payload_delta"] = metadata.payload_delta
+    if database_name != graph_id:
+      backup_metadata["database_name"] = database_name
+
+    return cls(
+      graph_id=graph_id,
+      database_name=database_name,
+      backup_type=BackupType.FULL.value,
+      initiated_by=initiated_by,
+      status=BackupStatus.COMPLETED.value,
+      s3_bucket=s3_bucket,
+      s3_key=metadata.s3_key or "",
+      s3_metadata_key=metadata.s3_metadata_key,
+      original_size_bytes=metadata.original_size,
+      compressed_size_bytes=metadata.compressed_size,
+      compression_ratio=metadata.compression_ratio,
+      node_count=metadata.node_count,
+      relationship_count=metadata.relationship_count,
+      database_version=metadata.database_version,
+      backup_duration_seconds=metadata.backup_duration_seconds,
+      checksum=metadata.checksum,
+      compression_enabled=True,
+      backup_metadata=backup_metadata,
+      started_at=metadata.timestamp,
+      completed_at=now,
+      expires_at=now + timedelta(days=retention_days),
+    )
 
   @classmethod
   def get_by_id(cls, backup_id: str, session: Session) -> Optional["GraphBackup"]:

--- a/robosystems/operations/graph/deprovision_service.py
+++ b/robosystems/operations/graph/deprovision_service.py
@@ -8,7 +8,7 @@ and do not block the overall deprovisioning flow.
 """
 
 from dataclasses import dataclass, field
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 
 from sqlalchemy.orm import Session
 
@@ -34,6 +34,7 @@ class DeprovisionResult:
   registry_deallocated: bool = False
   records_cleaned: bool = False
   documents_deleted: int = 0
+  connections_revoked: int = 0
   connections_deleted: int = 0
   search_purged: bool = False
   report_bundles_deleted: int = 0
@@ -236,6 +237,12 @@ class GraphDeprovisionService:
     # enumerate what it still holds — so this must run first.
     self._purge_staged_uploads(graph_id, session, result)
 
+    # --- 5b. Revoke provider-side grants BEFORE the credentials they need ---
+    # Deleting our copy of a refresh token stops sync; it does not end the
+    # authorization at the provider. The provider cleanup reads the stored
+    # token to revoke it, so it has to run while the credential row exists.
+    await self._revoke_provider_grants(graph_id, session, result)
+
     # --- 6. Clean PostgreSQL records ---
     self._clean_pg_records(graph_id, session, result)
 
@@ -257,6 +264,7 @@ class GraphDeprovisionService:
         "subgraphs_deleted": result.subgraphs_deleted,
         "database_deleted": result.database_deleted,
         "documents_deleted": result.documents_deleted,
+        "connections_revoked": result.connections_revoked,
         "connections_deleted": result.connections_deleted,
         "search_purged": result.search_purged,
         "report_bundles_deleted": result.report_bundles_deleted,
@@ -381,47 +389,17 @@ class GraphDeprovisionService:
     already gone, leaving their records looking live. The savepoint contains
     the failure to this row alone.
     """
-    from ...models.core.graph.graph_backup import (
-      BackupInitiator,
-      BackupStatus,
-      BackupType,
-      GraphBackup,
-    )
-
-    now = datetime.now(UTC)
-    backup_metadata: dict = {
-      "backup_format": metadata.backup_format,
-      "compression_ratio": metadata.compression_ratio,
-    }
-    if metadata.memory:
-      backup_metadata["memory"] = metadata.memory
-    if metadata.payload_delta:
-      backup_metadata["payload_delta"] = metadata.payload_delta
+    from ...models.core.graph.graph_backup import BackupInitiator, GraphBackup
 
     with session.begin_nested():
       session.add(
-        GraphBackup(
+        GraphBackup.from_completed_export(
           graph_id=graph.graph_id,
           database_name=graph.graph_id,
-          backup_type=BackupType.FULL.value,
-          initiated_by=BackupInitiator.FINAL.value,
-          status=BackupStatus.COMPLETED.value,
+          metadata=metadata,
           s3_bucket=s3_bucket,
-          s3_key=metadata.s3_key or "",
-          s3_metadata_key=metadata.s3_metadata_key,
-          original_size_bytes=metadata.original_size,
-          compressed_size_bytes=metadata.compressed_size,
-          compression_ratio=metadata.compression_ratio,
-          node_count=metadata.node_count,
-          relationship_count=metadata.relationship_count,
-          database_version=metadata.database_version,
-          backup_duration_seconds=metadata.backup_duration_seconds,
-          checksum=metadata.checksum,
-          compression_enabled=True,
-          backup_metadata=backup_metadata,
-          started_at=metadata.timestamp,
-          completed_at=now,
-          expires_at=now + timedelta(days=retention_days),
+          retention_days=retention_days,
+          initiated_by=BackupInitiator.FINAL.value,
         )
       )
     result.backup_registered = True
@@ -692,6 +670,73 @@ class GraphDeprovisionService:
       error_msg = f"Staged upload purge failed: {e}"
       result.errors.append(error_msg)
       logger.warning(error_msg, extra={"graph_id": graph_id})
+
+  async def _revoke_provider_grants(
+    self, graph_id: str, session: Session, result: DeprovisionResult
+  ) -> None:
+    """Revoke each connection's provider-side grant before teardown deletes it.
+
+    The user-initiated disconnect revokes at the provider and then deletes
+    the local rows; teardown deleted the rows and never revoked, so a departed
+    customer's authorization stayed live at the provider until it expired on
+    its own. Same provider hook as the disconnect path, per connection.
+
+    Best-effort per connection: the provider cleanup logs its own failures
+    and does not raise, and a provider disabled by flag has nothing to call.
+    Anything that does raise is recorded and the teardown continues — the
+    credential row is deleted either way, and a stranded grant is an operator
+    follow-up, not a reason to leave the tenant's data in place.
+    """
+    try:
+      from ...models.core.connection.connection import Connection
+      from ...operations.providers.registry import provider_registry
+
+      rows = (
+        session.query(Connection.id, Connection.provider, Connection.entity_name)
+        .filter(Connection.graph_id == graph_id)
+        .all()
+      )
+    except Exception as e:
+      error_msg = f"Provider grant revocation could not list connections: {e}"
+      result.errors.append(error_msg)
+      logger.warning(error_msg, extra={"graph_id": graph_id})
+      return
+
+    for connection_id, provider, entity_name in rows:
+      provider_type = (provider or "").lower()
+      try:
+        await provider_registry.cleanup_connection(
+          provider_type,
+          {
+            "id": connection_id,
+            "connection_id": connection_id,
+            "provider": provider_type,
+            "entity_name": entity_name,
+            "graph_id": graph_id,
+          },
+          graph_id,
+        )
+        result.connections_revoked += 1
+        logger.info(
+          f"Revoked provider grant for connection {connection_id} ({provider_type}) "
+          f"during teardown of {graph_id}",
+          extra={"graph_id": graph_id, "connection_id": connection_id},
+        )
+      except ValueError:
+        # Provider disabled by feature flag in this deployment: no client to
+        # call. Mirrors the disconnect endpoint, which also skips cleanup here.
+        logger.warning(
+          f"Provider {provider_type} disabled; skipping grant revocation for "
+          f"connection {connection_id} during teardown of {graph_id}",
+          extra={"graph_id": graph_id, "connection_id": connection_id},
+        )
+      except Exception as e:
+        error_msg = (
+          f"Provider grant revocation failed for connection {connection_id} "
+          f"({provider_type}): {e}"
+        )
+        result.errors.append(error_msg)
+        logger.warning(error_msg, extra={"graph_id": graph_id})
 
   def _clean_pg_records(
     self, graph_id: str, session: Session, result: DeprovisionResult

--- a/robosystems/operations/graph/deprovision_service.py
+++ b/robosystems/operations/graph/deprovision_service.py
@@ -427,9 +427,12 @@ class GraphDeprovisionService:
         result.errors.append(error_msg)
         logger.warning(error_msg)
 
-      # Purge staged uploads before the PG records that index them (see the
-      # parent path), then clean subgraph PG records.
+      # Same ordering as the parent path: purge staged uploads before the PG
+      # records that index them, revoke provider grants before the credentials
+      # they read (a connection may be scoped directly to a subgraph), then
+      # clean the subgraph's PG records.
       self._purge_staged_uploads(subgraph.graph_id, session, result)
+      await self._revoke_provider_grants(subgraph.graph_id, session, result)
       self._clean_pg_records(subgraph.graph_id, session, result)
       self._purge_search_index(subgraph.graph_id, result)
 
@@ -712,6 +715,9 @@ class GraphDeprovisionService:
             "connection_id": connection_id,
             "provider": provider_type,
             "entity_name": entity_name,
+            # The disconnect endpoint's payload carries entity_id = graph_id;
+            # the provider cleanup logs it.
+            "entity_id": graph_id,
             "graph_id": graph_id,
           },
           graph_id,

--- a/robosystems/operations/graph/subgraph_service.py
+++ b/robosystems/operations/graph/subgraph_service.py
@@ -432,11 +432,13 @@ class SubgraphService:
   ) -> dict[str, Any]:
     """Delete a subgraph's database. Destructive and not recoverable here.
 
-    Refuses a database that holds any nodes unless ``force`` is set.
-    ``create_backup`` is accepted but not yet implemented — take a backup
-    through the backup operations before forcing.
+    Refuses a database that holds any nodes unless ``force`` is set. With
+    ``create_backup`` a full backup of the subgraph is taken first and
+    registered on the parent graph's backup list; if that backup fails the
+    subgraph is not deleted.
 
-    Returns ``{status: "deleted"|"not_found", ...}``.
+    Returns ``{status: "deleted"|"not_found", backup_created, backup_location,
+    backup_id, ...}``.
     """
     subgraph_info = parse_subgraph_id(subgraph_id)
     if not subgraph_info:
@@ -487,6 +489,9 @@ class SubgraphService:
           "graph_id": subgraph_id,
           "message": "Subgraph database does not exist",
           "search_purged": search_purged,
+          "backup_created": False,
+          "backup_location": None,
+          "backup_id": None,
         }
 
       if is_local:
@@ -501,6 +506,16 @@ class SubgraphService:
             f"Subgraph {subgraph_id} contains data. "
             "Use force=True to delete anyway, or create a backup first."
           )
+
+      backup: dict[str, Any] = {
+        "backup_created": False,
+        "backup_location": None,
+        "backup_id": None,
+      }
+      if create_backup:
+        backup = await self._backup_before_delete(
+          subgraph_id, parent_graph_id, database_name
+        )
 
       logger.info(f"Deleting database {database_name} from instance {instance_id}")
       await client.delete_database(database_name)
@@ -517,11 +532,93 @@ class SubgraphService:
         "instance_id": instance_id,
         "deleted_at": datetime.now(UTC).isoformat(),
         "search_purged": search_purged,
+        **backup,
       }
 
+    except GraphAllocationError:
+      # Already a domain refusal with its own message (data without force, a
+      # failed pre-delete backup) — re-wrapping would only prefix it.
+      raise
     except Exception as e:
       logger.error(f"Failed to delete subgraph database {subgraph_id}: {e}")
       raise GraphAllocationError(f"Failed to delete subgraph: {e!s}")
+
+  async def _backup_before_delete(
+    self, subgraph_id: str, parent_graph_id: str, database_name: str
+  ) -> dict[str, Any]:
+    """Take a full backup of the subgraph and register it on the parent.
+
+    The subgraph's own row is hard-deleted right after this, so a backup row
+    keyed on the subgraph id would be unreachable through the listing and
+    download surfaces. Registering it under the parent — with the archive's
+    ``database_name`` recorded — keeps it on the backup list the customer
+    still has. Retention follows the parent tier's hosting window, the same
+    rule a graph's final backup uses at teardown.
+
+    Raises ``GraphAllocationError`` if the backup or its registration fails,
+    so the delete never proceeds on a promise it cannot keep.
+    """
+    from ...config.deprovisioning import get_deprovisioning_config
+    from ...database import SessionFactory
+    from ...models.core.graph import Graph
+    from ...models.core.graph.graph_backup import BackupInitiator, GraphBackup
+    from .engine.backup_manager import BackupFormat, BackupJob, BackupManager
+
+    # Independent session (see platform_session docs).
+    session = SessionFactory()
+    try:
+      parent = session.query(Graph).filter(Graph.graph_id == parent_graph_id).first()
+      tier = (
+        str(parent.graph_tier)
+        if parent is not None and parent.graph_tier
+        else "ladybug-standard"
+      )
+      retention_days = get_deprovisioning_config().get_backup_hosting_days(tier)
+
+      manager = BackupManager()
+      try:
+        metadata = await manager.create_backup(
+          BackupJob(
+            graph_id=subgraph_id,
+            backup_format=BackupFormat.FULL_DUMP,
+            retention_days=retention_days,
+            compression=True,
+          )
+        )
+      except Exception as e:
+        raise GraphAllocationError(
+          f"Backup of subgraph {subgraph_id} failed, so it was not deleted: {e!s}"
+        ) from e
+
+      try:
+        row = GraphBackup.from_completed_export(
+          graph_id=parent_graph_id,
+          database_name=database_name,
+          metadata=metadata,
+          s3_bucket=manager.s3_adapter.bucket_name,
+          retention_days=retention_days,
+          initiated_by=BackupInitiator.FINAL.value,
+        )
+        session.add(row)
+        session.commit()
+      except Exception as e:
+        session.rollback()
+        raise GraphAllocationError(
+          f"Backup of subgraph {subgraph_id} landed at {metadata.s3_key} but could "
+          f"not be registered, so it was not deleted: {e!s}"
+        ) from e
+
+      logger.info(
+        f"Backed up subgraph {subgraph_id} to {metadata.s3_key} before deletion "
+        f"(registered on parent {parent_graph_id} as backup {row.id})"
+      )
+      return {
+        "backup_created": True,
+        "backup_location": metadata.s3_key,
+        "backup_id": row.id,
+      }
+    finally:
+      session.close()
 
   async def _purge_subgraph_search_index(self, subgraph_id: str) -> bool:
     """Drop a subgraph's documents from the shared OpenSearch index.

--- a/robosystems/routers/graphs/operations.py
+++ b/robosystems/routers/graphs/operations.py
@@ -298,7 +298,10 @@ async def delete_subgraph_op(
         "parent_graph_id": subgraph.parent_graph_id,
         "user_id": user.id,
         "forced": body.force,
-        "backup_created": body.backup_first,
+        # What happened, not what was asked: the service reports whether the
+        # pre-delete backup was actually taken.
+        "backup_created": bool(deletion_result.get("backup_created")),
+        "backup_id": deletion_result.get("backup_id"),
       },
       risk_level="medium",
     )
@@ -306,7 +309,9 @@ async def delete_subgraph_op(
     return {
       "graph_id": subgraph_id,
       "status": "deleted",
+      "backup_created": bool(deletion_result.get("backup_created")),
       "backup_location": backup_location,
+      "backup_id": deletion_result.get("backup_id"),
     }
 
   return await _dispatch(ctx, _runner, cache)

--- a/tests/middleware/mcp/tools/test_graph_tools.py
+++ b/tests/middleware/mcp/tools/test_graph_tools.py
@@ -355,6 +355,12 @@ class TestDeleteSubgraphExecute:
       ) as mock_svc_class,
     ):
       mock_svc = AsyncMock()
+      mock_svc.delete_subgraph_database.return_value = {
+        "status": "deleted",
+        "backup_created": True,
+        "backup_location": "graph-backups/kg_x/dev.lbug.zip",
+        "backup_id": "gbk_01",
+      }
       mock_svc_class.return_value = mock_svc
 
       result = await DeleteSubgraphTool(_client()).execute(
@@ -365,10 +371,51 @@ class TestDeleteSubgraphExecute:
       "deleted": True,
       "subgraph_id": f"{GRAPH_ID}_dev",
       "backup_created": True,
+      "backup_location": "graph-backups/kg_x/dev.lbug.zip",
+      "backup_id": "gbk_01",
     }
     mock_svc.delete_subgraph_database.assert_awaited_once()
+    assert mock_svc.delete_subgraph_database.call_args.kwargs["create_backup"] is True
     mock_db.delete.assert_called_once_with(subgraph)
     mock_db.commit.assert_called_once()
+
+  @pytest.mark.asyncio
+  async def test_backup_created_reports_what_happened_not_what_was_asked(
+    self, mock_db: MagicMock
+  ) -> None:
+    """The result used to echo the `backup_first` flag while no backup was
+    taken. It now carries the service's own account of the backup."""
+    subgraph = MagicMock()
+    subgraph.is_subgraph = True
+    filter_chain = MagicMock()
+    filter_chain.first.side_effect = [subgraph]
+    mock_db.query.return_value.filter.return_value = filter_chain
+
+    with (
+      patch(
+        "robosystems.models.core.graph.graph_user.GraphUser.user_has_admin_access",
+        return_value=True,
+      ),
+      patch(
+        "robosystems.operations.graph.subgraph_service.SubgraphService"
+      ) as mock_svc_class,
+    ):
+      mock_svc = AsyncMock()
+      mock_svc.delete_subgraph_database.return_value = {
+        "status": "deleted",
+        "backup_created": False,
+        "backup_location": None,
+        "backup_id": None,
+      }
+      mock_svc_class.return_value = mock_svc
+
+      result = await DeleteSubgraphTool(_client()).execute(
+        {"subgraph_id": f"{GRAPH_ID}_dev", "force": True, "backup_first": True}
+      )
+
+    assert result["deleted"] is True
+    assert result["backup_created"] is False
+    assert result["backup_location"] is None
 
 
 # ══════════════════════════════════════════════════════════════════════════

--- a/tests/models/core/graph/test_graph_backup.py
+++ b/tests/models/core/graph/test_graph_backup.py
@@ -849,3 +849,83 @@ class TestDailyBackupQuotaCounting:
     self._make(db_session, "kg_quota_f")
 
     assert GraphBackup.count_user_initiated_today("kg_quota_f", db_session) == 1
+
+
+class TestFromCompletedExport:
+  """The one mapping from a manager export onto a COMPLETED row, shared by a
+  graph's final backup at teardown and a subgraph's pre-delete backup."""
+
+  def _metadata(self):
+    from datetime import UTC, datetime
+    from unittest.mock import MagicMock
+
+    m = MagicMock()
+    m.s3_key = "graph-backups/kg_parent/dev.lbug.zip"
+    m.s3_metadata_key = "graph-backups/kg_parent/dev.lbug.zip.metadata.json"
+    m.original_size = 2048
+    m.compressed_size = 512
+    m.compression_ratio = 0.75
+    m.node_count = 12
+    m.relationship_count = 7
+    m.database_version = "1.0"
+    m.backup_duration_seconds = 1.5
+    m.checksum = "abc123"
+    m.backup_format = "full_dump"
+    m.timestamp = datetime(2026, 8, 25, 12, 0, tzinfo=UTC)
+    m.memory = None
+    m.payload_delta = {"node_count": 1}
+    return m
+
+  def test_maps_the_export_onto_a_completed_row(self):
+    from datetime import UTC, datetime, timedelta
+
+    from robosystems.models.core.graph.graph_backup import (
+      BackupInitiator,
+      BackupStatus,
+      BackupType,
+      GraphBackup,
+    )
+
+    now = datetime(2026, 8, 25, 13, 0, tzinfo=UTC)
+    row = GraphBackup.from_completed_export(
+      graph_id="kg_parent",
+      database_name="kg_parent",
+      metadata=self._metadata(),
+      s3_bucket="robosystems-test",
+      retention_days=90,
+      initiated_by=BackupInitiator.FINAL.value,
+      now=now,
+    )
+
+    assert row.status == BackupStatus.COMPLETED.value
+    assert row.backup_type == BackupType.FULL.value
+    assert row.initiated_by == BackupInitiator.FINAL.value
+    assert row.s3_bucket == "robosystems-test"
+    assert row.s3_key == "graph-backups/kg_parent/dev.lbug.zip"
+    assert row.original_size_bytes == 2048
+    assert row.compressed_size_bytes == 512
+    assert row.node_count == 12
+    assert row.checksum == "abc123"
+    assert row.completed_at == now
+    assert row.expires_at == now + timedelta(days=90)
+    assert row.backup_metadata["payload_delta"] == {"node_count": 1}
+    assert "database_name" not in row.backup_metadata
+
+  def test_records_the_database_name_when_registered_on_another_graph(self):
+    from robosystems.models.core.graph.graph_backup import (
+      BackupInitiator,
+      GraphBackup,
+    )
+
+    row = GraphBackup.from_completed_export(
+      graph_id="kg_parent",
+      database_name="kg_parent_dev",
+      metadata=self._metadata(),
+      s3_bucket="robosystems-test",
+      retention_days=7,
+      initiated_by=BackupInitiator.FINAL.value,
+    )
+
+    assert row.graph_id == "kg_parent"
+    assert row.database_name == "kg_parent_dev"
+    assert row.backup_metadata["database_name"] == "kg_parent_dev"

--- a/tests/operations/graph/test_deprovision_service.py
+++ b/tests/operations/graph/test_deprovision_service.py
@@ -1057,6 +1057,72 @@ class TestProviderGrantRevocationAtTeardown:
     assert self._credential_rows(db_session, connection_id) == 0
 
   @pytest.mark.asyncio
+  async def test_revokes_connections_scoped_to_a_subgraph_too(
+    self, service, db_session, test_graph, test_user
+  ):
+    """Connections can be created directly on a subgraph id. Full teardown
+    cleans each subgraph's PG records, so it must revoke there as well — the
+    same leak one level down."""
+    from robosystems.operations.providers.registry import provider_registry
+
+    subgraph = Graph(
+      graph_id=f"{test_graph.graph_id}_dev",
+      graph_name="Dev Subgraph",
+      graph_type="entity",
+      org_id=test_graph.org_id,
+      graph_tier=test_graph.graph_tier,
+      parent_graph_id=test_graph.graph_id,
+      is_subgraph=True,
+      subgraph_index=0,
+      subgraph_name="dev",
+      status=GraphStatus.ACTIVE.value,
+    )
+    db_session.add(subgraph)
+    db_session.commit()
+
+    parent_conn = self._seed_quickbooks_connection(db_session, test_graph, test_user)
+    sub_conn = self._seed_quickbooks_connection(db_session, subgraph, test_user)
+    seen: list[tuple[str, str, int]] = []
+
+    async def _cleanup(provider_type, connection, graph_id):
+      seen.append(
+        (
+          connection["id"],
+          graph_id,
+          self._credential_rows(db_session, connection["id"]),
+        )
+      )
+
+    infra = self._infra()
+    with (
+      infra[0] as mock_get_client,
+      infra[1] as mock_alloc_cls,
+      infra[2],
+      patch("robosystems.operations.graph.subgraph_service.LadybugAllocationManager"),
+      patch(
+        "robosystems.operations.graph.subgraph_service.SubgraphService"
+      ) as mock_sub_cls,
+      patch.object(provider_registry, "cleanup_connection", side_effect=_cleanup),
+    ):
+      mock_get_client.return_value = AsyncMock()
+      mock_alloc_cls.return_value = AsyncMock()
+      mock_sub_cls.return_value = AsyncMock()
+
+      result = await service.deprovision_graph(
+        test_graph.graph_id, db_session, create_backup=False
+      )
+
+    assert result.status == "success", result.errors
+    assert result.subgraphs_deleted == 1
+    assert result.connections_revoked == 2
+    assert result.connections_deleted == 2
+    by_connection = {cid: (gid, rows) for cid, gid, rows in seen}
+    assert by_connection[sub_conn] == (subgraph.graph_id, 1)
+    assert by_connection[parent_conn] == (test_graph.graph_id, 1)
+    assert self._credential_rows(db_session, sub_conn) == 0
+    assert self._credential_rows(db_session, parent_conn) == 0
+
+  @pytest.mark.asyncio
   async def test_a_failed_revoke_is_recorded_and_teardown_still_completes(
     self, service, db_session, test_graph, test_user
   ):

--- a/tests/operations/graph/test_deprovision_service.py
+++ b/tests/operations/graph/test_deprovision_service.py
@@ -964,6 +964,166 @@ class TestDeprovisionService:
       assert isinstance(test_graph.deleted_at, datetime)
 
 
+class TestProviderGrantRevocationAtTeardown:
+  """Teardown deletes our copy of a connection's credentials; it must also end
+  the grant at the provider, the way the disconnect endpoint does — and it must
+  do so while the credential row still exists, because that is what the
+  provider cleanup reads."""
+
+  def _seed_quickbooks_connection(self, db_session, test_graph, test_user):
+    from robosystems.models.core.connection.connection import Connection
+    from robosystems.models.core.connection.connection_credentials import (
+      ConnectionCredentials,
+    )
+
+    connection = Connection.create(
+      graph_id=test_graph.graph_id,
+      user_id=test_user.id,
+      provider="quickbooks",
+      session=db_session,
+      realm_id="realm-departed",
+    )
+    db_session.add(
+      ConnectionCredentials(
+        connection_id=connection.id,
+        provider="quickbooks",
+        user_id=test_user.id,
+        encrypted_credentials="ciphertext-standing-in-for-a-refresh-token",
+      )
+    )
+    db_session.commit()
+    return connection.id
+
+  def _credential_rows(self, db_session, connection_id) -> int:
+    from robosystems.models.core.connection.connection_credentials import (
+      ConnectionCredentials,
+    )
+
+    return (
+      db_session.query(ConnectionCredentials)
+      .filter(ConnectionCredentials.connection_id == connection_id)
+      .count()
+    )
+
+  def _infra(self):
+    return (
+      patch(
+        "robosystems.graph_api.client.factory.get_graph_client",
+        new_callable=AsyncMock,
+      ),
+      patch("robosystems.middleware.graph.allocation_manager.LadybugAllocationManager"),
+      patch("robosystems.middleware.auth.cache.api_key_cache"),
+    )
+
+  @pytest.mark.asyncio
+  async def test_revokes_at_the_provider_while_the_credential_still_exists(
+    self, service, db_session, test_graph, test_user
+  ):
+    from robosystems.operations.providers.registry import provider_registry
+
+    connection_id = self._seed_quickbooks_connection(db_session, test_graph, test_user)
+    seen: list[tuple[str, dict, int]] = []
+
+    async def _cleanup(provider_type, connection, graph_id):
+      # The provider cleanup loads the stored token to revoke it — so the
+      # credential row must still be there when this is called.
+      seen.append(
+        (provider_type, connection, self._credential_rows(db_session, connection_id))
+      )
+
+    infra = self._infra()
+    with (
+      infra[0] as mock_get_client,
+      infra[1] as mock_alloc_cls,
+      infra[2],
+      patch.object(provider_registry, "cleanup_connection", side_effect=_cleanup),
+    ):
+      mock_get_client.return_value = AsyncMock()
+      mock_alloc_cls.return_value = AsyncMock()
+
+      result = await service.deprovision_graph(
+        test_graph.graph_id, db_session, create_backup=False
+      )
+
+    assert result.status == "success", result.errors
+    assert result.connections_revoked == 1
+    assert result.connections_deleted == 1
+    assert len(seen) == 1
+    provider_type, payload, rows_at_call = seen[0]
+    assert provider_type == "quickbooks"
+    assert payload["id"] == connection_id
+    assert payload["connection_id"] == connection_id
+    assert rows_at_call == 1, "revoke ran after the credential row was deleted"
+    assert self._credential_rows(db_session, connection_id) == 0
+
+  @pytest.mark.asyncio
+  async def test_a_failed_revoke_is_recorded_and_teardown_still_completes(
+    self, service, db_session, test_graph, test_user
+  ):
+    from robosystems.operations.providers.registry import provider_registry
+
+    connection_id = self._seed_quickbooks_connection(db_session, test_graph, test_user)
+
+    infra = self._infra()
+    with (
+      infra[0] as mock_get_client,
+      infra[1] as mock_alloc_cls,
+      infra[2],
+      patch.object(
+        provider_registry,
+        "cleanup_connection",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("intuit unreachable"),
+      ),
+    ):
+      mock_get_client.return_value = AsyncMock()
+      mock_alloc_cls.return_value = AsyncMock()
+
+      result = await service.deprovision_graph(
+        test_graph.graph_id, db_session, create_backup=False
+      )
+
+    # A stranded grant is an operator follow-up, not a reason to keep the
+    # tenant's data — so the teardown finishes and reports partial.
+    assert result.status == "partial"
+    assert any(connection_id in e and "revocation failed" in e for e in result.errors)
+    assert result.connections_revoked == 0
+    assert result.connections_deleted == 1
+    assert self._credential_rows(db_session, connection_id) == 0
+
+  @pytest.mark.asyncio
+  async def test_a_provider_disabled_by_flag_is_skipped_not_failed(
+    self, service, db_session, test_graph, test_user
+  ):
+    from robosystems.operations.providers.registry import provider_registry
+
+    connection_id = self._seed_quickbooks_connection(db_session, test_graph, test_user)
+
+    infra = self._infra()
+    with (
+      infra[0] as mock_get_client,
+      infra[1] as mock_alloc_cls,
+      infra[2],
+      patch.object(
+        provider_registry,
+        "cleanup_connection",
+        new_callable=AsyncMock,
+        side_effect=ValueError("Provider quickbooks is not enabled"),
+      ),
+    ):
+      mock_get_client.return_value = AsyncMock()
+      mock_alloc_cls.return_value = AsyncMock()
+
+      result = await service.deprovision_graph(
+        test_graph.graph_id, db_session, create_backup=False
+      )
+
+    assert result.status == "success", result.errors
+    assert result.connections_revoked == 0
+    assert result.connections_deleted == 1
+    assert self._credential_rows(db_session, connection_id) == 0
+
+
 class TestReportBundlePurge:
   """Published report artifacts must not outlive the tenant.
 

--- a/tests/operations/graph/test_subgraph_service.py
+++ b/tests/operations/graph/test_subgraph_service.py
@@ -417,6 +417,160 @@ class TestSubgraphService:
         assert result["status"] == "deleted"
         mock_lbug_client.delete_database.assert_called_once()
 
+  def _backup_metadata(self):
+    metadata = Mock()
+    metadata.s3_key = "graph-backups/kg5f2e5e0da65d45d69645/analysis.lbug.zip"
+    metadata.s3_metadata_key = f"{metadata.s3_key}.metadata.json"
+    metadata.original_size = 2048
+    metadata.compressed_size = 512
+    metadata.compression_ratio = 0.75
+    metadata.node_count = 12
+    metadata.relationship_count = 7
+    metadata.database_version = "1.0"
+    metadata.backup_duration_seconds = 1.5
+    metadata.checksum = "abc123"
+    metadata.backup_format = "full_dump"
+    from datetime import UTC, datetime
+
+    metadata.timestamp = datetime(2026, 8, 25, tzinfo=UTC)
+    metadata.memory = None
+    metadata.payload_delta = None
+    return metadata
+
+  @pytest.mark.asyncio
+  async def test_delete_with_backup_takes_it_before_deleting_and_registers_on_parent(
+    self, service, mock_allocation_manager, mock_lbug_client, mock_parent_location
+  ):
+    """`create_backup` used to be accepted and ignored. It now takes a full
+    backup first, registers it on the parent graph's backup list (the row the
+    customer still has after the subgraph is gone), and only then deletes."""
+    mock_allocation_manager.find_database_location.return_value = mock_parent_location
+    mock_lbug_client.list_databases.return_value = {
+      "databases": [{"graph_id": "kg5f2e5e0da65d45d69645_analysis"}]
+    }
+    mock_lbug_client.execute.return_value = [{"node_count": 100}]
+
+    calls: list[str] = []
+    metadata = self._backup_metadata()
+
+    async def _backup(job):
+      calls.append(("backup", job.graph_id))
+      return metadata
+
+    async def _delete(name):
+      calls.append(("delete", name))
+
+    mock_lbug_client.delete_database = AsyncMock(side_effect=_delete)
+    manager = Mock()
+    manager.create_backup = AsyncMock(side_effect=_backup)
+    manager.s3_adapter.bucket_name = "robosystems-test"
+
+    parent = Mock()
+    parent.graph_tier = "ladybug-standard"
+    session = Mock()
+    session.query.return_value.filter.return_value.first.return_value = parent
+
+    with (
+      patch(
+        "robosystems.operations.graph.subgraph_service.get_graph_client_for_instance",
+        return_value=mock_lbug_client,
+      ),
+      patch("robosystems.graph_api.client.GraphClient", return_value=mock_lbug_client),
+      patch(
+        "robosystems.operations.graph.engine.backup_manager.BackupManager",
+        return_value=manager,
+      ),
+      patch("robosystems.database.SessionFactory", return_value=session),
+    ):
+      result = await service.delete_subgraph_database(
+        "kg5f2e5e0da65d45d69645_analysis", force=True, create_backup=True
+      )
+
+    assert calls == [
+      ("backup", "kg5f2e5e0da65d45d69645_analysis"),
+      ("delete", "kg5f2e5e0da65d45d69645_analysis"),
+    ]
+    assert result["status"] == "deleted"
+    assert result["backup_created"] is True
+    assert result["backup_location"] == metadata.s3_key
+
+    from robosystems.models.core.graph.graph_backup import BackupInitiator, GraphBackup
+
+    session.add.assert_called_once()
+    row = session.add.call_args.args[0]
+    assert isinstance(row, GraphBackup)
+    assert row.graph_id == "kg5f2e5e0da65d45d69645"
+    assert row.database_name == "kg5f2e5e0da65d45d69645_analysis"
+    assert row.initiated_by == BackupInitiator.FINAL.value
+    assert row.s3_key == metadata.s3_key
+    session.commit.assert_called_once()
+    session.close.assert_called_once()
+
+  @pytest.mark.asyncio
+  async def test_delete_with_backup_fails_closed_when_the_backup_fails(
+    self, service, mock_allocation_manager, mock_lbug_client, mock_parent_location
+  ):
+    mock_allocation_manager.find_database_location.return_value = mock_parent_location
+    mock_lbug_client.list_databases.return_value = {
+      "databases": [{"graph_id": "kg5f2e5e0da65d45d69645_analysis"}]
+    }
+    mock_lbug_client.execute.return_value = [{"node_count": 100}]
+
+    manager = Mock()
+    manager.create_backup = AsyncMock(side_effect=RuntimeError("s3 is down"))
+    session = Mock()
+    session.query.return_value.filter.return_value.first.return_value = None
+
+    with (
+      patch(
+        "robosystems.operations.graph.subgraph_service.get_graph_client_for_instance",
+        return_value=mock_lbug_client,
+      ),
+      patch("robosystems.graph_api.client.GraphClient", return_value=mock_lbug_client),
+      patch(
+        "robosystems.operations.graph.engine.backup_manager.BackupManager",
+        return_value=manager,
+      ),
+      patch("robosystems.database.SessionFactory", return_value=session),
+    ):
+      with pytest.raises(GraphAllocationError, match="was not deleted"):
+        await service.delete_subgraph_database(
+          "kg5f2e5e0da65d45d69645_analysis", force=True, create_backup=True
+        )
+
+    mock_lbug_client.delete_database.assert_not_called()
+    session.add.assert_not_called()
+    session.close.assert_called_once()
+
+  @pytest.mark.asyncio
+  async def test_delete_without_backup_reports_none_taken(
+    self, service, mock_allocation_manager, mock_lbug_client, mock_parent_location
+  ):
+    mock_allocation_manager.find_database_location.return_value = mock_parent_location
+    mock_lbug_client.list_databases.return_value = {
+      "databases": [{"graph_id": "kg5f2e5e0da65d45d69645_analysis"}]
+    }
+    mock_lbug_client.execute.return_value = [{"node_count": 0}]
+
+    with (
+      patch(
+        "robosystems.operations.graph.subgraph_service.get_graph_client_for_instance",
+        return_value=mock_lbug_client,
+      ),
+      patch("robosystems.graph_api.client.GraphClient", return_value=mock_lbug_client),
+      patch(
+        "robosystems.operations.graph.engine.backup_manager.BackupManager"
+      ) as manager_cls,
+    ):
+      result = await service.delete_subgraph_database(
+        "kg5f2e5e0da65d45d69645_analysis", create_backup=False
+      )
+
+    assert result["status"] == "deleted"
+    assert result["backup_created"] is False
+    assert result["backup_location"] is None
+    manager_cls.assert_not_called()
+
   # NOTE: test_delete_subgraph_with_backup removed - create_backup capability
   # was removed from subgraph_service.py as part of S3 bucket restructure
 


### PR DESCRIPTION
## Summary

Two teardown paths said one thing and did another. Graph deprovisioning deleted our copy of a QuickBooks connection's credentials and never ended the authorization at the provider, so a departed customer's grant stayed live at Intuit until it expired on its own — while the user-initiated disconnect has always revoked first. And `delete-subgraph` accepted `backup_first` (default `true`), took no backup, and still reported `backup_created` in its security-audit event and MCP result. Both now do what they claim. Records §7c items 1 and 2 of `local/RoboSystems/specs/security/data-deletion-and-retention.md`; item 3 (the `delete_database` 404 path) is not in this PR.

## Changes

**Teardown revokes provider grants** (`operations/graph/deprovision_service.py`)
- New step 5b `_revoke_provider_grants`, placed before `_clean_pg_records` because the provider cleanup reads the stored token it revokes. It calls the same `provider_registry.cleanup_connection` hook the disconnect endpoint uses, once per connection on the graph. Best-effort per connection: a provider disabled by flag is skipped (same as the endpoint), any other failure is recorded in `result.errors` (teardown finishes as `partial`) and the credential rows are still deleted — a stranded grant is an operator follow-up, not a reason to keep the tenant's data. `DeprovisionResult.connections_revoked` added and included in the teardown log line.

**`delete-subgraph` takes the backup it advertises** (`operations/graph/subgraph_service.py`, `routers/graphs/operations.py`, `middleware/mcp/tools/graph_tools.py`, `models/api/graphs/operations.py`)
- `SubgraphService.delete_subgraph_database(create_backup=True)` now runs a full-dump `BackupJob` for the subgraph through `BackupManager` (the same path the nightly job uses for subgraphs) after the data/`force` check and before `delete_database`. If the backup or its registration fails it raises `GraphAllocationError` and nothing is deleted. The result dict carries `backup_created`, `backup_location`, `backup_id`.
- The backup row is registered on the **parent** graph (`graph_id=parent`, `database_name=<subgraph db>`, initiator `final`, retention = the parent tier's hosting window), because the subgraph's own `Graph` row is hard-deleted right after and a row keyed on it would be unreachable through the listing and download surfaces. `GraphBackup.graph_id` carries no FK, so the row survives the subgraph's deletion.
- Domain `GraphAllocationError`s from the delete path (data without `force`, a failed pre-delete backup) now pass through with their own message instead of being re-wrapped with a generic prefix.
- REST handler: the audit event's `backup_created` and the operation result report what the service did, not what was asked; `backup_id` added to both. Request-model description rewritten to describe the real behavior; the default stays `true`.
- MCP tool: description rewritten (it previously told operators to run `create-backup` on the parent, which does not cover a subgraph's database); the result reports `backup_created` / `backup_location` / `backup_id` from the service.

**Shared row mapping** (`models/core/graph/graph_backup.py`)
- New `GraphBackup.from_completed_export(...)` builds — without persisting — a `COMPLETED` row from a manager export. The teardown's `_register_final_backup` now delegates to it (still under its SAVEPOINT, still uncommitted), and the subgraph path adds/commits it in its own session. One mapping, two callers.

## Breaking Changes

None. `DeleteSubgraphOp` is unchanged in shape and default; its description text changed. The `delete-subgraph` operation result gains `backup_created` and `backup_id` alongside the existing `backup_location` (additive; the envelope's `result` is untyped). The MCP `delete-subgraph` result gains `backup_location` and `backup_id`. No SDK facade changes; an SDK regen would only pick up the description text.

## Testing

- `uv run pytest` over `tests/operations/graph/test_deprovision_service.py`, `tests/operations/graph/test_subgraph_service.py`, `tests/middleware/mcp/tools/test_graph_tools.py`, `tests/routers/graphs/test_ops_shared_repo_gates.py`, `tests/models/core/graph/test_graph_backup.py`, `tests/routers/graphs/test_delete_graph_op.py`: **168 passed**. The one pre-existing test that asserted the echoed flag (`TestDeleteSubgraphExecute.test_happy_path`) was rewritten to assert the service's report.
- New tests: revoke runs while the credential row still exists (asserted from inside the patched hook), revoke failure → `partial` with the credentials still deleted, disabled provider → skipped; backup runs before delete (call order asserted) and is registered on the parent with initiator `final`; backup failure → `GraphAllocationError`, no delete, no row; `create_backup=False` → reported as not taken; MCP result reflects the service; `from_completed_export` field mapping including the cross-graph `database_name` note.
- Mutation checks: reverting `deprovision_service.py` fails the three revoke tests; reverting `subgraph_service.py` fails the three backup tests; reverting `graph_tools.py` fails the two MCP result tests.
- `just test-code`: ruff check, ruff format, basedpyright (0 errors, 0 warnings), cf-lint — all passed.
- `just test-all` was not run.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
