### PR TITLE
docs(release): note the deploy-identity hardening in v1.11.0

### DIFF
--- a/.github/release-notes/v1.11.0.md
+++ b/.github/release-notes/v1.11.0.md
@@ -117,6 +117,11 @@ MCP gateway and Cursor (dynamic registration).
 
 - The test suite runs in parallel with `pytest-xdist` — the full non-slow
   suite in about two minutes on 14 cores, against twelve-plus serial (#1262).
+- Deploy-identity hardening: the frontend deploy role, the bastion instance
+  role, the worker's cross-stack grants and the rotation Lambdas' invoke
+  permissions are each pinned to the resources they operate on, and the
+  production deploy pipeline binds the `production` GitHub environment so
+  its protection rules gate the run (#1277).
 
 ## Deploying this release
 
@@ -126,8 +131,16 @@ MCP gateway and Cursor (dynamic registration).
   build if duplicate live `(resource_type, resource_id, user_id)` rows exist,
   and the daemon's fail-closed boot will then refuse to start — run the check
   in the migration's comment against each environment first.
-- **One stack update** rides the deploy: `graph-volumes` gains the
-  `SharedMasterVolumeCreated` alarm.
+- **Stack updates** ride the deploy: `graph-volumes` gains the
+  `SharedMasterVolumeCreated` alarm; `postgres`, `valkey`, `api`,
+  `graph-infra`, `bastion` and `worker` carry the identity hardening
+  (#1277). The `postgres` stack takes a new `VpcCidr` parameter and the
+  worker stack a `GraphVolumesStackName` parameter, both supplied by the
+  workflows.
+- **Owner steps**, outside the workflow: re-run `just bootstrap` to apply
+  the updated OIDC stack, then set the `production` GitHub environment's
+  protection rules — a required reviewer and deployment branches `main`,
+  `release/*` and `v*` — for the new gate to take effect.
 - `MCP_OAUTH_ENABLED` gates the whole OAuth surface; off, it answers 404.
 - **SDKs**: `robosystems-client` and `@robosystems/client` 1.12.0 are
   generated from this API line and are published.


### PR DESCRIPTION
## Summary

Adds the deploy-identity hardening (#1277) to the curated v1.11.0 release notes: one line under Infrastructure, and the extra stack updates plus the two owner steps under "Deploying this release". #1276 merged before this landed on its branch, so it rides separately; it must be on `main` before `create-release.yml` is dispatched.

## Changes

- `.github/release-notes/v1.11.0.md` — Infrastructure bullet for #1277; "Deploying this release" now lists the six additional stacks, the two new stack parameters the workflows supply, and the owner steps (`just bootstrap` re-run; `production` environment protection rules).

## Breaking Changes

None.

## Testing

Documentation only; pre-commit hooks passed.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
