### PR TITLE
chore(mcp): serve the ChatGPT app-directory domain-verification token

### DIFF
--- a/main.py
+++ b/main.py
@@ -235,6 +235,17 @@ def create_app() -> FastAPI:
     async def glama_json() -> JSONResponse:
       return JSONResponse(glama_content)
 
+  # ChatGPT app-directory domain verification (same pattern): the portal
+  # issues a token per submission and checks for exactly that token, as
+  # plain text, at the MCP origin's well-known URL.
+  openai_challenge_file = Path("static") / "openai-apps-challenge"
+  if openai_challenge_file.exists():
+    openai_challenge_token = openai_challenge_file.read_text(encoding="utf-8").strip()
+
+    @app.get("/.well-known/openai-apps-challenge", include_in_schema=False)
+    async def openai_apps_challenge() -> PlainTextResponse:
+      return PlainTextResponse(openai_challenge_token)
+
   # Custom dark-themed Swagger + ReDoc (served inline from docs_template).
   @app.get("/", response_class=HTMLResponse, include_in_schema=False)
   async def custom_docs():

--- a/static/openai-apps-challenge
+++ b/static/openai-apps-challenge
@@ -1,0 +1,1 @@
+60lFK0j2-3udrtICiIZrzUVAwns4l3EajPfSUIp0Zqg

--- a/tests/test_main_security_baseline.py
+++ b/tests/test_main_security_baseline.py
@@ -164,3 +164,17 @@ class TestGlamaClaim:
     body = response.json()
     assert body["$schema"] == "https://glama.ai/mcp/schemas/connector.json"
     assert body["maintainers"] == [{"email": "admin@robosystems.ai"}]
+
+
+class TestOpenAIAppsChallenge:
+  def test_challenge_token_served_as_plain_text(self, client):
+    """The ChatGPT app-directory portal verifies the MCP origin by fetching
+    exactly its issued token, as plain text, from this well-known URL."""
+    from pathlib import Path
+
+    expected = Path("static/openai-apps-challenge").read_text(encoding="utf-8").strip()
+    assert expected and "\n" not in expected
+    response = client.get("/.well-known/openai-apps-challenge")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+    assert response.text == expected


### PR DESCRIPTION
## Summary

- Serves the ChatGPT app-directory verification token as plain text at `/.well-known/openai-apps-challenge` on the MCP origin, from a committed `static/openai-apps-challenge` — the same static-file pattern as `security.txt` and `glama.json`.
- The portal issues one token per submission and checks for exactly that string; there is nothing secret in it.

## Test plan

- [x] `TestOpenAIAppsChallenge` asserts 200, `text/plain`, body identical to the file's single line
- [x] `just test-code` clean
- [ ] After deploy: **Verify Domain** in the portal turns green