### PR TITLE
chore(release): curated notes for v1.11.0; dev client pin to 1.12.0

### DIFF
--- a/.github/release-notes/v1.11.0.md
+++ b/.github/release-notes/v1.11.0.md
@@ -1,0 +1,133 @@
+RoboSystems 1.11.0 is the release where an MCP client connects with a sign-in
+instead of a pasted key. It closes the 1.10 series (22 pull requests since
+v1.10.0) with the OAuth 2.1 authorization server built for the marketplace
+listings, the review that hardened it, the connected-apps endpoints that let a
+user disconnect one client at a time, and a run of correctness fixes across the
+period close, the self-serve billing path, and graph teardown.
+
+## MCP OAuth 2.1 — the second front door
+
+Every MCP marketplace requires OAuth for an authenticated remote server, so the
+platform now carries its own OAuth 2.1 authorization server rather than a
+bought one (#1264, gated by `MCP_OAUTH_ENABLED`):
+
+- **Discovery and flow** — RFC 8414 / RFC 9728 metadata under `/.well-known`,
+  authorization-code with mandatory PKCE, a consent screen on the login home
+  where the user picks the one graph a grant covers, a token endpoint with
+  rotating refresh tokens and family revocation on replay, RFC 7009
+  revocation, RFC 9207 `iss`.
+- **Three ways to register** — Client ID Metadata Documents (Claude, ChatGPT,
+  VS Code), RFC 7591 dynamic registration (Cursor, Docker's gateway), and
+  operator pre-registered clients via `admin oauth create-client`.
+- **Two routes, one rule** — `POST /v1/graphs/{graph_id}/mcp` accepts an OAuth
+  bearer bound to that exact URL alongside the header key; the new
+  **`POST /v1/mcp`** is OAuth-only and dispatches on the grant's graph. A grant
+  covers exactly one graph; switching graphs is a reconnect.
+- **The `?token=` carriage is retired** (#1268). It carried a graph-scoped key
+  for connector clients that could not send headers — the bridge to OAuth, and
+  the first thing to go once OAuth covered those clients. A URL that still
+  carries one is answered with the OAuth discovery challenge, which moves that
+  client onto the flow. The header key stays: it is the same credential the
+  whole REST API takes.
+- **Connected apps** (#1275) — `GET /v1/user/oauth/grants` lists the clients a
+  user has authorized and the graph each reaches; `DELETE
+  /v1/user/oauth/grants/{grant_id}` revokes one grant and every token minted
+  from it. Until now the only per-user revocation was a password change.
+- **Hardening after review** (#1274) — a line-by-line review of the server
+  closed six defects: user deletion sweeps OAuth grants and tokens; `/v1/mcp`
+  is categorized as MCP traffic and budgeted by the grant's graph; the token
+  and revocation endpoints serve the mirrored client registration when a
+  metadata host is unreachable, so an outage there cannot fail every refresh;
+  the authorization endpoint's rate limit fails closed; an hourly sweep retires
+  dead tokens and never-consented registrations; the subgraph tools give an
+  OAuth connector the right credential answer.
+
+Four independent client families were walked end to end against production in
+the week it shipped — Claude Code and claude.ai (metadata documents), Docker's
+MCP gateway and Cursor (dynamic registration).
+
+## Listing surface
+
+- Every MCP tool carries a `title` and explicit read-only / destructive /
+  idempotent / open-world annotations (#1264). `read-graph-cypher` is hinted
+  read-only now that the statement guard enforces it on every execution path,
+  and the GraphQL tools are no longer advertised on shared repositories, which
+  have no typed schema to query (#1270).
+- `server.json` for the official MCP registry (`ai.robosystems/robosystems`),
+  with a description aligned to the directory listing (#1267);
+  `/.well-known/glama.json` so the Glama mirror can be claimed (#1269); the
+  ChatGPT app-directory domain-verification token at
+  `/.well-known/openai-apps-challenge` (#1271).
+- The public SEC MCP copy matches the subscription gate it sits behind, and
+  the plan manifest is guarded so a rate-limited plan cannot describe itself
+  as unlimited (#1256).
+
+## Removed
+
+- **The REST MCP tool endpoints** — `GET /v1/graphs/{graph_id}/mcp/tools` and
+  `POST …/mcp/call-tool` (#1264). MCP clients speak the Streamable HTTP
+  transport directly; thirty days of production traffic showed no caller, and
+  the `@robosystems/mcp` bridge dropped its legacy mode with them. For the
+  SDKs this is a generated-tier removal — `listMcpTools` / `callMcpTool` and
+  `api.mcp.*` — named in both clients' 1.12.0 release notes; nothing on the
+  stable tier changes. The showcase runner and the isolation harness, which
+  still targeted the pair, moved to the transport (#1266).
+- The `?token=` query credential on the per-graph MCP route (#1268), above.
+
+## Close integrity
+
+- A refused worker close no longer persists as a closed period (#1255).
+- The REST `close-period` forwards `allow_reconciling_items`, which the MCP
+  tool and the worker already honored; a structural test pins that every
+  `allow_*` override the request model declares reaches the kernel (#1257).
+- An over-budget close can no longer be recorded FAILED while its thread runs
+  on and commits: the wait is fenced as a background job, and a duplicate
+  dispatch overlapping a running close of the same period waits for the
+  receipt instead of being refused (#1260).
+
+## Billing, teardown, and the data plane
+
+- Five places on the self-serve billing path where money and delivery could
+  come apart — checkout retry, graph delete, card-on-file subscribe, renewal —
+  are closed at their chokepoints (#1258).
+- Graph deprovisioning revokes the provider grant at QuickBooks, as the
+  user-initiated disconnect always has; `delete-subgraph`'s `backup_first`
+  takes a real backup, registered on the parent graph's backup list, and a
+  failed backup aborts the delete (#1259).
+- Deleting a graph whose `.lbug` file is already gone still disposes its side
+  stores, so a teardown that died mid-way cannot leave a Lance directory or a
+  DuckDB staging area for the next tenant (#1261).
+- The daily stale-volume sweep no longer ages a parked shared master's data
+  volume from its creation date, the launch path recovers a
+  tagged-but-unregistered volume before minting a new one, and a shared master
+  minting a volume at all now pages (#1265).
+
+## Authentication and documentation
+
+- Session refresh and the public password-strength check share the same
+  token-purpose and abuse bounds as the rest of login (#1255).
+- `SECURITY.md` catalogues the OAuth authorization server (#1272); the OpenAPI
+  description states which credential each surface takes — API key for REST,
+  GraphQL and per-graph MCP, OAuth bearer for `/v1/mcp`, JWT for browser
+  sessions (#1273); enterprise SSO, SCIM and passkeys are documented beyond
+  `SECURITY.md` (#1254); the parallel test harness and its rules are recorded
+  in `tests/README.md` (#1263).
+
+## Infrastructure
+
+- The test suite runs in parallel with `pytest-xdist` — the full non-slow
+  suite in about two minutes on 14 cores, against twelve-plus serial (#1262).
+
+## Deploying this release
+
+- **Two platform migrations**: `39c73ea18599` (the `oauth_clients`,
+  `oauth_grants` and `oauth_tokens` tables) and `8c8e469f4a0a` (a partial
+  unique index over live `billing_subscriptions` rows). The second fails to
+  build if duplicate live `(resource_type, resource_id, user_id)` rows exist,
+  and the daemon's fail-closed boot will then refuse to start — run the check
+  in the migration's comment against each environment first.
+- **One stack update** rides the deploy: `graph-volumes` gains the
+  `SharedMasterVolumeCreated` alarm.
+- `MCP_OAUTH_ENABLED` gates the whole OAuth surface; off, it answers 404.
+- **SDKs**: `robosystems-client` and `@robosystems/client` 1.12.0 are
+  generated from this API line and are published.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # RoboSystems client for demo and testing.
-    "robosystems-client>=1.11.0,<2.0",
+    "robosystems-client>=1.12.0,<2.0",
     # Testing framework
     "pytest>=9.0.0,<10.0",
     "pytest-asyncio>=1.4.0,<2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3819,7 +3819,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.34.2,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=15.0.0,<16.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = ">=1.11.0,<2.0" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = ">=1.12.0,<2.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3844,7 +3844,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "1.11.0"
+version = "1.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3852,9 +3852,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/90/7ddee9bdaff584c9dafc0b5e989a1329f7b7268b497f33c41cf78e3c65b7/robosystems_client-1.11.0.tar.gz", hash = "sha256:df188901220dfe8520cd673784a2d5bb496f37afd4b4395e701dd2de8243a9cb", size = 538045, upload-time = "2026-08-22T02:47:06.325Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/c0/9e7fd68367a343602925185e144e0ad4004c97ef8c27c7de350c49bf4f5c/robosystems_client-1.12.0.tar.gz", hash = "sha256:3a1920fe69e7472120a1de28d3ff03a780d3db6dd0874b3b7ce9ee508d3239fc", size = 546608, upload-time = "2026-08-27T03:10:58.485Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/6a/1f8c336e640d531f155024eebda3cef1d43ca51ef1f92cd8824e79a7b9ce/robosystems_client-1.11.0-py3-none-any.whl", hash = "sha256:0f7966d2f660cc3500e59a888325ca99e56ce706cbd764e4f079bf9623ad040a", size = 1250614, upload-time = "2026-08-22T02:47:04.715Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/32/777615816a24ee3ef0d667fc450d867f920d4360fa76e5da8edf624dd401/robosystems_client-1.12.0-py3-none-any.whl", hash = "sha256:abad04811c4c8ce9fd802444da56ccbc870e4633c0f9197c952bdf88f4cfeead", size = 1272429, upload-time = "2026-08-27T03:10:56.517Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Curated release notes for **v1.11.0**, the minor that closes the 1.10 series (22 PRs since v1.10.0: #1254–#1275), written per `.github/release-notes/README.md` — body only, the workflow supplies the heading and links. Must be merged to `main` **before** `create-release.yml` is dispatched with `minor`, or the file is not at the tagged ref and the release falls back to the generated changelog. Also moves the `dev` extra's `robosystems-client` pin to the client generated from this line.

## Changes

- `.github/release-notes/v1.11.0.md` — the OAuth 2.1 authorization server and its hardening review, the connected-apps endpoints, the retired `?token=` carriage and REST MCP tool endpoints (the generated-tier removal, cross-referenced to the clients' 1.12.0 notes), the close-integrity and billing fixes, teardown and data-plane fixes, docs, and a **Deploying this release** section: two platform migrations (`39c73ea18599`, `8c8e469f4a0a` — with #1258's duplicate-row pre-check), the `graph-volumes` stack update (`SharedMasterVolumeCreated` alarm), and the `MCP_OAUTH_ENABLED` gate. Every line is grounded in a PR body from the series; security-adjacent items stay at title neutrality.
- `pyproject.toml`, `uv.lock` — `robosystems-client>=1.12.0,<2.0` in the `dev` extra (was `>=1.11.0`); lock resolves 1.12.0.

## Breaking Changes

None.

## Testing

`just test-code` — passes (the pre-commit hook re-ran it: ruff, format, basedpyright 0 errors, cf-lint). No behavior changes; the notes were reviewed against each PR's body and the range diff (`git diff v1.10.0..main` for migrations, CloudFormation and route decorators).

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
