### PR TITLE
fix(infra): tighten deploy-identity boundaries across roles and stacks

### DIFF
--- a/.github/workflows/deploy-dagster.yml
+++ b/.github/workflows/deploy-dagster.yml
@@ -108,6 +108,10 @@ on:
         required: false
         type: string
         default: ""
+      graph_volumes_stack_name:
+        description: "CloudFormation stack name of the graph-volumes stack whose volume-manager Lambda the worker invokes"
+        required: true
+        type: string
       worker_enabled:
         description: "Enable background worker deployment (true/false)"
         required: false
@@ -444,6 +448,7 @@ jobs:
                 ParameterKey=DagsterClusterArn,ParameterValue=${{ steps.dagster-outputs.outputs.cluster_arn }} \
                 ParameterKey=DagsterClusterName,ParameterValue=$CLUSTER_NAME \
                 ParameterKey=DagsterSecurityGroupId,ParameterValue=${{ steps.dagster-outputs.outputs.sg_id }} \
+                ParameterKey=GraphVolumesStackName,ParameterValue=${{ inputs.graph_volumes_stack_name }} \
                 ParameterKey=ECRRepositoryUrl,ParameterValue=${{ inputs.ecr_repository_url }} \
                 ParameterKey=ECRImageTag,ParameterValue=${{ inputs.ecr_image_tag }} \
                 ParameterKey=WorkerCpu,ParameterValue=${{ inputs.worker_cpu }} \

--- a/.github/workflows/deploy-postgres.yml
+++ b/.github/workflows/deploy-postgres.yml
@@ -29,6 +29,10 @@ on:
         description: "VPC ID for RDS instance"
         required: true
         type: string
+      vpc_cidr:
+        description: "VPC CIDR block admitted to the database port (from the VPC stack)"
+        required: true
+        type: string
       subnet_ids:
         description: "Comma-separated subnet IDs for RDS (minimum 2 for multi-AZ)"
         required: true
@@ -182,6 +186,7 @@ jobs:
                 ParameterKey=EnablePerformanceInsights,ParameterValue=${{ inputs.performance_insights_enabled }} \
                 ParameterKey=PerformanceInsightsRetentionPeriod,ParameterValue=${{ inputs.performance_insights_retention_days }} \
                 ParameterKey=VpcId,ParameterValue=${{ inputs.vpc_id }} \
+                ParameterKey=VpcCidr,ParameterValue=${{ inputs.vpc_cidr }} \
                 ParameterKey=SubnetId1,ParameterValue=$(echo ${{ inputs.subnet_ids }} | cut -d ',' -f1) \
                 ParameterKey=SubnetId2,ParameterValue=$(echo ${{ inputs.subnet_ids }} | cut -d ',' -f2) \
                 ParameterKey=SNSAlertEmail,ParameterValue=${{ inputs.aws_sns_alert_email }} \

--- a/.github/workflows/deploy-vpc.yml
+++ b/.github/workflows/deploy-vpc.yml
@@ -109,6 +109,9 @@ on:
       vpc_id:
         description: "VPC ID"
         value: ${{ jobs.deploy.outputs.vpc_id }}
+      vpc_cidr:
+        description: "VPC CIDR block"
+        value: ${{ jobs.deploy.outputs.vpc_cidr }}
       private_subnet_ids:
         description: "Private Subnet IDs"
         value: ${{ jobs.deploy.outputs.private_subnet_ids }}
@@ -125,6 +128,7 @@ jobs:
       contents: read
     outputs:
       vpc_id: ${{ steps.stack-outputs.outputs.vpc_id }}
+      vpc_cidr: ${{ steps.stack-outputs.outputs.vpc_cidr }}
       private_subnet_ids: ${{ steps.stack-outputs.outputs.private_subnet_ids }}
       public_subnet_ids: ${{ steps.stack-outputs.outputs.public_subnet_ids }}
 
@@ -234,6 +238,20 @@ jobs:
             echo "VPC configured successfully"
           else
             echo "Error: Could not retrieve VPC ID"
+            exit 1
+          fi
+
+          # Get VPC CIDR (the postgres stack admits it to the database port)
+          VPC_CIDR=$(aws cloudformation describe-stacks \
+            --stack-name ${{ inputs.stack_name }} \
+            --query "Stacks[0].Outputs[?OutputKey=='VpcCidr'].OutputValue" \
+            --output text)
+
+          if [ -n "$VPC_CIDR" ] && [ "$VPC_CIDR" != "None" ]; then
+            echo "vpc_cidr=$VPC_CIDR" >> $GITHUB_OUTPUT
+            echo "VPC CIDR: $VPC_CIDR"
+          else
+            echo "Error: Could not retrieve VPC CIDR"
             exit 1
           fi
 

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -156,6 +156,10 @@ jobs:
   create-deployment:
     needs: [runner, test, build, stack-config]
     runs-on: ${{ fromJSON(needs.runner.outputs.runner_config) }}
+    # Every deploy-* job fans in through this one, so the production
+    # environment's protection rules (required reviewer, deployment branches)
+    # gate the whole run here, once.
+    environment: production
     outputs:
       deployment_id: ${{ steps.deployment.outputs.deployment_id }}
     steps:
@@ -261,6 +265,7 @@ jobs:
       # AWS Configuration
       aws_region: ${{ vars.AWS_REGION || 'us-east-1' }}
       vpc_id: ${{ needs.deploy-vpc.outputs.vpc_id }}
+      vpc_cidr: ${{ needs.deploy-vpc.outputs.vpc_cidr }}
       subnet_ids: ${{ needs.deploy-vpc.outputs.private_subnet_ids }}
       # Database Version Configuration
       postgres_version: ${{ vars.DATABASE_POSTGRES_VERSION_PROD || '16.11' }}
@@ -647,6 +652,7 @@ jobs:
       max_concurrent_runs: ${{ vars.DAGSTER_MAX_CONCURRENT_RUNS_PROD || '20' }}
       # Worker Configuration
       worker_stack_name: ${{ needs.stack-config.outputs.worker_stack }}
+      graph_volumes_stack_name: ${{ needs.stack-config.outputs.graph_volumes_stack }}
       worker_enabled: ${{ vars.WORKER_ENABLED_PROD || 'false' }}
       worker_cpu: ${{ vars.WORKER_CPU_PROD || '512' }}
       worker_memory: ${{ vars.WORKER_MEMORY_PROD || '1024' }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -278,6 +278,7 @@ jobs:
       # AWS Configuration
       aws_region: ${{ vars.AWS_REGION || 'us-east-1' }}
       vpc_id: ${{ needs.deploy-vpc.outputs.vpc_id }}
+      vpc_cidr: ${{ needs.deploy-vpc.outputs.vpc_cidr }}
       subnet_ids: ${{ needs.deploy-vpc.outputs.private_subnet_ids }}
       # Database Version Configuration
       postgres_version: ${{ vars.DATABASE_POSTGRES_VERSION_STAGING || '16.11' }}
@@ -664,6 +665,7 @@ jobs:
       max_concurrent_runs: ${{ vars.DAGSTER_MAX_CONCURRENT_RUNS_STAGING || '20' }}
       # Worker Configuration
       worker_stack_name: ${{ needs.stack-config.outputs.worker_stack }}
+      graph_volumes_stack_name: ${{ needs.stack-config.outputs.graph_volumes_stack }}
       worker_enabled: ${{ vars.WORKER_ENABLED_STAGING || 'false' }}
       worker_cpu: ${{ vars.WORKER_CPU_STAGING || '512' }}
       worker_memory: ${{ vars.WORKER_MEMORY_STAGING || '1024' }}

--- a/bin/lambda/postgres_rotation.py
+++ b/bin/lambda/postgres_rotation.py
@@ -38,42 +38,40 @@ rds_client = boto3.client("rds")
 def get_database_connection_info(secret_arn: str, environment: str) -> dict[str, Any]:
   """Resolve host, port, and database name for the RDS instance this secret guards.
 
-  The environment is read out of the secret name rather than taken from the
-  caller, and matched against RDS instance identifiers.
+  The instance is addressed by its exact identifier (DB_INSTANCE_IDENTIFIER,
+  set by the stack that owns both the secret and the instance) — never by
+  searching the account for a name that merely contains the environment. The
+  environment segment of the secret name must agree with the function's own
+  ENVIRONMENT, so a secret from another environment handed to this function
+  is refused rather than rotated against the wrong database.
   """
-  # Parse the secret name from ARN to determine the database
   # Format: arn:aws:secretsmanager:region:account:secret:robosystems/env/postgres-xxxxx
   secret_name = secret_arn.split(":")[-1].rsplit("-", 1)[0]
   env_from_secret = secret_name.split("/")[1]
+  if env_from_secret != environment:
+    raise ValueError(
+      f"Secret environment {env_from_secret!r} does not match this function's "
+      f"environment {environment!r}"
+    )
 
-  # Find the database instance
-  db_info = {
-    "host": None,
-    "port": None,
-    "database": "robosystems",  # Default database name
-    "instance_id": None,
-  }
+  instance_id = os.environ.get("DB_INSTANCE_IDENTIFIER")
+  if not instance_id:
+    raise ValueError("DB_INSTANCE_IDENTIFIER is not set")
 
-  # Find the RDS instance. Use a paginator so accounts with >100 RDS instances
-  # aren't silently truncated to the first page of describe_db_instances.
   try:
-    paginator = rds_client.get_paginator("describe_db_instances")
-    for page in paginator.paginate():
-      for instance in page["DBInstances"]:
-        if env_from_secret in instance["DBInstanceIdentifier"]:
-          db_info["host"] = instance["Endpoint"]["Address"]
-          db_info["port"] = instance["Endpoint"]["Port"]
-          db_info["instance_id"] = instance["DBInstanceIdentifier"]
-          db_info["engine"] = "postgres"
-          db_info["database"] = instance.get("DBName", "robosystems")
-          logger.info(f"Found RDS instance: {instance['DBInstanceIdentifier']}")
-          return db_info
-  except Exception as e:
-    logger.warning(f"Error checking RDS instances: {e!s}")
+    response = rds_client.describe_db_instances(DBInstanceIdentifier=instance_id)
+  except rds_client.exceptions.DBInstanceNotFoundFault:
+    raise ValueError(f"RDS instance {instance_id} not found") from None
 
-  raise ValueError(
-    f"Could not find database instance for environment: {env_from_secret}"
-  )
+  instance = response["DBInstances"][0]
+  logger.info(f"Found RDS instance: {instance['DBInstanceIdentifier']}")
+  return {
+    "host": instance["Endpoint"]["Address"],
+    "port": instance["Endpoint"]["Port"],
+    "database": instance.get("DBName", "robosystems"),
+    "instance_id": instance["DBInstanceIdentifier"],
+    "engine": "postgres",
+  }
 
 
 def create_new_password() -> str:

--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -195,7 +195,7 @@ Parameters are documented in each template — read the `Parameters:` block for 
 
 **Exports** (all carry an `{Env}` segment):
 - `{StackName}-{Env}-ValkeyEndpoint`, `-ValkeyPort`, `-ValkeyConfigEndpoint`
-- `{StackName}-{Env}-ValkeyUrl`, `-ValkeyUrlWithAuth`
+- `{StackName}-{Env}-ValkeyUrl` (no credentials — clients build the authenticated URL from the secret)
 - `{StackName}-{Env}-ValkeyClientSecurityGroupId` - attach this to clients
 - `{StackName}-{Env}-ValkeyAuthSecretArn`, `-ValkeyAuthSecretName`
 - plus engine/encryption/replication-group metadata exports

--- a/cloudformation/api.yaml
+++ b/cloudformation/api.yaml
@@ -1449,6 +1449,7 @@ Resources:
       FunctionName: !Ref ApiKeyRotationLambda
       Action: lambda:InvokeFunction
       Principal: secretsmanager.amazonaws.com
+      SourceAccount: !Ref AWS::AccountId
 
   # Rotation schedule — cadence managed by secrets-rotation.yml workflow;
   # high AutomaticallyAfterDays prevents SM from auto-triggering outside the workflow.

--- a/cloudformation/bastion.yaml
+++ b/cloudformation/bastion.yaml
@@ -120,18 +120,21 @@ Resources:
                 Condition:
                   StringEquals:
                     "ec2:ResourceTag/Component": "Bastion"
+              # Scoped to this environment's own secrets: the VPC is shared, so
+              # a bastion must not be a path to the other environment's
+              # database or cache credentials.
               - Effect: Allow
                 Action:
                   - secretsmanager:GetSecretValue
                 Resource:
-                  - !Sub "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:robosystems/*/postgres*"
-                  - !Sub "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:robosystems/*/valkey*"
+                  - !Sub "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:robosystems/${Environment}/postgres*"
+                  - !Sub "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:robosystems/${Environment}/valkey*"
               - Effect: Allow
                 Action:
                   - secretsmanager:DescribeSecret
                 Resource:
-                  - !Sub "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:robosystems/*/postgres*"
-                  - !Sub "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:robosystems/*/valkey*"
+                  - !Sub "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:robosystems/${Environment}/postgres*"
+                  - !Sub "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:robosystems/${Environment}/valkey*"
               # OpenSearch access for admin CLI (search queries, index stats).
               # ESHttpPost is required for _search and _count API calls.
               - Effect: Allow

--- a/cloudformation/bootstrap-oidc.yaml
+++ b/cloudformation/bootstrap-oidc.yaml
@@ -518,6 +518,56 @@ Resources:
   # =============================================================================
   # FRONTEND ROLE - Limited permissions for frontend app deployments
   # =============================================================================
+  # Ceiling for the IAM roles the frontend stacks create — the App Runner
+  # access and instance roles. The app templates set PermissionsBoundary on
+  # those roles to this policy (ARN exported below); the frontend deploy role
+  # may then create roles and attach policies only inside it, so a compromised
+  # frontend workflow cannot mint a privileged role within the name prefix it
+  # owns. The document is the union of what those roles legitimately hold:
+  # pull the app image, read the app's own secret, publish contact-form mail.
+  FrontendRoleBoundary:
+    Type: AWS::IAM::ManagedPolicy
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Retain
+    Properties:
+      ManagedPolicyName: !Sub ${ServiceTag}FrontendRoleBoundary
+      Description: Permissions ceiling for the App Runner roles created by the frontend stacks
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: ECRLogin
+            Effect: Allow
+            Action:
+              - ecr:GetAuthorizationToken
+            Resource: "*"
+          - Sid: PullAppImages
+            Effect: Allow
+            Action:
+              - ecr:BatchGetImage
+              - ecr:GetDownloadUrlForLayer
+              - ecr:BatchCheckLayerAvailability
+              - ecr:DescribeImages
+            Resource:
+              - !Sub arn:aws:ecr:*:${AWS::AccountId}:repository/robosystems-app*
+              - !Sub arn:aws:ecr:*:${AWS::AccountId}:repository/roboledger-app*
+              - !Sub arn:aws:ecr:*:${AWS::AccountId}:repository/roboinvestor-app*
+          # The apps read the environment's base secret (robosystems/<env>);
+          # the "<env>-" suffix form matches that secret's ARN and none of the
+          # component secrets under robosystems/<env>/....
+          - Sid: ReadAppSecret
+            Effect: Allow
+            Action:
+              - secretsmanager:GetSecretValue
+              - secretsmanager:DescribeSecret
+            Resource:
+              - !Sub arn:aws:secretsmanager:*:${AWS::AccountId}:secret:robosystems/prod-*
+              - !Sub arn:aws:secretsmanager:*:${AWS::AccountId}:secret:robosystems/staging-*
+          - Sid: ContactFormNotifications
+            Effect: Allow
+            Action:
+              - sns:Publish
+            Resource: !Sub arn:aws:sns:*:${AWS::AccountId}:*
+
   GitHubActionsFrontendRole:
     Type: AWS::IAM::Role
     DeletionPolicy: Delete
@@ -563,13 +613,25 @@ Resources:
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
-              # CloudFormation - for deploying frontend stacks
-              - Sid: CloudFormation
+              # CloudFormation - mutations are pinned to the frontend stacks
+              # (RoboSystemsApp*, RoboLedgerApp*, RoboInvestorApp*,
+              # RoboSystemsHolonViewer*, each with its S3 sibling). Reads stay
+              # account-wide: the deploy workflows describe their own stacks
+              # by name and the calls carry no resource ARN.
+              - Sid: CloudFormationWrite
                 Effect: Allow
                 Action:
                   - cloudformation:CreateStack
                   - cloudformation:UpdateStack
                   - cloudformation:DeleteStack
+                Resource:
+                  - !Sub arn:aws:cloudformation:*:${AWS::AccountId}:stack/RoboSystemsApp*/*
+                  - !Sub arn:aws:cloudformation:*:${AWS::AccountId}:stack/RoboLedgerApp*/*
+                  - !Sub arn:aws:cloudformation:*:${AWS::AccountId}:stack/RoboInvestorApp*/*
+                  - !Sub arn:aws:cloudformation:*:${AWS::AccountId}:stack/RoboSystemsHolonViewer*/*
+              - Sid: CloudFormationRead
+                Effect: Allow
+                Action:
                   - cloudformation:DescribeStacks
                   - cloudformation:DescribeStackEvents
                   - cloudformation:DescribeStackResources
@@ -602,45 +664,6 @@ Resources:
                   - ecr:GetAuthorizationToken
                 Resource: "*"
 
-              # ECS - for container deployments (including cluster management)
-              - Sid: ECS
-                Effect: Allow
-                Action:
-                  - ecs:CreateCluster
-                  - ecs:DeleteCluster
-                  - ecs:DescribeClusters
-                  - ecs:ListClusters
-                  - ecs:UpdateClusterSettings
-                  - ecs:CreateService
-                  - ecs:UpdateService
-                  - ecs:DeleteService
-                  - ecs:DescribeServices
-                  - ecs:DescribeTasks
-                  - ecs:DescribeTaskDefinition
-                  - ecs:RegisterTaskDefinition
-                  - ecs:DeregisterTaskDefinition
-                  - ecs:ListServices
-                  - ecs:ListTasks
-                  - ecs:ListTaskDefinitions
-                  - ecs:TagResource
-                  - ecs:UntagResource
-                  - ecs:ListTagsForResource
-                Resource: "*"
-
-              # ELB - for load balancers
-              - Sid: ELB
-                Effect: Allow
-                Action:
-                  - elasticloadbalancing:*
-                Resource: "*"
-
-              # Auto Scaling - for ECS auto scaling
-              - Sid: AutoScaling
-                Effect: Allow
-                Action:
-                  - application-autoscaling:*
-                Resource: "*"
-
               # S3 - scoped to frontend app buckets
               - Sid: S3
                 Effect: Allow
@@ -662,31 +685,16 @@ Resources:
                   - s3:GetBucketLocation
                 Resource: "*"
 
-              # Secrets Manager - read-only for app secrets
-              - Sid: SecretsManager
+              # Secrets Manager - the deploy workflows resolve the app secret's
+              # ARN by name and hand it to the stack; its value is read at
+              # runtime by the App Runner instance role, never by the deploy
+              # identity. Metadata only, no GetSecretValue.
+              - Sid: SecretsManagerDescribe
                 Effect: Allow
                 Action:
-                  - secretsmanager:GetSecretValue
                   - secretsmanager:DescribeSecret
                 Resource:
                   - !Sub arn:aws:secretsmanager:*:${AWS::AccountId}:secret:robosystems/*
-
-              # CloudWatch Logs
-              - Sid: CloudWatchLogs
-                Effect: Allow
-                Action:
-                  - logs:CreateLogGroup
-                  - logs:DeleteLogGroup
-                  - logs:CreateLogStream
-                  - logs:PutLogEvents
-                  - logs:DescribeLogGroups
-                  - logs:DescribeLogStreams
-                  - logs:TagLogGroup
-                  - logs:UntagLogGroup
-                  - logs:PutRetentionPolicy
-                  - logs:DeleteRetentionPolicy
-                  - logs:ListTagsLogGroup
-                Resource: "*"
 
               # Route53 - for DNS
               - Sid: Route53
@@ -742,11 +750,13 @@ Resources:
               # (robosystems-app-*, roboledger-*, roboinvestor-*), so a
               # compromised frontend workflow cannot attach policies to, or pass,
               # backend/deploy/SSO roles. Reads stay broad; PassRole is
-              # additionally constrained by iam:PassedToService. NOTE: role-name
-              # prefixing alone does not stop creating a NEW admin role within the
-              # prefix — full closure requires a permissions boundary on
-              # iam:CreateRole (tracked for a follow-up; needs the app templates
-              # to set PermissionsBoundary on the roles they create).
+              # additionally constrained by iam:PassedToService. Role-name
+              # prefixing alone does not stop creating a NEW privileged role
+              # within the prefix — that is what FrontendRoleBoundary is for.
+              # Once every app template sets PermissionsBoundary on its roles,
+              # add the iam:PermissionsBoundary condition to this statement so
+              # CreateRole/AttachRolePolicy/PutRolePolicy only succeed inside
+              # the boundary.
               - Sid: IAMRoleManagement
                 Effect: Allow
                 Action:
@@ -789,55 +799,35 @@ Resources:
                     "iam:PassedToService":
                       - build.apprunner.amazonaws.com
                       - tasks.apprunner.amazonaws.com
-                      - ecs-tasks.amazonaws.com
+              # Setting the boundary is allowed only to this one policy, so the
+              # frontend role can install the ceiling but never swap it for a
+              # looser one. Removing it (DeleteRolePermissionsBoundary) is not
+              # granted at all.
+              - Sid: IAMRoleBoundary
+                Effect: Allow
+                Action:
+                  - iam:PutRolePermissionsBoundary
+                Resource:
+                  - !Sub arn:aws:iam::${AWS::AccountId}:role/robosystems-app-*-apprunner-*
+                  - !Sub arn:aws:iam::${AWS::AccountId}:role/roboledger-*-apprunner-*
+                  - !Sub arn:aws:iam::${AWS::AccountId}:role/roboinvestor-*-apprunner-*
+                Condition:
+                  StringEquals:
+                    "iam:PermissionsBoundary": !Ref FrontendRoleBoundary
               - Sid: IAMServiceLinkedRole
                 Effect: Allow
                 Action:
                   - iam:CreateServiceLinkedRole
-                Resource: "*"
-
-              # EC2 - read-only for VPC/subnet info
-              - Sid: EC2ReadOnly
-                Effect: Allow
-                Action:
-                  - ec2:DescribeVpcs
-                  - ec2:DescribeSubnets
-                  - ec2:DescribeSecurityGroups
-                  - ec2:DescribeNetworkInterfaces
-                  - ec2:DescribeManagedPrefixLists
-                Resource: "*"
-
-              # EC2 Security Groups - create/manage for ECS tasks
-              - Sid: EC2SecurityGroups
-                Effect: Allow
-                Action:
-                  - ec2:CreateSecurityGroup
-                  - ec2:DeleteSecurityGroup
-                  - ec2:AuthorizeSecurityGroupIngress
-                  - ec2:AuthorizeSecurityGroupEgress
-                  - ec2:RevokeSecurityGroupIngress
-                  - ec2:RevokeSecurityGroupEgress
-                  - ec2:CreateTags
-                  - ec2:DeleteTags
-                Resource: "*"
+                Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/apprunner.amazonaws.com/*
+                Condition:
+                  StringEquals:
+                    "iam:AWSServiceName": apprunner.amazonaws.com
 
               # STS - for identity
               - Sid: STS
                 Effect: Allow
                 Action:
                   - sts:GetCallerIdentity
-                Resource: "*"
-
-              # CloudWatch - for alarms
-              - Sid: CloudWatch
-                Effect: Allow
-                Action:
-                  - cloudwatch:PutMetricAlarm
-                  - cloudwatch:DeleteAlarms
-                  - cloudwatch:DescribeAlarms
-                  - cloudwatch:TagResource
-                  - cloudwatch:UntagResource
-                  - cloudwatch:ListTagsForResource
                 Resource: "*"
 
               # App Runner - for serverless container deployments
@@ -857,36 +847,6 @@ Resources:
                   - apprunner:TagResource
                   - apprunner:UntagResource
                   - apprunner:ListTagsForResource
-                Resource: "*"
-
-              # Lambda - for CloudFront edge functions
-              - Sid: Lambda
-                Effect: Allow
-                Action:
-                  - lambda:CreateFunction
-                  - lambda:DeleteFunction
-                  - lambda:GetFunction
-                  - lambda:GetFunctionConfiguration
-                  - lambda:UpdateFunctionCode
-                  - lambda:UpdateFunctionConfiguration
-                  - lambda:PublishVersion
-                  - lambda:CreateAlias
-                  - lambda:UpdateAlias
-                  - lambda:DeleteAlias
-                  - lambda:AddPermission
-                  - lambda:RemovePermission
-                  - lambda:InvokeFunction
-                  - lambda:TagResource
-                  - lambda:UntagResource
-                  - lambda:ListTags
-                  - lambda:EnableReplication
-                Resource:
-                  - !Sub arn:aws:lambda:*:${AWS::AccountId}:function:*-WwwRedirect*
-                  - !Sub arn:aws:lambda:*:${AWS::AccountId}:function:*-www-redirect*
-              - Sid: LambdaGlobal
-                Effect: Allow
-                Action:
-                  - lambda:ListFunctions
                 Resource: "*"
       Tags:
         - Key: Name
@@ -1071,6 +1031,12 @@ Outputs:
     Value: !Ref GitHubActionsFrontendRole
     Export:
       Name: !Sub ${AWS::StackName}-GitHubActionsFrontendRoleName
+
+  FrontendRoleBoundaryArn:
+    Description: Permissions boundary the frontend stacks set on the App Runner roles they create
+    Value: !Ref FrontendRoleBoundary
+    Export:
+      Name: !Sub ${AWS::StackName}-FrontendRoleBoundaryArn
 
   WorkflowExample:
     Description: Example workflow configuration for GitHub Actions

--- a/cloudformation/bootstrap-oidc.yaml
+++ b/cloudformation/bootstrap-oidc.yaml
@@ -562,11 +562,15 @@ Resources:
             Resource:
               - !Sub arn:aws:secretsmanager:*:${AWS::AccountId}:secret:robosystems/prod-*
               - !Sub arn:aws:secretsmanager:*:${AWS::AccountId}:secret:robosystems/staging-*
+          # Each app names its topic <app>-<env>-contact-form.
           - Sid: ContactFormNotifications
             Effect: Allow
             Action:
               - sns:Publish
-            Resource: !Sub arn:aws:sns:*:${AWS::AccountId}:*
+            Resource:
+              - !Sub arn:aws:sns:*:${AWS::AccountId}:robosystems-app-*
+              - !Sub arn:aws:sns:*:${AWS::AccountId}:roboledger-app-*
+              - !Sub arn:aws:sns:*:${AWS::AccountId}:roboinvestor-app-*
 
   GitHubActionsFrontendRole:
     Type: AWS::IAM::Role

--- a/cloudformation/graph-infra.yaml
+++ b/cloudformation/graph-infra.yaml
@@ -484,6 +484,7 @@ Resources:
       FunctionName: !Ref SecretRotationLambda
       Action: lambda:InvokeFunction
       Principal: secretsmanager.amazonaws.com
+      SourceAccount: !Ref AWS::AccountId
 
   # ===== Monitoring Infrastructure =====
   # SNS Topic for Infrastructure Alerts

--- a/cloudformation/postgres.yaml
+++ b/cloudformation/postgres.yaml
@@ -15,6 +15,12 @@ Parameters:
   VpcId:
     Type: AWS::EC2::VPC::Id
     Description: VPC ID
+  VpcCidr:
+    Type: String
+    Description: VPC CIDR block admitted to the database port (the VPC stack's VpcCidr output)
+    Default: 10.0.0.0/16
+    AllowedPattern: ^\d{1,3}(\.\d{1,3}){3}/\d{1,2}$
+    ConstraintDescription: Must be an IPv4 CIDR block
   SubnetId1:
     Type: AWS::EC2::Subnet::Id
     Description: First subnet ID for RDS multi-AZ deployment
@@ -295,6 +301,7 @@ Resources:
         Variables:
           SECRETS_MANAGER_ENDPOINT: !Sub https://secretsmanager.${AWS::Region}.amazonaws.com
           ENVIRONMENT: !Ref Environment
+          DB_INSTANCE_IDENTIFIER: !Sub ${DBInstanceName}-${Environment}
       Code:
         ImageUri: !Ref LambdaImageUri
       ImageConfig:
@@ -386,6 +393,7 @@ Resources:
       FunctionName: !GetAtt PostgresSecretRotationLambda.Arn
       Action: lambda:InvokeFunction
       Principal: secretsmanager.amazonaws.com
+      SourceAccount: !Ref AWS::AccountId
 
   # Rotation Schedule - links Lambda to secret and enables on-demand rotation
   # Actual rotation timing is managed via GitHub Actions (secrets-rotation.yml)
@@ -522,7 +530,11 @@ Resources:
         - IpProtocol: tcp
           FromPort: 5432
           ToPort: 5432
-          CidrIp: 10.0.0.0/16 # Restrict to VPC CIDR only
+          # Whole-VPC admission. Dagster and the worker already attach this
+          # security group to their tasks; once the API service, the bastion,
+          # and the graph instances do too, this rule becomes a
+          # self-referencing SourceSecurityGroupId and the CIDR goes away.
+          CidrIp: !Ref VpcCidr
       Tags:
         - Key: Name
           Value: !Sub sg-postgres-${Environment}

--- a/cloudformation/valkey.yaml
+++ b/cloudformation/valkey.yaml
@@ -409,6 +409,7 @@ Resources:
       FunctionName: !GetAtt ValkeySecretRotationLambda.Arn
       Action: lambda:InvokeFunction
       Principal: secretsmanager.amazonaws.com
+      SourceAccount: !Ref AWS::AccountId
 
   # Rotation Schedule - links Lambda to secret and enables on-demand rotation
   # Actual rotation timing is managed via GitHub Actions (secrets-rotation.yml)
@@ -586,16 +587,6 @@ Outputs:
       - !Sub "redis://${ValkeyReplicationGroup.PrimaryEndPoint.Address}:${ValkeyReplicationGroup.PrimaryEndPoint.Port}"
     Export:
       Name: !Sub "${AWS::StackName}-${Environment}-ValkeyUrl"
-
-  ValkeyUrlWithAuth:
-    Description: Full Redis URL for Valkey ElastiCache with authentication
-    Value: !Sub
-      - "rediss://default:${AuthToken}@${Address}:${Port}"
-      - AuthToken: !Sub "{{resolve:secretsmanager:${ValkeyAuthSecret}:SecretString:VALKEY_AUTH_TOKEN}}"
-        Address: !GetAtt ValkeyReplicationGroup.PrimaryEndPoint.Address
-        Port: !GetAtt ValkeyReplicationGroup.PrimaryEndPoint.Port
-    Export:
-      Name: !Sub "${AWS::StackName}-${Environment}-ValkeyUrlWithAuth"
 
   ValkeyConfigurationEndpoint:
     Condition: IsMultiNode

--- a/cloudformation/worker.yaml
+++ b/cloudformation/worker.yaml
@@ -25,6 +25,13 @@ Parameters:
     Description: Security group ID from Dagster stack (VPC-internal access)
     AllowedPattern: ^sg-[0-9a-f]+$
 
+  # Graph Volumes Stack Reference (cross-stack)
+  GraphVolumesStackName:
+    Type: String
+    Description: Stack name of this environment's graph-volumes stack, which owns the volume-manager Lambda
+    Default: RoboSystemsGraphVolumesProd
+    AllowedPattern: ^[A-Za-z][A-Za-z0-9-]*$
+
   # Container & Application Configuration
   ECRRepositoryUrl:
     Type: String
@@ -271,12 +278,14 @@ Resources:
                 Resource:
                   - !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/robosystems-graph-${Environment}-*"
                   - !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/robosystems-graph-${Environment}-*/index/*"
-              # Lambda invocation (Volume Manager for tier upgrades)
+              # Lambda invocation (Volume Manager for tier upgrades) — this
+              # environment's function only; the stack name carries the
+              # environment, a wildcard would not.
               - Effect: Allow
                 Action:
                   - lambda:InvokeFunction
                 Resource:
-                  - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:RoboSystemsGraphVolumes*-volume-manager"
+                  - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${GraphVolumesStackName}-volume-manager"
               # Auto Scaling (graph instance allocation, tier upgrades)
               - Effect: Allow
                 Action:

--- a/tests/lambda/conftest.py
+++ b/tests/lambda/conftest.py
@@ -104,3 +104,24 @@ def gvmon(aws):
 def gcr(aws):
   """graph_container_refresh module under mock_aws."""
   yield _import_lambda("graph_container_refresh")
+
+
+@pytest.fixture
+def pgrot(aws_env, monkeypatch):
+  """postgres_rotation module under mock_aws, with two RDS instances: the one
+  the function is bound to, and a decoy whose identifier also contains the
+  environment name (what a substring search would have matched first)."""
+  monkeypatch.setenv("ENVIRONMENT", "prod")
+  monkeypatch.setenv("DB_INSTANCE_IDENTIFIER", "robosystems-prod")
+  with mock_aws():
+    rds = boto3.client("rds", region_name="us-east-1")
+    for identifier in ("robosystems-prod-restore", "robosystems-prod"):
+      rds.create_db_instance(
+        DBInstanceIdentifier=identifier,
+        DBInstanceClass="db.t4g.micro",
+        Engine="postgres",
+        MasterUsername="postgres",
+        MasterUserPassword="irrelevant",
+        DBName="robosystems",
+      )
+    yield _import_lambda("postgres_rotation")

--- a/tests/lambda/test_postgres_rotation.py
+++ b/tests/lambda/test_postgres_rotation.py
@@ -1,0 +1,39 @@
+"""Tests for the PostgreSQL rotation Lambda's instance resolution."""
+
+import pytest
+
+SECRET_ARN = "arn:aws:secretsmanager:us-east-1:123456789012:secret:robosystems/prod/postgres-AbCdEf"
+
+
+@pytest.mark.unit
+def test_resolves_instance_by_exact_identifier(pgrot):
+  info = pgrot.get_database_connection_info(SECRET_ARN, "prod")
+
+  assert info["instance_id"] == "robosystems-prod"
+  assert info["database"] == "robosystems"
+  assert info["port"] == 5432
+  assert info["host"]
+
+
+@pytest.mark.unit
+def test_refuses_secret_from_another_environment(pgrot):
+  staging_arn = SECRET_ARN.replace("/prod/", "/staging/")
+
+  with pytest.raises(ValueError, match="does not match"):
+    pgrot.get_database_connection_info(staging_arn, "prod")
+
+
+@pytest.mark.unit
+def test_missing_instance_is_an_error(pgrot, monkeypatch):
+  monkeypatch.setenv("DB_INSTANCE_IDENTIFIER", "robosystems-missing")
+
+  with pytest.raises(ValueError, match="robosystems-missing"):
+    pgrot.get_database_connection_info(SECRET_ARN, "prod")
+
+
+@pytest.mark.unit
+def test_unset_identifier_is_an_error(pgrot, monkeypatch):
+  monkeypatch.delenv("DB_INSTANCE_IDENTIFIER")
+
+  with pytest.raises(ValueError, match="DB_INSTANCE_IDENTIFIER"):
+    pgrot.get_database_connection_info(SECRET_ARN, "prod")


### PR DESCRIPTION
## Summary

Narrows several deploy-time and instance identities to the resources they actually operate on, and binds the production deploy pipeline to the `production` GitHub environment so its protection rules gate the run. Design notes and the residual list live in `local/RoboSystems/specs/security/deploy-identity-boundary.md`.

## Changes

- `cloudformation/bootstrap-oidc.yaml` — frontend deploy role: CloudFormation mutations pinned to the frontend stacks; Secrets Manager access reduced to what the deploy workflows call; statements for services the frontend stacks never create (ECS, ELB, application-autoscaling, EC2 security groups, Lambda, Logs, CloudWatch alarms) removed; `ecs-tasks` dropped from the PassRole condition; service-linked-role creation scoped to App Runner. New `FrontendRoleBoundary` managed policy (ARN exported) with `iam:PutRolePermissionsBoundary` conditioned to it — the enabling step for a permissions boundary on the App Runner roles the app stacks create.
- `cloudformation/bastion.yaml` — bastion secret reads scoped to its own environment.
- `cloudformation/postgres.yaml` — `VpcCidr` parameter replaces the CIDR literal on the database security group; rotation Lambda receives `DB_INSTANCE_IDENTIFIER`; invoke permission carries `SourceAccount`.
- `cloudformation/valkey.yaml` — `ValkeyUrlWithAuth` output/export removed (no importers; `ValkeyUrl` is what the services consume); `SourceAccount` on the rotation permission.
- `cloudformation/api.yaml`, `cloudformation/graph-infra.yaml` — `SourceAccount` on the rotation-Lambda invoke permissions.
- `cloudformation/worker.yaml` — `GraphVolumesStackName` parameter; the volume-manager invoke is pinned to this environment's function.
- Workflows — `deploy-vpc.yml` exports `vpc_cidr`; `deploy-postgres.yml` takes `vpc_cidr`; `deploy-dagster.yml` takes `graph_volumes_stack_name` (required); `prod.yml`/`staging.yml` pass both from existing outputs. `prod.yml`'s `create-deployment` job, which every `deploy-*` job fans in through, now declares `environment: production`.
- `bin/lambda/postgres_rotation.py` — resolves the RDS instance by exact identifier instead of scanning the account, and refuses a secret whose environment segment differs from the function's. `tests/lambda/test_postgres_rotation.py` covers the decoy-instance, mismatched-environment, missing-instance, and unset-identifier cases; `tests/lambda/conftest.py` gains the `pgrot` fixture.
- `cloudformation/README.md` — export list updated.

## Breaking Changes

None to the API or the SDKs. Operational notes: `bootstrap-oidc.yaml` is owner-deployed (`just bootstrap`) and should be re-applied after merge; the `production` GitHub environment needs its protection rules set (required reviewer, deployment branches) for the new gate to have effect. The `FrontendRoleBoundary` condition on `iam:CreateRole`/`AttachRolePolicy`/`PutRolePolicy` is deliberately not enabled here — it lands once the three app templates set `PermissionsBoundary` on their roles.

## Testing

- `just test-code` (ruff, format, basedpyright, cf-lint) — passed.
- `tests/lambda` — 89 passed, including the 4 new tests.
- `just lint-actions` — clean.
- `just test-all` unit suite — not run; the only Python change is the Lambda module, which is covered above.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
