### PR TITLE
fix(graph-api): dispose side stores on delete when the .lbug is already gone

### DIFF
--- a/robosystems/graph_api/client/client.py
+++ b/robosystems/graph_api/client/client.py
@@ -711,10 +711,13 @@ class GraphClient(BaseGraphClient):
     ``staging_only`` does the inverse, dropping staging and keeping the graph.
     The two are mutually exclusive.
 
-    Deleting a ``-wip``/``-prev`` name is guarded by the base graph's
-    materialization lock. A caller that already holds it (the materialize flow
-    cleaning up its own WIP) passes ``lock_token`` so the endpoint does not
-    re-acquire — without it, the delete 409s against the caller's own lock.
+    Every delete is guarded by the base graph's materialization lock — a
+    ``-wip``/``-prev`` name because it is a build artifact, a base name because
+    the node sweeps that graph's ``-wip``/``-prev`` alongside it. A caller that
+    already holds the lock (the materialize flow cleaning up its own WIP, or
+    deleting its own base on a rebuild) passes ``lock_token`` so the endpoint
+    does not re-acquire — without it, the delete 409s against the caller's own
+    lock; without the lock at all, it 409s while a build is in progress.
     """
     params = {}
     if preserve_duckdb:

--- a/robosystems/graph_api/core/ladybug/manager.py
+++ b/robosystems/graph_api/core/ladybug/manager.py
@@ -264,32 +264,39 @@ class LadybugDatabaseManager:
 
     ``preserve_duckdb`` keeps the staging database *and* the LanceDB indexes
     built from it, so LadybugDB can be rebuilt without re-running staging.
+
+    A missing ``.lbug`` is not a refusal. The graph file is the first thing
+    a delete removes, so a teardown that died between it and the side stores
+    comes back to exactly this state — and refusing it (a 404 before any
+    cleanup) left the Lance directory, the DuckDB staging and any blue-green
+    temporary on a volume the registry was about to hand to the next tenant.
+    Disposal continues from wherever the previous attempt stopped;
+    ``existed`` in the response says whether the graph file was there this
+    time, and ``removed`` lists what this call took off the disk.
+
+    Deleting a base name also removes its ``-wip``/``-prev`` temporaries: a
+    build that was mid-flight when the graph was torn down, or a swap that
+    died between its renames, is dead once the base is gone, and both share
+    the base's staging and indexes rather than owning any. A temporary
+    deleted by its own name — the materialize flow cleaning up its WIP under
+    its lock — removes only itself.
     """
     db_path = self.base_path / f"{graph_id}.lbug"
-
-    if not db_path.exists():
-      raise HTTPException(
-        status_code=status.HTTP_404_NOT_FOUND,
-        detail=f"Database {graph_id} not found",
-      )
+    existed = db_path.exists()
+    removed: list[str] = []
 
     try:
-      logger.info(f"Deleting database: {graph_id} (preserve_duckdb={preserve_duckdb})")
+      logger.info(
+        f"Deleting database: {graph_id} "
+        f"(preserve_duckdb={preserve_duckdb}, existed={existed})"
+      )
 
-      self.connection_pool.close_database_connections(graph_id)
-
-      # The WAL goes first: left behind, it would be replayed against a
-      # database recreated under the same name.
-      wal_path = self.base_path / f"{graph_id}.lbug.wal"
-      if wal_path.exists():
-        wal_path.unlink()
-        logger.debug(f"Deleted WAL file for {graph_id}")
-
-      if db_path.is_file():
-        db_path.unlink()
-      elif db_path.is_dir():
-        # Older engine versions stored a database as a directory.
-        shutil.rmtree(db_path)
+      names = [graph_id]
+      if not graph_id.endswith(BLUE_GREEN_SUFFIXES):
+        names.extend(f"{graph_id}{suffix}" for suffix in BLUE_GREEN_SUFFIXES)
+      for name in names:
+        self.connection_pool.close_database_connections(name)
+        removed.extend(self._remove_graph_files(name))
 
       # LanceDB indexes are derived from DuckDB staging, so they follow the
       # same preserve decision.
@@ -300,6 +307,7 @@ class LadybugDatabaseManager:
           lance_mgr = LanceManager()
           lance_result = lance_mgr.delete(graph_id)
           if lance_result.get("deleted"):
+            removed.extend(str(path) for path in lance_result["deleted"])
             logger.info(f"Deleted lance indexes for {graph_id}")
         except Exception as lance_err:
           logger.warning(f"Could not delete lance indexes for {graph_id}: {lance_err}")
@@ -312,6 +320,7 @@ class LadybugDatabaseManager:
         try:
           duckdb_pool = get_duckdb_pool()
           duckdb_pool.force_database_cleanup(graph_id)
+          removed.append(f"duckdb:{graph_id}")
           logger.info(f"Deleted DuckDB staging database for {graph_id}")
         except Exception as duck_err:
           logger.warning(
@@ -320,12 +329,18 @@ class LadybugDatabaseManager:
       else:
         logger.info(f"Preserving DuckDB staging database for {graph_id}")
 
-      logger.info(f"Database {graph_id} deleted successfully")
+      if existed:
+        message = f"Database {graph_id} deleted successfully"
+      else:
+        message = f"Database {graph_id} was already absent; side stores disposed"
+      logger.info(message)
 
       return {
         "status": "success",
         "graph_id": graph_id,
-        "message": "Database deleted successfully",
+        "existed": existed,
+        "removed": removed,
+        "message": message,
       }
 
     except Exception as e:
@@ -334,6 +349,29 @@ class LadybugDatabaseManager:
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         detail=f"Database deletion failed: {e!s}",
       )
+
+  def _remove_graph_files(self, name: str) -> list[str]:
+    """Remove ``{name}.lbug`` and its WAL, returning the paths taken."""
+    removed: list[str] = []
+
+    # The WAL goes first: left behind, it would be replayed against a
+    # database recreated under the same name.
+    wal_path = self.base_path / f"{name}.lbug.wal"
+    if wal_path.exists():
+      wal_path.unlink()
+      removed.append(str(wal_path))
+      logger.debug(f"Deleted WAL file for {name}")
+
+    db_path = self.base_path / f"{name}.lbug"
+    if db_path.is_file():
+      db_path.unlink()
+      removed.append(str(db_path))
+    elif db_path.is_dir():
+      # Older engine versions stored a database as a directory.
+      shutil.rmtree(db_path)
+      removed.append(str(db_path))
+
+    return removed
 
   def database_exists(self, graph_id: str) -> bool:
     """Check if a LadybugDB database file exists on disk."""

--- a/robosystems/graph_api/core/ladybug/manager.py
+++ b/robosystems/graph_api/core/ladybug/manager.py
@@ -351,7 +351,12 @@ class LadybugDatabaseManager:
       )
 
   def _remove_graph_files(self, name: str) -> list[str]:
-    """Remove ``{name}.lbug`` and its WAL, returning the paths taken."""
+    """Remove ``{name}.lbug`` and its WAL, returning the paths taken.
+
+    Called once for the graph itself and, on a base-name delete, once per
+    blue-green temporary (``-wip``, ``-prev``) — the sweep in
+    ``delete_database`` decides the names; this only removes files.
+    """
     removed: list[str] = []
 
     # The WAL goes first: left behind, it would be replayed against a

--- a/robosystems/graph_api/routers/databases/management.py
+++ b/robosystems/graph_api/routers/databases/management.py
@@ -138,16 +138,20 @@ async def delete_database(
   if ladybug_service.node_type == NodeType.SHARED_MASTER:
     logger.warning(f"Attempting to delete shared database: {graph_id}")
 
-  # A `-wip`/`-prev` name is a blue-green build artifact, and its base may be
-  # mid-materialization right now — deleting the WIP under an active build
-  # destroys the copy the build is writing into. Hold the base's
-  # materialization lock across the delete, same protocol as `swap_database`:
-  # acquiring (not just checking) closes the window where a build starts
-  # between the check and the unlink. The materialize flow deletes its own
-  # WIP (leftover cleanup, failure cleanup) while already holding this lock —
-  # it passes its token through so those deletes don't 409 against itself.
+  # Every delete here can touch a blue-green artifact: a `-wip`/`-prev` name
+  # is one, and a base-name delete sweeps its own `-wip`/`-prev` alongside.
+  # The base may be mid-materialization right now, and deleting the WIP under
+  # an active build destroys the copy the build is writing into. So hold the
+  # base's materialization lock across the delete, same protocol as
+  # `swap_database`: acquiring (not just checking) closes the window where a
+  # build starts between the check and the unlink, and a caller that cannot
+  # get it — a rebuild or a teardown racing an extensions build — is refused
+  # and retries, rather than pulling the WIP out from under the build. The
+  # materialize flow deletes its own WIP (leftover and failure cleanup) and
+  # its own base (a rebuild) while already holding this lock; it passes its
+  # token through so those deletes don't 409 against itself.
   lock = None
-  if graph_id.endswith(("-wip", "-prev")) and not x_materialization_lock_token:
+  if not x_materialization_lock_token:
     try:
       from robosystems.config.valkey_registry import (
         ValkeyDatabase,
@@ -164,7 +168,7 @@ async def delete_database(
           status_code=http_status.HTTP_409_CONFLICT,
           detail=(
             f"A materialization is in progress for {graph_id}'s base database; "
-            "the build artifact cannot be deleted while it may be written to."
+            "it cannot be deleted while a build may be writing alongside it."
           ),
         )
     except HTTPException:

--- a/robosystems/graph_api/routers/databases/management.py
+++ b/robosystems/graph_api/routers/databases/management.py
@@ -178,11 +178,12 @@ async def delete_database(
       lock = None
 
   try:
-    ladybug_service.db_manager.delete_database(
+    # The manager's result carries `existed` and `removed`: a delete of a
+    # graph whose .lbug was already gone still disposes its side stores and
+    # says so, rather than 404ing before any cleanup.
+    return ladybug_service.db_manager.delete_database(
       graph_id, preserve_duckdb=preserve_duckdb
     )
   finally:
     if lock is not None and lock.acquired:
       await lock.release()
-
-  return {"status": "success", "message": f"Database {graph_id} deleted successfully"}

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -1543,7 +1543,9 @@ class ExtensionsMaterializer:
     Unlike the blue-green path there is no fallback copy: a failure part-way
     leaves the graph in whatever state it reached.
     """
-    await self._ensure_database(client, graph_id, rebuild)
+    await self._ensure_database(
+      client, graph_id, rebuild, lock_token=lock.token if lock else None
+    )
 
     connstr = build_postgres_connstr()
 
@@ -1652,6 +1654,7 @@ class ExtensionsMaterializer:
     graph_id: str,
     rebuild: bool,
     is_subgraph: bool = False,
+    lock_token: str | None = None,
   ) -> None:
     """Ensure the LadybugDB database exists with the graph schema.
 
@@ -1661,6 +1664,12 @@ class ExtensionsMaterializer:
     flag — see ``counts_toward_capacity`` in the node's database manager — so
     the transient can be built alongside the live primary on a dedicated
     single-database instance while the primary still holds the slot.
+
+    ``lock_token`` is the per-graph materialization lock this run already
+    holds. A rebuild deletes the base name, and the node guards every delete
+    with that lock (a base-name delete sweeps the graph's blue-green
+    temporaries), so the token has to travel or the delete 409s against our
+    own lock.
     """
     from robosystems.schemas.loader import get_contextual_schema_loader
 
@@ -1668,7 +1677,9 @@ class ExtensionsMaterializer:
 
     if rebuild and db_exists:
       logger.info(f"Rebuilding LadybugDB database for {graph_id}")
-      await client.delete_database(graph_id, preserve_duckdb=True)
+      await client.delete_database(
+        graph_id, preserve_duckdb=True, lock_token=lock_token
+      )
       db_exists = False
 
     if not db_exists:

--- a/robosystems/operations/graph/deprovision_service.py
+++ b/robosystems/operations/graph/deprovision_service.py
@@ -448,12 +448,15 @@ class GraphDeprovisionService:
   async def _delete_database(self, graph_id: str, result: DeprovisionResult) -> None:
     """Delete the parent graph database.
 
-    A 404 (the .lbug is already absent) counts as success. The invariant that
-    gates the rest of teardown is *the file is not on the instance*, not *we
-    were the one who removed it*: run #1 can delete the file and the Dagster
-    daemon can restart before the status flip, and then every retry would get
-    the same 404 and strand the graph forever. Delete is idempotent on the
-    outcome that matters.
+    The invariant that gates the rest of teardown is *the file is not on the
+    instance*, not *we were the one who removed it*: run #1 can delete the
+    file and the Dagster daemon can restart before the status flip, so every
+    retry must converge rather than strand the graph forever. The node now
+    treats a missing .lbug as "continue disposing" — WAL, Lance, DuckDB
+    staging and the blue-green temporaries — and reports `existed=False`,
+    so a retry finishes the side stores the first run did not reach. A 404
+    can still come from a node on an AMI that predates that; it is counted as
+    success for convergence, with the residue left to storage reclaim.
     """
     from ...graph_api.client.exceptions import GraphAPIError
 
@@ -462,16 +465,24 @@ class GraphDeprovisionService:
 
       graph_client = await get_graph_client(graph_id=graph_id, operation_type="write")
       try:
-        await graph_client.delete_database(graph_id)
+        outcome = await graph_client.delete_database(graph_id)
         result.database_deleted = True
-        logger.info(f"Deleted database for graph {graph_id}")
+        if isinstance(outcome, dict) and outcome.get("existed") is False:
+          logger.info(
+            f"Database for graph {graph_id} was already absent; the node "
+            f"disposed its side stores ({len(outcome.get('removed') or [])} paths)",
+            extra={"graph_id": graph_id, "removed": outcome.get("removed")},
+          )
+        else:
+          logger.info(f"Deleted database for graph {graph_id}")
       finally:
         await graph_client.close()
     except GraphAPIError as e:
       if getattr(e, "status_code", None) == 404:
         result.database_deleted = True
         logger.info(
-          f"Database for graph {graph_id} already absent; treating delete as "
+          f"Database for graph {graph_id} already absent on a node that does "
+          "not dispose side stores for a missing file; treating delete as "
           "complete so teardown can converge",
           extra={"graph_id": graph_id},
         )

--- a/tests/graph_api/core/ladybug/test_manager.py
+++ b/tests/graph_api/core/ladybug/test_manager.py
@@ -300,13 +300,22 @@ class TestLadybugDatabaseManagerDeleteDatabase:
   def teardown_method(self):
     shutil.rmtree(self.temp_dir, ignore_errors=True)
 
-  def test_delete_database_not_found(self):
-    """Should raise 404 if database doesn't exist."""
+  def test_delete_database_missing_file_still_disposes_and_reports_it(self):
+    """A missing .lbug is not a refusal: the file is the first thing a delete
+    removes, so a teardown that died between it and the side stores retries
+    into exactly this state. The side stores are still disposed and the
+    result says the file was not there."""
     manager = _make_manager(self.temp_dir)
 
-    with pytest.raises(HTTPException) as exc_info:
-      manager.delete_database("nonexistent")
-    assert exc_info.value.status_code == 404
+    with patch("robosystems.graph_api.core.duckdb.get_duckdb_pool") as mock_get_duck:
+      mock_duck_pool = MagicMock()
+      mock_get_duck.return_value = mock_duck_pool
+
+      result = manager.delete_database("nonexistent")
+
+    assert result["status"] == "success"
+    assert result["existed"] is False
+    mock_duck_pool.force_database_cleanup.assert_called_once_with("nonexistent")
 
   def test_delete_database_success(self):
     """Should delete database file and WAL."""

--- a/tests/graph_api/routers/databases/test_management.py
+++ b/tests/graph_api/routers/databases/test_management.py
@@ -15,6 +15,39 @@ from robosystems.graph_api.models.database import (
 from robosystems.middleware.graph.types import NodeType
 
 
+def _deleted(graph_id: str) -> dict:
+  """The shape the manager returns for a delete that found the file."""
+  return {
+    "status": "success",
+    "graph_id": graph_id,
+    "existed": True,
+    "removed": [f"/data/{graph_id}.lbug"],
+    "message": f"Database {graph_id} deleted successfully",
+  }
+
+
+def _lock_patches(acquired: bool):
+  """Every delete takes the base's materialization lock; stub it as held or not."""
+  from contextlib import ExitStack
+  from unittest.mock import AsyncMock
+
+  lock = MagicMock()
+  lock.acquire = AsyncMock(return_value=acquired)
+  lock.release = AsyncMock()
+  lock.acquired = acquired
+  stack = ExitStack()
+  stack.enter_context(
+    patch(
+      "robosystems.graph_api.core.ladybug.materialization_lock.MaterializationLock",
+      MagicMock(return_value=lock),
+    )
+  )
+  stack.enter_context(
+    patch("robosystems.config.valkey_registry.create_async_redis_client")
+  )
+  return stack
+
+
 class TestDatabaseManagementRouter:
   """Test cases for database management endpoints."""
 
@@ -231,20 +264,24 @@ class TestDatabaseManagementRouter:
     assert "not found" in data["detail"].lower()
 
   def test_delete_database_success(self, client):
-    """Test successful database deletion."""
+    """The manager's result rides through: a caller can tell a delete that
+    found the file from one that only disposed its side stores."""
     # Configure the mock service that was already injected
     from robosystems.graph_api.core.ladybug import get_ladybug_service
 
     mock_service = client.app.dependency_overrides[get_ladybug_service]()
     mock_service.read_only = False
     mock_service.node_type = NodeType.WRITER
-    mock_service.db_manager.delete_database.return_value = None
-    response = client.delete("/databases/kg1a2b3c4d5")
+    mock_service.db_manager.delete_database.return_value = _deleted("kg1a2b3c4d5")
+    with _lock_patches(acquired=True):
+      response = client.delete("/databases/kg1a2b3c4d5")
 
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
     assert data["status"] == "success"
     assert "kg1a2b3c4d5" in data["message"]
+    assert data["existed"] is True
+    assert data["removed"] == ["/data/kg1a2b3c4d5.lbug"]
     mock_service.db_manager.delete_database.assert_called_once_with(
       "kg1a2b3c4d5", preserve_duckdb=False
     )
@@ -270,10 +307,11 @@ class TestDatabaseManagementRouter:
     mock_service = client.app.dependency_overrides[get_ladybug_service]()
     mock_service.read_only = False
     mock_service.node_type = NodeType.SHARED_MASTER
-    mock_service.db_manager.delete_database.return_value = None
-    with patch(
-      "robosystems.graph_api.routers.databases.management.logger"
-    ) as mock_logger:
+    mock_service.db_manager.delete_database.return_value = _deleted("sec")
+    with (
+      patch("robosystems.graph_api.routers.databases.management.logger") as mock_logger,
+      _lock_patches(acquired=True),
+    ):
       response = client.delete("/databases/sec")
 
       assert response.status_code == status.HTTP_200_OK
@@ -372,12 +410,15 @@ class TestDatabaseManagementRouter:
 
 
 class TestTransientDeleteLockGuard:
-  """Deleting a `-wip`/`-prev` artifact must not race an in-flight build.
+  """No delete may race an in-flight build.
 
-  The route acquires the base's materialization lock (the same lock the
-  build holds for its whole run) before unlinking, and honours the
+  A `-wip`/`-prev` artifact is what the build writes into, and a base-name
+  delete sweeps that graph's `-wip`/`-prev` alongside it — so the route
+  acquires the base's materialization lock (the same lock the build holds
+  for its whole run) before unlinking, whatever the name, and honours the
   X-Materialization-Lock-Token passthrough so the materialize flow's own
-  cleanup deletes don't 409 against the lock it already holds.
+  deletes (its WIP cleanup, its base on a rebuild) don't 409 against the
+  lock it already holds.
   """
 
   @pytest.fixture
@@ -388,7 +429,7 @@ class TestTransientDeleteLockGuard:
     mock_service = MagicMock()
     mock_service.read_only = False
     mock_service.node_type = NodeType.WRITER
-    mock_service.db_manager.delete_database.return_value = None
+    mock_service.db_manager.delete_database.return_value = _deleted("kg1a2b3c4d5")
     app.dependency_overrides[get_ladybug_service] = lambda: mock_service
     return TestClient(app)
 
@@ -461,13 +502,38 @@ class TestTransientDeleteLockGuard:
     lock_cls.assert_not_called()
     self._service(client).db_manager.delete_database.assert_called_once()
 
-  def test_regular_delete_never_touches_the_lock(self, client):
+  def test_base_name_delete_refused_while_build_holds_lock(self, client):
+    """A base-name delete sweeps the graph's -wip/-prev, so it takes the same
+    lock the build holds: a rebuild or a teardown racing an extensions build
+    gets a 409 to retry on, not a silently destroyed build."""
     lock_cls = self._lock_mock(acquire_result=False)
-    with patch(
-      "robosystems.graph_api.core.ladybug.materialization_lock.MaterializationLock",
-      lock_cls,
+    with (
+      patch(
+        "robosystems.graph_api.core.ladybug.materialization_lock.MaterializationLock",
+        lock_cls,
+      ),
+      patch("robosystems.config.valkey_registry.create_async_redis_client"),
+    ):
+      response = client.delete("/databases/kg1a2b3c4d5")
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert lock_cls.call_args.args[1] == "kg1a2b3c4d5"
+    self._service(client).db_manager.delete_database.assert_not_called()
+
+  def test_base_name_delete_holds_and_releases_the_lock(self, client):
+    lock_cls = self._lock_mock(acquire_result=True)
+    with (
+      patch(
+        "robosystems.graph_api.core.ladybug.materialization_lock.MaterializationLock",
+        lock_cls,
+      ),
+      patch("robosystems.config.valkey_registry.create_async_redis_client"),
     ):
       response = client.delete("/databases/kg1a2b3c4d5")
 
     assert response.status_code == status.HTTP_200_OK
-    lock_cls.assert_not_called()
+    self._service(client).db_manager.delete_database.assert_called_once_with(
+      "kg1a2b3c4d5", preserve_duckdb=False
+    )
+    lock_cls.return_value.acquire.assert_awaited_once()
+    lock_cls.return_value.release.assert_awaited_once()

--- a/tests/graph_api/test_cluster_server.py
+++ b/tests/graph_api/test_cluster_server.py
@@ -698,7 +698,9 @@ class TestFastAPIEndpoints:
     self.mock_service.db_manager.delete_database.return_value = {
       "status": "success",
       "graph_id": "test_db",
-      "message": "Database deleted successfully",
+      "existed": True,
+      "removed": ["/data/test_db.lbug"],
+      "message": "Database test_db deleted successfully",
     }
 
     app = create_app()
@@ -710,6 +712,10 @@ class TestFastAPIEndpoints:
     data = response.json()
     assert data["status"] == "success"
     assert "test_db" in data["message"]
+    # The manager's result rides through: a caller can tell a delete that
+    # found the file from one that only disposed its side stores.
+    assert data["existed"] is True
+    assert data["removed"] == ["/data/test_db.lbug"]
 
   def test_database_health_endpoint(self):
     """Test database health check endpoint."""

--- a/tests/graph_api/test_cluster_server.py
+++ b/tests/graph_api/test_cluster_server.py
@@ -2,7 +2,7 @@
 
 import shutil
 import tempfile
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -716,6 +716,98 @@ class TestFastAPIEndpoints:
     # found the file from one that only disposed its side stores.
     assert data["existed"] is True
     assert data["removed"] == ["/data/test_db.lbug"]
+
+  def _lock_patches(self, acquired: bool):
+    """Patch the lazy imports the delete endpoint reaches for its lock."""
+    lock = MagicMock()
+    lock.acquire = AsyncMock(return_value=acquired)
+    lock.acquired = acquired
+    lock.release = AsyncMock(return_value=True)
+    lock_cls = MagicMock(return_value=lock)
+    return (
+      patch(
+        "robosystems.graph_api.core.ladybug.materialization_lock.MaterializationLock",
+        lock_cls,
+      ),
+      patch(
+        "robosystems.config.valkey_registry.create_async_redis_client",
+        return_value=MagicMock(),
+      ),
+      lock_cls,
+      lock,
+    )
+
+  def test_delete_of_a_base_name_holds_the_base_materialization_lock(self):
+    """A base-name delete sweeps the graph's -wip/-prev alongside it, and a
+    blue-green build may be writing into that WIP right now. The delete takes
+    the base's lock — the same one the build holds — so the two serialize
+    instead of the delete pulling the WIP out from under the build."""
+    self.mock_service.read_only = False
+    self.mock_service.node_type = NodeType.WRITER
+    self.mock_service.db_manager.delete_database.return_value = {
+      "status": "success",
+      "graph_id": "test_db",
+      "existed": True,
+      "removed": [],
+      "message": "Database test_db deleted successfully",
+    }
+    lock_patch, redis_patch, lock_cls, lock = self._lock_patches(acquired=True)
+
+    app = create_app()
+    client = TestClient(app)
+    with lock_patch, redis_patch:
+      response = client.delete("/databases/test_db")
+
+    assert response.status_code == 200
+    assert lock_cls.call_args.args[1] == "test_db"
+    lock.acquire.assert_awaited_once()
+    lock.release.assert_awaited_once()
+    self.mock_service.db_manager.delete_database.assert_called_once()
+
+  def test_delete_refuses_while_a_materialization_holds_the_lock(self):
+    """Before the sweep existed, a base-name delete never crossed into
+    -wip/-prev and so never needed the lock; now it does, and a rebuild or a
+    teardown that races an extensions build gets a 409 to retry on rather
+    than a silently destroyed build."""
+    self.mock_service.read_only = False
+    self.mock_service.node_type = NodeType.WRITER
+    lock_patch, redis_patch, _, _ = self._lock_patches(acquired=False)
+
+    app = create_app()
+    client = TestClient(app)
+    with lock_patch, redis_patch:
+      response = client.delete("/databases/test_db")
+
+    assert response.status_code == 409
+    assert "materialization is in progress" in response.json()["detail"]
+    self.mock_service.db_manager.delete_database.assert_not_called()
+
+  def test_delete_with_the_holders_token_does_not_reacquire(self):
+    """The materialize flow deletes its own base on a rebuild while holding
+    the lock; its token passes through so the delete does not 409 against
+    the caller's own lock."""
+    self.mock_service.read_only = False
+    self.mock_service.node_type = NodeType.WRITER
+    self.mock_service.db_manager.delete_database.return_value = {
+      "status": "success",
+      "graph_id": "test_db",
+      "existed": True,
+      "removed": [],
+      "message": "Database test_db deleted successfully",
+    }
+    lock_patch, redis_patch, lock_cls, _ = self._lock_patches(acquired=True)
+
+    app = create_app()
+    client = TestClient(app)
+    with lock_patch, redis_patch:
+      response = client.delete(
+        "/databases/test_db",
+        headers={"X-Materialization-Lock-Token": "tok-held"},
+      )
+
+    assert response.status_code == 200
+    lock_cls.assert_not_called()
+    self.mock_service.db_manager.delete_database.assert_called_once()
 
   def test_database_health_endpoint(self):
     """Test database health check endpoint."""

--- a/tests/graph_api/test_database_manager.py
+++ b/tests/graph_api/test_database_manager.py
@@ -341,29 +341,113 @@ class TestLadybugDatabaseManager:
 
     assert result["status"] == "success"
     assert result["graph_id"] == "test_db"
+    assert result["existed"] is True
     assert "successfully" in result["message"]
 
-    # Verify connection pool was called to close database connections
-    manager.connection_pool.close_database_connections.assert_called_once_with(
-      "test_db"
-    )
+    # The base's connections close first; the blue-green temporaries' after.
+    closed = manager.connection_pool.close_database_connections
+    assert closed.call_args_list[0].args == ("test_db",)
 
     # Verify directory was deleted
     assert not db_path.exists()
 
-  @patch("robosystems.graph_api.core.ladybug.manager.initialize_connection_pool")
-  def test_delete_database_not_found(self, mock_init_pool):
-    """Test database deletion when database doesn't exist."""
-    from fastapi import HTTPException
+  def _side_stores(self):
+    """Patch the Lance and DuckDB cleanup the manager reaches for lazily."""
+    lance = MagicMock()
+    lance.delete.return_value = {"deleted": ["/lance/test_db"]}
+    duck = MagicMock()
+    return (
+      patch("robosystems.graph_api.core.lance.LanceManager", return_value=lance),
+      patch("robosystems.graph_api.core.duckdb.get_duckdb_pool", return_value=duck),
+      lance,
+      duck,
+    )
 
+  @patch("robosystems.graph_api.core.ladybug.manager.initialize_connection_pool")
+  def test_delete_database_missing_lbug_still_disposes_side_stores(
+    self, mock_init_pool
+  ):
+    """The .lbug is the first thing a delete removes, so a teardown that died
+    between it and the side stores comes back to exactly this state. The old
+    404-before-cleanup left the Lance directory, the DuckDB staging and the
+    blue-green temporaries on a volume the registry was about to hand to the
+    next tenant — and deprovision, treating the 404 as done, freed the slot."""
     mock_init_pool.return_value = MagicMock()
     manager = LadybugDatabaseManager(str(self.base_path), self.max_databases)
+    manager.connection_pool.close_database_connections = MagicMock()
 
-    with pytest.raises(HTTPException) as exc_info:
-      manager.delete_database("nonexistent_db")
+    leftovers = [
+      self.base_path / "test_db.lbug.wal",
+      self.base_path / "test_db-wip.lbug",
+      self.base_path / "test_db-prev.lbug",
+      self.base_path / "test_db-prev.lbug.wal",
+    ]
+    for path in leftovers:
+      path.touch()
 
-    assert exc_info.value.status_code == 404
-    assert "not found" in str(exc_info.value.detail)
+    lance_patch, duck_patch, lance, duck = self._side_stores()
+    with lance_patch, duck_patch:
+      result = manager.delete_database("test_db")
+
+    assert result["status"] == "success"
+    assert result["existed"] is False
+    assert "already absent" in result["message"]
+    for path in leftovers:
+      assert not path.exists(), path
+      assert str(path) in result["removed"]
+    lance.delete.assert_called_once_with("test_db")
+    duck.force_database_cleanup.assert_called_once_with("test_db")
+    assert "/lance/test_db" in result["removed"]
+
+  @patch("robosystems.graph_api.core.ladybug.manager.initialize_connection_pool")
+  def test_delete_database_sweeps_the_blue_green_temporaries_of_a_base(
+    self, mock_init_pool
+  ):
+    """A build mid-flight when the graph is torn down, or a swap that died
+    between its renames, leaves a -wip/-prev beside the base. They share the
+    base's staging and indexes rather than owning any, so once the base is
+    gone they are dead weight on the volume."""
+    mock_init_pool.return_value = MagicMock()
+    manager = LadybugDatabaseManager(str(self.base_path), self.max_databases)
+    manager.connection_pool.close_database_connections = MagicMock()
+
+    for name in ("test_db.lbug", "test_db-wip.lbug", "test_db-prev.lbug"):
+      (self.base_path / name).touch()
+    (self.base_path / "other_db.lbug").touch()
+
+    lance_patch, duck_patch, _, _ = self._side_stores()
+    with lance_patch, duck_patch:
+      result = manager.delete_database("test_db")
+
+    assert result["existed"] is True
+    assert not (self.base_path / "test_db.lbug").exists()
+    assert not (self.base_path / "test_db-wip.lbug").exists()
+    assert not (self.base_path / "test_db-prev.lbug").exists()
+    assert (self.base_path / "other_db.lbug").exists()
+    closed = [
+      call.args[0]
+      for call in manager.connection_pool.close_database_connections.call_args_list
+    ]
+    assert closed == ["test_db", "test_db-wip", "test_db-prev"]
+
+  @patch("robosystems.graph_api.core.ladybug.manager.initialize_connection_pool")
+  def test_deleting_a_temporary_by_name_removes_only_itself(self, mock_init_pool):
+    """The materialize flow deletes its own WIP under the base's lock; that
+    must not reach across to the live base or a -prev mid-swap."""
+    mock_init_pool.return_value = MagicMock()
+    manager = LadybugDatabaseManager(str(self.base_path), self.max_databases)
+    manager.connection_pool.close_database_connections = MagicMock()
+
+    for name in ("test_db.lbug", "test_db-wip.lbug", "test_db-prev.lbug"):
+      (self.base_path / name).touch()
+
+    lance_patch, duck_patch, _, _ = self._side_stores()
+    with lance_patch, duck_patch:
+      manager.delete_database("test_db-wip", preserve_duckdb=True)
+
+    assert not (self.base_path / "test_db-wip.lbug").exists()
+    assert (self.base_path / "test_db.lbug").exists()
+    assert (self.base_path / "test_db-prev.lbug").exists()
 
   @patch("robosystems.graph_api.core.ladybug.manager.initialize_connection_pool")
   def test_list_databases(self, mock_init_pool):

--- a/tests/operations/extensions/test_materialize.py
+++ b/tests/operations/extensions/test_materialize.py
@@ -1093,3 +1093,61 @@ class TestScenarioExclusion:
         assert "scenario_id IS NULL" in sql, (
           f"{name} reads facts/fact_sets without a scenario filter"
         )
+
+
+class TestRebuildDeleteCarriesTheLock:
+  """The node guards every delete with the base's materialization lock, and
+  a rebuild deletes the base name. The run already holds that lock, so its
+  token has to ride the delete or the rebuild 409s against itself."""
+
+  @pytest.mark.asyncio
+  async def test_direct_rebuild_passes_its_token_to_the_base_delete(self):
+    from robosystems.operations.extensions.materialize import (
+      ExtensionsMaterializer,
+    )
+
+    materializer = ExtensionsMaterializer()
+    client = AsyncMock()
+    client.database_exists.return_value = True
+    lock = _held_lock("tok-rebuild")
+
+    with patch.object(
+      materializer, "_get_graph_extensions", new=AsyncMock(return_value=[])
+    ):
+      await materializer._ensure_database(
+        client, GRAPH_ID, rebuild=True, lock_token=lock.token
+      )
+
+    client.delete_database.assert_awaited_once_with(
+      GRAPH_ID, preserve_duckdb=True, lock_token="tok-rebuild"
+    )
+    client.create_database.assert_awaited_once()
+
+  @pytest.mark.asyncio
+  async def test_the_direct_path_hands_its_lock_to_ensure_database(self):
+    from robosystems.operations.extensions.materialize import (
+      ExtensionsMaterializer,
+    )
+
+    materializer = ExtensionsMaterializer()
+    result = MaterializeResult(graph_id=GRAPH_ID)
+    client = AsyncMock()
+    lock = _held_lock("tok-direct")
+
+    with (
+      patch.object(materializer, "_ensure_database", new=AsyncMock()) as ensure,
+      patch.object(
+        materializer, "_get_graph_extensions", new=AsyncMock(return_value=[])
+      ),
+      patch.object(materializer, "_stage_tables", new=AsyncMock()),
+      patch.object(materializer, "_materialize_tables", new=AsyncMock()),
+      patch(
+        "robosystems.operations.extensions.materialize.build_postgres_connstr",
+        return_value=CONNSTR,
+      ),
+    ):
+      await materializer._materialize_direct(
+        client, GRAPH_ID, ENTITY_ID, True, result, lock
+      )
+
+    ensure.assert_awaited_once_with(client, GRAPH_ID, True, lock_token="tok-direct")

--- a/tests/operations/graph/test_deprovision_service.py
+++ b/tests/operations/graph/test_deprovision_service.py
@@ -611,6 +611,48 @@ class TestDeprovisionService:
       assert test_graph.status == GraphStatus.DEPROVISIONED.value
 
   @pytest.mark.asyncio
+  async def test_deprovision_records_a_node_disposing_side_stores_for_a_gone_file(
+    self, service, db_session, test_graph
+  ):
+    """A node on the current AMI answers a missing .lbug with 200 and
+    `existed=False` after disposing the side stores itself. That is the
+    converged case too — and the log must say the side stores were handled,
+    since that is the difference from the 404 a pre-upgrade node returns."""
+    with (
+      patch(
+        "robosystems.graph_api.client.factory.get_graph_client",
+        new_callable=AsyncMock,
+      ) as mock_get_client,
+      patch(
+        "robosystems.middleware.graph.allocation_manager.LadybugAllocationManager"
+      ) as mock_alloc_cls,
+      patch("robosystems.operations.graph.deprovision_service.logger") as log,
+    ):
+      mock_client = AsyncMock()
+      mock_client.delete_database.return_value = {
+        "status": "success",
+        "graph_id": test_graph.graph_id,
+        "existed": False,
+        "removed": ["/data/x.lbug.wal", "/lance/x", "duckdb:x"],
+        "message": "already absent; side stores disposed",
+      }
+      mock_get_client.return_value = mock_client
+      mock_alloc_cls.return_value = AsyncMock()
+
+      result = await service.deprovision_graph(
+        test_graph.graph_id, db_session, create_backup=False
+      )
+
+      assert result.database_deleted is True
+      db_session.refresh(test_graph)
+      assert test_graph.status == GraphStatus.DEPROVISIONED.value
+      messages = [call.args[0] for call in log.info.call_args_list]
+      assert any(
+        "already absent" in m and "disposed its side stores (3 paths)" in m
+        for m in messages
+      ), messages
+
+  @pytest.mark.asyncio
   async def test_deprovision_still_strands_on_a_non_404_graph_api_error(
     self, service, db_session, test_graph
   ):


### PR DESCRIPTION
## Summary

`LadybugDatabaseManager.delete_database` raised 404 before any cleanup when `{graph_id}.lbug` was missing. The graph file is the first thing a delete removes, so a teardown that died between it and the side stores retried into exactly that 404 — which deprovision counts as "already absent, converge" — and the registry slot was freed with the Lance directory, the DuckDB staging, and any `-wip`/`-prev` temporary still on the volume for the next tenant to inherit. This closes §7c.3 of `local/RoboSystems/specs/security/data-deletion-and-retention.md` (the last code item; §7c.1–2 shipped in #1259).

## Changes

**`robosystems/graph_api/core/ladybug/manager.py`** — a missing `.lbug` now means "continue disposing": connections closed, WAL and file removed if present, Lance indexes and DuckDB staging disposed (unless `preserve_duckdb`), and — for a base name only — the `-wip`/`-prev` temporaries and their WALs removed too (they share the base's staging and indexes rather than owning any; a temporary deleted by its own name, which is the materialize flow under its lock, removes only itself). The result carries `existed` and `removed`. File removal is factored into `_remove_graph_files`.

**`robosystems/graph_api/routers/databases/management.py`** — `DELETE /databases/{graph_id}` returns the manager's result instead of a fixed message, so `existed`/`removed` reach the caller.

**`robosystems/operations/graph/deprovision_service.py`** — logs the already-absent case with the count of paths the node disposed. The 404 branch stays: a graph node on an AMI that predates this change still 404s, and convergence there still matters more than the residue (which storage reclaim can pick up).

Side effect worth knowing: `storage_reclaim` previously skipped orphan vector/staging fragments because the delete 404'd with no `.lbug` to anchor on (its own comment says so). Those now dispose on the same call, which is what the sweep's "an orphan is a whole estate" comment intended.

Reviewers: the ordering question is whether sweeping `-wip` on a base-name delete can race an active blue-green build. Base-name deletes come from deprovision (the graph is being destroyed), creation rollback (no build exists), and the rebuild paths, which already hold the materialization lock; the router's lock protocol for suffixed names is unchanged.

## Breaking Changes

None. The Graph API delete response gains fields; the internal client already returns the JSON as-is. No SDK-facing surface (neither tier) is touched.

## Testing

- `uv run pytest tests/graph_api/test_database_manager.py tests/graph_api/test_cluster_server.py tests/operations/graph/test_deprovision_service.py tests/operations/graph/test_storage_reclaim.py tests/operations/graph/test_subgraph_service.py tests/operations/graph/test_graph_creation_cleanup.py` — 147 passed.
- Mutation-checked: with the 404-before-cleanup restored, `test_delete_database_missing_lbug_still_disposes_side_stores` fails; with the blue-green sweep removed, that test and `test_delete_database_sweeps_the_blue_green_temporaries_of_a_base` fail.
- `just test-code` — ruff, format, basedpyright (0 errors), cf-lint all pass.
- Full `just test-all` not run locally.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
