### PR TITLE
fix(graph): keep a parked shared master's volume row out of the stale-volume sweep

### DIFF
--- a/bin/lambda/graph_volume_manager.py
+++ b/bin/lambda/graph_volume_manager.py
@@ -205,7 +205,14 @@ def handle_instance_launch(event: dict[str, Any]) -> dict[str, Any]:
     # attaching — two concurrent master launches must not both attach the same
     # volume and burn the VolumeInUse retry loop.
     reclaim_stale_claims(az, tier)
-    for existing_volume in find_volumes_with_database("sec", az, tier):
+    candidates = find_volumes_with_database("sec", az, tier)
+    if not candidates:
+      # The registry row is the only thing this path consults, but the EBS
+      # volume's tags carry the same facts durably. When the row is gone and
+      # the volume is not, re-register it — minting an empty replacement while
+      # the real one sits available in the same AZ is the worse failure.
+      candidates = recover_unregistered_shared_volumes("sec", az, tier)
+    for existing_volume in candidates:
       volume_id = existing_volume["volume_id"]
       if not claim_volume(volume_id, instance_id):
         continue
@@ -294,6 +301,8 @@ def handle_instance_launch(event: dict[str, Any]) -> dict[str, Any]:
 
   # No existing volume found, create new one
   logger.info("No existing volume found, creating new volume")
+  if node_type == "shared_master":
+    report_shared_master_volume_created(instance_id, az, tier)
   return create_and_attach_volume(instance_id, tier, az, databases, node_type)
 
 
@@ -319,6 +328,96 @@ def find_volumes_with_database(database: str, az: str, tier: str) -> list[dict]:
   return sorted(
     response.get("Items", []),
     key=lambda item: (item.get("created_at") or "", item.get("volume_id") or ""),
+  )
+
+
+def recover_unregistered_shared_volumes(
+  database: str, az: str, tier: str
+) -> list[dict]:
+  """Re-register EC2 volumes tagged for ``database`` that the registry has lost.
+
+  A registry sweep dropped the parked SEC master's row on 2026-08-23 (it aged
+  the row from the volume's creation date), and the next launch minted an
+  empty 200 GB replacement while the 300 GB original sat ``available`` in the
+  same AZ. The volume's tags are the durable record: rebuild the row from
+  them so the launch claims the real volume. Returns the rebuilt rows, oldest
+  first, in the shape ``find_volumes_with_database`` returns.
+  """
+  response = ec2.describe_volumes(
+    Filters=[
+      {"Name": "availability-zone", "Values": [az]},
+      {"Name": "status", "Values": ["available"]},
+      {"Name": "tag:Environment", "Values": [ENVIRONMENT]},
+      {"Name": "tag:ManagedBy", "Values": ["GraphVolumeManager"]},
+      {"Name": "tag:Tier", "Values": [tier]},
+      {"Name": "tag:DatabaseId", "Values": [database]},
+    ]
+  )
+
+  recovered = []
+  for volume in sorted(response.get("Volumes", []), key=lambda v: v["CreateTime"]):
+    volume_id = volume["VolumeId"]
+    if table.get_item(Key={"volume_id": volume_id}).get("Item"):
+      continue
+    tags = {tag["Key"]: tag["Value"] for tag in volume.get("Tags", [])}
+    item = {
+      "volume_id": volume_id,
+      "instance_id": "unattached",
+      "availability_zone": az,
+      "tier": tier,
+      "status": "available",
+      "databases": [database],
+      "node_type": tags.get("NodeType", "shared_master"),
+      "created_at": volume["CreateTime"].isoformat(),
+      "size": volume["Size"],
+      "iops": volume.get("Iops", DEFAULT_IOPS),
+      "throughput": volume.get("Throughput", DEFAULT_THROUGHPUT),
+      "recovered_at": datetime.now(UTC).isoformat(),
+    }
+    table.put_item(Item=item)
+    recovered.append(item)
+    logger.warning(
+      f"Volume {volume_id} is tagged for {database} but had no registry row; "
+      "re-registered it from its EC2 tags instead of minting a replacement"
+    )
+
+  if recovered:
+    send_alert(
+      f"Re-registered {len(recovered)} unregistered {database} volume(s)",
+      f"Volumes {[v['volume_id'] for v in recovered]} in {az} ({tier}) are "
+      f"tagged for {database} but were missing from {TABLE_NAME}. They were "
+      "re-registered from EC2 tags and offered to the launching instance. "
+      "Find out what dropped the rows.",
+    )
+  return recovered
+
+
+def report_shared_master_volume_created(instance_id: str, az: str, tier: str) -> None:
+  """Page when a shared master mints a data volume.
+
+  That is a once-per-lifetime event for a shared repository; every later
+  occurrence means neither the registry nor the EC2 tags surfaced the real
+  volume, and the master is about to boot empty — which fails the nightly
+  chain and, unnoticed, leaves the original volume with no row to protect it.
+  """
+  logger.warning(
+    f"Creating a NEW shared-master data volume for {instance_id} in {az} "
+    f"({tier}): no registered or tagged shared volume was available"
+  )
+  try:
+    cloudwatch.put_metric_data(
+      Namespace=f"RoboSystems/Graph/{ENVIRONMENT}",
+      MetricData=[
+        {"MetricName": "SharedMasterVolumeCreated", "Value": 1, "Unit": "Count"}
+      ],
+    )
+  except Exception as e:
+    logger.error(f"Failed to publish SharedMasterVolumeCreated metric: {e}")
+  send_alert(
+    "New shared-master data volume created",
+    f"Instance {instance_id} ({tier}, {az}) found no shared data volume to "
+    "claim and is creating an empty one. If a shared volume exists, its "
+    "registry row was lost — see the incident-triage runbook.",
   )
 
 
@@ -1451,6 +1550,10 @@ def sync_registry_with_ec2(event: dict[str, Any]) -> dict[str, Any]:
       # Extract info from tags
       tags = {tag["Key"]: tag["Value"] for tag in volume.get("Tags", [])}
       databases = json.loads(tags.get("Databases", "[]"))
+      if not databases and tags.get("DatabaseId") not in (None, "", "unassigned"):
+        # Volumes carry their primary database as DatabaseId (see
+        # create_and_attach_volume); the Databases list is a snapshot tag.
+        databases = [tags["DatabaseId"]]
       tier = tags.get("Tier", "ladybug-standard")
       node_type = tags.get("NodeType", "writer")
 

--- a/cloudformation/graph-volumes.yaml
+++ b/cloudformation/graph-volumes.yaml
@@ -477,6 +477,25 @@ Resources:
       AlarmActions:
         - !Ref VolumeAlertTopic
 
+  # A shared master minting a data volume is a once-per-lifetime event; any
+  # repeat means neither the registry nor the EC2 tags surfaced the real volume
+  # and the master booted empty.
+  SharedMasterVolumeCreatedAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "robosystems-graph-volumes-${Environment}-shared-master-volume-created"
+      AlarmDescription: A shared master created a new data volume instead of claiming the existing one
+      MetricName: SharedMasterVolumeCreated
+      Namespace: !Sub "RoboSystems/Graph/${Environment}"
+      Statistic: Sum
+      Period: 3600
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref VolumeAlertTopic
+
   # Failed Attachments Alarm
   FailedAttachmentsAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/robosystems/dagster/jobs/infrastructure.py
+++ b/robosystems/dagster/jobs/infrastructure.py
@@ -359,7 +359,8 @@ def cleanup_stale_volume_entries(context: OpExecutionContext) -> dict[str, Any]:
   Removes or updates:
   - Volumes stuck in 'attaching' state to non-existent instances
   - Volumes with missing instance references
-  - Old unattached volumes (older than 30 days)
+  - Empty volumes unattached for more than 30 days (rows carrying databases
+    are never dropped)
   """
   from robosystems.operations.graph.infrastructure import InstanceMonitor
 

--- a/robosystems/operations/graph/infrastructure.py
+++ b/robosystems/operations/graph/infrastructure.py
@@ -558,8 +558,10 @@ class InstanceMonitor:
     """Correct or drop volume-registry rows that no longer reflect reality.
 
     A volume stuck ``attaching`` to a dead instance is marked ``failed`` and
-    unattached; an unattached volume older than ``STALE_VOLUME_DAYS`` is
-    dropped from the registry. Neither path deletes the EBS volume itself.
+    unattached; a volume that carries no databases and has been unattached
+    for more than ``STALE_VOLUME_DAYS`` is dropped from the registry. Rows
+    that still list databases are never dropped. Neither path deletes the
+    EBS volume itself.
     """
     logger.info("Starting volume registry cleanup")
 
@@ -611,17 +613,34 @@ class InstanceMonitor:
               f"non-existent instance {instance_id}"
             )
 
-        if instance_id == "unattached" and status == "available" and created_at:
-          try:
-            created_time = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
-            age_days = (datetime.now(UTC) - created_time).days
-            if age_days > STALE_VOLUME_DAYS:
-              should_remove = True
-              logger.info(
-                f"Removing old unattached volume {volume_id}: {age_days} days old"
-              )
-          except Exception:
-            pass
+        if instance_id == "unattached" and status == "available":
+          # A row that still lists databases is the only link between those
+          # graphs and their data; dropping it makes the next launch mint an
+          # empty replacement volume. Mirror the orphan sweep in the volume
+          # manager, which refuses to delete a volume that carries databases.
+          if item.get("databases"):
+            continue
+
+          # Age from the last detach, not the creation date: a volume that
+          # parks nightly is "unattached" for most of every day and would
+          # otherwise be dropped by the first sweep it sleeps through after
+          # turning STALE_VOLUME_DAYS old. Rows that have never been through
+          # a detach fall back to last_attached, then created_at.
+          age_anchor = (
+            item.get("last_detached") or item.get("last_attached") or created_at
+          )
+          if age_anchor:
+            try:
+              anchor_time = datetime.fromisoformat(age_anchor.replace("Z", "+00:00"))
+              age_days = (datetime.now(UTC) - anchor_time).days
+              if age_days > STALE_VOLUME_DAYS:
+                should_remove = True
+                logger.info(
+                  f"Removing old unattached volume {volume_id}: "
+                  f"unattached for {age_days} days"
+                )
+            except Exception:
+              pass
 
         if should_update and new_status:
           try:

--- a/tests/lambda/test_graph_volume_manager.py
+++ b/tests/lambda/test_graph_volume_manager.py
@@ -1055,6 +1055,120 @@ def test_shared_master_launch_still_attaches_when_reconcile_is_deferred(gvm):
   assert _volume_perf(volume_id) == (3000, 125)
 
 
+def _create_tagged_shared_volume(database: str = "sec", size: int = 300) -> str:
+  """An EBS volume carrying the tags create_and_attach_volume stamps, with no
+  registry row — the state the registry sweep left the SEC master's volume in."""
+  ec2 = boto3.client("ec2", region_name="us-east-1")
+  resp = ec2.create_volume(
+    AvailabilityZone="us-east-1c",
+    Size=size,
+    VolumeType="gp3",
+    Iops=12000,
+    Throughput=500,
+    Encrypted=True,
+    TagSpecifications=[
+      {
+        "ResourceType": "volume",
+        "Tags": [
+          {"Key": "Environment", "Value": "test"},
+          {"Key": "ManagedBy", "Value": "GraphVolumeManager"},
+          {"Key": "Tier", "Value": "ladybug-shared"},
+          {"Key": "NodeType", "Value": "shared_master"},
+          {"Key": "DatabaseId", "Value": database},
+        ],
+      }
+    ],
+  )
+  return resp["VolumeId"]
+
+
+def test_shared_master_recovers_tagged_volume_missing_from_registry(gvm):
+  """The registry lost the SEC volume's row but the volume, tagged for sec,
+  still exists in the AZ: launch must re-register and claim it rather than
+  mint an empty replacement (2026-08-23/25)."""
+  instance_id = _create_test_instance()
+  volume_id = _create_tagged_shared_volume()
+
+  with patch.object(gvm, "send_alert") as alert:
+    result = gvm.handle_instance_launch(
+      {
+        "instance_id": instance_id,
+        "node_type": "shared_master",
+        "tier": "ladybug-shared",
+      }
+    )
+
+  assert result["statusCode"] == 200
+  assert result["volume_id"] == volume_id
+  item = _registry_item(volume_id)
+  assert item["status"] == "attached"
+  assert item["instance_id"] == instance_id
+  assert "sec" in item["databases"]
+  assert item["node_type"] == "shared_master"
+  assert int(item["size"]) == 300
+  alert.assert_called_once()
+  assert "Re-registered" in alert.call_args.args[0]
+
+
+def test_shared_master_prefers_registered_volume_over_tag_recovery(gvm):
+  """Tag recovery only runs when the registry has nothing to offer."""
+  instance_id = _create_test_instance()
+  registered = _create_test_volume()
+  _seed_sec_volume(registered)
+  stray = _create_tagged_shared_volume()
+
+  result = gvm.handle_instance_launch(
+    {"instance_id": instance_id, "node_type": "shared_master", "tier": "ladybug-shared"}
+  )
+
+  assert result["volume_id"] == registered
+  ddb = boto3.resource("dynamodb", region_name="us-east-1")
+  assert "Item" not in ddb.Table("test-volume-registry").get_item(
+    Key={"volume_id": stray}
+  )
+
+
+def test_new_shared_master_volume_pages(gvm):
+  """Minting a shared-master volume publishes the metric the alarm watches
+  and sends an alert; a writer minting its first volume is routine."""
+  instance_id = _create_test_instance()
+
+  with (
+    patch.object(gvm, "send_alert") as alert,
+    patch.object(gvm.cloudwatch, "put_metric_data") as metric,
+  ):
+    result = gvm.handle_instance_launch(
+      {
+        "instance_id": instance_id,
+        "node_type": "shared_master",
+        "tier": "ladybug-shared",
+      }
+    )
+
+  assert result["statusCode"] == 200
+  metric.assert_called_once()
+  assert metric.call_args.kwargs["MetricData"][0]["MetricName"] == (
+    "SharedMasterVolumeCreated"
+  )
+  alert.assert_called_once()
+
+  writer_id = _create_test_instance()
+  with (
+    patch.object(gvm, "send_alert") as alert,
+    patch.object(gvm.cloudwatch, "put_metric_data") as metric,
+  ):
+    gvm.handle_instance_launch(
+      {
+        "instance_id": writer_id,
+        "node_type": "writer",
+        "tier": "ladybug-standard",
+        "databases": ["kg_new"],
+      }
+    )
+  metric.assert_not_called()
+  alert.assert_not_called()
+
+
 def test_new_shared_volume_is_created_to_spec(gvm):
   instance_id = _create_test_instance()
 

--- a/tests/operations/graph/test_infrastructure.py
+++ b/tests/operations/graph/test_infrastructure.py
@@ -632,6 +632,75 @@ class TestCleanupStaleVolumes:
     volume_table.delete_item.assert_called_once_with(Key={"volume_id": "vol-old"})
 
   @pytest.mark.unit
+  def test_keeps_old_volume_that_detached_recently(self, monitor):
+    """Age is measured from the last detach, not the creation date.
+
+    A nightly-parked shared master is unattached for most of every day; the
+    pre-fix sweep dropped its row the first time it slept through a sweep
+    after the volume turned 30 days old, and the next wake minted an empty
+    replacement volume.
+    """
+    volume_table = _make_dynamo_table(
+      items=[
+        {
+          "volume_id": "vol-parked",
+          "status": "available",
+          "instance_id": "unattached",
+          "created_at": (datetime.now(UTC) - timedelta(days=45)).isoformat(),
+          "last_attached": (datetime.now(UTC) - timedelta(days=3)).isoformat(),
+          "last_detached": (datetime.now(UTC) - timedelta(days=2)).isoformat(),
+        },
+      ]
+    )
+    instance_table = _make_dynamo_table(items=[])
+
+    def table_router(name):
+      if name == "test-volume":
+        return volume_table
+      if name == "test-instance":
+        return instance_table
+      return _make_dynamo_table()
+
+    monitor._dynamodb.Table.side_effect = table_router
+
+    result = monitor.cleanup_stale_volumes()
+
+    assert result.removed_count == 0
+    volume_table.delete_item.assert_not_called()
+
+  @pytest.mark.unit
+  def test_never_removes_row_that_carries_databases(self, monitor):
+    """A row listing databases is the only link between those graphs and
+    their data, however long the volume has sat unattached."""
+    volume_table = _make_dynamo_table(
+      items=[
+        {
+          "volume_id": "vol-sec",
+          "status": "available",
+          "instance_id": "unattached",
+          "databases": ["sec"],
+          "created_at": (datetime.now(UTC) - timedelta(days=90)).isoformat(),
+          "last_detached": (datetime.now(UTC) - timedelta(days=60)).isoformat(),
+        },
+      ]
+    )
+    instance_table = _make_dynamo_table(items=[])
+
+    def table_router(name):
+      if name == "test-volume":
+        return volume_table
+      if name == "test-instance":
+        return instance_table
+      return _make_dynamo_table()
+
+    monitor._dynamodb.Table.side_effect = table_router
+
+    result = monitor.cleanup_stale_volumes()
+
+    assert result.removed_count == 0
+    volume_table.delete_item.assert_not_called()
+
+  @pytest.mark.unit
   def test_exception_sets_error_message(self, monitor):
     """Top-level exception is captured in error_message."""
     monitor._dynamodb.Table.side_effect = Exception("volume scan failed")


### PR DESCRIPTION
## Summary

The daily stale-volume sweep aged unattached volume-registry rows from the volume's *creation* date, so a data volume that parks nightly (the shared SEC master's) lost its registry row the first time the master slept through a sweep after the volume turned 30 days old. The next wake found no registered SEC volume, minted an empty replacement while the original sat `available` in the same AZ, and the nightly chain failed at staging with nothing alarming. This fixes the sweep, teaches the launch path to recover a tagged-but-unregistered volume before minting, and pages when a shared master mints a volume at all.

## Changes

- **`robosystems/operations/graph/infrastructure.py`** — `InstanceMonitor.cleanup_stale_volumes` now measures "unattached for more than `STALE_VOLUME_DAYS`" from `last_detached` (falling back to `last_attached`, then `created_at` for rows that have never been through a detach), and never drops a row that still lists databases — mirroring the volume manager's orphan sweep, which already refuses to delete a volume carrying data. Docstrings updated here and on the Dagster op (`robosystems/dagster/jobs/infrastructure.py`).
- **`bin/lambda/graph_volume_manager.py`**
  - `handle_instance_launch` (shared-master path): when the registry offers no SEC volume, `recover_unregistered_shared_volumes` looks for `available` EC2 volumes in the AZ tagged `ManagedBy=GraphVolumeManager` / `Tier` / `DatabaseId` for the database, rebuilds their registry rows from the tags (oldest first), alerts, and offers them to the normal claim loop. Only then does the path fall through to minting.
  - `report_shared_master_volume_created`: publishes a `SharedMasterVolumeCreated` metric and sends an SNS alert before a shared master mints a new data volume. Writers minting their first volume are unaffected.
  - `sync_registry_with_ec2` add-missing path: falls back to the `DatabaseId` tag volumes actually carry when the `Databases` tag (a snapshot tag) is absent, so a re-added row is not written with `databases=[]`.
- **`cloudformation/graph-volumes.yaml`** — new `SharedMasterVolumeCreatedAlarm` (`robosystems-graph-volumes-${Environment}-shared-master-volume-created`) on that metric, wired to the existing volume alert topic. Reviewers: this is a once-per-lifetime event for a shared repository, so the threshold is any occurrence in an hour.
- **Tests** — `tests/operations/graph/test_infrastructure.py`: a 45-day-old row detached 2 days ago is kept; a row carrying databases is never dropped regardless of age. `tests/lambda/test_graph_volume_manager.py`: a tagged volume with no registry row is re-registered and claimed (with alert); a registered volume takes precedence over tag recovery; minting a shared-master volume emits the metric + alert while a writer minting its first volume does not.

## Breaking Changes

None. No API, GraphQL, or SDK surface is touched; the volume-registry row gains optional `size` / `recovered_at` attributes on recovered rows only.

## Testing

- `uv run pytest tests/operations/graph/test_infrastructure.py tests/lambda/test_graph_volume_manager.py` — 72 passed (against the local stack).
- `just test-code` — ruff, format, basedpyright, cf-lint all clean.
- The full `just test-all` unit run was not executed in-session.
- Live: the recovery procedure this PR automates was performed by hand in production today (registry row restored, manual wake claimed the original volume, incremental staging proceeded on it).

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
