### PR TITLE
fix(mcp): read-only hints on the Cypher read tools; no GraphQL tools on shared repositories

### DIFF
--- a/robosystems/adapters/sec/manifest.py
+++ b/robosystems/adapters/sec/manifest.py
@@ -37,8 +37,7 @@ SEC_MANIFEST = SharedRepositoryManifest(
     '- Map a concept like "revenue" to its XBRL element qname → '
     "`resolve-element`.\n"
     "- Full-text search across filings → `search-documents`.\n"
-    "- Typed GraphQL reads → `query-graphql`; raw graph traversal → "
-    "`read-graph-cypher`.\n"
+    "- Raw graph traversal → `read-graph-cypher`.\n"
     "\n"
     "NOTES\n"
     # The `sec_historical` subgraph was advertised here until 2026-08-14 and is

--- a/robosystems/middleware/mcp/tools/manager.py
+++ b/robosystems/middleware/mcp/tools/manager.py
@@ -171,9 +171,12 @@ class GraphMCPTools:
 
     # Layer 1: GraphQL escape-hatch tools (gated by EXTENSIONS_GRAPHQL_ENABLED)
     # MCP_GRAPHQL_ENABLED is a runtime kill switch checked at dispatch time.
+    # Excluded on shared repos: the typed surface is the extensions OLTP
+    # schema, which a shared repository like 'sec' does not have —
+    # introspection answers, but every real query errors.
     self.graphql_schema_tool: GraphqlSchemaTool | None = None
     self.graphql_query_tool: GraphqlQueryTool | None = None
-    if env.EXTENSIONS_GRAPHQL_ENABLED:
+    if env.EXTENSIONS_GRAPHQL_ENABLED and not self._is_shared_repository():
       self.graphql_schema_tool = GraphqlSchemaTool(graph_client)
       self.graphql_query_tool = GraphqlQueryTool(
         graph_client, schema_extensions=self.schema_extensions

--- a/robosystems/routers/graphs/mcp/remote.py
+++ b/robosystems/routers/graphs/mcp/remote.py
@@ -322,15 +322,15 @@ def _tool_annotations(name: str, title: str) -> dict[str, Any]:
   authorization classification) are read-only and idempotent; everything
   else is a write and is hinted destructive — conservatively, since the
   authorization gauntlet treats every non-read tool as a mutation. The
-  Cypher tools carry neither hint: they are classified per statement by the
-  StatementKernel and can run a write on a tenant graph, so a read-only
-  hint would promise what the tool does not enforce. All tools act on this
-  graph alone (closed world).
+  Cypher read tools are hinted read-only too: ``assert_read_only_cypher``
+  refuses write, bulk, admin and schema-DDL statements on every path that
+  executes on their behalf, so the hint promises exactly what the tool
+  enforces (``write-graph-cypher`` stays destructive). Directory scans —
+  ChatGPT's in particular — reject a tool that carries no hints. All tools
+  act on this graph alone (closed world).
   """
   annotations: dict[str, Any] = {"title": title, "openWorldHint": False}
-  if name in _CYPHER_READ_TOOLS:
-    return annotations
-  if name in READ_ONLY_MCP_TOOLS:
+  if name in READ_ONLY_MCP_TOOLS or name in _CYPHER_READ_TOOLS:
     annotations.update(
       {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True}
     )

--- a/tests/middleware/mcp/tools/test_manager_helpers.py
+++ b/tests/middleware/mcp/tools/test_manager_helpers.py
@@ -108,6 +108,46 @@ class TestGetToolDefinitionHelpers:
     assert "financial-statement-analysis" in names
     assert "live-financial-statement" not in names
 
+  def test_graphql_tools_absent_on_shared_repo(self, mock_client):
+    """The GraphQL escape hatch reads the extensions OLTP schema, which a
+    shared repo like SEC does not have: introspection answers but every real
+    query errors. Neither tool is advertised there."""
+    mock_client.graph_id = "sec"
+    with (
+      patch.object(GraphMCPTools, "_should_include_semantic_tools", return_value=False),
+      patch.object(GraphMCPTools, "_is_shared_repository", return_value=True),
+      patch("robosystems.middleware.mcp.tools.manager.env") as mock_env,
+    ):
+      mock_env.EXTENSIONS_GRAPHQL_ENABLED = True
+      mock_env.MCP_GRAPHQL_ENABLED = True
+      mock_env.MCP_WORKSPACE_ENABLED = False
+      mock_env.MCP_SUBGRAPH_OPS_ENABLED = False
+      mock_env.FACT_GRID_ENABLED = False
+      tools = GraphMCPTools(mock_client, schema_extensions=["roboledger"])
+      names = {d["name"] for d in tools.get_tool_definitions_as_dict()}
+
+    assert tools.graphql_schema_tool is None
+    assert tools.graphql_query_tool is None
+    assert not names & {"get-graphql-schema", "query-graphql"}
+
+  def test_graphql_tools_present_on_tenant_graph(self, mock_client):
+    with (
+      patch.object(GraphMCPTools, "_should_include_semantic_tools", return_value=False),
+      patch.object(GraphMCPTools, "_is_shared_repository", return_value=False),
+      patch("robosystems.middleware.mcp.tools.manager.env") as mock_env,
+    ):
+      mock_env.EXTENSIONS_GRAPHQL_ENABLED = True
+      mock_env.MCP_GRAPHQL_ENABLED = True
+      mock_env.MCP_WORKSPACE_ENABLED = False
+      mock_env.MCP_SUBGRAPH_OPS_ENABLED = False
+      mock_env.FACT_GRID_ENABLED = False
+      tools = GraphMCPTools(mock_client, schema_extensions=["roboledger"])
+      names = {d["name"] for d in tools.get_tool_definitions_as_dict()}
+
+    assert tools.graphql_schema_tool is not None
+    assert tools.graphql_query_tool is not None
+    assert {"get-graphql-schema", "query-graphql"} <= names
+
   def test_live_statement_tool_absent_on_read_only(self, mock_client):
     """Read-only graphs must NOT get the OLTP live-statement tool."""
     with (

--- a/tests/routers/graphs/mcp/test_mcp_remote.py
+++ b/tests/routers/graphs/mcp/test_mcp_remote.py
@@ -311,10 +311,16 @@ class TestToolsList:
       "destructiveHint": False,
       "idempotentHint": True,
     }
-    # Cypher reads carry neither hint — the StatementKernel classifies them
-    # per statement, and they can carry writes on a tenant graph.
-    assert "readOnlyHint" not in tools["read-graph-cypher"]["annotations"]
-    assert "destructiveHint" not in tools["read-graph-cypher"]["annotations"]
+    # Cypher reads are hinted read-only: assert_read_only_cypher refuses
+    # every non-read statement on every execution path, so the hint
+    # promises what the tool enforces (directory scans reject unhinted tools).
+    assert tools["read-graph-cypher"]["annotations"] == {
+      "title": "Read graph cypher",
+      "openWorldHint": False,
+      "readOnlyHint": True,
+      "destructiveHint": False,
+      "idempotentHint": True,
+    }
 
   def test_write_tools_are_hinted_destructive(self):
     assert remote._tool_annotations("close-period", "Close period") == {


### PR DESCRIPTION
## Summary

Two fixes to the tool surface a directory scan sees on a shared repository (`sec`), both surfaced while preparing the ChatGPT app submission.

1. **`read-graph-cypher` is hinted read-only.** `assert_read_only_cypher` refuses write, bulk, admin and schema-DDL statements on every execution path (direct, streaming, Operator, queued), so the annotation now promises exactly what the tool enforces: `readOnlyHint: true`, `destructiveHint: false`, `idempotentHint: true` (its `read-neo4j-cypher` / `read-ladybug-cypher` aliases too; `write-graph-cypher` stays destructive). The old "carry neither hint" rule predates the guard. Directory tool scans reject unhinted tools.
2. **`get-graphql-schema` / `query-graphql` are no longer advertised on shared repositories.** The typed surface is the extensions OLTP schema, which a shared repo does not have — introspection answered but every real query errored. Gated at registration in `tools/manager.py`; the `query-graphql` line is dropped from the SEC manifest instructions (the tenant instruction builder was already conditional). `sec` now exposes 10 tools, all of which work there.

## Test plan

- [x] `test_mcp_remote.py` asserts the read-only annotations on `read-graph-cypher`
- [x] `test_manager_helpers.py`: GraphQL tools absent on a shared repo, present on a tenant graph (full definition list)
- [x] `uv run pytest tests/routers/graphs/mcp tests/middleware/mcp tests/adapters/sec tests/config` — 1785 passed
- [x] `just test-code` clean