### PR TITLE
fix(examples): seed showcase memories via the remember operation; move isolation MCP probes to the transport

### DIFF
--- a/examples/_scenario/runner.py
+++ b/examples/_scenario/runner.py
@@ -901,9 +901,7 @@ def update_disclosure_notes(graph_id: str, notes: list[dict]) -> int:
       continue
 
     block = client.get_information_block(graph_id, structure.id)
-    rollups = [
-      r for r in (block.rules if block else []) if r.rule_pattern == "RollUp"
-    ]
+    rollups = [r for r in (block.rules if block else []) if r.rule_pattern == "RollUp"]
     # `rule_variables` is typed `list[RuleVariableLite] | Unset`, and `Unset`
     # defines neither `__iter__` nor `__len__` — iterating or measuring it
     # raises TypeError rather than reading as empty. Its `__bool__` is False,
@@ -1689,40 +1687,46 @@ def run_forecast_scenario(
 
 
 def seed_memories(graph_id: str, memories: list[dict]) -> int:
-  """Seed the graph's semantic memory through the MCP tool surface.
+  """Seed the graph's semantic memory through the ``remember`` operation.
 
-  Memory writes are deliberately MCP-only (``remember``; REST is
-  read/governance — list/get/recall), so seeding goes through
-  ``POST /v1/graphs/{g}/mcp/call-tool`` — still the public HTTP API, and
-  it exercises the same tool an AI Operator uses during the close.
+  ``POST /v1/graphs/{g}/operations/remember`` — the same content operation
+  the MCP ``remember`` tool delegates to, so seeded memories are
+  indistinguishable from ones an AI Operator stores during the close.
   Degrades gracefully when semantic memory is disabled on the deployment.
   """
-  import httpx
+  from robosystems_client.api.content_operations.remember import (
+    sync_detailed as api_remember,
+  )
+  from robosystems_client.client import AuthenticatedClient
+  from robosystems_client.models import RememberOp
 
-  api_key = _client_config()["token"]
+  client = AuthenticatedClient(
+    base_url=BASE_URL,
+    token=_client_config()["token"],
+    prefix="",
+    auth_header_name="X-API-Key",
+  )
   seeded = 0
   for memory in memories:
-    resp = httpx.post(
-      f"{BASE_URL}/v1/graphs/{graph_id}/mcp/call-tool",
-      json={
-        "name": "remember",
-        "arguments": {
-          "text": memory["text"],
-          "memory_type": memory.get("memory_type", "fact"),
-          "tags": memory.get("tags", []),
-        },
-      },
-      headers={"X-API-Key": api_key, "Content-Type": "application/json"},
-      timeout=60.0,
+    response = api_remember(
+      graph_id=graph_id,
+      client=client,
+      body=RememberOp(
+        text=memory["text"],
+        source="demo",
+        memory_type=memory.get("memory_type", "fact"),
+        tags=memory.get("tags", []),
+      ),
     )
-    if resp.status_code >= 400:
-      print(f"  WARNING: remember -> HTTP {resp.status_code}: {resp.text[:160]}")
-      continue
-    body = resp.json() or {}
-    payload = body.get("result") or body
-    if isinstance(payload, dict) and payload.get("error"):
-      print(f"  (skipped) {payload.get('message', payload['error'])}")
+    if response.status_code in (403, 404, 503):
+      # Memory disabled on the deployment, or not offered on this graph.
+      detail = response.content.decode("utf-8", "replace")[:160]
+      print(f"  (skipped) remember -> HTTP {response.status_code}: {detail}")
       return seeded
+    if response.status_code >= 400:
+      detail = response.content.decode("utf-8", "replace")[:160]
+      print(f"  WARNING: remember -> HTTP {response.status_code}: {detail}")
+      continue
     seeded += 1
   return seeded
 
@@ -1899,9 +1903,7 @@ def create_schedules(
 
   # Find or create schedule taxonomy
   existing_taxonomies = client.list_taxonomies(graph_id, taxonomy_type="schedule")
-  schedule_tax = next(
-    (t for t in existing_taxonomies if t.name == taxonomy_name), None
-  )
+  schedule_tax = next((t for t in existing_taxonomies if t.name == taxonomy_name), None)
   if schedule_tax:
     taxonomy_id = schedule_tax.id
     # Clean up prior-run schedules for idempotency
@@ -2184,7 +2186,9 @@ def generate_annual_report(
   # for loop/CI runs whose local files nobody will ever open, the same
   # bundles export on demand from the report UI.
   if skip_artifacts:
-    print("  Artifacts:    skipped (--no-artifacts) — export bundles from the report UI")
+    print(
+      "  Artifacts:    skipped (--no-artifacts) — export bundles from the report UI"
+    )
   else:
     _download_bundles(client, graph_id, report_id, output_dir, scenario)
 

--- a/robosystems/routers/graphs/mcp/execute.py
+++ b/robosystems/routers/graphs/mcp/execute.py
@@ -204,9 +204,9 @@ async def authorize_mcp_tool_call(
 ) -> str:
   """Run the shared MCP tool-call authorization gauntlet.
 
-  Used by both the REST endpoint (POST /mcp/call-tool) and the remote JSON-RPC
-  transport (POST /mcp) so the two surfaces cannot drift: fail-closed write
-  classification, StatementKernel statement policy for cypher read tools,
+  Used by the remote JSON-RPC transport (POST /mcp, both the per-graph and
+  the OAuth-only route) and the in-process operator path so the surfaces
+  cannot drift: fail-closed write classification, StatementKernel statement policy for cypher read tools,
   per-graph role validation, shared-repo subscription lookup, and dual-layer
   volume rate limiting.
 

--- a/tests/middleware/rate_limits/test_graph_tier_resolver.py
+++ b/tests/middleware/rate_limits/test_graph_tier_resolver.py
@@ -24,7 +24,7 @@ class TestExtractGraphId:
     "path,expected",
     [
       ("/v1/graphs/kg1abc/query/cypher", "kg1abc"),
-      ("/v1/graphs/kg1abc/mcp/call-tool", "kg1abc"),
+      ("/v1/graphs/kg1abc/mcp", "kg1abc"),
       ("/extensions/kg1abc/graphql", "kg1abc"),
       ("/extensions/roboledger/kg1abc/operations/close-period", "kg1abc"),
       ("/extensions/roboinvestor/kg1abc/operations/create-security", "kg1abc"),

--- a/tests/security/isolation/README.md
+++ b/tests/security/isolation/README.md
@@ -36,7 +36,8 @@ A JSON report lands at `.local/isolation-report.json` (override with
   - the `add-member` write, plus the destructive/sensitive **core ops**
     (`delete-graph`, `materialize`, `change-tier`, `create-backup`,
     `create-subgraph`, `update-graph-metadata`),
-  - MCP (`read-graph-cypher` + `write-graph-cypher` via `/mcp/call-tool`),
+  - MCP (`read-graph-cypher` + `write-graph-cypher` as JSON-RPC `tools/call`
+    over the `/mcp` transport),
   - GraphQL (`/extensions/{graph_id}/graphql`): `{ hello }` (access probe) and
     `{ entity { name } }` (data-leak probe),
   - the **extensions command surfaces** for both products — roboledger

--- a/tests/security/isolation/matrix.py
+++ b/tests/security/isolation/matrix.py
@@ -53,17 +53,32 @@ CORE_OP_WRITES: list[str] = [
   "delete-graph",
 ]
 
-# MCP is always mounted (no domain flag). read-graph-cypher is a data probe;
-# write-graph-cypher is a cross-tenant write probe.
-MCP_PATH = "/v1/graphs/{graph_id}/mcp/call-tool"
-MCP_READ_BODY = {
-  "name": "read-graph-cypher",
-  "arguments": {"query": "MATCH (n) RETURN count(n) AS c", "parameters": {}},
-}
-MCP_WRITE_BODY = {
-  "name": "write-graph-cypher",
-  "arguments": {"query": "CREATE (n:IsoHarnessProbe {marker: 1}) RETURN n"},
-}
+# MCP is always mounted (no domain flag) as the JSON-RPC transport; the REST
+# call-tool endpoint was removed in v1.10.2. read-graph-cypher is a data
+# probe; write-graph-cypher is a cross-tenant write probe. Denials arrive as
+# HTTP 401/403 from the transport's auth dependency; a tool that runs but
+# fails answers HTTP 200 with `result.isError`, which the oracle reads as
+# acceptance — conservative in the right direction for a leak probe.
+MCP_PATH = "/v1/graphs/{graph_id}/mcp"
+
+
+def _mcp_call(name: str, arguments: dict) -> dict:
+  return {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {"name": name, "arguments": arguments},
+  }
+
+
+MCP_READ_BODY = _mcp_call(
+  "read-graph-cypher",
+  {"query": "MATCH (n) RETURN count(n) AS c", "parameters": {}},
+)
+MCP_WRITE_BODY = _mcp_call(
+  "write-graph-cypher",
+  {"query": "CREATE (n:IsoHarnessProbe {marker: 1}) RETURN n"},
+)
 
 # GraphQL is flag-gated (EXTENSIONS_GRAPHQL_ENABLED AND a domain flag). Two
 # probes: `hello` echoes the caller (access-control probe), while `entity` reads

--- a/tests/security/isolation/test_vertical.py
+++ b/tests/security/isolation/test_vertical.py
@@ -196,24 +196,43 @@ def test_viewer_cannot_use_classifier_verbs(
 
 
 def _mcp_tool_result(response) -> dict:
-  """Decode the tool's own JSON result out of an MCP call-tool response."""
+  """Decode the tool's own JSON out of an MCP ``tools/call`` JSON-RPC response.
+
+  Tool failures (including the authorization gauntlet's refusals) arrive as
+  HTTP 200 with ``result.isError`` and the detail as the first text content.
+  """
   if response.status_code // 100 != 2:
     return {"_http_status": response.status_code}
   try:
     body = response.json()
+    if body.get("error"):
+      return {"_rpc_error": body["error"]}
     result = body.get("result", body)
-    text = result.get("text") if isinstance(result, dict) else None
+    content = result.get("content") if isinstance(result, dict) else None
+    text = next(
+      (item.get("text") for item in content or [] if item.get("type") == "text"),
+      None,
+    )
     return json.loads(text) if isinstance(text, str) else {"_raw": result}
   except (ValueError, AttributeError):
     return {"_raw": response.text[:200]}
 
 
+def _mcp_call(name: str, arguments: dict) -> dict:
+  return {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {"name": name, "arguments": arguments},
+  }
+
+
 def test_member_cannot_create_subgraph_via_mcp(tenants, client: Client) -> None:
   member = _role(tenants, "member")
   r = client.post(
-    f"/v1/graphs/{tenants.graph_a}/mcp/call-tool",
+    f"/v1/graphs/{tenants.graph_a}/mcp",
     principal=member,
-    json={"name": "create-subgraph", "arguments": {"name": "isomcp"}},
+    json=_mcp_call("create-subgraph", {"name": "isomcp"}),
   )
   if r.status_code in (401, 403):
     return  # denied at the transport — fine
@@ -228,9 +247,9 @@ def test_member_cannot_create_subgraph_via_mcp(tenants, client: Client) -> None:
 def test_member_cannot_create_backup_via_mcp(tenants, client: Client) -> None:
   member = _role(tenants, "member")
   r = client.post(
-    f"/v1/graphs/{tenants.graph_a}/mcp/call-tool",
+    f"/v1/graphs/{tenants.graph_a}/mcp",
     principal=member,
-    json={"name": "create-backup", "arguments": {}},
+    json=_mcp_call("create-backup", {}),
   )
   if r.status_code in (401, 403):
     return


### PR DESCRIPTION
## Summary

Two leftovers from the REST MCP endpoint removal in v1.10.2 (#1264):

- **Showcase runner** (`examples/_scenario/runner.py`): memory seeding still posted to `POST …/mcp/call-tool`, which soft-failed, so demo tenants provisioned since 1.10.2 came up without their seeded memories. Now seeds through `POST /v1/graphs/{g}/operations/remember` via the SDK (`content_operations.remember`, `RememberOp`) — the same content operation the MCP `remember` tool delegates to. The stale "memory writes are MCP-only" docstring is gone with it.
- **Isolation harness** (`tests/security/isolation/`): the horizontal `test_mcp_is_isolated` matrix and the two vertical MCP escalation tests targeted the removed endpoint, so against a live target they would have read a 404 as a denial. They now post JSON-RPC `tools/call` to `/v1/graphs/{g}/mcp` and decode tool outcomes from `result.content` / `isError`, per the transport contract. README and the tier-resolver path example updated to match.

Also fixes the `authorize_mcp_tool_call` docstring that still named the REST endpoint.

## Test plan

- [x] ruff / format / basedpyright on the touched files
- [ ] CI (the isolation suite skips without a target; the resolver and MCP router tests run there)
- [ ] `just demo-up coffee-roaster` from this ref against prod — the reviewer tenant for the Connectors Directory submission is the first run