### PR TITLE
chore(mcp): registry listing 1.10.2 with the directory-aligned description

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "ai.robosystems/robosystems",
   "title": "RoboSystems",
-  "description": "Financial knowledge graphs: SEC XBRL filings, ledgers, reports and forecasts over MCP.",
-  "version": "1.10.1",
+  "description": "Accounting knowledge graphs: SEC XBRL filings, QuickBooks ledgers, reports and forecasts over MCP.",
+  "version": "1.10.2",
   "websiteUrl": "https://robosystems.ai",
   "repository": {
     "url": "https://github.com/RoboFinSystems/robosystems",


### PR DESCRIPTION
## Summary

`server.json` for the official MCP registry: version 1.10.2 and a description aligned with the Connectors Directory listing (98 chars; the registry caps it at 100).

Published to `registry.modelcontextprotocol.io` as `ai.robosystems/robosystems` 1.10.2 from this commit (DNS-verified namespace). The version describes the listing, not the API — bump it only when this file changes, then re-publish; no per-release step.