### PR TITLE
fix(oauth): harden the MCP OAuth server after its implementation review

### DIFF
--- a/robosystems/config/rate_limits.py
+++ b/robosystems/config/rate_limits.py
@@ -331,6 +331,12 @@ class RateLimitConfig:
     if path.startswith("/v1/"):
       path = path[4:]
 
+    # The graph-agnostic MCP transport (POST /v1/mcp): the OAuth grant, not
+    # the path, names the graph, so the route is categorized by its suffix
+    # alone — it must land in the MCP bucket like its per-graph sibling.
+    if path == "mcp":
+      return EndpointCategory.GRAPH_MCP
+
     # Non-graph scoped endpoints - check these first
     if path.startswith("auth/"):
       return EndpointCategory.AUTH

--- a/robosystems/dagster/jobs/infrastructure.py
+++ b/robosystems/dagster/jobs/infrastructure.py
@@ -20,7 +20,7 @@ from sqlalchemy import and_, or_
 
 from robosystems.config import env
 from robosystems.dagster.resources import DatabaseResource
-from robosystems.models.core import UserAPIKey
+from robosystems.models.core import OAuthClient, OAuthToken, UserAPIKey
 
 # ============================================================================
 # Environment-based Schedule Status
@@ -104,10 +104,44 @@ def cleanup_stale_api_keys(context: OpExecutionContext, db: DatabaseResource) ->
     }
 
 
+@op
+def cleanup_stale_oauth_artifacts(
+  context: OpExecutionContext, db: DatabaseResource
+) -> dict:
+  """Drop OAuth rows that can no longer authenticate anything.
+
+  Tokens: expired or revoked longer ago than the retention window. Refresh
+  rotation mints two rows an hour per always-on connector, so the table
+  grows by ~50 dead rows a day per connector; the recently dead are kept
+  so a late refresh replay is still detectable. Clients: dynamic
+  registrations that never reached a consent — a client that consented had
+  its expiry cleared, so nothing holding a grant is touched. Neither kind
+  can hold a live validation-cache entry (access tokens outlive their cache
+  entry by days before they qualify), so no cache scan is needed.
+  """
+  with db.get_session() as session:
+    tokens_deleted = OAuthToken.cleanup_expired(
+      session, older_than_days=REVOKED_KEY_RETENTION_DAYS
+    )
+    clients_deleted = OAuthClient.cleanup_expired_registrations(session)
+
+    context.log.info(
+      f"OAuth cleanup: {tokens_deleted} tokens, "
+      f"{clients_deleted} unused registrations deleted"
+    )
+
+    return {
+      "tokens_deleted": tokens_deleted,
+      "clients_deleted": clients_deleted,
+      "timestamp": datetime.now(UTC).isoformat(),
+    }
+
+
 @job(tags={"dagster/priority": "1", "dagster/max_retries": 3})
 def hourly_auth_cleanup_job():
   """Hourly auth cleanup job."""
   cleanup_stale_api_keys()
+  cleanup_stale_oauth_artifacts()
 
 
 # ============================================================================

--- a/robosystems/middleware/mcp/tools/graph_tools.py
+++ b/robosystems/middleware/mcp/tools/graph_tools.py
@@ -117,6 +117,28 @@ def _verify_admin_on_graph(user, graph_id: str, session) -> dict[str, Any] | Non
 # ══════════════════════════════════════════════════════════════════════════
 
 
+def _subgraph_credential_hint(parent_graph_id: str) -> str:
+  """What credential reaches a subgraph's ``connector_url`` from this
+  connector. A graph-scoped key covers the parent's subgraphs; an OAuth
+  grant is bound to exactly one route, so the OAuth answer is "authorize
+  the new URL" — telling an OAuth connector to reuse its token would send
+  it into a 401-and-refresh loop at the subgraph."""
+  from robosystems.security.request_context import current_principal
+
+  principal = current_principal()
+  if principal is not None and principal.auth_method == "oauth":
+    return (
+      "This connector is authorized with OAuth, and an OAuth grant is bound "
+      "to exactly one URL — its token does not reach the subgraph. Add "
+      "connector_url as a new connector and authorize it; the consent screen "
+      "shows the subgraph locked in. No API key is involved."
+    )
+  return (
+    "Reuse this connector's API key — a key scoped to "
+    f"'{parent_graph_id}' covers its subgraphs. No new key needed."
+  )
+
+
 class CreateSubgraphTool:
   """Create an isolated subgraph (workspace) under the current parent graph."""
 
@@ -143,8 +165,12 @@ class CreateSubgraphTool:
         "`connector_url`. A subgraph is a separate MCP endpoint, not a mode of "
         "this one: this connector is anchored to its own graph by URL and "
         "cannot reach the new subgraph. To work in it, add an MCP connector "
-        "for `connector_url` — the API key this connector already uses covers "
-        "its own subgraphs, so reuse it as-is rather than generating a new one."
+        "for `connector_url`. Credential: a key-based connector reuses its "
+        "key as-is (a key scoped to the parent covers its subgraphs); an "
+        "OAuth connector authorizes the new URL when adding it, because an "
+        "OAuth grant is bound to exactly one URL — the consent screen shows "
+        "the subgraph locked in. The result's `credential` field says which "
+        "applies to this connector."
       ),
       "inputSchema": {
         "type": "object",
@@ -288,10 +314,7 @@ class CreateSubgraphTool:
         "subgraph_type": subgraph_type,
         "operation_id": result.get("operation_id"),
         "connector_url": f"{env.ROBOSYSTEMS_API_URL}/v1/graphs/{subgraph_id}/mcp",
-        "credential": (
-          "Reuse this connector's API key — a key scoped to "
-          f"'{parent_graph_id}' covers its subgraphs. No new key needed."
-        ),
+        "credential": _subgraph_credential_hint(parent_graph_id),
         "next_step": (
           "Add an MCP connector for connector_url. This connector is anchored "
           "to its own graph by URL and cannot switch to the new subgraph."
@@ -461,12 +484,15 @@ class ListSubgraphsTool:
         "connector is anchored to its own graph by URL and cannot be "
         "retargeted. To work in a subgraph, add its `connector_url` as its "
         "own MCP connector.\n\n"
-        "**Credential:** a key scoped to a parent graph also covers that "
-        "parent's subgraphs, so a connector on the parent can reuse its own "
-        "key on any subgraph listed here. Going the other way — from a "
-        "subgraph to its parent or a sibling — a subgraph-scoped key does "
-        "not reach, and a key for the target is generated from the app's MCP "
-        "page (/connect)."
+        "**Credential:** depends on how this connector authenticates — the "
+        "result's `credential` field says which. A key scoped to a parent "
+        "graph also covers that parent's subgraphs, so a key-based connector "
+        "on the parent reuses its own key on any subgraph listed here. An "
+        "OAuth grant is bound to exactly one URL, so an OAuth connector "
+        "authorizes the subgraph URL when adding it (consent shows it locked "
+        "in). Going the other way — from a subgraph to its parent or a "
+        "sibling — neither reaches: authorize the target URL, or generate a "
+        "key for it from the app's MCP page (/connect)."
       ),
       "inputSchema": {
         "type": "object",
@@ -521,6 +547,7 @@ class ListSubgraphsTool:
       return {
         "primary_graph_id": parent_id,
         "total_subgraphs": len(out) - 1,
+        "credential": _subgraph_credential_hint(parent_id),
         "subgraphs": out,
       }
     finally:

--- a/robosystems/middleware/rate_limits/rate_limiting.py
+++ b/robosystems/middleware/rate_limits/rate_limiting.py
@@ -471,9 +471,13 @@ def oidc_rate_limit_dependency(request: Request):
 def oauth_authorize_rate_limit_dependency(request: Request):
   """The OAuth authorization endpoint: a browser GET, IP-keyed (anonymous
   callers get limit//10, ~12/min per IP — several consent flows plus
-  retries)."""
+  retries). Fails closed: the endpoint cannot complete without Valkey
+  anyway, and the client-metadata fetch it triggers must never run
+  unmetered."""
   limit = BURST_LIMITS["oauth_authorize"]
-  return create_custom_rate_limit_dependency(limit, 60, "oauth_authorize")(request)
+  return create_custom_rate_limit_dependency(
+    limit, 60, "oauth_authorize", fail_closed=True
+  )(request)
 
 
 def oauth_consent_rate_limit_dependency(request: Request):
@@ -706,6 +710,13 @@ def subscription_aware_rate_limit_dependency(request: Request):
   #      has not run yet (router-level mounting) and no cached decision
   #      exists, the request stays on the caller's own budget.
   graph_id = extract_graph_id(request.url.path) if user_id else None
+  if graph_id is None and user_id:
+    # The graph-agnostic MCP route names no graph in its path; the OAuth
+    # dependency has already published the grant's graph on request.state,
+    # so a directory connector draws from that graph's budget too.
+    published = getattr(request.state, "auth_graph_id", None)
+    if isinstance(published, str):
+      graph_id = published
   if (
     graph_id
     and user_id

--- a/robosystems/middleware/rate_limits/subscription_rate_limits.py
+++ b/robosystems/middleware/rate_limits/subscription_rate_limits.py
@@ -28,6 +28,11 @@ def should_use_subscription_limits(path: str) -> bool:
   if path.startswith("/extensions/"):
     return True
 
+  # The graph-agnostic MCP transport carries no graph in its path; it is
+  # tenant-scoped through the OAuth grant and takes the MCP buckets.
+  if path == "/v1/mcp":
+    return True
+
   # Always use subscription limits for graph-scoped endpoints
   if path.startswith("/v1/") and len(path.split("/")) >= 4:
     # Check if it's a graph-scoped endpoint (has graph_id)

--- a/robosystems/models/core/user/oauth_client.py
+++ b/robosystems/models/core/user/oauth_client.py
@@ -14,15 +14,16 @@ connector cannot widen anyone's access.
 import hashlib
 import secrets
 from datetime import UTC, datetime, timedelta
-from typing import Optional
+from typing import Optional, cast
 
 from sqlalchemy import Boolean, Column, DateTime, Index, String
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from robosystems.config.constants import OAUTH_DCR_UNUSED_REGISTRATION_TTL_HOURS
 from robosystems.database import Model
+from robosystems.logger import logger
 from robosystems.security import SecurityAuditLogger, SecurityEventType
 from robosystems.utils.ulid import generate_prefixed_ulid
 
@@ -308,6 +309,22 @@ class OAuthClient(Model):
     try:
       session.commit()
       session.refresh(client)
+    except IntegrityError:
+      # Two first contacts with the same document raced on the unique
+      # client_id; the loser re-reads the winner's row and updates it.
+      session.rollback()
+      if not created or cls.get_by_client_id(client_id, session) is None:
+        raise
+      return cls.upsert_cimd(
+        client_id=client_id,
+        client_name=client_name,
+        redirect_uris=redirect_uris,
+        session=session,
+        is_trusted=is_trusted,
+        client_uri=client_uri,
+        logo_uri=logo_uri,
+        scope=scope,
+      )
     except SQLAlchemyError:
       session.rollback()
       raise
@@ -324,6 +341,33 @@ class OAuthClient(Model):
         risk_level="low",
       )
     return client
+
+  @classmethod
+  def cleanup_expired_registrations(cls, session: Session) -> int:
+    """Delete dynamic registrations that expired without a consent. The
+    first consent clears ``expires_at`` (``mark_used``), so no row that
+    holds a grant is ever eligible."""
+    now = datetime.now(UTC)
+    # The attribute reads as Optional to the type checker because mark_used
+    # assigns None to it; the class-level column itself never is.
+    expires_at = cast(Column[datetime | None], cls.expires_at)
+    try:
+      count = (
+        session.query(cls)
+        .filter(
+          cls.registration_source == REGISTRATION_DCR,
+          expires_at.isnot(None),
+          expires_at < now,
+        )
+        .delete(synchronize_session=False)
+      )
+      session.commit()
+    except SQLAlchemyError:
+      session.rollback()
+      raise
+    if count:
+      logger.info(f"Cleaned up {count} expired OAuth client registrations")
+    return count
 
   def mark_used(self, session: Session) -> None:
     """Stamp ``last_used_at`` and clear a dynamic registration's expiry —

--- a/robosystems/models/core/user/oauth_token.py
+++ b/robosystems/models/core/user/oauth_token.py
@@ -16,7 +16,7 @@ import secrets
 from datetime import UTC, datetime, timedelta
 from typing import Optional
 
-from sqlalchemy import Column, DateTime, ForeignKey, Index, String
+from sqlalchemy import Column, DateTime, ForeignKey, Index, String, or_
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
@@ -288,11 +288,18 @@ class OAuthToken(Model):
 
   @classmethod
   def cleanup_expired(cls, session: Session, *, older_than_days: int = 30) -> int:
-    """Delete tokens expired more than ``older_than_days`` ago. Recently
-    expired rows are kept so a late refresh replay is still detectable."""
+    """Delete tokens that expired, or were revoked, more than
+    ``older_than_days`` ago. Recently dead rows are kept so a late refresh
+    replay is still detectable — rotation revokes the previous access token
+    and a replay revokes a whole family, so revoked rows accrue as fast as
+    expired ones."""
     cutoff = datetime.now(UTC) - timedelta(days=older_than_days)
     try:
-      count = session.query(cls).filter(cls.expires_at < cutoff).delete()
+      count = (
+        session.query(cls)
+        .filter(or_(cls.expires_at < cutoff, cls.revoked_at < cutoff))
+        .delete(synchronize_session=False)
+      )
       session.commit()
     except SQLAlchemyError:
       session.rollback()

--- a/robosystems/operations/admin/user_deletion.py
+++ b/robosystems/operations/admin/user_deletion.py
@@ -29,6 +29,8 @@ from robosystems.models.core import (
   GraphCredits,
   GraphStatus,
   GraphUser,
+  OAuthGrant,
+  OAuthToken,
   Org,
   OrgInvitation,
   OrgLimits,
@@ -41,6 +43,7 @@ from robosystems.models.core import (
   UserToken,
 )
 from robosystems.models.core.billing.subscription import TERMINAL_SUBSCRIPTION_STATUSES
+from robosystems.models.core.user.oauth_token import TOKEN_TYPE_ACCESS
 from robosystems.models.core.user.user_repository import RepositoryAccessLevel
 from robosystems.models.core.user.user_repository_credits import (
   UserRepositoryCreditTransaction,
@@ -222,6 +225,7 @@ def plan_user_deletion(user_id: str, session: Session) -> UserDeletionPlan:
   removals = {
     "api_keys": session.query(UserAPIKey).filter_by(user_id=user_id).count(),
     "tokens": session.query(UserToken).filter_by(user_id=user_id).count(),
+    "oauth_grants": session.query(OAuthGrant).filter_by(user_id=user_id).count(),
     "graph_grants": session.query(GraphUser).filter_by(user_id=user_id).count(),
     "connections": session.query(Connection).filter_by(user_id=user_id).count(),
     "documents": session.query(Document).filter_by(user_id=user_id).count(),
@@ -310,6 +314,14 @@ def execute_user_deletion(
     .all()
     if row.key_fingerprint
   ]
+  # OAuth access tokens are cached under their digest in the same store;
+  # refresh tokens are never cached. Same capture-then-purge discipline.
+  oauth_token_digests = [
+    row.token_hash
+    for row in session.query(OAuthToken.token_hash)
+    .filter_by(user_id=user_id, token_type=TOKEN_TYPE_ACCESS)
+    .all()
+  ]
 
   # Audit and billing history survive the account — the actor is de-referenced,
   # never deleted, because retention is itself a compliance requirement.
@@ -366,6 +378,10 @@ def execute_user_deletion(
   session.query(Document).filter_by(user_id=user_id).delete(synchronize_session=False)
   session.query(Connection).filter_by(user_id=user_id).delete(synchronize_session=False)
   session.query(GraphUser).filter_by(user_id=user_id).delete(synchronize_session=False)
+  # OAuth consents: tokens hang off grants, grants off the user — deepest
+  # first, or the FK into users refuses the account row below.
+  session.query(OAuthToken).filter_by(user_id=user_id).delete(synchronize_session=False)
+  session.query(OAuthGrant).filter_by(user_id=user_id).delete(synchronize_session=False)
   session.query(UserAPIKey).filter_by(user_id=user_id).delete(synchronize_session=False)
   session.query(UserToken).filter_by(user_id=user_id).delete(synchronize_session=False)
   session.query(OrgUser).filter_by(user_id=user_id).delete(synchronize_session=False)
@@ -388,7 +404,7 @@ def execute_user_deletion(
     session.rollback()
     raise
 
-  _invalidate_auth_caches(user_id, api_key_fingerprints)
+  _invalidate_auth_caches(user_id, api_key_fingerprints + oauth_token_digests)
 
   logger.info(
     f"Deleted user {user_id} ({plan.email}) by {actor}",

--- a/robosystems/operations/oauth_server/cimd.py
+++ b/robosystems/operations/oauth_server/cimd.py
@@ -141,7 +141,7 @@ def fetch_client_metadata(
             "invalid_client", "client metadata document is not available"
           )
         declared = response.headers.get("content-length")
-        if declared and int(declared) > CIMD_MAX_BYTES:
+        if declared and declared.isdigit() and int(declared) > CIMD_MAX_BYTES:
           raise ClientError("invalid_client", "client metadata document is too large")
         body = bytearray()
         for chunk in response.iter_bytes():

--- a/robosystems/operations/oauth_server/clients.py
+++ b/robosystems/operations/oauth_server/clients.py
@@ -15,6 +15,7 @@ from urllib.parse import urlsplit
 
 from sqlalchemy.orm import Session
 
+from robosystems.logger import logger
 from robosystems.models.core.user.oauth_client import (
   AUTH_METHOD_NONE,
   SUPPORTED_AUTH_METHODS,
@@ -219,7 +220,9 @@ def register_dynamic_client(
   )
 
 
-def resolve_client(client_id: str | None, session: Session) -> OAuthClient:
+def resolve_client(
+  client_id: str | None, session: Session, *, allow_stale_mirror: bool = False
+) -> OAuthClient:
   """The registered, usable client for a presented ``client_id``.
 
   An HTTPS ``client_id`` is a Client ID Metadata Document: its document is
@@ -228,6 +231,14 @@ def resolve_client(client_id: str | None, session: Session) -> OAuthClient:
   rest of the flow — redirect matching, grants, the consent page — sees
   one client model. Raises ``invalid_client`` for unknown, deactivated, and
   expired-unused registrations alike — indistinguishable to the caller.
+
+  ``allow_stale_mirror`` is for the token and revocation endpoints, where
+  the client's identity only has to match the grant being refreshed: when
+  the document cannot be fetched or no longer validates, the mirrored row
+  (the last document that did) stands in, so an outage at the metadata
+  host does not take every refresh down with it. The authorization
+  endpoint never takes the fallback — a redirect URI must come from a
+  live document.
   """
   if not client_id or not isinstance(client_id, str) or len(client_id) > 512:
     raise ClientError("invalid_client", "Unknown client")
@@ -239,12 +250,21 @@ def resolve_client(client_id: str | None, session: Session) -> OAuthClient:
     if existing is not None and not existing.is_active:
       # Operator-deactivated: the document is not consulted again.
       raise ClientError("invalid_client", "Unknown client")
-    document = dict(get_client_metadata(client_id))
-    # CIMD clients authenticate with PKCE alone (``none``); a document that
-    # names an auth method we do not speak (private_key_jwt) still gets the
-    # public-client treatment rather than a rejection.
-    document["token_endpoint_auth_method"] = AUTH_METHOD_NONE
-    metadata = validate_registration_metadata(document)
+    try:
+      document = dict(get_client_metadata(client_id))
+      # CIMD clients authenticate with PKCE alone (``none``); a document that
+      # names an auth method we do not speak (private_key_jwt) still gets the
+      # public-client treatment rather than a rejection.
+      document["token_endpoint_auth_method"] = AUTH_METHOD_NONE
+      metadata = validate_registration_metadata(document)
+    except ClientError as exc:
+      if allow_stale_mirror and existing is not None and existing.is_usable:
+        logger.warning(
+          "CIMD document unavailable; serving the mirrored registration",
+          extra={"oauth_client_id": existing.id, "error": exc.error},
+        )
+        return existing
+      raise
     return OAuthClient.upsert_cimd(
       client_id=client_id,
       client_name=metadata.client_name,

--- a/robosystems/operations/oauth_server/tokens.py
+++ b/robosystems/operations/oauth_server/tokens.py
@@ -166,9 +166,6 @@ def refresh_access_token(
   if grant is None or str(grant.oauth_client_id) != str(client.id):
     raise TokenError("invalid_grant", "Invalid refresh token")
 
-  if row.revoked_at is not None or row.is_expired:
-    raise TokenError("invalid_grant", "Refresh token expired or revoked")
-
   def _replay() -> TokenError:
     revoked = OAuthToken.revoke_family(
       str(row.family_id), session, reason="refresh_token_replay"
@@ -186,8 +183,17 @@ def refresh_access_token(
     )
     return TokenError("invalid_grant", "Refresh token has already been used")
 
+  # A consumed token presented again is replay whatever else is true of the
+  # row: an expired one may still have a live successor in its family, so
+  # this comes before the expiry check, not after it. Once the family is
+  # revoked there is nothing left to revoke, and the replay is not re-logged.
   if row.used_at is not None:
-    raise _replay()
+    if row.revoked_at is None:
+      raise _replay()
+    raise TokenError("invalid_grant", "Refresh token has already been used")
+
+  if row.revoked_at is not None or row.is_expired:
+    raise TokenError("invalid_grant", "Refresh token expired or revoked")
 
   if grant.is_revoked:
     raise TokenError("invalid_grant", "The grant has been revoked")

--- a/robosystems/routers/oauth/server.py
+++ b/robosystems/routers/oauth/server.py
@@ -300,7 +300,7 @@ def _client_credentials(request: Request, form: Any) -> tuple[str | None, str | 
 def _authenticated_client(request: Request, form: Any, session: Session) -> OAuthClient:
   client_id, client_secret = _client_credentials(request, form)
   try:
-    client = resolve_client(client_id, session)
+    client = resolve_client(client_id, session, allow_stale_mirror=True)
     authenticate_client(client, client_secret)
   except ClientError as exc:
     raise TokenError(exc.error, exc.description, status_code=401) from exc

--- a/tests/dagster/test_infrastructure_jobs.py
+++ b/tests/dagster/test_infrastructure_jobs.py
@@ -14,9 +14,11 @@ from dagster import build_op_context
 from robosystems.dagster.jobs.infrastructure import (
   REVOKED_KEY_RETENTION_DAYS,
   cleanup_stale_api_keys,
+  cleanup_stale_oauth_artifacts,
   hourly_auth_cleanup_job,
   weekly_health_check_job,
 )
+from robosystems.models.core import OAuthClient, OAuthGrant, OAuthToken
 from robosystems.models.core.user.user_api_key import UserAPIKey
 
 
@@ -44,7 +46,7 @@ class TestJobGraphs:
     job_def = hourly_auth_cleanup_job
 
     assert job_def.name == "hourly_auth_cleanup_job"
-    assert len(job_def.all_node_defs) == 1  # Single op
+    assert len(job_def.all_node_defs) == 2  # API keys + OAuth artifacts
 
   @pytest.mark.unit
   def test_weekly_health_check_job_graph(self):
@@ -178,3 +180,72 @@ class TestJobExecution:
       job_def = hourly_auth_cleanup_job
       assert job_def is not None
       assert job_def.name == "hourly_auth_cleanup_job"
+
+
+class TestStaleOAuthCleanup:
+  """Dead tokens and never-consented registrations go; live rows and the
+  recently dead stay, so a late refresh replay is still detectable."""
+
+  @pytest.mark.unit
+  def test_sweeps_dead_tokens_and_unused_registrations(self, test_db, test_user):
+    now = datetime.now(UTC)
+    retention = timedelta(days=REVOKED_KEY_RETENTION_DAYS + 1)
+    client, _ = OAuthClient.register_preregistered(
+      client_name="Claude",
+      redirect_uris=["https://claude.ai/api/mcp/auth_callback"],
+      confidential=False,
+      session=test_db,
+    )
+    grant = OAuthGrant.create(
+      user_id=str(test_user.id),
+      oauth_client_id=str(client.id),
+      graph_id="kg19fb490f76871d22e835",
+      resource="https://api.test.example/v1/mcp",
+      scope="mcp",
+      session=test_db,
+    )
+
+    def pair():
+      access, _, refresh, _, _ = OAuthToken.mint_pair(
+        grant_id=str(grant.id), user_id=str(test_user.id), session=test_db
+      )
+      return access, refresh
+
+    live_access, live_refresh = pair()
+    long_expired, recently_revoked = pair()
+    long_expired.expires_at = now - retention
+    recently_revoked.revoked_at = now - timedelta(days=1)
+    long_revoked, its_refresh = pair()
+    long_revoked.revoked_at = now - retention
+
+    stale_registration, _ = OAuthClient.register_dynamic(
+      client_name="stale",
+      redirect_uris=["http://localhost/callback"],
+      token_endpoint_auth_method="none",
+      session=test_db,
+    )
+    stale_registration.expires_at = now - timedelta(hours=1)
+    fresh_registration, _ = OAuthClient.register_dynamic(
+      client_name="fresh",
+      redirect_uris=["http://localhost/callback"],
+      token_endpoint_auth_method="none",
+      session=test_db,
+    )
+    test_db.commit()
+    # Captured before the sweep: a deleted instance cannot refresh its id.
+    kept = {live_access.id, live_refresh.id, recently_revoked.id, its_refresh.id}
+    grant_id, client_id = str(grant.id), str(client.id)
+    stale_id, fresh_id = str(stale_registration.id), str(fresh_registration.id)
+
+    result = cleanup_stale_oauth_artifacts(build_op_context(), _db(test_db))
+
+    assert result["tokens_deleted"] == 2
+    assert result["clients_deleted"] == 1
+    remaining = {
+      row.id for row in test_db.query(OAuthToken).filter_by(grant_id=grant_id)
+    }
+    assert remaining == kept
+    assert OAuthClient.get_by_id(stale_id, test_db) is None
+    assert OAuthClient.get_by_id(fresh_id, test_db) is not None
+    # A registration that consented has no expiry and is never eligible.
+    assert OAuthClient.get_by_id(client_id, test_db) is not None

--- a/tests/middleware/auth/test_oauth_dependencies.py
+++ b/tests/middleware/auth/test_oauth_dependencies.py
@@ -122,6 +122,23 @@ class TestPerGraphRoute:
       await deps.get_current_user_with_graph_or_oauth(request, KG, api_key=None)
     assert exc.value.status_code == 401
 
+  async def test_parent_grant_does_not_reach_a_subgraph_url(self):
+    """A grant is bound to one route. Unlike a graph-scoped key it does not
+    extend to the parent's subgraphs — which is why the subgraph tools'
+    credential copy branches on the carriage."""
+    subgraph = f"{KG}_dev"
+    request = _request(
+      {"authorization": f"Bearer {TOKEN}"}, path=f"/v1/graphs/{subgraph}/mcp"
+    )
+    with (
+      patch.object(deps, "validate_oauth_access_token", return_value=_principal()),
+      patch.object(deps, "SecurityAuditLogger"),
+      pytest.raises(HTTPException) as exc,
+    ):
+      await deps.get_current_user_with_graph_or_oauth(request, subgraph, api_key=None)
+    assert exc.value.status_code == 401
+    assert 'error="invalid_token"' in exc.value.headers["WWW-Authenticate"]
+
   async def test_invalid_token_is_401(self):
     request = _request({"authorization": f"Bearer {TOKEN}"})
     with (

--- a/tests/middleware/mcp/tools/test_graph_tools.py
+++ b/tests/middleware/mcp/tools/test_graph_tools.py
@@ -34,6 +34,7 @@ from robosystems.middleware.mcp.tools.graph_tools import (
   MaterializeTool,
   SetWritePolicyTool,
   SyncConnectionTool,
+  _subgraph_credential_hint,
 )
 
 MODULE = "robosystems.middleware.mcp.tools.graph_tools"
@@ -455,6 +456,8 @@ class TestListSubgraphsExecute:
     names = [entry["subgraph_id"] for entry in result["subgraphs"]]
     assert GRAPH_ID in names  # primary row
     assert f"{GRAPH_ID}_dev" in names
+    # The carriage-specific credential answer rides on the result.
+    assert "credential" in result
 
 
 # ══════════════════════════════════════════════════════════════════════════
@@ -979,3 +982,46 @@ class TestSyncConnectionExecute:
     assert result["error"] == "sync_in_progress"
     assert result["holder_id"] == "holder_abc"
     assert result["ttl_remaining_seconds"] == 1200
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# Subgraph credential hint — carriage-aware
+# ══════════════════════════════════════════════════════════════════════════
+
+
+class TestSubgraphCredentialHint:
+  """A graph-scoped key covers the parent's subgraphs; an OAuth grant is
+  bound to exactly one URL. The hint must say which applies to the calling
+  connector — "reuse your key" sends an OAuth connector into a 401-and-
+  refresh loop at the subgraph."""
+
+  @staticmethod
+  def _hint_as(auth_method: str | None) -> str:
+    from robosystems.security.request_context import (
+      RequestPrincipal,
+      bind_principal,
+      reset_principal,
+    )
+
+    principal = (
+      RequestPrincipal(user_id="u1", auth_method=auth_method) if auth_method else None
+    )
+    token = bind_principal(principal)
+    try:
+      return _subgraph_credential_hint(GRAPH_ID)
+    finally:
+      reset_principal(token)
+
+  def test_key_carriage_reuses_the_key(self) -> None:
+    hint = self._hint_as("api_key")
+    assert "Reuse this connector's API key" in hint
+    assert GRAPH_ID in hint
+
+  def test_oauth_carriage_authorizes_the_new_url(self) -> None:
+    hint = self._hint_as("oauth")
+    assert "bound to exactly one URL" in hint
+    assert "authorize it" in hint
+    assert "Reuse" not in hint
+
+  def test_no_principal_defaults_to_the_key_answer(self) -> None:
+    assert "Reuse this connector's API key" in self._hint_as(None)

--- a/tests/middleware/rate_limits/test_rate_limiting.py
+++ b/tests/middleware/rate_limits/test_rate_limiting.py
@@ -620,3 +620,29 @@ class TestScimBucketsFailClosed:
 
     scim_ip_rate_limit_dependency(request)
     assert mock_cache.check_rate_limit.call_args.kwargs["fail_closed"] is True
+
+
+class TestOAuthBucketsFailClosed:
+  """The OAuth endpoints that trigger an outbound fetch or mint a credential
+  must refuse, not run unmetered, when the limiter's store is down. The
+  consent endpoints sit behind a JWT session and stay fail-open like the
+  rest of the authenticated API."""
+
+  @pytest.mark.parametrize(
+    "dependency, bucket, closed",
+    [
+      ("oauth_authorize_rate_limit_dependency", "oauth_authorize", True),
+      ("oauth_token_rate_limit_dependency", "oauth_token", True),
+      ("oauth_register_rate_limit_dependency", "oauth_register", True),
+      ("oauth_consent_rate_limit_dependency", "oauth_consent", False),
+    ],
+  )
+  def test_bucket_posture(self, dependency, bucket, closed):
+    from robosystems.middleware.rate_limits import rate_limiting
+
+    with patch.object(rate_limiting, "create_custom_rate_limit_dependency") as factory:
+      factory.return_value = lambda request: None
+      getattr(rate_limiting, dependency)(MagicMock())
+
+    assert factory.call_args.args[2] == bucket
+    assert bool(factory.call_args.kwargs.get("fail_closed")) is closed

--- a/tests/middleware/rate_limits/test_subscription_rate_limiting.py
+++ b/tests/middleware/rate_limits/test_subscription_rate_limiting.py
@@ -74,6 +74,8 @@ class TestSubscriptionRateLimits:
     # Graph-scoped endpoints should use subscription limits
     assert should_use_subscription_limits("/v1/graphs/kg1a2b3c/entity/")
     assert should_use_subscription_limits("/v1/graphs/kg1a2b3c/mcp/query")
+    # The graph-agnostic OAuth transport is tenant-scoped through its grant.
+    assert should_use_subscription_limits("/v1/mcp")
     assert should_use_subscription_limits("/v1/graphs/sec/entity/")
 
     # Non-graph endpoints that should use subscription limits
@@ -265,6 +267,34 @@ class TestSubscriptionAwareRateLimiting:
   @patch(
     "robosystems.middleware.rate_limits.rate_limiting.rate_limit_cache.check_rate_limit"
   )
+  def test_agnostic_mcp_route_draws_from_the_grant_graph_budget(
+    self, mock_check_rate_limit, mock_get_user, mock_request
+  ):
+    """POST /v1/mcp names no graph in its path. The OAuth dependency
+    publishes the grant's graph on request.state before the limiter runs,
+    and that graph's budget — not the caller's — is what a directory
+    connector must draw from."""
+    mock_get_user.return_value = "user_456"
+    mock_check_rate_limit.return_value = (True, 4)
+    mock_request.url.path = "/v1/mcp"
+    mock_request.method = "POST"
+    mock_request.state.auth_graph_id = "kg1a2b3c"
+
+    subscription_aware_rate_limit_dependency(mock_request)
+
+    limit, window = get_subscription_rate_limit(
+      "ladybug-standard", EndpointCategory.GRAPH_MCP
+    )
+    mock_check_rate_limit.assert_called_once_with(
+      "graph_sub:kg1a2b3c:graph_mcp", limit, window
+    )
+    assert mock_request.state.rate_limit_category == "graph_mcp"
+    assert mock_request.state.rate_limit_tier == "ladybug-standard"
+
+  @patch("robosystems.middleware.rate_limits.rate_limiting.get_user_from_request")
+  @patch(
+    "robosystems.middleware.rate_limits.rate_limiting.rate_limit_cache.check_rate_limit"
+  )
   @patch(
     "robosystems.middleware.rate_limits.rate_limiting.SecurityAuditLogger.log_rate_limit_exceeded"
   )
@@ -329,6 +359,8 @@ class TestSubscriptionAwareRateLimiting:
       get_endpoint_category("/v1/graphs/kg1a2b3c/mcp/benchmark")
       == EndpointCategory.GRAPH_MCP
     )
+    # The graph-agnostic route lands in the same bucket as its per-graph sibling.
+    assert get_endpoint_category("/v1/mcp", "POST") == EndpointCategory.GRAPH_MCP
 
     # Check MCP limits for different tiers
     limit, window = get_subscription_rate_limit("base", EndpointCategory.GRAPH_MCP)

--- a/tests/operations/admin/test_user_deletion.py
+++ b/tests/operations/admin/test_user_deletion.py
@@ -12,6 +12,9 @@ from robosystems.models.core import (
   BillingAuditLog,
   BillingSubscription,
   Graph,
+  OAuthClient,
+  OAuthGrant,
+  OAuthToken,
   Org,
   OrgRole,
   OrgType,
@@ -143,6 +146,38 @@ class TestDeletionExecution:
     assert plan.orgs_to_delete == [org_id]
     assert User.get_by_email(email, test_db) is None
     assert Org.get_by_id(org_id, test_db) is None
+
+  def test_oauth_consents_go_with_the_account(self, test_db, test_user):
+    """A grant is a FK into users with no cascade: the sweep must take the
+    tokens and grants first, or the account row cannot be deleted at all."""
+    user = _create_user(test_db, test_user.password_hash)
+    _personal_org(test_db, user)
+    client, _ = OAuthClient.register_preregistered(
+      client_name="Claude",
+      redirect_uris=["https://claude.ai/api/mcp/auth_callback"],
+      confidential=False,
+      session=test_db,
+    )
+    grant = OAuthGrant.create(
+      user_id=str(user.id),
+      oauth_client_id=str(client.id),
+      graph_id="kg19fb490f76871d22e835",
+      resource="https://api.test.example/v1/mcp",
+      scope="mcp",
+      session=test_db,
+    )
+    OAuthToken.mint_pair(grant_id=str(grant.id), user_id=str(user.id), session=test_db)
+    # Captured before the rows go: a deleted instance cannot refresh its id.
+    user_id, grant_id, client_id = str(user.id), str(grant.id), str(client.id)
+
+    plan = execute_user_deletion(user_id, test_db, actor="admin:test")
+
+    assert plan.removals["oauth_grants"] == 1
+    assert User.get_by_id(user_id, test_db) is None
+    assert OAuthGrant.get_by_id(grant_id, test_db) is None
+    assert test_db.query(OAuthToken).filter_by(user_id=user_id).count() == 0
+    # The client is not the user's — it outlives every grant it held.
+    assert OAuthClient.get_by_id(client_id, test_db) is not None
 
   def test_invited_member_leaves_the_org_standing(self, test_db, test_user):
     """Deleting a member of a shared org removes them, not the organization."""

--- a/tests/operations/oauth_server/test_cimd.py
+++ b/tests/operations/oauth_server/test_cimd.py
@@ -161,6 +161,21 @@ class TestFetch:
       )
     assert "too large" in exc.value.description
 
+  def test_bogus_content_length_is_ignored(self):
+    """A non-numeric Content-Length is a malformed peer, not a 500: the
+    streamed size cap still applies."""
+    body = json.dumps(VSCODE_DOC).encode()
+
+    def handler(request):
+      return httpx.Response(
+        200,
+        content=body,
+        headers={"content-length": "not-a-number", "content-type": "application/json"},
+      )
+
+    doc, _ = fetch_client_metadata(VSCODE_ID, transport=_transport(handler))
+    assert doc["client_id"] == VSCODE_ID
+
   def test_network_failure(self):
     def handler(request):
       raise httpx.ConnectError("boom")
@@ -282,6 +297,62 @@ class TestResolveClient:
     with self._serve(doc):
       with pytest.raises(ClientError):
         resolve_client(VSCODE_ID, test_db)
+
+  def test_token_path_serves_the_mirror_when_the_document_is_unreachable(
+    self, test_db, cimd_redis
+  ):
+    """The metadata host going down must not take every refresh with it.
+    The token and revocation endpoints only need the client's identity to
+    match the grant, so the last validated document — the mirror — stands
+    in; the authorization endpoint never takes that fallback, because a
+    redirect URI has to come from a live document."""
+    with self._serve(VSCODE_DOC):
+      mirror = resolve_client(VSCODE_ID, test_db)
+    # The cached document lapses; every resolve below has to fetch.
+    cimd_redis.store.clear()
+    unreachable = patch.object(
+      cimd,
+      "fetch_client_metadata",
+      side_effect=ClientError("invalid_client", "document is not available"),
+    )
+    with unreachable, pytest.raises(ClientError):
+      resolve_client(VSCODE_ID, test_db)
+    with unreachable:
+      served = resolve_client(VSCODE_ID, test_db, allow_stale_mirror=True)
+    assert served.id == mirror.id
+    # Never a deactivated mirror, and never a mirror that does not exist.
+    mirror.deactivate(test_db)
+    with unreachable, pytest.raises(ClientError):
+      resolve_client(VSCODE_ID, test_db, allow_stale_mirror=True)
+    with unreachable, pytest.raises(ClientError):
+      resolve_client(UNKNOWN_ID, test_db, allow_stale_mirror=True)
+
+  def test_first_contact_race_updates_the_winner(self, test_db, cimd_redis):
+    """Two concurrent first resolutions of one document: the loser's INSERT
+    hits the unique client_id and must fall through to an update of the
+    winner's row rather than surface as a 500."""
+    with self._serve(VSCODE_DOC):
+      winner = resolve_client(VSCODE_ID, test_db)
+
+    real_lookup = OAuthClient.get_by_client_id
+    calls = {"n": 0}
+
+    def racing_lookup(client_id, session):
+      # The loser read "no row" before the winner committed.
+      calls["n"] += 1
+      return None if calls["n"] == 1 else real_lookup(client_id, session)
+
+    with patch.object(OAuthClient, "get_by_client_id", side_effect=racing_lookup):
+      loser = OAuthClient.upsert_cimd(
+        client_id=VSCODE_ID,
+        client_name="VS Code (raced)",
+        redirect_uris=["https://vscode.dev/redirect"],
+        session=test_db,
+        is_trusted=True,
+      )
+    assert loser.id == winner.id
+    assert loser.client_name == "VS Code (raced)"
+    assert calls["n"] >= 2
 
   def test_deactivated_mirror_is_not_refetched(self, test_db):
     with self._serve(VSCODE_DOC):

--- a/tests/operations/oauth_server/test_tokens.py
+++ b/tests/operations/oauth_server/test_tokens.py
@@ -312,6 +312,39 @@ class TestRefresh:
       )
     assert exc.value.error == "invalid_grant"
 
+  def test_replay_of_an_expired_consumed_token_still_revokes_the_family(
+    self, test_db, issued, client_row
+  ):
+    """A consumed refresh token replayed after its own expiry is still a
+    replay — its successor may be live — so the family goes; the expiry
+    must not mask it."""
+    rotated = refresh_access_token(
+      refresh_token=issued.refresh_token,
+      client=client_row,
+      scope=None,
+      resource=None,
+      session=test_db,
+    )
+    consumed = OAuthToken.get_by_plaintext(
+      issued.refresh_token, TOKEN_TYPE_REFRESH, test_db
+    )
+    consumed.expires_at = datetime.now(UTC) - timedelta(days=1)
+    test_db.commit()
+
+    with pytest.raises(TokenError) as exc:
+      refresh_access_token(
+        refresh_token=issued.refresh_token,
+        client=client_row,
+        scope=None,
+        resource=None,
+        session=test_db,
+      )
+    assert exc.value.error == "invalid_grant"
+    successor = OAuthToken.get_by_plaintext(
+      rotated.refresh_token, TOKEN_TYPE_REFRESH, test_db
+    )
+    assert successor.revoked_at is not None
+
 
 @pytest.mark.usefixtures("oauth_env", "fake_redis")
 class TestRevocation:


### PR DESCRIPTION
## Summary

Hardening pass on the MCP OAuth 2.1 authorization server (`v1.10.2`) following a line-by-line review of the implementation. Six defects and three low-severity edge cases, each with a regression test. No new surface, no schema change.

## Changes

**Account lifecycle**
- `operations/admin/user_deletion.py` — deleting a user now sweeps their OAuth tokens and grants (deepest first) before the account row, and purges the access-token validation cache entries the same way API-key fingerprints are purged. `oauth_grants.user_id` is a plain FK into `users`, so any account that had ever connected an OAuth client could not be deleted. The deletion plan's `removals` gains an `oauth_grants` count.

**Rate limiting for the graph-agnostic route**
- `config/rate_limits.py`, `middleware/rate_limits/subscription_rate_limits.py` — `POST /v1/mcp` is now categorized as `GRAPH_MCP` and opted into subscription-tier limits. Previously it fell through to the generic API limiter because both functions key on `/v1/graphs/{graph_id}/…`.
- `middleware/rate_limits/rate_limiting.py` — when the path names no graph, the limiter reads the graph the auth dependency published on `request.state.auth_graph_id`, so a directory connector draws from the grant's graph budget rather than the caller's account tier. The existing membership gate still applies.
- The authorization endpoint's burst limit now fails closed like the token and registration endpoints (it cannot complete without Valkey, and it triggers a client-metadata fetch).

**Resilience of the token path**
- `operations/oauth_server/clients.py`, `routers/oauth/server.py` — `resolve_client(..., allow_stale_mirror=True)` on the token and revocation endpoints: when a Client ID Metadata Document cannot be fetched or no longer validates, the mirrored `oauth_clients` row (the last document that did validate) stands in, so an outage at a metadata host does not fail every refresh for that client's users. The authorization endpoint never takes the fallback — redirect URIs must come from a live document. Deactivated mirrors are never served.
- `models/core/user/oauth_client.py` — `upsert_cimd` handles the first-contact race (two concurrent first resolutions of one document) by re-reading the winner's row instead of surfacing the unique-violation as a 500.
- `operations/oauth_server/cimd.py` — a non-numeric `Content-Length` on the metadata response no longer raises; the streamed size cap still applies.

**Refresh-token replay**
- `operations/oauth_server/tokens.py` — the consumed-token check now runs before the expiry check, so a replayed refresh token that has since expired still revokes its family (its successor may be live). A replay against an already-revoked family answers `invalid_grant` without re-logging.

**Retention**
- `dagster/jobs/infrastructure.py` — new `cleanup_stale_oauth_artifacts` op on `hourly_auth_cleanup_job`: deletes tokens expired or revoked past the 30-day retention window (`OAuthToken.cleanup_expired` now covers revoked rows too) and dynamic registrations that expired without ever reaching a consent (`OAuthClient.cleanup_expired_registrations`, new). Rotation mints two rows per refresh, so nothing was reclaiming them.

**MCP tool copy**
- `middleware/mcp/tools/graph_tools.py` — `create-subgraph` and `list-subgraphs` no longer tell every connector to "reuse this connector's API key" on a subgraph URL. An OAuth grant is bound to exactly one route, so for an OAuth connector the answer is to add the subgraph URL and authorize it. The descriptions state both cases; the results carry a `credential` field resolved from the request's auth method.

Reviewers may want to look closest at the `allow_stale_mirror` fallback (deliberately not offered to `/v1/oauth/authorize`) and the `request.state.auth_graph_id` read in the limiter (guarded to `str`, and still subject to `_caller_is_authorized_on_graph`).

## Breaking Changes

None. All OAuth endpoints are excluded from the OpenAPI schema, so neither SDK tier is affected. The `credential` key added to the `list-subgraphs` tool result and the `oauth_grants` key in the deletion plan are additive.

## Testing

`just test-code` — passes (ruff, format, basedpyright 0 errors, cf-lint).

Targeted `pytest` over `tests/operations/oauth_server`, `tests/routers/oauth`, `tests/middleware/auth/test_oauth_dependencies.py`, `tests/routers/graphs/mcp`, `tests/operations/admin/test_user_deletion.py`, `tests/middleware/mcp/tools/test_graph_tools.py`, `tests/middleware/rate_limits`, `tests/dagster/test_infrastructure_jobs.py`, `tests/dagster/test_definitions.py`, `tests/models/core/user`, `tests/routers/admin` — 916 passed. New tests cover: user deletion with a grant and tokens; a parent-graph grant refused at a subgraph URL; `/v1/mcp` categorization and graph-budget keying; the stale-mirror fallback (token path only, never a deactivated mirror); the CIMD first-contact race; the bogus `Content-Length`; replay-after-expiry family revocation; the OAuth sweep op; and the fail-closed posture of the four OAuth buckets.

The full `just test-all` suite was not run in-session.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
