### PR TITLE
feat(oauth): connected-apps endpoints to list and revoke a user's grants

### DIFF
--- a/robosystems/middleware/auth/README.md
+++ b/robosystems/middleware/auth/README.md
@@ -83,8 +83,13 @@ and revoked tokens answer **401 `invalid_token`** (clients refresh); a valid
 token whose user lost access answers **403 `insufficient_scope`**. Password
 change, deactivation and any other `session_version` bump revoke the user's
 OAuth tokens outright (`User._revoke_oauth_tokens`), since like API keys they
-carry no session version. OAuth tokens are accepted on the two MCP routes only
-— `get_current_user` and the graph-scoped REST dependencies never resolve them.
+carry no session version. A user revokes one connection at a time through the
+connected-apps endpoints (`GET`/`DELETE /v1/user/oauth/grants`,
+`operations/oauth_server/grants.py`) — the grant and every token minted from
+it go together, and their cache entries are cleared, so the client fails at
+its next call rather than its next cache miss. OAuth tokens are accepted on the
+two MCP routes only — `get_current_user` and the graph-scoped REST dependencies
+never resolve them.
 
 ### Key scoping
 

--- a/robosystems/models/api/__init__.py
+++ b/robosystems/models/api/__init__.py
@@ -131,6 +131,8 @@ from .user import (
   CreateAPIKeyRequest,
   CreateAPIKeyResponse,
   GraphInfo,
+  OAuthGrantInfo,
+  OAuthGrantsResponse,
   UpdateAPIKeyRequest,
   UpdatePasswordRequest,
   UpdateUserRequest,
@@ -218,6 +220,8 @@ __all__ = [
   "MCPToolCall",
   "OAuthCallbackRequest",
   "OAuthConnectionUpdate",
+  "OAuthGrantInfo",
+  "OAuthGrantsResponse",
   "OAuthInitRequest",
   "OAuthInitResponse",
   # OAuth models

--- a/robosystems/models/api/user.py
+++ b/robosystems/models/api/user.py
@@ -304,6 +304,37 @@ class APIKeysResponse(BaseModel):
   api_keys: list[APIKeyInfo] = Field(..., description="List of user's API keys")
 
 
+class OAuthGrantInfo(BaseModel):
+  """A connected app: one OAuth consent for one client on one graph."""
+
+  id: str = Field(..., description="Grant ID")
+  client_name: str = Field(..., description="The connected client's display name")
+  client_uri: str | None = Field(None, description="The client's homepage, if declared")
+  client_is_trusted: bool = Field(
+    ...,
+    description="Whether the client is on the trusted list (pre-registered, or a "
+    "known metadata-document host). Untrusted clients registered themselves.",
+  )
+  graph_id: str = Field(..., description="The one graph this consent reaches")
+  graph_name: str | None = Field(
+    None, description="The graph's display name, when the graph still exists"
+  )
+  resource: str = Field(
+    ..., description="The MCP URL the grant's tokens are bound to (their audience)"
+  )
+  scope: str = Field(..., description="Granted scopes, space-separated")
+  created_at: str = Field(..., description="When the user consented")
+  last_used_at: str | None = Field(None, description="Last token use, if any")
+
+
+class OAuthGrantsResponse(BaseModel):
+  """Response model for listing connected apps."""
+
+  grants: list[OAuthGrantInfo] = Field(
+    ..., description="Active OAuth grants, newest first"
+  )
+
+
 class UpdateAPIKeyRequest(BaseModel):
   """Request model for updating an API key."""
 

--- a/robosystems/operations/oauth_server/grants.py
+++ b/robosystems/operations/oauth_server/grants.py
@@ -1,0 +1,73 @@
+"""Connected apps: a user's OAuth grants — list and revoke.
+
+A grant is one consent (user x client x graph x resource). Listing shows
+what a user has connected and where each connection reaches; revoking a
+grant kills every token minted from it and clears their validation-cache
+entries, so the connector stops at its next call rather than at the next
+cache miss. This is the proportionate answer to "disconnect this app" —
+the alternatives are a password change (every grant) or an operator
+deactivating the client (every user of it).
+"""
+
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from robosystems.models.api.user import OAuthGrantInfo
+from robosystems.models.core import Graph, OAuthGrant
+
+
+class GrantNotFound(Exception):
+  """No live grant with that id belongs to the user. Deliberately one
+  answer for "unknown" and "someone else's" — no existence oracle."""
+
+
+def _iso(value: datetime | None) -> str | None:
+  return value.isoformat() if value else None
+
+
+def list_user_grants(user_id: str, session: Session) -> list[OAuthGrantInfo]:
+  """Active grants only. A revoked grant cannot be reinstated from this
+  surface, so listing it would only grow the list with rows the user can
+  take no action on (the API-key listing follows the same rule)."""
+  grants = OAuthGrant.get_active_by_user_id(user_id, session)
+  graph_ids = {str(grant.graph_id) for grant in grants}
+  graph_names: dict[str, str] = {}
+  if graph_ids:
+    # Straight off the table, not Graph.get_by_id: a grant on a graph that
+    # has since been deprovisioned still deserves its name in the listing.
+    for graph_id, graph_name in (
+      session.query(Graph.graph_id, Graph.graph_name)
+      .filter(Graph.graph_id.in_(graph_ids))
+      .all()
+    ):
+      graph_names[str(graph_id)] = str(graph_name)
+
+  out: list[OAuthGrantInfo] = []
+  for grant in grants:
+    client = grant.client
+    out.append(
+      OAuthGrantInfo(
+        id=str(grant.id),
+        client_name=str(client.client_name) if client else "Unknown client",
+        client_uri=client.client_uri if client else None,
+        client_is_trusted=bool(client.is_trusted) if client else False,
+        graph_id=str(grant.graph_id),
+        graph_name=graph_names.get(str(grant.graph_id)),
+        resource=str(grant.resource),
+        scope=str(grant.scope),
+        created_at=grant.created_at.isoformat(),
+        last_used_at=_iso(grant.last_used_at),
+      )
+    )
+  return out
+
+
+def revoke_user_grant(user_id: str, grant_id: str, session: Session) -> int:
+  """Revoke one of the user's grants and every token minted from it.
+  Returns the number of tokens revoked. Idempotent: revoking an already
+  revoked grant re-asserts the token revocation and returns 0."""
+  grant = OAuthGrant.get_by_id(grant_id, session)
+  if grant is None or str(grant.user_id) != str(user_id):
+    raise GrantNotFound(grant_id)
+  return grant.revoke(session, reason="user_revoked")

--- a/robosystems/routers/user/__init__.py
+++ b/robosystems/routers/user/__init__.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter
 
 from .api_keys import router as api_keys_router
 from .main import router as main_router
+from .oauth_grants import router as oauth_grants_router
 from .password import router as password_router
 
 router = APIRouter()
@@ -11,5 +12,6 @@ router = APIRouter()
 router.include_router(main_router)
 router.include_router(password_router)
 router.include_router(api_keys_router)
+router.include_router(oauth_grants_router)
 
 __all__ = ["router"]

--- a/robosystems/routers/user/oauth_grants.py
+++ b/robosystems/routers/user/oauth_grants.py
@@ -1,0 +1,137 @@
+"""Connected apps: the user's MCP OAuth grants."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ...database import get_db_session
+from ...logger import logger
+from ...middleware.auth.dependencies import get_current_user
+from ...middleware.otel.metrics import (
+  endpoint_metrics_decorator,
+  get_endpoint_metrics,
+)
+from ...middleware.rate_limits import user_management_rate_limit_dependency
+from ...models.api.common import (
+  AUTHENTICATED_ERROR_RESPONSES,
+  RESOURCE_ERROR_RESPONSES,
+  ErrorCode,
+  SuccessResponse,
+  create_error_response,
+)
+from ...models.api.user import OAuthGrantsResponse
+from ...models.core import User
+from ...operations.oauth_server.grants import (
+  GrantNotFound,
+  list_user_grants,
+  revoke_user_grant,
+)
+
+router = APIRouter(tags=["User"])
+
+
+@router.get(
+  "/user/oauth/grants",
+  response_model=OAuthGrantsResponse,
+  summary="List Connected Apps",
+  description=(
+    "Every MCP client the user has authorized through OAuth, with the one graph "
+    "each connection reaches. Active grants only: a revoked grant cannot be "
+    "reinstated, so it leaves the list."
+  ),
+  operation_id="listUserOAuthGrants",
+  responses={**AUTHENTICATED_ERROR_RESPONSES},
+)
+@endpoint_metrics_decorator(
+  endpoint_name="/v1/user/oauth/grants", business_event_type="oauth_grants_listed"
+)
+async def list_oauth_grants(
+  current_user: User = Depends(get_current_user),
+  db: Session = Depends(get_db_session),
+  _rate_limit: None = Depends(user_management_rate_limit_dependency),
+) -> OAuthGrantsResponse:
+  user_id = str(current_user.id)
+  try:
+    grants = list_user_grants(user_id, db)
+    get_endpoint_metrics().record_business_event(
+      endpoint="/v1/user/oauth/grants",
+      method="GET",
+      event_type="oauth_grants_listed",
+      event_data={"user_id": user_id, "active_grants": len(grants)},
+      user_id=user_id,
+    )
+    return OAuthGrantsResponse(grants=grants)
+  except HTTPException:
+    raise
+  except Exception as e:
+    logger.error(f"Error listing OAuth grants: {e!s}")
+    raise create_error_response(
+      status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+      detail="Error listing connected apps",
+      code=ErrorCode.INTERNAL_ERROR,
+    )
+
+
+@router.delete(
+  "/user/oauth/grants/{grant_id}",
+  response_model=SuccessResponse,
+  summary="Revoke Connected App",
+  description=(
+    "Revokes the grant and every access and refresh token minted from it. The "
+    "client's next request fails with 401 and it must ask the user to authorize "
+    "again. Revoking an already revoked grant succeeds and changes nothing."
+  ),
+  operation_id="revokeUserOAuthGrant",
+  responses={**RESOURCE_ERROR_RESPONSES},
+)
+@endpoint_metrics_decorator(
+  endpoint_name="/v1/user/oauth/grants/{grant_id}",
+  business_event_type="oauth_grant_revoked",
+)
+async def revoke_oauth_grant(
+  grant_id: str,
+  current_user: User = Depends(get_current_user),
+  db: Session = Depends(get_db_session),
+  _rate_limit: None = Depends(user_management_rate_limit_dependency),
+) -> SuccessResponse:
+  user_id = str(current_user.id)
+  try:
+    tokens_revoked = revoke_user_grant(user_id, grant_id, db)
+  except GrantNotFound:
+    get_endpoint_metrics().record_business_event(
+      endpoint="/v1/user/oauth/grants/{grant_id}",
+      method="DELETE",
+      event_type="oauth_grant_revoke_not_found",
+      event_data={"user_id": user_id, "requested_grant_id": grant_id},
+      user_id=user_id,
+    )
+    raise create_error_response(
+      status_code=status.HTTP_404_NOT_FOUND,
+      detail="Grant not found or access denied",
+      code=ErrorCode.NOT_FOUND,
+    )
+  except HTTPException:
+    raise
+  except Exception as e:
+    logger.error(f"Error revoking OAuth grant: {e!s}")
+    raise create_error_response(
+      status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+      detail="Error revoking connected app",
+      code=ErrorCode.INTERNAL_ERROR,
+    )
+
+  get_endpoint_metrics().record_business_event(
+    endpoint="/v1/user/oauth/grants/{grant_id}",
+    method="DELETE",
+    event_type="oauth_grant_revoked",
+    event_data={
+      "user_id": user_id,
+      "grant_id": grant_id,
+      "tokens_revoked": tokens_revoked,
+    },
+    user_id=user_id,
+  )
+  return SuccessResponse(
+    success=True,
+    message="Connected app revoked",
+    data={"grant_id": grant_id, "tokens_revoked": tokens_revoked},
+  )

--- a/tests/routers/user/test_oauth_grants.py
+++ b/tests/routers/user/test_oauth_grants.py
@@ -1,0 +1,153 @@
+"""Connected apps: a user sees only their own live grants, and revoking one
+kills its tokens — the proportionate alternative to a password change."""
+
+from uuid import uuid4
+
+from robosystems.middleware.auth.jwt import create_jwt_token
+from robosystems.models.core import Graph, OAuthClient, OAuthGrant, OAuthToken, User
+from robosystems.models.core.user.oauth_token import TOKEN_TYPE_ACCESS
+
+RESOURCE = "https://api.test.example/v1/mcp"
+
+
+def _auth(user):
+  return {"Authorization": f"Bearer {create_jwt_token(user.id)}"}
+
+
+def _client_row(session, name="Claude", trusted=True):
+  client, _ = OAuthClient.register_preregistered(
+    client_name=name,
+    redirect_uris=["https://claude.ai/api/mcp/auth_callback"],
+    confidential=False,
+    session=session,
+  )
+  if not trusted:
+    client.is_trusted = False
+    session.commit()
+  return client
+
+
+def _grant(session, user, client, graph_id="sec"):
+  return OAuthGrant.create(
+    user_id=str(user.id),
+    oauth_client_id=str(client.id),
+    graph_id=graph_id,
+    resource=RESOURCE,
+    scope="mcp offline_access",
+    session=session,
+  )
+
+
+def _ensure_sec(session):
+  if Graph.get_by_id("sec", session) is None:
+    Graph.create(
+      graph_id="sec",
+      org_id=None,
+      graph_name="SEC EDGAR Filings",
+      graph_type="repository",
+      session=session,
+    )
+
+
+def _other_user(session, like):
+  user = User(
+    email=f"other+{uuid4().hex[:8]}@example.com",
+    name="Other",
+    password_hash=like.password_hash,
+  )
+  session.add(user)
+  session.commit()
+  session.refresh(user)
+  return user
+
+
+class TestListConnectedApps:
+  def test_lists_own_live_grants_with_client_and_graph(
+    self, client, test_user, test_db
+  ):
+    _ensure_sec(test_db)
+    trusted = _client_row(test_db, "Claude")
+    untrusted = _client_row(test_db, "Some IDE", trusted=False)
+    live = _grant(test_db, test_user, trusted)
+    on_unknown_graph = _grant(
+      test_db, test_user, untrusted, graph_id="kg00000000000000000abc"
+    )
+    revoked = _grant(test_db, test_user, trusted)
+    revoked.revoke(test_db)
+    other = _other_user(test_db, test_user)
+    _grant(test_db, other, trusted)
+    # Captured before the request: the endpoint's session handling detaches
+    # instances created beforehand, so their attributes cannot refresh after.
+    live_id, unknown_id = str(live.id), str(on_unknown_graph.id)
+
+    resp = client.get("/v1/user/oauth/grants", headers=_auth(test_user))
+
+    assert resp.status_code == 200
+    rows = {row["id"]: row for row in resp.json()["grants"]}
+    assert set(rows) == {live_id, unknown_id}
+    sec = rows[live_id]
+    assert sec["client_name"] == "Claude"
+    assert sec["client_is_trusted"] is True
+    assert sec["graph_id"] == "sec"
+    assert sec["graph_name"] == "SEC EDGAR Filings"
+    assert sec["resource"] == RESOURCE
+    assert sec["scope"] == "mcp offline_access"
+    unknown = rows[unknown_id]
+    assert unknown["client_is_trusted"] is False
+    assert unknown["graph_name"] is None
+
+  def test_requires_authentication(self, client):
+    assert client.get("/v1/user/oauth/grants").status_code == 401
+
+
+class TestRevokeConnectedApp:
+  def test_revokes_grant_and_its_tokens(self, client, test_user, test_db):
+    grant = _grant(test_db, test_user, _client_row(test_db))
+    access, _, refresh, _, _ = OAuthToken.mint_pair(
+      grant_id=str(grant.id), user_id=str(test_user.id), session=test_db
+    )
+    grant_id, access_id, refresh_id = str(grant.id), str(access.id), str(refresh.id)
+
+    resp = client.delete(f"/v1/user/oauth/grants/{grant_id}", headers=_auth(test_user))
+
+    assert resp.status_code == 200
+    assert resp.json()["data"] == {"grant_id": grant_id, "tokens_revoked": 2}
+    assert OAuthGrant.get_by_id(grant_id, test_db).revoked_at is not None
+    for token_id in (access_id, refresh_id):
+      row = test_db.query(OAuthToken).filter(OAuthToken.id == token_id).one()
+      assert row.revoked_at is not None
+    assert (
+      test_db.query(OAuthToken)
+      .filter(
+        OAuthToken.grant_id == grant_id, OAuthToken.token_type == TOKEN_TYPE_ACCESS
+      )
+      .one()
+      .is_live
+      is False
+    )
+    # It has left the list.
+    listed = client.get("/v1/user/oauth/grants", headers=_auth(test_user)).json()
+    assert grant_id not in {row["id"] for row in listed["grants"]}
+
+  def test_revoking_twice_is_idempotent(self, client, test_user, test_db):
+    grant_id = str(_grant(test_db, test_user, _client_row(test_db)).id)
+    first = client.delete(f"/v1/user/oauth/grants/{grant_id}", headers=_auth(test_user))
+    second = client.delete(
+      f"/v1/user/oauth/grants/{grant_id}", headers=_auth(test_user)
+    )
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.json()["data"]["tokens_revoked"] == 0
+
+  def test_someone_elses_grant_and_unknown_ids_are_both_404(
+    self, client, test_user, test_db
+  ):
+    other = _other_user(test_db, test_user)
+    theirs = str(_grant(test_db, other, _client_row(test_db)).id)
+
+    resp = client.delete(f"/v1/user/oauth/grants/{theirs}", headers=_auth(test_user))
+    assert resp.status_code == 404
+    assert OAuthGrant.get_by_id(theirs, test_db).revoked_at is None
+
+    resp = client.delete("/v1/user/oauth/grants/oag_nope", headers=_auth(test_user))
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Adds the connected-apps surface for MCP OAuth: a user can list the clients they have authorized and revoke one at a time. Until now the only ways to revoke an OAuth grant were a password change (every grant) or an operator deactivating the client (every user of it). This is the API half of a connected-apps page and lands now so it rides the next SDK minor.

## Changes

- `operations/oauth_server/grants.py` (new) — `list_user_grants` (active grants with the client's name/URI/trust flag, the graph and its display name, resource, scope, timestamps; graph names read straight off the table so a grant on a since-deprovisioned graph still shows one) and `revoke_user_grant` (owner-checked; revokes the grant and every token minted from it via the existing `OAuthGrant.revoke`, which also clears the tokens' validation-cache entries; idempotent). `GrantNotFound` is one answer for unknown and someone-else's — no existence oracle.
- `routers/user/oauth_grants.py` (new), registered in `routers/user/__init__.py` — `GET /v1/user/oauth/grants` (`listUserOAuthGrants`) and `DELETE /v1/user/oauth/grants/{grant_id}` (`revokeUserOAuthGrant`), tag `User`, standard `get_current_user` + user-management rate limit, same error and metrics discipline as the API-key endpoints. Active grants only, mirroring the API-key listing rule.
- `models/api/user.py`, `models/api/__init__.py` — `OAuthGrantInfo`, `OAuthGrantsResponse`.
- `middleware/auth/README.md` — documents the endpoints next to the existing revocation paths.

## Breaking Changes

None. Purely additive: two new operations and two new response models on the generated tier — an SDK regen opportunity for the upcoming client minor.

## Testing

`just test-code` — passes (ruff, format, basedpyright 0 errors, cf-lint).

`pytest tests/routers/user tests/operations/oauth_server tests/routers/oauth tests/models/api` — 576 passed. New `tests/routers/user/test_oauth_grants.py` covers: the listing returns only the caller's live grants with client and graph details (another user's and a revoked grant excluded; an unknown graph yields `graph_name: null`); revoking marks the grant and both its tokens revoked and drops it from the list; revoking twice is idempotent; someone else's grant and an unknown id are both 404.

Verified against the running local stack that both operations appear in `openapi.json` under the `User` tag.

The full `just test-all` suite was not run in-session.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
