### PR TITLE
fix(worker): let an over-budget close land; fence waits as a background job

### DIFF
--- a/robosystems/operations/locking.py
+++ b/robosystems/operations/locking.py
@@ -191,7 +191,9 @@ def acquire_shared_period_fence(
 
 
 @contextmanager
-def exclusive_period_fence(graph_id: str, period: str, *, detail: str):
+def exclusive_period_fence(
+  graph_id: str, period: str, *, detail: str, wait_ms: int | None = None
+):
   """Hold a session-scoped exclusive fence on ``(graph_id, period)``.
 
   Uses a dedicated connection, not the caller's ``Session``. The close
@@ -199,6 +201,14 @@ def exclusive_period_fence(graph_id: str, period: str, *, detail: str):
   would return the session's connection to the pool and drop any lock
   taken on it. A session-scoped advisory lock on a connection we hold
   ourselves survives that commit.
+
+  ``wait_ms`` bounds the wait for whoever holds the fence. The default is
+  the request wait, per the module rule: a request handler that sat out a
+  whole close would pin a pooled connection for it. A background closer —
+  the worker close — passes its own budget instead. What it is most likely
+  waiting on is another close of the same period, and waiting turns a
+  duplicate dispatch into "already closed, here is the receipt" rather
+  than a refusal the operator is told to retry.
 
   Unlock (or invalidate the connection, so the pool discards it) before
   returning the connection — a pooled connection still holding this
@@ -208,10 +218,11 @@ def exclusive_period_fence(graph_id: str, period: str, *, detail: str):
 
   ident = period_fence_ident(graph_id, period)
   params = {"classid": _PERIOD_FENCE_CLASS, "ident": ident}
+  wait = _LOCK_TIMEOUT_MS if wait_ms is None else wait_ms
   conn = get_extensions_engine().connect()
   acquired = False
   try:
-    conn.execute(text(f"SET lock_timeout = '{_LOCK_TIMEOUT_MS}ms'"))
+    conn.execute(text(f"SET lock_timeout = '{wait}ms'"))
     try:
       conn.execute(
         text("SELECT pg_advisory_lock(:classid, hashtext(:ident))"),
@@ -221,7 +232,7 @@ def exclusive_period_fence(graph_id: str, period: str, *, detail: str):
     except OperationalError as exc:
       # The failed statement aborted the transaction; roll it back and clear
       # the session-level timeout before the connection goes back to the
-      # pool, or the next borrower inherits a 3s lock_timeout it never set.
+      # pool, or the next borrower inherits a lock_timeout it never set.
       try:
         conn.rollback()
         conn.execute(text("RESET lock_timeout"))

--- a/robosystems/operations/roboledger/commands/fiscal_calendar.py
+++ b/robosystems/operations/roboledger/commands/fiscal_calendar.py
@@ -194,12 +194,17 @@ def close_period(
   actor_type: str = "user",
   allow_stranded_obligations: bool = False,
   allow_reconciling_items: bool = False,
+  fence_wait_ms: int | None = None,
 ) -> ClosePeriodResponse:
   """Close a fiscal period — the final commit action.
 
   `actor_type` defaults to `"user"` for REST callers; MCP tools pass
   `"agent"` so the audit log distinguishes Claude-driven closes from
   human-driven ones.
+
+  `fence_wait_ms` is how long to wait for the period fence. `None` is the
+  request wait (request handlers do not wait); the worker close passes its
+  own budget, because a background job waits.
 
   Raises `CloseGateFailed`, `PeriodNotFoundError`,
   `PeriodAlreadyClosedError`, `RowLockedError`,
@@ -218,6 +223,7 @@ def close_period(
       f"Period {period} is being closed or reopened by another process. "
       "Retry in a moment."
     ),
+    wait_ms=fence_wait_ms,
   ):
     result = close_service.close(
       session,

--- a/robosystems/operations/roboledger/tasks/period_close.py
+++ b/robosystems/operations/roboledger/tasks/period_close.py
@@ -7,7 +7,10 @@ had to know not to retry a write that had already landed.
 
 Running it here decouples the work from the listener. The close itself is
 unchanged: same command, same exclusive period fence, same mid-flow commit
-of the publish markers. What changes is who waits.
+of the publish markers. What changes is who waits — and, because this is a
+background job, how long: the fence wait is the task's own budget rather
+than the request wait, so a duplicate dispatch queues behind the close it
+duplicates and comes back with that close's receipt instead of a refusal.
 
 **A refused close is a result, not a failure.** The consumer reduces any
 raised exception to a plain string, so a gate rejection that propagated
@@ -18,7 +21,6 @@ they need. Domain outcomes are therefore returned (shaped by
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from robosystems.logger import get_logger
@@ -52,8 +54,11 @@ class PeriodCloseTask(BaseTask):
     await self.report_progress(f"Closing {period}…", percent=5)
 
     # The close is synchronous and blocks on QuickBooks, so it cannot run on
-    # the event loop the consumer uses to emit progress.
-    result = await asyncio.to_thread(self._run_close)
+    # the event loop the consumer uses to emit progress — and the budget
+    # cannot cancel the thread it runs on, so `run_blocking` waits for the
+    # thread when the budget expires rather than reporting a close that is
+    # about to land as one that failed.
+    result = await self.run_blocking(self._run_close)
 
     outcome = result.get("outcome")
     await self.report_progress(
@@ -111,6 +116,12 @@ class PeriodCloseTask(BaseTask):
           allow_reconciling_items=bool(
             self.params.get("allow_reconciling_items", False)
           ),
+          # Background jobs wait. The request wait (3s) is sized so a
+          # request handler never pins a pooled connection behind a close;
+          # this *is* the close, and what holds the fence against it is
+          # most often another close of the same period — worth waiting
+          # out, since the answer is then "already closed" with a receipt.
+          fence_wait_ms=self.budget_seconds * 1000,
         )
       except CLOSE_DOMAIN_ERRORS as exc:
         payload = close_error_payload(exc, period=period)

--- a/robosystems/worker/constants.py
+++ b/robosystems/worker/constants.py
@@ -50,11 +50,14 @@ TASK_TIMEOUTS: dict[str, int] = {
   # The close publishes one QuickBooks entry per in-period draft, and the
   # Intuit SDK sets no per-request timeout — a single call that hits the
   # retry ladder backs off ~31s on its own. A 34-entry month runs ~30s;
-  # a heavier one, or one slow call, runs much longer. The failure mode
-  # decides the size: an under-budget close is cancelled mid-flight while
-  # its thread keeps running and can still commit, so the operation reports
-  # FAILED for a close that landed. Matching the operator's 600s leaves room
-  # for that rather than inviting it.
+  # a heavier one, or one slow call, runs much longer. The budget cannot
+  # cancel the thread the close runs on; ``BaseTask.run_blocking`` waits one
+  # more budget for it to land and reports what it produced, and only past
+  # that grace is the close abandoned as still running. So this number is
+  # doing three jobs — the budget, the grace, and (as ``fence_wait_ms``) how
+  # long a worker close waits behind another close of the same period — and
+  # matching the operator's 600s keeps the ordinary overrun inside the
+  # first of them.
   "period_close": 600,  # 10 minutes
 }
 DEFAULT_TASK_TIMEOUT = 120  # 2 minutes

--- a/robosystems/worker/consumer.py
+++ b/robosystems/worker/consumer.py
@@ -36,6 +36,7 @@ from robosystems.worker.task_protection import (
   TaskProtectionManager,
 )
 from robosystems.worker.tasks import get_task_handler
+from robosystems.worker.tasks.base import BaseTask
 
 logger = logging.getLogger(__name__)
 
@@ -182,12 +183,17 @@ async def _process_task(
     # Only long tasks need scale-in protection; short ones drain within the
     # SIGTERM grace, so protecting them would just churn the ECS API.
     protect_task = timeout >= PROTECT_MIN_TIMEOUT_SECONDS
+    handler: BaseTask | None = None
     try:
       if protect_task:
         await protection.protect()
       await manager.emit_progress(task_id, "Starting...", progress_percent=0)
 
       handler = handler_cls(task_id, graph_id, user_id, params, manager)
+      # The budget cancels the coroutine. A handler running sync work in a
+      # thread (`BaseTask.run_blocking`) absorbs that cancel for one more
+      # budget so the thread can land and report its real outcome; the
+      # TimeoutError below reaches us only once that grace is also spent.
       result = await asyncio.wait_for(handler.execute(), timeout=timeout)
       duration_ms = (time.time() - start_time) * 1000
 
@@ -205,21 +211,37 @@ async def _process_task(
 
     except TimeoutError:
       duration_ms = (time.time() - start_time) * 1000
+      # A thread the budget could not cancel is still running: the stored
+      # error must say so, because "timed out" alone reads as "did not
+      # happen" and invites a retry of a write that may be about to land.
+      still_running = bool(handler is not None and handler.abandoned_work)
       logger.error(
-        f"Task timed out: {task_type} ({task_id}) after {timeout}s",
+        f"Task timed out: {task_type} ({task_id}) after {duration_ms / 1000:.0f}s "
+        f"(budget {timeout}s)"
+        + (
+          "; blocking work is still running and may still commit"
+          if still_running
+          else ""
+        ),
         extra={
           "task_id": task_id,
           "task_type": task_type,
           "graph_id": graph_id,
           "timeout_seconds": timeout,
           "duration_ms": duration_ms,
+          "still_running": still_running,
         },
       )
       await _fail_quietly(
         manager,
         task_id,
-        error=f"Task timed out after {timeout}s",
-        error_details={"error_type": "TimeoutError", "timeout_seconds": timeout},
+        error=f"Task timed out after {timeout}s"
+        + ("; work already in flight may still complete" if still_running else ""),
+        error_details={
+          "error_type": "TimeoutError",
+          "timeout_seconds": timeout,
+          "still_running": still_running,
+        },
       )
 
     except Exception as e:
@@ -244,8 +266,13 @@ async def _process_task(
 
     finally:
       # Clear scale-in protection — worker is idle again and safe to terminate.
+      # A thread abandoned past its grace loses this: that is the accepted
+      # residue of bounding the join, and it is logged above as such.
       if protect_task:
         await protection.unprotect()
       # Remove from inflight — task completed (successfully or not)
       await queue.lrem(inflight_key, 1, task_json)
+      # Disposal closes checked-in connections only; one an abandoned thread
+      # still holds stays open to it and is discarded on checkin rather than
+      # handed to the next tenant's pool.
       cleanup_connections()

--- a/robosystems/worker/task_protection.py
+++ b/robosystems/worker/task_protection.py
@@ -26,9 +26,11 @@ logger = get_logger(__name__)
 METADATA_URI_ENV = "ECS_CONTAINER_METADATA_URI_V4"
 
 # Protection lease length. Must exceed the longest task timeout
-# (dagster_job_monitor = 3600s = 60 min) so protection never lapses mid-task.
-# If an unprotect call fails, the lease self-expires and the worker becomes
-# eligible for scale-in again — a safe fallback.
+# (dagster_job_monitor = 3600s = 60 min) so protection never lapses mid-task —
+# and twice the budget of any task that runs its work through
+# ``BaseTask.run_blocking``, whose thread-join grace is one more budget
+# (period_close: 2 x 600s). If an unprotect call fails, the lease self-expires
+# and the worker becomes eligible for scale-in again — a safe fallback.
 PROTECTION_EXPIRES_MINUTES = 90
 
 # Timeout for the one-shot metadata fetch.

--- a/robosystems/worker/tasks/__init__.py
+++ b/robosystems/worker/tasks/__init__.py
@@ -34,6 +34,10 @@ def register_task(task_type: str):
         f"{TASK_REGISTRY[task_type].__name__} -> {cls.__name__}"
       )
     TASK_REGISTRY[task_type] = cls
+    # The handler's own key into TASK_TIMEOUTS: a task sizes the waits it
+    # makes (a fence wait, a thread-join grace) from its budget, and the
+    # budget is looked up by this string.
+    cls.task_type = task_type
     return cls
 
   return decorator

--- a/robosystems/worker/tasks/base.py
+++ b/robosystems/worker/tasks/base.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 from abc import ABC, abstractmethod
-from typing import Any
+from collections.abc import Callable
+from typing import Any, ClassVar
 
+from robosystems.logger import get_logger
 from robosystems.middleware.sse.event_storage import OperationStatus
 from robosystems.middleware.sse.operation_manager import OperationManager
+from robosystems.worker.constants import DEFAULT_TASK_TIMEOUT, TASK_TIMEOUTS
+
+logger = get_logger(__name__)
 
 
 class BaseTask(ABC):
@@ -14,8 +20,16 @@ class BaseTask(ABC):
 
   Subclasses must implement execute() and return a result dict.
   Use report_progress() for SSE updates and is_cancelled() to
-  check for user-initiated cancellation between steps.
+  check for user-initiated cancellation between steps. Sync work that
+  blocks — database and network calls — goes through ``run_blocking``,
+  which is what keeps the consumer's budget honest for a thread.
   """
+
+  # Stamped by ``@register_task``: the key the consumer sizes this task's
+  # budget by, so a handler can derive the waits it makes from that budget
+  # rather than from a constant that knows nothing about it. None on a
+  # subclass that was never registered.
+  task_type: ClassVar[str | None] = None
 
   def __init__(
     self,
@@ -30,11 +44,92 @@ class BaseTask(ABC):
     self.user_id = user_id
     self.params = params
     self.manager = manager
+    self._abandoned: list[asyncio.Future[Any]] = []
 
   @abstractmethod
   async def execute(self) -> dict[str, Any]:
     """Execute the task. Must return a result dict."""
     raise NotImplementedError
+
+  @property
+  def budget_seconds(self) -> int:
+    """The consumer's budget for this task type, from ``TASK_TIMEOUTS``."""
+    return TASK_TIMEOUTS.get(self.task_type or "", DEFAULT_TASK_TIMEOUT)
+
+  @property
+  def abandoned_work(self) -> list[asyncio.Future[Any]]:
+    """Blocking work still running after the budget and its grace expired."""
+    return [work for work in self._abandoned if not work.done()]
+
+  async def run_blocking(self, func: Callable[..., Any], *args: Any) -> Any:
+    """Run sync work — database and network calls — in a thread.
+
+    The consumer enforces the task budget with ``asyncio.wait_for``, which
+    cancels this coroutine and cannot cancel the thread. Left alone, that
+    reports the operation FAILED while the thread runs on and can still
+    commit: a close that landed, described to the operator as one that did
+    not. So the thread is shielded, and an expired budget becomes a bounded
+    wait for it — one more budget of grace. If the thread lands inside
+    that, its outcome is the task's outcome and the overrun is logged; only
+    past it is the work abandoned (tracked in ``abandoned_work``, so the
+    consumer can say so) and the timeout let through.
+
+    While this waits, the consumer's ``finally`` has not run: scale-in
+    protection stays on and the engines are not disposed, so a slow close is
+    not exposed to scale-in mid-publish and is not handed a second tenant's
+    task while its thread is still on the first.
+    """
+    work = asyncio.ensure_future(asyncio.to_thread(func, *args))
+    try:
+      return await asyncio.shield(work)
+    except asyncio.CancelledError:
+      if work.done() and not work.cancelled():
+        return work.result()
+      grace = self.budget_seconds
+      logger.warning(
+        f"Task {self.task_id} ({self.task_type}) ran out of budget with blocking "
+        f"work still running; waiting up to {grace}s more for it to finish"
+      )
+      try:
+        done, _ = await asyncio.wait({work}, timeout=grace)
+      except asyncio.CancelledError:
+        self._abandon(work)
+        raise
+      if work in done:
+        logger.warning(
+          f"Task {self.task_id} ({self.task_type}) finished its blocking work "
+          "past its budget; reporting that outcome rather than a timeout"
+        )
+        return work.result()
+      self._abandon(work)
+      raise
+
+  def _abandon(self, work: asyncio.Future[Any]) -> None:
+    self._abandoned.append(work)
+    work.add_done_callback(self._log_abandoned_outcome)
+    logger.error(
+      f"Task {self.task_id} ({self.task_type}) abandoned blocking work after its "
+      f"budget and {self.budget_seconds}s grace; the thread is still running "
+      "and may still commit"
+    )
+
+  def _log_abandoned_outcome(self, work: asyncio.Future[Any]) -> None:
+    # Nothing awaits an abandoned future, so its outcome would otherwise be
+    # dropped (or surface as "exception was never retrieved" on stderr).
+    if work.cancelled():
+      return
+    exc = work.exception()
+    if exc is None:
+      logger.warning(
+        f"Task {self.task_id} ({self.task_type}) abandoned blocking work "
+        "finished after the operation was already reported as timed out"
+      )
+    else:
+      logger.warning(
+        f"Task {self.task_id} ({self.task_type}) abandoned blocking work "
+        f"failed after the operation was reported as timed out: "
+        f"{type(exc).__name__}: {exc}"
+      )
 
   async def report_progress(
     self,

--- a/tests/operations/roboledger/commands/test_fiscal_calendar.py
+++ b/tests/operations/roboledger/commands/test_fiscal_calendar.py
@@ -81,7 +81,7 @@ def _stub_period_lock(session, fp):
 
 
 class TestClosePeriodResponseMapping:
-  def _run(self, result: PeriodCloseResult):
+  def _run(self, result: PeriodCloseResult, **overrides):
     close_service = MagicMock()
     close_service.close.return_value = result
     with (
@@ -98,6 +98,7 @@ class TestClosePeriodResponseMapping:
         note=None,
         service=MagicMock(),
         close_service=close_service,
+        **overrides,
       )
 
   def test_stamp_fields_ride_the_response(self):
@@ -151,6 +152,22 @@ class TestClosePeriodResponseMapping:
     self._run(_close_result())
     _noop_exclusive_period_fence.assert_called_once()
     assert _noop_exclusive_period_fence.call_args.args[:2] == (GRAPH_ID, "2026-01")
+
+  def test_a_request_close_takes_the_request_fence_wait(
+    self, _noop_exclusive_period_fence
+  ):
+    """REST and the synchronous MCP paths pass nothing, and get the fence's
+    own default — the bounded request wait."""
+    self._run(_close_result())
+    assert _noop_exclusive_period_fence.call_args.kwargs["wait_ms"] is None
+
+  def test_a_background_close_passes_its_wait_through_to_the_fence(
+    self, _noop_exclusive_period_fence
+  ):
+    """The worker close is a background job and waits its budget; the
+    command has to hand that to the fence rather than swallow it."""
+    self._run(_close_result(), fence_wait_ms=600_000)
+    assert _noop_exclusive_period_fence.call_args.kwargs["wait_ms"] == 600_000
 
 
 class TestReopenRetractsCanonicalSets:

--- a/tests/operations/roboledger/tasks/test_period_close.py
+++ b/tests/operations/roboledger/tasks/test_period_close.py
@@ -276,3 +276,22 @@ class TestFaults:
 
     with pytest.raises(OperationalError):
       _run(_task(), close_error=fault)
+
+
+class TestBackgroundWaits:
+  def test_the_worker_close_waits_its_whole_budget_for_the_fence(self):
+    """Background jobs wait. The 3s request wait exists so a request handler
+    never pins a connection behind a close; the worker close *is* the close,
+    and what holds the fence against it is most often another close of the
+    same period — after which this one reports 'already closed' with the
+    receipt instead of a refusal the operator is told to retry."""
+    from robosystems.worker.constants import TASK_TIMEOUTS
+
+    spy = MagicMock()
+    task = _task()
+    assert task.task_type == "period_close"
+    assert task.budget_seconds == TASK_TIMEOUTS["period_close"]
+
+    _run(task, close_result=_close_response(), close_spy=spy)
+
+    assert spy.call_args.kwargs["fence_wait_ms"] == TASK_TIMEOUTS["period_close"] * 1000

--- a/tests/operations/test_locking.py
+++ b/tests/operations/test_locking.py
@@ -78,3 +78,39 @@ class TestExclusivePeriodFence:
 
 def test_period_fence_ident_is_graph_and_period():
   assert period_fence_ident("kg1", "2026-01") == "kg1:2026-01"
+
+
+class TestFenceWait:
+  """Request handlers do not wait; background jobs do. The fence takes the
+  wait from its caller so the worker close can pass its own budget."""
+
+  def _connect(self, mock_engine):
+    conn = MagicMock()
+    mock_engine.return_value.connect.return_value = conn
+    return conn
+
+  def _set_statements(self, conn):
+    return [
+      str(call.args[0])
+      for call in conn.execute.call_args_list
+      if call.args and "lock_timeout" in str(call.args[0])
+    ]
+
+  @patch("robosystems.db.extensions.get_extensions_engine")
+  def test_the_default_is_the_request_wait(self, mock_engine):
+    from robosystems.operations.locking import _LOCK_TIMEOUT_MS
+
+    conn = self._connect(mock_engine)
+    with exclusive_period_fence("kgabc", "2026-01", detail="held"):
+      pass
+    assert self._set_statements(conn)[0] == f"SET lock_timeout = '{_LOCK_TIMEOUT_MS}ms'"
+
+  @patch("robosystems.db.extensions.get_extensions_engine")
+  def test_a_background_closer_waits_as_long_as_it_says(self, mock_engine):
+    conn = self._connect(mock_engine)
+    with exclusive_period_fence("kgabc", "2026-01", detail="held", wait_ms=600_000):
+      pass
+    statements = self._set_statements(conn)
+    assert statements[0] == "SET lock_timeout = '600000ms'"
+    # The longer wait is still scrubbed before the connection goes back.
+    assert "RESET lock_timeout" in statements[-1]

--- a/tests/worker/test_base_task.py
+++ b/tests/worker/test_base_task.py
@@ -175,3 +175,119 @@ class TestReleaseLock:
     assert args[2] == "lock:graph_materialize:kg1"
     assert args[3] == "stale"
     redis_client.delete.assert_not_called()
+
+
+class TestRunBlocking:
+  """The consumer's budget cancels the coroutine and never the thread. What
+  happens in the gap decides whether a close that lands is reported as one
+  that failed."""
+
+  def _task(self, mock_manager, work):
+    class BlockingTask(BaseTask):
+      async def execute(self) -> dict[str, Any]:
+        return await self.run_blocking(work)
+
+    return BlockingTask(
+      task_id="op_01TEST",
+      graph_id="kg0123456789abcdef",
+      user_id="user_01TEST",
+      params={},
+      manager=mock_manager,
+    )
+
+  @pytest.mark.asyncio
+  async def test_a_thread_that_lands_inside_the_grace_is_the_result(self, mock_manager):
+    """The budget expires at 50ms; the thread needs 200ms; the grace is a
+    second. The outcome is the thread's, and `wait_for` returns it rather
+    than raising — the stdlib contract for a task that absorbs its cancel."""
+    import time
+
+    def work():
+      time.sleep(0.2)
+      return {"landed": True}
+
+    task = self._task(mock_manager, work)
+    with patch("robosystems.worker.tasks.base.DEFAULT_TASK_TIMEOUT", 1):
+      import asyncio
+
+      result = await asyncio.wait_for(task.execute(), timeout=0.05)
+
+    assert result == {"landed": True}
+    assert task.abandoned_work == []
+
+  @pytest.mark.asyncio
+  async def test_a_thread_that_fails_inside_the_grace_raises_its_own_error(
+    self, mock_manager
+  ):
+    """A fault after the budget is still that fault, not a timeout — the
+    consumer records its type, and a timeout would hide it."""
+    import asyncio
+    import time
+
+    def work():
+      time.sleep(0.1)
+      raise RuntimeError("stamp failed")
+
+    task = self._task(mock_manager, work)
+    with patch("robosystems.worker.tasks.base.DEFAULT_TASK_TIMEOUT", 1):
+      with pytest.raises(RuntimeError, match="stamp failed"):
+        await asyncio.wait_for(task.execute(), timeout=0.02)
+
+  @pytest.mark.asyncio
+  async def test_a_thread_that_outlives_the_grace_is_abandoned_and_the_timeout_stands(
+    self, mock_manager
+  ):
+    """Past budget + grace the worker must move on — a hung QuickBooks call
+    would otherwise wedge the only worker. The thread is tracked so the
+    consumer can say 'still running', and its late outcome is logged rather
+    than dropped as never retrieved."""
+    import asyncio
+    import threading
+
+    release = threading.Event()
+
+    def work():
+      release.wait(5)
+      return {"late": True}
+
+    task = self._task(mock_manager, work)
+    try:
+      with patch("robosystems.worker.tasks.base.DEFAULT_TASK_TIMEOUT", 0.05):
+        with pytest.raises(TimeoutError):
+          await asyncio.wait_for(task.execute(), timeout=0.05)
+      assert len(task.abandoned_work) == 1
+    finally:
+      release.set()
+
+    with patch("robosystems.worker.tasks.base.logger") as log:
+      await asyncio.wait(task._abandoned, timeout=2)
+      # Give the done-callback its turn on the loop.
+      await asyncio.sleep(0)
+    assert task.abandoned_work == []
+    assert log.warning.called
+    assert "abandoned blocking work finished" in log.warning.call_args.args[0]
+
+
+class TestBudget:
+  def test_register_task_stamps_the_type_the_budget_is_looked_up_by(self):
+    from robosystems.worker.tasks import TASK_REGISTRY, register_task
+
+    original = dict(TASK_REGISTRY)
+    try:
+
+      @register_task("test_budgeted")
+      class Budgeted(ConcreteTask):
+        pass
+
+      assert Budgeted.task_type == "test_budgeted"
+      task = Budgeted("op", None, "u", {}, MagicMock())
+      with patch("robosystems.worker.tasks.base.TASK_TIMEOUTS", {"test_budgeted": 7}):
+        assert task.budget_seconds == 7
+    finally:
+      TASK_REGISTRY.clear()
+      TASK_REGISTRY.update(original)
+
+  def test_an_unregistered_task_falls_back_to_the_default_budget(self, task):
+    assert task.task_type is None
+    with patch("robosystems.worker.tasks.base.DEFAULT_TASK_TIMEOUT", 42):
+      assert task.budget_seconds == 42

--- a/tests/worker/test_consumer.py
+++ b/tests/worker/test_consumer.py
@@ -247,3 +247,93 @@ async def test_timeout_marks_failed(
 
   # Cleanup still called
   mock_cleanup.assert_called_once()
+
+
+class ThreadBackedTask(BaseTask):
+  """A task whose work runs where the budget cannot cancel it."""
+
+  release: Any = None
+
+  async def execute(self) -> dict[str, Any]:
+    return await self.run_blocking(self._work)
+
+  def _work(self) -> dict[str, Any]:
+    import time
+
+    if self.release is not None:
+      self.release.wait(5)
+    else:
+      time.sleep(0.2)
+    return {"landed": True}
+
+
+@pytest.mark.asyncio
+@patch("robosystems.worker.consumer.cleanup_connections")
+@patch("robosystems.worker.consumer.get_tracer")
+async def test_a_thread_that_lands_past_its_budget_is_completed_not_failed(
+  mock_tracer, mock_cleanup, mock_manager, mock_queue
+):
+  """The failure mode named in TASK_TIMEOUTS: a close whose thread keeps
+  running after the budget cancels the coroutine, and then commits. The
+  operation must report what the thread produced, not FAILED — and cleanup
+  must run only once the thread has joined."""
+  mock_tracer.return_value = MagicMock()
+  mock_tracer.return_value.start_as_current_span.return_value.__enter__ = MagicMock()
+  mock_tracer.return_value.start_as_current_span.return_value.__exit__ = MagicMock()
+  TASK_REGISTRY["test_thread"] = ThreadBackedTask
+
+  with (
+    patch("robosystems.worker.consumer.TASK_TIMEOUTS", {}),
+    patch("robosystems.worker.consumer.DEFAULT_TASK_TIMEOUT", 0.05),
+    patch("robosystems.worker.tasks.base.DEFAULT_TASK_TIMEOUT", 1),
+  ):
+    await _call_process_task(_make_task_data("test_thread"), mock_queue, mock_manager)
+
+  mock_manager.complete_operation.assert_called_once()
+  assert mock_manager.complete_operation.call_args[1]["result"] == {"landed": True}
+  mock_manager.fail_operation.assert_not_called()
+  mock_cleanup.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("robosystems.worker.consumer.cleanup_connections")
+@patch("robosystems.worker.consumer.get_tracer")
+async def test_a_thread_abandoned_past_its_grace_is_reported_as_still_running(
+  mock_tracer, mock_cleanup, mock_manager, mock_queue
+):
+  """'Timed out' alone reads as 'did not happen' and invites a retry of a
+  write that may be about to land. The stored failure has to say the work is
+  still in flight."""
+  import asyncio
+  import threading
+
+  mock_tracer.return_value = MagicMock()
+  mock_tracer.return_value.start_as_current_span.return_value.__enter__ = MagicMock()
+  mock_tracer.return_value.start_as_current_span.return_value.__exit__ = MagicMock()
+
+  release = threading.Event()
+
+  class StuckTask(ThreadBackedTask):
+    pass
+
+  StuckTask.release = release
+  TASK_REGISTRY["test_stuck"] = StuckTask
+
+  try:
+    with (
+      patch("robosystems.worker.consumer.TASK_TIMEOUTS", {}),
+      patch("robosystems.worker.consumer.DEFAULT_TASK_TIMEOUT", 0.05),
+      patch("robosystems.worker.tasks.base.DEFAULT_TASK_TIMEOUT", 0.05),
+    ):
+      await _call_process_task(_make_task_data("test_stuck"), mock_queue, mock_manager)
+  finally:
+    release.set()
+
+  mock_manager.fail_operation.assert_called_once()
+  call_args = mock_manager.fail_operation.call_args
+  assert "may still complete" in call_args[1]["error"]
+  assert call_args[1]["error_details"]["still_running"] is True
+  mock_manager.complete_operation.assert_not_called()
+  mock_cleanup.assert_called_once()
+  # Let the released thread finish before the loop closes.
+  await asyncio.sleep(0.1)

--- a/tests/worker/test_task_protection.py
+++ b/tests/worker/test_task_protection.py
@@ -123,3 +123,11 @@ def test_protection_lease_outlives_longest_task():
   """The protection lease must exceed the longest task timeout."""
   longest = max([*TASK_TIMEOUTS.values(), DEFAULT_TASK_TIMEOUT])
   assert longest < PROTECTION_EXPIRES_MINUTES * 60
+
+
+def test_protection_lease_outlives_a_thread_backed_task_and_its_grace():
+  """A task that runs its work through ``BaseTask.run_blocking`` can hold the
+  worker for its budget plus one more budget of thread-join grace. The lease
+  must cover both, or the close it exists to protect is exposed to scale-in
+  precisely when it is running long."""
+  assert 2 * TASK_TIMEOUTS["period_close"] < PROTECTION_EXPIRES_MINUTES * 60

--- a/tests/worker/test_task_timeout_coverage.py
+++ b/tests/worker/test_task_timeout_coverage.py
@@ -164,28 +164,32 @@ def test_period_close_budget_covers_one_slow_publish_and_the_locks() -> None:
 
   Sizing here is decided by the failure mode rather than by how long a close
   usually takes. `asyncio.wait_for` cancels the coroutine but cannot cancel
-  the thread doing the QuickBooks publish, so an under-budget close is marked
-  FAILED while its thread runs on — and can still commit. Reporting a
-  landed close as a failure is far worse than waiting longer for a slow one.
+  the thread doing the QuickBooks publish. `BaseTask.run_blocking` waits one
+  more budget for that thread and reports what it produced, so an overrun
+  costs the operator a grace-length wait for the receipt rather than a
+  FAILED for a close that landed — but only inside that grace. Past it the
+  close is abandoned as still running, which is the outcome this budget
+  exists to keep rare.
 
-  Pinned against the constants that actually bound the run: one QuickBooks
-  call's retry ladder, the per-statement ceiling, and the period fence's
-  lock wait. Raising any of them without raising the budget fails here.
+  Pinned against the constants that bound the run on the request policy: one
+  QuickBooks call's retry ladder and the per-statement ceiling. The period
+  fence is not in the sum — on the worker its wait *is* this budget
+  (`PeriodCloseTask` passes `budget_seconds` as `fence_wait_ms`), so it
+  cannot drift from it. Raising either constant without raising the budget
+  fails here.
   """
   from robosystems.config.defaults import DatabaseDefaults
-  from robosystems.operations.locking import _LOCK_TIMEOUT_MS
 
   # One QuickBooks call that exhausts its retry ladder: 5 attempts with
   # exponential backoff capped at 60s. The floor below counts only the
   # backoff between attempts, not the calls themselves.
   qb_retry_backoff = 1 + 2 + 4 + 8
   statement_ceiling = DatabaseDefaults.EXTENSIONS_STATEMENT_TIMEOUT_MS / 1000
-  fence_wait = _LOCK_TIMEOUT_MS / 1000
 
-  internal_waits = qb_retry_backoff + statement_ceiling + fence_wait
+  internal_waits = qb_retry_backoff + statement_ceiling
   assert TASK_TIMEOUTS["period_close"] > internal_waits * 2, (
     f"period_close budget ({TASK_TIMEOUTS['period_close']}s) must clear its own "
     f"waits ({internal_waits}s) with wide headroom: a real month publishes one "
     "QuickBooks entry per draft, any of which can hit that retry ladder, and a "
-    "cancelled close keeps running in its thread."
+    "close past its budget is reported late at best."
   )


### PR DESCRIPTION
## Summary

The worker's task budget (`asyncio.wait_for`) cancels the handler coroutine but cannot cancel the thread a period close runs on, so an over-budget close was recorded FAILED while its thread ran on and could still commit — and the consumer's `finally` dropped scale-in protection and moved to the next tenant while it did. Separately, the worker close took the period fence with the 3 s *request* wait, so a duplicate dispatch overlapping a running close of the same period was refused (`row_locked`) rather than waiting for the receipt. This closes §2 and §4 of `local/RoboSystems/specs/ledger/async-close-integrity.md`; §1 and §3 shipped in #1255 / #1257.

## Changes

**`robosystems/worker/tasks/base.py`** — new `BaseTask.run_blocking(func, *args)`: runs sync work in a thread, shielded from the budget's cancel. When the budget expires it waits up to one more budget (the *grace*) for the thread; if the thread lands, its outcome becomes the task's outcome (the stdlib `wait_for` contract: a task that absorbs its cancel and returns a value returns that value) and the overrun is logged. Only past the grace is the work abandoned — tracked in `abandoned_work`, with its late outcome logged rather than dropped — and the `TimeoutError` let through. New `budget_seconds` property reads `TASK_TIMEOUTS` by the handler's own `task_type`.

**`robosystems/worker/tasks/__init__.py`** — `register_task` stamps `cls.task_type`, so a handler can size its own waits from its budget.

**`robosystems/worker/consumer.py`** — the timeout branch reports `still_running` (in the stored error text and `error_details`) when the handler has abandoned work, so "timed out" cannot read as "did not happen". `finally` ordering is unchanged; comments record why that is safe (`Engine.dispose()` closes checked-in connections only — verified against SQLAlchemy 2.0.50, which corrects the spec's claim that the fence connection was killed mid-flight).

**`robosystems/operations/locking.py`** — `exclusive_period_fence(..., wait_ms=None)`: the wait is the caller's. Default stays the request wait.

**`robosystems/operations/roboledger/commands/fiscal_calendar.py`** — `close_period(..., fence_wait_ms=None)` forwards to the fence. REST and the synchronous MCP paths pass nothing.

**`robosystems/operations/roboledger/tasks/period_close.py`** — uses `run_blocking`; passes `fence_wait_ms = budget_seconds * 1000` (background jobs wait).

**`robosystems/worker/constants.py`, `task_protection.py`** — comments: the `period_close` budget now does three jobs (budget, grace, fence wait); the protection lease must cover budget + grace.

Reviewers: the interesting file is `base.py`. The abandon-after-grace bound is a deliberate judgment — the spec asked for "do not dispose until the thread joins", but an unbounded join lets one hung QuickBooks call (the Intuit SDK sets no per-request timeout) wedge the single prod worker indefinitely; a thread abandoned 2× over budget loses scale-in protection, which is logged as the accepted residue.

## Breaking Changes

None. `close_period` and `exclusive_period_fence` gain optional keyword parameters with unchanged defaults; no SDK-facing surface changes (neither tier).

## Testing

- `uv run pytest tests/worker tests/operations/test_locking.py tests/operations/roboledger/tasks/test_period_close.py tests/operations/roboledger/commands/test_fiscal_calendar.py` — 107 passed.
- Mutation-checked: with the grace wait removed, all five new `run_blocking` / consumer tests fail (`wait_for` raises `TimeoutError`); with the task's `fence_wait_ms` dropped, `test_the_worker_close_waits_its_whole_budget_for_the_fence` fails; with the fence ignoring `wait_ms`, `test_a_background_closer_waits_as_long_as_it_says` fails.
- `just test-code` — ruff, format, basedpyright (0 errors), cf-lint all pass.
- Full `just test-all` not run locally.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
