### PR TITLE
chore(auth): retire the MCP ?token= carriage now that OAuth covers header-less clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ RoboSystems provides comprehensive client libraries for building applications:
 
 ### MCP (Model Context Protocol)
 
-Every graph is an MCP server, and the graph's URL is the preferred way to connect — Claude, Claude Code, Cursor, or any MCP client that supports HTTP transports, no install required. The URL picks the graph (`sec` for the public SEC repository, your graph id for your own); your API key goes in the `X-API-Key` header, or rides inside a generated connector URL for clients that cannot send headers.
+Every graph is an MCP server, and the graph's URL is the preferred way to connect — Claude, Claude Code, Cursor, or any MCP client that supports HTTP transports, no install required. The URL picks the graph (`sec` for the public SEC repository, your graph id for your own); sign in with OAuth, or put your API key in the `X-API-Key` header — never in the URL.
 
 **OAuth — sign in and pick a graph.** The graph-agnostic endpoint `https://api.robosystems.ai/v1/mcp` accepts OAuth only: an OAuth-capable client (claude.ai, Claude Code, ChatGPT, VS Code, Cursor) discovers the authorization server from the endpoint, you sign in and choose the graph the connection covers, and the client holds a revocable token bound to that graph — no key to paste. Per-graph URLs accept OAuth too, alongside the key header. (Deployment flag: `MCP_OAUTH_ENABLED`.)
 
@@ -306,7 +306,7 @@ claude mcp add --transport http robosystems-sec \
 }
 ```
 
-**Claude (claude.ai / Desktop)** — generate a connector URL from the **MCP page** in the app (`/connect`) and paste it into Settings → Connectors → Add custom connector. The URL carries its own graph-scoped API key (Claude's connectors can't send custom headers), valid only for that graph and revocable anytime from Settings → API Keys.
+**Claude (claude.ai / Desktop)** — Settings → Connectors → Add custom connector with `https://api.robosystems.ai/v1/mcp` (or a per-graph URL): Claude detects OAuth and you pick the graph at sign-in. The **MCP page** in the app (`/connect`) has every snippet filled in for the selected graph, and mints graph-scoped keys for header-only clients.
 
 - **Documentation**: [Wiki guide](https://github.com/RoboFinSystems/robosystems/wiki/AI-Operators-and-MCP) | [stdio bridge](https://github.com/RoboFinSystems/robosystems-mcp-client) (proxy mode) for clients without HTTP transport support
 

--- a/robosystems/middleware/auth/README.md
+++ b/robosystems/middleware/auth/README.md
@@ -95,34 +95,38 @@ refuses scoped keys. A NULL `graph_id` means account-wide. The authoritative
 check is always the row's `graph_id`; the `rfsc` prefix is legibility for
 humans and incident response only.
 
-### Credentials in query parameters — the two deliberate doors
+### Credentials in query parameters — the one deliberate door
 
-Header carriage is the rule. Exactly two routes accept a credential via a
-`?token=` query parameter, both because their client cannot send custom
-headers. Both are covered by the redaction list in `middleware/logging.py` and
-by the OTel span redaction in `middleware/otel/setup.py`.
+Header carriage is the rule. Exactly one route accepts a credential via a
+`?token=` query parameter, because its client cannot send custom headers. It is
+covered by the redaction list in `middleware/logging.py` and by the OTel span
+redaction in `middleware/otel/setup.py`.
 
-| Route                                  | Dependency                              | Accepts                          | Why                                       |
-| -------------------------------------- | --------------------------------------- | -------------------------------- | ----------------------------------------- |
-| `GET /v1/operations/{id}/stream` (SSE) | `get_current_user_sse`                  | **JWT only** (30-min TTL)        | browser `EventSource` cannot set headers  |
-| `POST /v1/graphs/{graph_id}/mcp`       | `get_current_user_with_graph_or_url_token` | **graph-scoped API key only** | MCP connector clients cannot set headers  |
+| Route                                  | Dependency             | Accepts                   | Why                                      |
+| -------------------------------------- | ---------------------- | ------------------------- | ---------------------------------------- |
+| `GET /v1/operations/{id}/stream` (SSE) | `get_current_user_sse` | **JWT only** (30-min TTL) | browser `EventSource` cannot set headers |
 
-The graph-agnostic `POST /v1/mcp` (`get_oauth_mcp_principal`) is the
-counterpoint: it accepts **only** an OAuth bearer — no header key, no
-`?token=`, no JWT — because its tenant scope lives in the credential's grant
-and no other credential type carries one. Every other carriage there answers
-401 with the discovery challenge, not 403. A missing credential on either MCP
-route answers 401 with `WWW-Authenticate: Bearer resource_metadata="…"` naming
-the route's protected-resource document; that header is how an OAuth client
-finds the authorization server.
+There used to be a second door: `POST /v1/graphs/{graph_id}/mcp` honored a
+graph-scoped API key in `?token=`, for MCP connector clients that could not set
+headers. It was the bridge to OAuth and was retired once OAuth covered those
+clients — a durable key in a URL lands in client config, org-shared connector
+settings, and third-party logs, none of which a header reaches. The per-graph
+MCP route (`get_current_user_with_graph_or_oauth`) now reads nothing from the
+query string: an OAuth bearer bound to that exact route, or the header
+carriages exactly as `get_current_user_with_graph`. A URL that still carries a
+`?token=` is unauthenticated and gets the discovery challenge, which is what
+moves that client onto OAuth. The graph-agnostic `POST /v1/mcp`
+(`get_oauth_mcp_principal`) accepts **only** an OAuth bearer — no header key,
+no JWT — because its tenant scope lives in the credential's grant and no other
+credential type carries one; every other carriage there answers 401 with the
+discovery challenge, not 403. A missing credential on either MCP route answers
+401 with `WWW-Authenticate: Bearer resource_metadata="…"` naming the route's
+protected-resource document; that header is how an OAuth client finds the
+authorization server.
 
-The asymmetry is deliberate: the SSE door carries a short-lived session token,
-so no extra restriction is needed; the MCP door carries a durable key, so only
-graph-scoped keys are honored and account-wide keys are hard-rejected — the
-account credential must never be the one that travels in a URL. Header and JWT
-auth take precedence on both; the query parameter is consulted only when
-neither is present. Do not add a third door without matching this table, the
-redaction lists, and a scope story.
+The SSE door is tolerable because it carries a short-lived session token. Do
+not add another door without matching this table, the redaction lists, and a
+scope story.
 
 ### SSO — one word, two mechanisms
 
@@ -237,7 +241,7 @@ deliberately JWT-only for surfaces that manage sign-in credentials themselves.
 | `get_optional_user`                             | `User \| None` | Never raises for missing credentials.                             |
 | `get_optional_jwt_user`                         | `User \| None` | JWT sessions only — API keys read as anonymous. Passkey enrollment. |
 | `get_current_user_with_graph`                   | `User`  | Reads `graph_id` from the path and validates access.                    |
-| `get_current_user_with_graph_or_url_token`      | `User`  | As above, plus the `?token=` door. MCP only.                            |
+| `get_current_user_with_graph_or_oauth`          | `User`  | As above, plus an OAuth bearer bound to the route. MCP only.            |
 | `get_current_user_sse`                          | `User`  | As `get_current_user`, plus the `?token=` JWT door.                     |
 | `get_current_user_with_repository_access`       | `User`  | Shared repositories (SEC, etc.); resolves subgraphs to the parent.      |
 | `get_repository_user_dependency(repo, op_type)` | factory | Builds the above bound to a specific repository and operation type.     |

--- a/robosystems/middleware/auth/dependencies.py
+++ b/robosystems/middleware/auth/dependencies.py
@@ -719,33 +719,27 @@ def _resolve_oauth_principal(
   return principal
 
 
-async def get_current_user_with_graph_or_url_token(
+async def get_current_user_with_graph_or_oauth(
   request: Request,
   graph_id: str,
   api_key: str = Security(API_KEY_HEADER),
-  token: str | None = Query(
-    None,
-    description="Graph-scoped API key carried in the URL, for MCP connector "
-    "clients that cannot send custom headers",
-  ),
 ) -> User:
-  """Graph authentication for the per-graph MCP route: all three carriages.
+  """Graph authentication for the per-graph MCP route: bearer or header.
 
   ``Authorization: Bearer <opaque OAuth token>`` (when the OAuth surface is
   on) resolves through the grant bound to this exact route — the URL fixes
   the graph, and the token's audience must name it. Otherwise header and
-  JWT authentication behave exactly like ``get_current_user_with_graph``,
-  and the ``token`` query parameter is consulted only when neither is
-  present: it honors only keys whose scope covers the URL's graph — an
-  account-wide key in a URL is rejected outright, so the account credential
-  can never be the one that travels in a URL.
+  JWT authentication behave exactly like ``get_current_user_with_graph``.
+
+  Nothing is read from the query string. The ``?token=`` door that once
+  carried a graph-scoped key for connector clients that could not send
+  headers was retired when OAuth covered those clients; a URL that still
+  carries one is treated as unauthenticated and gets the discovery
+  challenge, which is exactly what moves such a client onto OAuth.
 
   A missing credential answers 401 with a ``WWW-Authenticate`` challenge
   that names the route's protected-resource metadata; that header is what
   lets an OAuth client find the authorization server.
-
-  ``token`` is in the sensitive-query-params redaction list
-  (``middleware/logging.py``), so it never appears in logged URLs.
   """
   from robosystems.config import env
 
@@ -753,55 +747,12 @@ async def get_current_user_with_graph_or_url_token(
   if oauth_token is not None and env.MCP_OAUTH_ENABLED:
     return _resolve_oauth_principal(request, oauth_token, graph_id).user
 
-  authorization = request.headers.get("authorization")
-  has_header_auth = bool(api_key) or bool(
-    authorization and authorization.startswith("Bearer ")
-  )
-
-  if has_header_auth or not token:
-    # Normal path — including the no-credentials 401, which carries the
-    # discovery challenge so an OAuth-capable client can proceed.
-    try:
-      return await get_current_user_with_graph(request, graph_id, api_key)
-    except HTTPException as exc:
-      if exc.status_code == status.HTTP_401_UNAUTHORIZED:
-        exc.headers = _mcp_challenge_headers(graph_id)
-      raise
-
-  client_ip = request.client.host if request.client else None
-  user_agent = request.headers.get("user-agent")
-  endpoint = str(request.url.path)
-
-  user = validate_api_key_with_graph(token, graph_id, require_scoped=True)
-  if user:
-    _stash_api_key_identity(request, token, user, auth_method="api_key_url")
-    SecurityAuditLogger.log_auth_success(
-      user_id=str(user.id),
-      ip_address=client_ip,
-      user_agent=user_agent,
-      auth_method="api_key_url",
-    )
-    return user
-
-  SecurityAuditLogger.log_security_event(
-    event_type=SecurityEventType.API_KEY_INVALID,
-    ip_address=client_ip,
-    user_agent=user_agent,
-    endpoint=endpoint,
-    details={
-      "api_key_prefix": token[:8] if token else "",
-      "graph_id": graph_id,
-      "carriage": "url_token",
-    },
-    risk_level="high",
-  )
-  # Same deliberate conflation as the header path: the two cases are
-  # indistinguishable to the caller.
-  raise HTTPException(
-    status_code=status.HTTP_403_FORBIDDEN,
-    detail="Invalid API key or access denied to graph",
-    headers={"WWW-Authenticate": "ApiKey"},
-  )
+  try:
+    return await get_current_user_with_graph(request, graph_id, api_key)
+  except HTTPException as exc:
+    if exc.status_code == status.HTTP_401_UNAUTHORIZED:
+      exc.headers = _mcp_challenge_headers(graph_id)
+    raise
 
 
 async def get_oauth_mcp_principal(

--- a/robosystems/middleware/auth/utils.py
+++ b/robosystems/middleware/auth/utils.py
@@ -202,17 +202,13 @@ def validate_api_key_with_graph(
   api_key: str,
   graph_id: str,
   db_session: Session | None = None,
-  require_scoped: bool = False,
   *,
   allow_deprovisioned: bool = False,
 ) -> User | None:
   """Validate an API key against a graph and return its user.
 
   Graph-scoped keys (``graph_id`` set on the row) are honored only for their
-  own graph and its subgraphs, regardless of how the key is carried. With
-  ``require_scoped=True`` (the MCP URL-token path), account-wide keys are
-  additionally rejected — the account credential must never be the one that
-  travels in a URL.
+  own graph and its subgraphs, regardless of how the key is carried.
 
   Returns None for an invalid key or an unauthorized graph, without
   distinguishing the two.
@@ -261,11 +257,6 @@ def validate_api_key_with_graph(
       if not _key_scope_allows(key_graph_id, graph_id):
         logger.debug(
           f"API key rejected: scoped to another graph: {api_key_hash[:8]}... -> {graph_id}"
-        )
-        return None
-      if require_scoped and not key_graph_id:
-        logger.debug(
-          f"API key rejected: account-wide key where a graph-scoped key is required: {api_key_hash[:8]}..."
         )
         return None
 
@@ -330,15 +321,6 @@ def validate_api_key_with_graph(
         _safe_cache_call("cache_graph_access", api_key_hash, graph_id, has_access=False)
       except Exception as e:
         logger.error(f"Failed to cache scoped-key mismatch result: {e}")
-      return None
-
-    # require_scoped rejects account-wide keys WITHOUT caching a negative
-    # access decision — the same key remains valid for this graph via headers,
-    # and the graph-access cache is shared across carriage paths.
-    if require_scoped and not key_record.graph_id:
-      logger.debug(
-        f"API key rejected: account-wide key where a graph-scoped key is required: {api_key_hash[:8]}..."
-      )
       return None
 
     from ..graph.utils import MultiTenantUtils

--- a/robosystems/middleware/mcp/README.md
+++ b/robosystems/middleware/mcp/README.md
@@ -300,4 +300,4 @@ the relevant SSM flag, in that order. Pool exhaustion is usually a missing
 - [`../../schemas/README.md`](../../schemas/README.md) — `schema_extensions` conventions
 - [`../../graph_api/README.md`](../../graph_api/README.md) — the Graph API this client calls
 - [`../graph/README.md`](../graph/README.md) — graph routing
-- [`../auth/README.md`](../auth/README.md) — the MCP `?token=` door and key scoping
+- [`../auth/README.md`](../auth/README.md) — the MCP credential carriages and key scoping

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -20,9 +20,9 @@ Transport rules:
 - Stateless: no ``Mcp-Session-Id``, no GET-side SSE channel, no resumability.
   A subgraph is addressed as another connector URL, never via in-session
   switching.
-- Three credential carriages on the per-graph route: ``X-API-Key``, the
-  graph-scoped ``?token=``, and an OAuth ``Authorization: Bearer`` bound to
-  this exact URL. The graph-agnostic ``POST /v1/mcp`` (``agnostic_router``)
+- Two credential carriages on the per-graph route: ``X-API-Key`` and an
+  OAuth ``Authorization: Bearer`` bound to this exact URL — nothing in the
+  query string. The graph-agnostic ``POST /v1/mcp`` (``agnostic_router``)
   is OAuth-only: the consent grant names the graph, and the transport
   dispatches on that resolved ``graph_id`` exactly as the per-graph route
   dispatches on the URL's.
@@ -44,7 +44,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from robosystems.logger import api_logger, logger
 from robosystems.middleware.auth.dependencies import (
-  get_current_user_with_graph_or_url_token,
+  get_current_user_with_graph_or_oauth,
   get_oauth_mcp_principal,
 )
 from robosystems.middleware.auth.oauth import OAuthPrincipal
@@ -1087,7 +1087,7 @@ async def mcp_remote_transport(
     pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN,
   ),
   _transport: None = Depends(_transport_gate),
-  current_user: User = Depends(get_current_user_with_graph_or_url_token),
+  current_user: User = Depends(get_current_user_with_graph_or_oauth),
   _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
 ) -> Response:
   """Streamable-HTTP MCP endpoint (JSON-RPC 2.0)."""

--- a/static/description.md
+++ b/static/description.md
@@ -129,7 +129,7 @@ https://api.robosystems.ai/v1/mcp
 
 An OAuth-capable client (claude.ai, Claude Code, ChatGPT, VS Code, Cursor) discovers the authorization server from the endpoint (`/.well-known/oauth-protected-resource/v1/mcp`), sends you to sign in, and the consent screen is where you choose the graph the connection covers — your own graphs or a subscribed repository such as `sec`. The client then holds a revocable token bound to that graph; revoke it at any time and the connection stops. Per-graph URLs accept OAuth too, alongside the `X-API-Key` header. (Deployment flag: `MCP_OAUTH_ENABLED`.)
 
-For claude.ai and Claude Desktop custom connectors that cannot send an API-key header, the alternative is a connector URL from the MCP page in the app (`/connect`): the URL carries its own graph-scoped, revocable API key, so it pastes straight into Settings → Connectors → Add custom connector. Clients without HTTP transport support can use the [stdio bridge](https://www.npmjs.com/package/@robosystems/mcp) in proxy mode.
+Header-only clients (scripts, CI, editors without OAuth) put an API key in `X-API-Key` on a per-graph URL — the MCP page in the app (`/connect`) mints keys scoped to one graph for exactly that. Credentials never travel in the URL. Clients without HTTP transport support can use the [stdio bridge](https://www.npmjs.com/package/@robosystems/mcp) in proxy mode.
 
 ## Clients
 

--- a/tests/middleware/auth/test_dependencies.py
+++ b/tests/middleware/auth/test_dependencies.py
@@ -1496,12 +1496,13 @@ class TestApiKeyIdentityStash:
     assert mock_request.state.auth_method == "api_key"
 
 
-class TestGetCurrentUserWithGraphOrUrlToken:
-  """The MCP URL-token carriage rule: header wins, query honors scoped keys only."""
+class TestGetCurrentUserWithGraphOrOauth:
+  """The per-graph MCP carriage rule: bearer or header, nothing from the URL."""
 
-  def _request(self, headers=None):
+  def _request(self, headers=None, query_params=None):
     mock_request = Mock(spec=Request)
     mock_request.headers = headers or {}
+    mock_request.query_params = query_params or {}
     mock_request.client = Mock()
     mock_request.client.host = "127.0.0.1"
     mock_request.url = Mock()
@@ -1511,69 +1512,28 @@ class TestGetCurrentUserWithGraphOrUrlToken:
 
   @pytest.mark.asyncio
   @patch("robosystems.middleware.auth.dependencies.get_current_user_with_graph")
-  async def test_header_auth_takes_precedence(self, mock_delegate):
+  async def test_header_auth_delegates(self, mock_delegate):
     from robosystems.middleware.auth.dependencies import (
-      get_current_user_with_graph_or_url_token,
+      get_current_user_with_graph_or_oauth,
     )
 
     mock_user = Mock(spec=User)
     mock_delegate.return_value = mock_user
     request = self._request()
 
-    result = await get_current_user_with_graph_or_url_token(
-      request, "kg123", api_key="rfs" + "a" * 64, token="rfsc" + "b" * 64
+    result = await get_current_user_with_graph_or_oauth(
+      request, "kg123", api_key="rfs" + "a" * 64
     )
 
     assert result == mock_user
     mock_delegate.assert_awaited_once()
 
   @pytest.mark.asyncio
-  @patch("robosystems.middleware.auth.dependencies.validate_api_key_with_graph")
-  async def test_url_token_authenticates_scoped_key(self, mock_validate):
-    from robosystems.middleware.auth.dependencies import (
-      get_current_user_with_graph_or_url_token,
-    )
-
-    mock_user = Mock(spec=User)
-    mock_user.id = "user123"
-    mock_validate.return_value = mock_user
-    request = self._request()
-
-    token = "rfsc" + "b" * 64
-    result = await get_current_user_with_graph_or_url_token(
-      request, "kg123", api_key=None, token=token
-    )
-
-    assert result == mock_user
-    mock_validate.assert_called_once_with(token, "kg123", require_scoped=True)
-    assert request.state.api_key_prefix == token[:8]
-    # The sanitized principal must be published for consumers that cannot
-    # reparse the URL credential — the rate limiter reads these.
-    assert request.state.auth_user_id == "user123"
-    assert request.state.auth_method == "api_key_url"
-
-  @pytest.mark.asyncio
-  @patch("robosystems.middleware.auth.dependencies.validate_api_key_with_graph")
-  async def test_url_token_invalid_returns_403(self, mock_validate):
-    from robosystems.middleware.auth.dependencies import (
-      get_current_user_with_graph_or_url_token,
-    )
-
-    mock_validate.return_value = None
-    request = self._request()
-
-    with pytest.raises(HTTPException) as exc_info:
-      await get_current_user_with_graph_or_url_token(
-        request, "kg123", api_key=None, token="rfs" + "b" * 64
-      )
-
-    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
-
-  @pytest.mark.asyncio
   @patch("robosystems.middleware.auth.dependencies.get_current_user_with_graph")
-  async def test_no_credentials_delegates_to_normal_401(self, mock_delegate):
+  async def test_no_credentials_is_401_with_discovery_challenge(self, mock_delegate):
+    from robosystems.config import env
     from robosystems.middleware.auth.dependencies import (
-      get_current_user_with_graph_or_url_token,
+      get_current_user_with_graph_or_oauth,
     )
 
     mock_delegate.side_effect = HTTPException(
@@ -1581,28 +1541,55 @@ class TestGetCurrentUserWithGraphOrUrlToken:
     )
     request = self._request()
 
-    with pytest.raises(HTTPException) as exc_info:
-      await get_current_user_with_graph_or_url_token(
-        request, "kg123", api_key=None, token=None
-      )
+    with (
+      patch.object(env, "MCP_OAUTH_ENABLED", True),
+      pytest.raises(HTTPException) as exc_info,
+    ):
+      await get_current_user_with_graph_or_oauth(request, "kg123", api_key=None)
 
     assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert "resource_metadata=" in exc_info.value.headers["WWW-Authenticate"]
     mock_delegate.assert_awaited_once()
 
   @pytest.mark.asyncio
+  @patch("robosystems.middleware.auth.dependencies.validate_api_key_with_graph")
   @patch("robosystems.middleware.auth.dependencies.get_current_user_with_graph")
-  async def test_jwt_header_takes_precedence_over_token(self, mock_delegate):
+  async def test_url_token_is_not_a_credential(self, mock_delegate, mock_validate):
+    """The retired ``?token=`` door: a key in the URL is ignored, and the
+    request is answered as unauthenticated — with the OAuth challenge, so a
+    client holding an old connector URL is steered onto the flow."""
+    from robosystems.config import env
     from robosystems.middleware.auth.dependencies import (
-      get_current_user_with_graph_or_url_token,
+      get_current_user_with_graph_or_oauth,
+    )
+
+    mock_delegate.side_effect = HTTPException(
+      status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required"
+    )
+    request = self._request(query_params={"token": "rfsc" + "b" * 64})
+
+    with (
+      patch.object(env, "MCP_OAUTH_ENABLED", True),
+      pytest.raises(HTTPException) as exc_info,
+    ):
+      await get_current_user_with_graph_or_oauth(request, "kg123", api_key=None)
+
+    assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert "resource_metadata=" in exc_info.value.headers["WWW-Authenticate"]
+    mock_validate.assert_not_called()
+
+  @pytest.mark.asyncio
+  @patch("robosystems.middleware.auth.dependencies.get_current_user_with_graph")
+  async def test_jwt_header_delegates(self, mock_delegate):
+    from robosystems.middleware.auth.dependencies import (
+      get_current_user_with_graph_or_oauth,
     )
 
     mock_user = Mock(spec=User)
     mock_delegate.return_value = mock_user
-    request = self._request(headers={"authorization": "Bearer some.jwt.token"})
+    request = self._request(headers={"authorization": "Bearer eyJ.jwt.token"})
 
-    result = await get_current_user_with_graph_or_url_token(
-      request, "kg123", api_key=None, token="rfsc" + "b" * 64
-    )
+    result = await get_current_user_with_graph_or_oauth(request, "kg123", api_key=None)
 
     assert result == mock_user
     mock_delegate.assert_awaited_once()

--- a/tests/middleware/auth/test_oauth_dependencies.py
+++ b/tests/middleware/auth/test_oauth_dependencies.py
@@ -83,9 +83,7 @@ class TestPerGraphRoute:
       patch.object(deps, "publish_principal") as publish,
       patch.object(deps, "SecurityAuditLogger"),
     ):
-      user = await deps.get_current_user_with_graph_or_url_token(
-        request, KG, api_key=None, token=None
-      )
+      user = await deps.get_current_user_with_graph_or_oauth(request, KG, api_key=None)
     assert user.id == "user-1"
     publish.assert_called_once()
     assert publish.call_args.args[2] == "oauth"
@@ -102,9 +100,7 @@ class TestPerGraphRoute:
       patch.object(deps, "SecurityAuditLogger"),
       pytest.raises(HTTPException) as exc,
     ):
-      await deps.get_current_user_with_graph_or_url_token(
-        request, KG, api_key=None, token=None
-      )
+      await deps.get_current_user_with_graph_or_oauth(request, KG, api_key=None)
     assert exc.value.status_code == 401
     challenge = exc.value.headers["WWW-Authenticate"]
     assert 'error="invalid_token"' in challenge
@@ -123,9 +119,7 @@ class TestPerGraphRoute:
       patch.object(deps, "SecurityAuditLogger"),
       pytest.raises(HTTPException) as exc,
     ):
-      await deps.get_current_user_with_graph_or_url_token(
-        request, KG, api_key=None, token=None
-      )
+      await deps.get_current_user_with_graph_or_oauth(request, KG, api_key=None)
     assert exc.value.status_code == 401
 
   async def test_invalid_token_is_401(self):
@@ -135,9 +129,7 @@ class TestPerGraphRoute:
       patch.object(deps, "SecurityAuditLogger"),
       pytest.raises(HTTPException) as exc,
     ):
-      await deps.get_current_user_with_graph_or_url_token(
-        request, KG, api_key=None, token=None
-      )
+      await deps.get_current_user_with_graph_or_oauth(request, KG, api_key=None)
     assert exc.value.status_code == 401
     assert 'error="invalid_token"' in exc.value.headers["WWW-Authenticate"]
 
@@ -153,9 +145,7 @@ class TestPerGraphRoute:
       patch.object(deps, "SecurityAuditLogger"),
       pytest.raises(HTTPException) as exc,
     ):
-      await deps.get_current_user_with_graph_or_url_token(
-        request, KG, api_key=None, token=None
-      )
+      await deps.get_current_user_with_graph_or_oauth(request, KG, api_key=None)
     assert exc.value.status_code == 403
     assert 'error="insufficient_scope"' in exc.value.headers["WWW-Authenticate"]
 
@@ -165,9 +155,7 @@ class TestPerGraphRoute:
       patch.object(deps, "SecurityAuditLogger"),
       pytest.raises(HTTPException) as exc,
     ):
-      await deps.get_current_user_with_graph_or_url_token(
-        request, KG, api_key=None, token=None
-      )
+      await deps.get_current_user_with_graph_or_oauth(request, KG, api_key=None)
     assert exc.value.status_code == 401
     challenge = exc.value.headers["WWW-Authenticate"]
     assert challenge.startswith("Bearer resource_metadata=")
@@ -181,8 +169,8 @@ class TestPerGraphRoute:
     with patch.object(
       deps, "get_current_user_with_graph", return_value=user
     ) as header_path:
-      resolved = await deps.get_current_user_with_graph_or_url_token(
-        request, KG, api_key="rfsabc", token=None
+      resolved = await deps.get_current_user_with_graph_or_oauth(
+        request, KG, api_key="rfsabc"
       )
     assert resolved.id == "user-2"
     header_path.assert_awaited_once()
@@ -199,9 +187,7 @@ class TestPerGraphRouteFlagOff:
       patch.object(deps, "extract_device_fingerprint", return_value=None),
       pytest.raises(HTTPException) as exc,
     ):
-      await deps.get_current_user_with_graph_or_url_token(
-        request, KG, api_key=None, token=None
-      )
+      await deps.get_current_user_with_graph_or_oauth(request, KG, api_key=None)
     validate.assert_not_called()
     assert exc.value.status_code == 401
     assert exc.value.headers["WWW-Authenticate"] == "Bearer, ApiKey"
@@ -220,7 +206,7 @@ class TestAgnosticRoute:
       patch.object(deps, "publish_principal"),
       patch.object(deps, "SecurityAuditLogger"),
     ):
-      resolved = await deps.get_oauth_mcp_principal(request, api_key=None, token=None)
+      resolved = await deps.get_oauth_mcp_principal(request, api_key=None)
     assert resolved.graph_id == KG
     assert request.state.auth_graph_id == KG
 
@@ -231,7 +217,7 @@ class TestAgnosticRoute:
       patch.object(deps, "SecurityAuditLogger"),
       pytest.raises(HTTPException) as exc,
     ):
-      await deps.get_oauth_mcp_principal(request, api_key=None, token=None)
+      await deps.get_oauth_mcp_principal(request, api_key=None)
     assert exc.value.status_code == 401
 
   @pytest.mark.parametrize(
@@ -266,5 +252,5 @@ class TestAgnosticRoute:
       patch.object(env, "MCP_OAUTH_ENABLED", False),
       pytest.raises(HTTPException) as exc,
     ):
-      await deps.get_oauth_mcp_principal(request, api_key=None, token=None)
+      await deps.get_oauth_mcp_principal(request, api_key=None)
     assert exc.value.status_code == 404

--- a/tests/middleware/auth/test_utils.py
+++ b/tests/middleware/auth/test_utils.py
@@ -509,9 +509,7 @@ class TestGraphScopedKeys:
     with patch(
       "robosystems.middleware.auth.utils.GraphUser.user_has_access", return_value=True
     ):
-      result = validate_api_key_with_graph(
-        "rfsc" + "a" * 64, "kg123", require_scoped=True
-      )
+      result = validate_api_key_with_graph("rfsc" + "a" * 64, "kg123")
 
     assert result is not None
     assert result.id == "user123"
@@ -531,47 +529,6 @@ class TestGraphScopedKeys:
     mock_cache.cache_graph_access.assert_called_once()
     assert mock_cache.cache_graph_access.call_args[1]["has_access"] is False
 
-  @patch("robosystems.database.SessionFactory")
-  @patch("robosystems.middleware.auth.utils.api_key_cache")
-  @patch("robosystems.middleware.auth.utils.UserAPIKey")
-  def test_require_scoped_rejects_account_wide_key_without_cache_poison(
-    self, mock_api_key_class, mock_cache, mock_session_factory
-  ):
-    """require_scoped rejects account-wide keys but must not cache a negative
-    access decision — the same key stays valid for this graph via headers."""
-    mock_cache.get_cached_api_key_validation.return_value = None
-    mock_cache.get_cached_graph_access.return_value = None
-    self._db_setup(mock_api_key_class, mock_session_factory, None)
-
-    result = validate_api_key_with_graph("rfs" + "a" * 64, "kg123", require_scoped=True)
-
-    assert result is None
-    mock_cache.cache_graph_access.assert_not_called()
-
-  @patch("robosystems.middleware.auth.utils.api_key_cache")
-  @patch("robosystems.middleware.auth.utils.UserAPIKey")
-  def test_require_scoped_rejects_account_wide_key_cache_hit(
-    self, mock_api_key_class, mock_cache
-  ):
-    """require_scoped rejection also holds on the cache-hit path."""
-    mock_cache.get_cached_api_key_validation.return_value = {
-      "is_active": True,
-      "user_data": {
-        "id": "user123",
-        "name": "Test User",
-        "email": "test@example.com",
-        "email_verified": True,
-        "is_active": True,
-        "key_graph_id": None,
-      },
-    }
-    mock_cache.get_cached_graph_access.return_value = True
-
-    result = validate_api_key_with_graph("rfs" + "a" * 64, "kg123", require_scoped=True)
-
-    assert result is None
-    mock_api_key_class.get_by_key.assert_not_called()
-
   @patch("robosystems.middleware.auth.utils.api_key_cache")
   @patch("robosystems.middleware.auth.utils.UserAPIKey")
   def test_scoped_key_subgraph_allowed_cache_hit(self, mock_api_key_class, mock_cache):
@@ -589,9 +546,7 @@ class TestGraphScopedKeys:
     }
     mock_cache.get_cached_graph_access.return_value = True
 
-    result = validate_api_key_with_graph(
-      "rfsc" + "a" * 64, "kg123_dev", require_scoped=True
-    )
+    result = validate_api_key_with_graph("rfsc" + "a" * 64, "kg123_dev")
 
     assert result is not None
     assert result.id == "user123"


### PR DESCRIPTION
## What

Removes the `?token=` query-string credential from `POST /v1/graphs/{graph_id}/mcp`. It carried a graph-scoped API key for connector clients that could not send headers; it was the bridge to OAuth, and with OAuth live on both MCP routes (v1.10.2) there is no client left that needs a credential in a URL.

- `get_current_user_with_graph_or_url_token` → **`get_current_user_with_graph_or_oauth`**: an OAuth bearer bound to the exact URL, or the header carriages exactly as `get_current_user_with_graph`. Nothing is read from the query string. A URL that still carries `?token=` is answered as unauthenticated **with the discovery challenge**, which steers that client onto OAuth.
- `validate_api_key_with_graph` loses `require_scoped` — this path was its only caller. Graph-scoped keys behave as before via the header.
- `token` stays on the log-redaction list as a leftover guard.
- Docs: `middleware/auth/README.md` (the "deliberate doors" section is now one door, SSE JWT, with the retirement recorded), `middleware/mcp/README.md`, root `README.md` §MCP, `static/description.md`.

## Why now

A durable key in a URL lands in client config files, org-shared connector settings, and third-party access logs — none of which a header reaches. claude.ai does OAuth natively and its connector dialog accepts custom request headers, so even the no-OAuth Claude case has a header path. No external user depends on a token URL; the app's MCP page (robosystems-app #332) already leads with OAuth and its remaining token snippet is being dropped alongside.

## Tests

- `tests/middleware/auth`: the URL-token cases replaced by three on the new dependency (header delegates; no credential → 401 with `resource_metadata=`; a `?token=` in the URL is not a credential and the key validator is never consulted); the `require_scoped` cases removed.
- `just test-code` clean; auth + MCP router suites 281 passed locally.

Follow-ups (separate PRs): `@robosystems/core` `createMcpConnectorUrl` stops building the token URL and the console `/mcp` leads with OAuth; both apps' getting-started pages; the demo loop stops minting connector URLs; wiki + bridge README wording.