### PR TITLE
chore(ci): build the production image behind the deployment approval gate

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -139,7 +139,7 @@ jobs:
     secrets: inherit
 
   build:
-    needs: [runner]
+    needs: [runner, create-deployment]
     uses: ./.github/workflows/build.yml
     with:
       environment: ${{ vars.ENVIRONMENT_PROD || 'prod' }}
@@ -154,11 +154,13 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   create-deployment:
-    needs: [runner, test, build, stack-config]
+    needs: [runner, test, stack-config]
     runs-on: ${{ fromJSON(needs.runner.outputs.runner_config) }}
     # Every deploy-* job fans in through this one, so the production
     # environment's protection rules (required reviewer, deployment branches)
-    # gate the whole run here, once.
+    # gate the whole run here, once. The image build sits behind it too:
+    # nothing reaches ECR or Docker Hub for a run that was never approved.
+    # Tests and the stack config run before the pause.
     environment: production
     outputs:
       deployment_id: ${{ steps.deployment.outputs.deployment_id }}


### PR DESCRIPTION
## Summary

Moves the production image build behind the deployment approval gate. Until now `build` ran in parallel with the tests, ahead of `create-deployment`, so the ECR push — and the Docker Hub publish it carries on tag/release refs — happened before anyone approved the run. Now nothing reaches a registry for a run that was never approved.

## Changes

- `.github/workflows/prod.yml` — `create-deployment` no longer needs `build`; `build` now needs `create-deployment`. Tests and `stack-config` still run before the pause, and every deploy job still fans in through `create-deployment` (the four that reach the tests only through it are unaffected). The jobs that consume `build` outputs already list `build` in their `needs`, so nothing else changes.
- The comment on `create-deployment` describes the new order.

Cost: the build (~8 min) no longer overlaps the tests (~11 min), so a prod release takes about that much longer wall-clock, and the approval prompt arrives after the tests rather than after the build. Staging is unaffected — it passes `publish_to_dockerhub: false` and has no gate.

## Breaking Changes

None.

## Testing

- `actionlint -shellcheck= .github/workflows/prod.yml` — clean (the only findings with shellcheck on are pre-existing `SC2086`/`SC2129` notes in `run:` blocks this PR does not touch)
- Job graph checked by hand: acyclic; `create-deployment` consumes no `build` outputs; every `needs.build.outputs.*` consumer already lists `build` in `needs`
- Not exercisable in-session; the next production release is the first real run

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
