### PR TITLE
chore(mcp): serve /.well-known/glama.json so the Glama listing can be claimed

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ headers), exception handlers, the core `/v1` routers, the flag-gated
 that injects the shared operation error/idempotency contract.
 """
 
+import json
 import time
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
@@ -222,6 +223,17 @@ def create_app() -> FastAPI:
     @app.get("/.well-known/security.txt", include_in_schema=False)
     async def security_txt() -> PlainTextResponse:
       return PlainTextResponse(security_txt_content)
+
+  # Glama connector-ownership claim (mirrors security.txt): the MCP endpoint's
+  # origin publishes the maintainers' role address and Glama matches it
+  # against its accounts.
+  glama_file = Path("static") / "glama.json"
+  if glama_file.exists():
+    glama_content = json.loads(glama_file.read_text(encoding="utf-8"))
+
+    @app.get("/.well-known/glama.json", include_in_schema=False)
+    async def glama_json() -> JSONResponse:
+      return JSONResponse(glama_content)
 
   # Custom dark-themed Swagger + ReDoc (served inline from docs_template).
   @app.get("/", response_class=HTMLResponse, include_in_schema=False)

--- a/static/glama.json
+++ b/static/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/connector.json",
+  "maintainers": [{ "email": "admin@robosystems.ai" }]
+}

--- a/tests/test_main_security_baseline.py
+++ b/tests/test_main_security_baseline.py
@@ -151,3 +151,16 @@ class TestSecurityTxt:
     """Control path: proves security.txt is a genuine route, not a catch-all."""
     response = client.get("/.well-known/does-not-exist.txt")
     assert response.status_code == 404
+
+
+class TestGlamaClaim:
+  def test_glama_json_served(self, client):
+    """Glama verifies connector ownership from this document on the MCP
+    endpoint's origin; the address is a role mailbox that matches the Glama
+    account, never a person."""
+    response = client.get("/.well-known/glama.json")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    body = response.json()
+    assert body["$schema"] == "https://glama.ai/mcp/schemas/connector.json"
+    assert body["maintainers"] == [{"email": "admin@robosystems.ai"}]


### PR DESCRIPTION
Glama already mirrors our official-registry entry at `glama.ai/mcp/connectors/ai.robosystems/robosystems`. Claiming it (edit the listing, analytics, health monitoring) works by publishing `/.well-known/glama.json` on the MCP endpoint's domain with the maintainers' emails; Glama detects and verifies it within minutes.

- `static/glama.json` — `$schema` + one maintainer, the **`admin@robosystems.ai`** role mailbox (the same intake behind `security@`). No personal address.
- `main.py` — served at `/.well-known/glama.json`, mirroring the `security.txt` route.
- Test in `tests/test_main_security_baseline.py`.

After deploy: create the Glama account under `admin@robosystems.ai` and the claim verifies itself. `just test-code` clean.