### PR TITLE
chore(tests): run the suite in parallel with pytest-xdist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,8 +238,11 @@ jobs:
       - name: Run tests
         timeout-minutes: 15
         run: |
-          # Run tests (exclude slow tests)
-          uv run pytest -v --tb=short -m "not slow"
+          # Run tests (exclude slow tests), one xdist worker per runner core.
+          # Each worker gets its own platform test database, created on demand
+          # (tests/xdist_workers.py); the extensions DB stays shared, which
+          # `--dist loadfile` makes safe. Same flags as `just test`.
+          uv run pytest -n auto --dist loadfile --tb=short -m "not slow"
 
       - name: Run dbt tests
         timeout-minutes: 1

--- a/justfile
+++ b/justfile
@@ -128,19 +128,23 @@ test-all:
     @just cf-lint-all
     @just lint-actions
 
-# Run tests (exclude slow tests)
+# Run tests (exclude slow tests). Parallel across cores: each xdist worker
+# gets its own platform test database (tests/xdist_workers.py); `loadfile`
+# keeps a file's tests on one worker so module-scoped tenant schemas in the
+# shared extensions DB never race themselves.
 test module="":
     uv run pytest \
         {{ if module != "" { "tests/" + module } else { "" } }} \
+        -n auto --dist loadfile \
         -m "not slow"
 
 # Run ALL tests including slow ones
 test-full:
-    uv run pytest
+    uv run pytest -n auto --dist loadfile
 
 # Run tests with coverage
 test-cov:
-    uv run pytest --cov=robosystems tests/
+    uv run pytest -n auto --dist loadfile --cov=robosystems tests/
 
 # Run the tenant-isolation harness against a deployment (default: local stack)
 test-isolation target="http://localhost:8000":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,25 +110,22 @@ dependencies = [
 dev = [
     # RoboSystems client for demo and testing.
     "robosystems-client>=1.11.0,<2.0",
-
     # Testing framework
     "pytest>=9.0.0,<10.0",
     "pytest-asyncio>=1.4.0,<2.0",
     "pytest-cov>=6.2.0",
     "pytest-env>=1.1.0,<2.0",
     "pytest-mock>=3.14.0,<4.0",
-
     # Code quality tools
     "ruff>=0.12.0,<1.0",
     "basedpyright>=1.22.0,<2.0",
-
     # AWS development tools
     "awscli-local>=0.22.0,<1.0",
     "cfn-lint>=1.50.1,<2.0",
     "moto[s3]>=5.2.2,<6.0",
-
     # Development utilities
-    "rich>=15.0.0,<16.0"
+    "rich>=15.0.0,<16.0",
+    "pytest-xdist>=3.6,<4.0",
 ]
 
 [build-system]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,9 @@
 # basedpyright: ignore
+
+# Under `pytest -n`, each worker must be pointed at its own platform test
+# database before anything imports `robosystems` (which binds its engine at
+# import). This package init is the earliest hook that runs after pytest-env
+# has applied the ini environment; see tests/xdist_workers.py.
+from tests.xdist_workers import isolate_worker_databases
+
+isolate_worker_databases()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -611,6 +611,7 @@ def setup_database(test_db):
     Graph,
     GraphBackup,
     GraphCredits,
+    GraphCreditTransaction,
     GraphUser,
     Org,
     OrgInvitation,
@@ -643,6 +644,7 @@ def setup_database(test_db):
     test_db.query(UserRepositoryCreditTransaction).delete()
     test_db.query(UserRepositoryCredits).delete()
     test_db.query(UserRepository).delete()
+    test_db.query(GraphCreditTransaction).delete()  # references graph_credits
     test_db.query(GraphCredits).delete()
     test_db.query(GraphUser).delete()
     test_db.query(GraphBackup).delete()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from datetime import UTC
 from unittest.mock import Mock, patch
 
@@ -612,12 +613,15 @@ def setup_database(test_db):
     GraphCredits,
     GraphUser,
     Org,
+    OrgInvitation,
     OrgLimits,
     OrgUser,
     ScimToken,
     User,
     UserAPIKey,
     UserIdentity,
+    UserMfaRecoveryCode,
+    UserPasskey,
     UserRepository,
     UserRepositoryCredits,
     UserRepositoryCreditTransaction,
@@ -628,7 +632,10 @@ def setup_database(test_db):
     # Delete in reverse dependency order to avoid foreign key constraints.
     # UserRepository → Graph FK is ondelete=RESTRICT, so user_repository*
     # rows must be cleared before graphs. Billing tables reference orgs,
-    # so they must be cleared before orgs.
+    # so they must be cleared before orgs. Every table with a plain (NO
+    # ACTION) FK to users/orgs must appear here before User/Org: one missed
+    # table makes the User delete fail, and the rollback below then keeps
+    # *every* row of this test alive for the rest of the session.
     test_db.query(Document).delete()
     test_db.query(ConnectionCredentials).delete()
     test_db.query(Connection).delete()
@@ -646,14 +653,27 @@ def setup_database(test_db):
     test_db.query(BillingSubscription).delete()
     test_db.query(BillingCustomer).delete()
     test_db.query(OrgLimits).delete()
+    test_db.query(OrgInvitation).delete()  # references orgs and users
     test_db.query(OrgUser).delete()  # Delete org memberships before users/orgs
     test_db.query(UserIdentity).delete()  # references users
+    test_db.query(UserPasskey).delete()  # references users
+    test_db.query(UserMfaRecoveryCode).delete()  # references users
     test_db.query(ScimToken).delete()  # references orgs
     test_db.query(User).delete()
     test_db.query(Org).delete()
     test_db.commit()
-  except Exception:
+  except Exception as exc:
     test_db.rollback()
+    # Never silent: a failed cleanup leaks this test's rows into every test
+    # that follows on this session, and the failures it causes show up in
+    # unrelated files as duplicate keys — which is how a missing table in the
+    # list above went unnoticed until files ran in a new order.
+    warnings.warn(
+      f"Test database cleanup failed and was rolled back: {exc!r}. Rows from "
+      f"this test leak into later tests — add the offending table to "
+      f"setup_database's delete list.",
+      stacklevel=1,
+    )
 
 
 # SEC XBRL Testing Fixtures

--- a/tests/graph_api/test_cluster_server.py
+++ b/tests/graph_api/test_cluster_server.py
@@ -575,7 +575,19 @@ class TestFastAPIEndpoints:
       "parameters": {"limit": 10},
     }
 
-    response = client.post("/databases/test_db/query", json=query_data)
+    # The endpoint consults the real admission controller, which reads host
+    # CPU and memory headroom — under a parallel test run those can cross the
+    # thresholds and 503 a request that has nothing to do with load. This
+    # test is about the query path, so admit unconditionally.
+    from robosystems.graph_api.core.admission_control import AdmissionDecision
+
+    admission = MagicMock()
+    admission.check_admission.return_value = (AdmissionDecision.ACCEPT, None)
+    with patch(
+      "robosystems.graph_api.routers.databases.query.get_admission_controller",
+      return_value=admission,
+    ):
+      response = client.post("/databases/test_db/query", json=query_data)
 
     assert response.status_code == 200
     data = response.json()

--- a/tests/operations/graph/test_table_service.py
+++ b/tests/operations/graph/test_table_service.py
@@ -191,10 +191,13 @@ class TestTableServiceS3Pattern:
     return TableService(mock_session)
 
   def test_get_s3_pattern_for_table(self, table_service, monkeypatch):
-    monkeypatch.setenv("USER_DATA_BUCKET", "test-bucket")
     from robosystems.config import env
 
-    env.USER_DATA_BUCKET = "test-bucket"
+    # `env` reads the variable at import, so the attribute is what the code
+    # under test sees — and it must be restored, or every later test in the
+    # session (the S3 adapter's bucket probe, for one) runs against a bucket
+    # that does not exist.
+    monkeypatch.setattr(env, "USER_DATA_BUCKET", "test-bucket")
 
     pattern = table_service.get_s3_pattern_for_table(
       graph_id="kg123", table_name="Company", user_id="user456"

--- a/tests/test_xdist_workers.py
+++ b/tests/test_xdist_workers.py
@@ -1,0 +1,84 @@
+"""The per-worker database isolation that makes ``pytest -n`` safe.
+
+Two kinds of test: the pure rewrite logic, and — only when actually running
+under xdist — the live assertion that this worker really is on its own
+database, both in the environment the fixtures read and in the engine the
+app bound at import.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from tests.xdist_workers import (
+  PER_WORKER_URL_KEYS,
+  WORKER_ENV,
+  database_name,
+  isolate_worker_databases,
+  per_worker_url,
+)
+
+BASE = "postgresql://postgres:postgres@localhost:5432/robosystems_test"
+
+
+class TestPerWorkerUrl:
+  def test_suffixes_the_database_name_only(self):
+    assert per_worker_url(BASE, "gw3") == (
+      "postgresql://postgres:postgres@localhost:5432/robosystems_test_gw3"
+    )
+
+  def test_keeps_credentials_host_and_query(self):
+    url = "postgresql://u:p@db.internal:6543/robosystems_test?sslmode=require"
+    out = per_worker_url(url, "gw0")
+    assert out.startswith("postgresql://u:p@db.internal:6543/")
+    assert database_name(out) == "robosystems_test_gw0"
+    assert out.endswith("?sslmode=require")
+
+
+class TestIsolateWorkerDatabases:
+  def test_does_nothing_outside_xdist(self):
+    env = dict.fromkeys(PER_WORKER_URL_KEYS, BASE)
+    with patch("tests.xdist_workers.ensure_database") as ensure:
+      assert isolate_worker_databases(env) is None
+    ensure.assert_not_called()
+    assert all(env[key] == BASE for key in PER_WORKER_URL_KEYS)
+
+  def test_moves_both_platform_urls_and_creates_the_database_once(self):
+    """`TEST_DATABASE_URL` (fixtures) and `DATABASE_URL` (the app engine) name
+    the same database, so they must move together — a fixture inspecting a
+    database the app is not writing to would pass every test vacuously."""
+    env = {WORKER_ENV: "gw2", **dict.fromkeys(PER_WORKER_URL_KEYS, BASE)}
+    with patch("tests.xdist_workers.ensure_database") as ensure:
+      assert isolate_worker_databases(env) == "gw2"
+    ensure.assert_called_once_with(per_worker_url(BASE, "gw2"))
+    for key in PER_WORKER_URL_KEYS:
+      assert database_name(env[key]) == "robosystems_test_gw2"
+
+  def test_leaves_the_extensions_database_shared(self):
+    env = {
+      WORKER_ENV: "gw1",
+      "TEST_DATABASE_URL": BASE,
+      "EXTENSIONS_DATABASE_URL": "postgresql://postgres:postgres@localhost:5432/extensions",
+    }
+    with patch("tests.xdist_workers.ensure_database"):
+      isolate_worker_databases(env)
+    assert database_name(env["EXTENSIONS_DATABASE_URL"]) == "extensions"
+
+
+@pytest.mark.skipif(
+  not os.environ.get(WORKER_ENV), reason="only meaningful under pytest -n"
+)
+def test_this_worker_runs_on_its_own_platform_database():
+  """Under xdist, the environment the fixtures read and the engine the app
+  bound at import must both point at this worker's copy. If the rewrite ran
+  too late — after `robosystems` was imported — the engine would still be on
+  the shared database while the fixtures truncate a private one."""
+  from robosystems.db.platform import engine
+
+  worker = os.environ[WORKER_ENV]
+  assert database_name(os.environ["TEST_DATABASE_URL"]).endswith(f"_{worker}")
+  assert engine.url.database is not None
+  assert engine.url.database.endswith(f"_{worker}")

--- a/tests/xdist_workers.py
+++ b/tests/xdist_workers.py
@@ -1,0 +1,110 @@
+"""Per-worker database isolation for ``pytest -n`` (pytest-xdist).
+
+Invoked from ``tests/__init__.py``, which is the earliest point that is
+both after pytest-env has applied the ``[pytest] env`` block and before
+anything imports ``robosystems``: ``robosystems.config.env`` reads
+``DATABASE_URL`` at import, and ``robosystems.db.platform`` builds the
+platform engine from it at import, so the rewrite has to land first.
+Outside xdist (no ``PYTEST_XDIST_WORKER``) nothing here runs.
+
+What is isolated, and what deliberately is not:
+
+- **Platform test DB — per worker.** The session-scoped ``test_db`` fixture
+  drops and recreates ``public``, and the autouse ``setup_database`` truncates
+  ~25 tables after every test. Two workers on one database race on that
+  truncation and read each other's rows. Each worker gets its own copy
+  (``robosystems_test`` → ``robosystems_test_gw0``), created here if missing.
+  ``TEST_DATABASE_URL`` (the fixtures) and ``DATABASE_URL`` (the app engine)
+  both move, so the app under test and the fixtures that inspect it agree.
+  The throwaway ``ext_*`` extensions schemas some tests build live in this
+  database too, so they follow it.
+
+- **Extensions DB — shared, with ``--dist loadfile``.** Its tests either use
+  those uuid-named throwaway schemas (never collide) or a module-scoped tenant
+  schema with a per-file name; ``loadfile`` keeps a file's tests on one worker,
+  so a file never runs concurrently against itself. The taxonomy library it
+  holds is read-only to tests, and cloning it per worker (``CREATE DATABASE …
+  TEMPLATE extensions``) needs the template free of connections, which the
+  local dev stack's API never leaves it.
+
+- **Valkey and LocalStack — shared.** Tests that touch them live key by their
+  own ids. The double ``-n auto`` run in the spec's verification is what
+  proves that holds as the suite grows; a collision found there is fixed in
+  the test, not by widening this module.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from urllib.parse import urlsplit, urlunsplit
+
+WORKER_ENV = "PYTEST_XDIST_WORKER"
+
+# The platform test database under both names the suite uses for it.
+PER_WORKER_URL_KEYS = ("TEST_DATABASE_URL", "DATABASE_URL")
+
+
+def per_worker_url(url: str, worker: str) -> str:
+  """``…/robosystems_test`` → ``…/robosystems_test_gw0``, everything else kept."""
+  parts = urlsplit(url)
+  name = parts.path.lstrip("/")
+  return urlunsplit(parts._replace(path=f"/{name}_{worker}"))
+
+
+def database_name(url: str) -> str:
+  return urlsplit(url).path.lstrip("/")
+
+
+def ensure_database(url: str) -> None:
+  """Create the database ``url`` names if it does not exist yet.
+
+  Connects to the server's ``postgres`` maintenance database with the same
+  credentials; ``CREATE DATABASE`` cannot run inside a transaction, hence
+  autocommit. Workers create distinct names, so two of them never race on
+  the same one.
+  """
+  from sqlalchemy import create_engine, text
+  from sqlalchemy.pool import NullPool
+
+  name = database_name(url)
+  maintenance = urlunsplit(urlsplit(url)._replace(path="/postgres"))
+  engine = create_engine(maintenance, isolation_level="AUTOCOMMIT", poolclass=NullPool)
+  try:
+    with engine.connect() as conn:
+      exists = conn.execute(
+        text("SELECT 1 FROM pg_database WHERE datname = :name"), {"name": name}
+      ).scalar()
+      if not exists:
+        conn.execute(text(f'CREATE DATABASE "{name}"'))
+  finally:
+    engine.dispose()
+
+
+def isolate_worker_databases(environ: dict[str, str] | None = None) -> str | None:
+  """Point this xdist worker at its own platform test database.
+
+  Returns the worker id when a rewrite happened, ``None`` otherwise. A
+  Postgres that cannot be reached is a warning, not a failure: the URLs are
+  still rewritten, and the tests that need the database fail on their own
+  terms exactly as they would serially.
+  """
+  env = os.environ if environ is None else environ
+  worker = env.get(WORKER_ENV)
+  if not worker:
+    return None
+
+  targets = {
+    key: per_worker_url(env[key], worker) for key in PER_WORKER_URL_KEYS if env.get(key)
+  }
+  for url in {*targets.values()}:
+    try:
+      ensure_database(url)
+    except Exception as exc:  # pragma: no cover - needs Postgres down
+      warnings.warn(
+        f"xdist worker {worker}: could not create {database_name(url)!r} "
+        f"({exc}); database-backed tests will fail on this worker",
+        stacklevel=2,
+      )
+  env.update(targets)
+  return worker

--- a/uv.lock
+++ b/uv.lock
@@ -1143,6 +1143,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.139.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3314,6 +3323,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3715,6 +3737,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-mock" },
+    { name = "pytest-xdist" },
     { name = "rich" },
     { name = "robosystems-client" },
     { name = "ruff" },
@@ -3786,6 +3809,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.2.0" },
     { name = "pytest-env", marker = "extra == 'dev'", specifier = ">=1.1.0,<2.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.0,<4.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6,<4.0" },
     { name = "python-multipart", specifier = ">=0.0.27,<1.0" },
     { name = "python-quickbooks", specifier = ">=0.9.0,<1.0" },
     { name = "python-ulid", specifier = ">=3.0.0" },


### PR DESCRIPTION
## Summary

Runs the test suite in parallel with `pytest-xdist` (`-n auto --dist loadfile`) in `just test` / `test-full` / `test-cov` and CI. The CI pytest step was at 12m36s (#1258) against its 15-minute timeout; locally the full non-slow suite (13,792 tests) now runs in ~2 minutes on 14 cores versus 12+ serial. Closes `local/RoboSystems/specs/tooling/test-suite-parallelization.md` §1.

## Changes

**`tests/xdist_workers.py`, `tests/__init__.py`** — each xdist worker gets its own platform test database (`robosystems_test` → `robosystems_test_gw0`, created on demand). The rewrite runs from the test package's `__init__`, which is the earliest point after pytest-env applies the `[pytest] env` block and before anything imports `robosystems` — `robosystems.config.env` reads `DATABASE_URL` at import and `robosystems.db.platform` binds its engine from it at import, so a later hook would leave the app on the shared database while the fixtures truncate a private one. Both `TEST_DATABASE_URL` (fixtures) and `DATABASE_URL` (app engine) move together. The extensions DB stays shared: its tests use uuid-named throwaway schemas (in the platform DB) or per-file module-scoped tenant schemas, and `--dist loadfile` keeps a file's tests on one worker. Valkey and LocalStack stay shared; tests key by their own ids. The module docstring records each of those choices and why.

**`tests/conftest.py`** — the per-test cleanup missed four tables with plain FKs into truncated ones (`org_invitations`, `user_passkeys`, `user_mfa_recovery_codes`, `graph_credit_transactions`). One file's leftover invitation rows made the `users` delete fail, and the silent `except: rollback()` then kept *every* later test's rows alive on that session — surfacing as duplicate-key errors in an unrelated billing file. Serially the billing file happened to sort earlier; `tests/routers/auth/test_auth.py tests/operations/billing/test_repository_subscriptions.py` reproduces it in that order on `main`. The cleanup now warns with the offending constraint instead of hiding it (that warning is how the fourth table was found). The complete gap list was computed by walking `Base.metadata` for non-CASCADE FKs into the truncated set.

**`tests/graph_api/test_cluster_server.py`** — `test_execute_query_endpoint` consulted the real admission controller, which reads host CPU/memory headroom and 503s under a parallel run; it now admits unconditionally like the other endpoint tests.

**`tests/test_xdist_workers.py`** — the URL rewrite, the no-op outside xdist, the extensions DB staying shared, and — only under `-n` — a live assertion that this worker's `TEST_DATABASE_URL` *and* the app's bound engine both point at the worker's copy.

**`justfile`, `.github/workflows/test.yml`, `pyproject.toml`, `uv.lock`** — `pytest-xdist` in the dev extras; `-n auto --dist loadfile` on the three test recipes and the CI step (same flags as `just test`).

Reviewers: the one design call worth a look is the shared extensions DB + `loadfile` rather than a per-worker clone; the alternative (`CREATE DATABASE … TEMPLATE extensions`) needs the template free of connections, which the local dev stack's API never leaves it.

## Breaking Changes

None. Test infrastructure only.

## Testing

- Eight full parallel runs during development (`-n auto --dist loadfile`, 14 cores). The final verification pair, after the last cleanup fix: **13,792 passed, 43 skipped — 2:12 and 2:10**, no cleanup warnings, no failures.
- `uv run pytest -n 2 tests/test_xdist_workers.py` — 6 passed including the live per-worker assertion; serial: 5 passed, 1 skipped.
- The order-dependence reproduction: `uv run pytest tests/routers/auth/test_auth.py tests/operations/billing/test_repository_subscriptions.py` — 4 errors before the conftest fix, 33 passed after; mutation-checked (dropping the `OrgInvitation` delete brings the 4 errors back and the new warning names the FK).
- `just test-code` — ruff, format, basedpyright (0 errors), cf-lint, actionlint all pass.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
