### PR TITLE
docs(release): the v1.11.0 migrations already shipped in 1.10.1 and 1.10.2

### DIFF
--- a/.github/release-notes/v1.11.0.md
+++ b/.github/release-notes/v1.11.0.md
@@ -125,12 +125,15 @@ MCP gateway and Cursor (dynamic registration).
 
 ## Deploying this release
 
-- **Two platform migrations**: `39c73ea18599` (the `oauth_clients`,
-  `oauth_grants` and `oauth_tokens` tables) and `8c8e469f4a0a` (a partial
-  unique index over live `billing_subscriptions` rows). The second fails to
-  build if duplicate live `(resource_type, resource_id, user_id)` rows exist,
-  and the daemon's fail-closed boot will then refuse to start — run the check
-  in the migration's comment against each environment first.
+- **Migrations**: the series carries two platform migrations —
+  `8c8e469f4a0a` (a partial unique index over live `billing_subscriptions`
+  rows, shipped in 1.10.1) and `39c73ea18599` (the `oauth_clients`,
+  `oauth_grants` and `oauth_tokens` tables, 1.10.2) — both already applied
+  wherever those patches were deployed, so an environment tracking the
+  patch line has nothing pending. A fresh environment applies both at boot;
+  the index fails to build if duplicate live `(resource_type, resource_id,
+  user_id)` rows exist, and the daemon's fail-closed boot then refuses to
+  start — run the check in the migration's comment first.
 - **Stack updates** ride the deploy: `graph-volumes` gains the
   `SharedMasterVolumeCreated` alarm; `postgres`, `valkey`, `api`,
   `graph-infra`, `bastion` and `worker` carry the identity hardening


### PR DESCRIPTION
## Summary

Corrects the "Deploying this release" migrations bullet in the v1.11.0 notes. Both platform migrations of the series shipped in patch releases (`8c8e469f4a0a` in 1.10.1, `39c73ea18599` in 1.10.2) and are applied on any environment tracking the patch line — verified against production's `alembic_version` and the live index — so the bullet no longer reads as a v1.11.0 deploy step while keeping the fresh-environment guidance. Must be on `main` before `create-release.yml` is dispatched.

## Changes

- `.github/release-notes/v1.11.0.md` — migrations bullet reworded.

## Breaking Changes

None.

## Testing

Documentation only; pre-commit hooks passed.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
