### PR TITLE
fix(security): last-4 tax IDs in the graph, email tokens by reference

### DIFF
--- a/robosystems/config/defaults.py
+++ b/robosystems/config/defaults.py
@@ -73,6 +73,7 @@ class CacheDefaults:
   # Authentication cache TTLs
   JWT_TTL = 1800  # 30 minutes for JWT validation cache
   API_KEY_TTL = SHORT  # 5 minutes for API key validation
+  EMAIL_TOKEN_REF_TTL = 900  # 15 minutes for a queued email's parked token
 
   # Graph/Schema cache TTLs
   SCHEMA_TTL = SHORT  # 5 minutes for schema/config cache

--- a/robosystems/dagster/jobs/notifications.py
+++ b/robosystems/dagster/jobs/notifications.py
@@ -1,5 +1,8 @@
 """Dagster jobs for notification operations (email, SMS, push)."""
 
+import secrets
+from typing import Any
+
 from dagster import (
   Backoff,
   Config,
@@ -9,6 +12,7 @@ from dagster import (
   op,
 )
 
+from robosystems.config.defaults import CacheDefaults
 from robosystems.logger import get_logger
 
 logger = get_logger(__name__)
@@ -22,7 +26,12 @@ class SendEmailConfig(Config):
   )
   to_email: str
   user_name: str
-  token: str | None = None  # For verification/reset/invitation emails
+  # Opaque reference to the raw verification/reset/invitation token, which
+  # is parked in Valkey for CacheDefaults.EMAIL_TOKEN_REF_TTL. The raw token
+  # never enters run config: Dagster persists run config indefinitely in run
+  # storage and renders it in its UI, while the platform DB deliberately
+  # holds only the token's hash.
+  token_ref: str | None = None
   app: str = "roboledger"
   operation_id: str | None = None  # For SSE tracking
   org_name: str | None = None  # For org_invitation emails
@@ -58,6 +67,32 @@ class EmailResult:
     }
 
 
+_EMAIL_TOKEN_KEY_PREFIX = "email_token:"
+
+
+def _token_store() -> Any:
+  from robosystems.config.valkey_registry import ValkeyDatabase, create_redis_client
+
+  return create_redis_client(ValkeyDatabase.AUTH)
+
+
+def _stash_email_token(token: str) -> str:
+  """Park a raw email token in Valkey; return the reference to carry in run config."""
+  ref = secrets.token_urlsafe(32)
+  _token_store().setex(
+    f"{_EMAIL_TOKEN_KEY_PREFIX}{ref}", CacheDefaults.EMAIL_TOKEN_REF_TTL, token
+  )
+  return ref
+
+
+def _fetch_email_token(ref: str) -> str | None:
+  return _token_store().get(f"{_EMAIL_TOKEN_KEY_PREFIX}{ref}") or None
+
+
+def _discard_email_token(ref: str) -> None:
+  _token_store().delete(f"{_EMAIL_TOKEN_KEY_PREFIX}{ref}")
+
+
 @op(
   retry_policy=RetryPolicy(
     max_retries=3,
@@ -70,7 +105,9 @@ def send_email_op(context: OpExecutionContext, config: SendEmailConfig) -> dict:
   """Send an email via SES.
 
   Token requirements by email_type:
-  - email_verification, password_reset, org_invitation: token required
+  - email_verification, password_reset, org_invitation: token_ref required,
+    and it must still resolve (the parked token expires after
+    CacheDefaults.EMAIL_TOKEN_REF_TTL and is discarded once sent)
   - org_invitation: org_name also required
   - welcome: no token
 
@@ -85,27 +122,37 @@ def send_email_op(context: OpExecutionContext, config: SendEmailConfig) -> dict:
     f"Sending {config.email_type} email to {config.to_email} for app {config.app}"
   )
 
+  token: str | None = None
+  if config.token_ref:
+    token = _fetch_email_token(config.token_ref)
+    if not token:
+      # Expired or already sent. The caller must issue a fresh token; a
+      # re-execution from the Dagster UI must not be able to resend one.
+      raise ValueError(
+        f"Token reference for {config.email_type} has expired or was already used"
+      )
+
   loop = asyncio.new_event_loop()
   try:
     if config.email_type == "email_verification":
-      if not config.token:
+      if not token:
         raise ValueError("Token required for email_verification")
       success = loop.run_until_complete(
         ses_service.send_verification_email(
           user_email=config.to_email,
           user_name=config.user_name,
-          token=config.token,
+          token=token,
           app=config.app,
         )
       )
     elif config.email_type == "password_reset":
-      if not config.token:
+      if not token:
         raise ValueError("Token required for password_reset")
       success = loop.run_until_complete(
         ses_service.send_password_reset_email(
           user_email=config.to_email,
           user_name=config.user_name,
-          token=config.token,
+          token=token,
           app=config.app,
         )
       )
@@ -118,7 +165,7 @@ def send_email_op(context: OpExecutionContext, config: SendEmailConfig) -> dict:
         )
       )
     elif config.email_type == "org_invitation":
-      if not config.token:
+      if not token:
         raise ValueError("Token required for org_invitation")
       if not config.org_name:
         raise ValueError("org_name required for org_invitation")
@@ -127,7 +174,7 @@ def send_email_op(context: OpExecutionContext, config: SendEmailConfig) -> dict:
           user_email=config.to_email,
           inviter_name=config.inviter_name or "A teammate",
           org_name=config.org_name,
-          token=config.token,
+          token=token,
           app=config.app,
         )
       )
@@ -171,6 +218,14 @@ def send_email_op(context: OpExecutionContext, config: SendEmailConfig) -> dict:
     # Raise to trigger retry
     raise RuntimeError(f"Failed to send {config.email_type} email to {config.to_email}")
 
+  if config.token_ref:
+    # Best-effort: the TTL is the backstop, and raising here would retry
+    # the op and send the email twice.
+    try:
+      _discard_email_token(config.token_ref)
+    except Exception as e:
+      context.log.warning(f"Could not discard token reference after send: {e}")
+
   if config.operation_id:
     _emit_email_result_to_sse(context, config.operation_id, result.to_dict())
 
@@ -204,15 +259,15 @@ def send_email_job():
   """Send an email via SES, with 3 retries at exponential backoff.
 
   Usage:
-    from robosystems.middleware.sse import run_and_monitor_dagster_job, build_notification_job_config
+    from robosystems.middleware.sse import run_and_monitor_dagster_job, build_email_job_config
 
-    # Queue email send with SSE monitoring
+    # Queue email send with SSE monitoring. The raw token is parked in
+    # Valkey by build_email_job_config; run config carries a reference.
     background_tasks.add_task(
       run_and_monitor_dagster_job,
       job_name="send_email_job",
       operation_id=operation_id,
-      run_config=build_notification_job_config(
-        "send_email_job",
+      run_config=build_email_job_config(
         email_type="email_verification",
         to_email="user@example.com",
         user_name="John",
@@ -242,7 +297,9 @@ def build_email_job_config(
 
   Args:
     email_type: email_verification, password_reset, welcome, or org_invitation
-    token: Verification/reset/invitation token (required for all but welcome)
+    token: Raw verification/reset/invitation token (required for all but
+      welcome). Parked in Valkey for CacheDefaults.EMAIL_TOKEN_REF_TTL; the
+      run config carries only an opaque reference to it.
     app: App identifier (roboledger, roboinvestor, robosystems)
     operation_id: SSE operation ID for progress tracking
     org_name: Organization name (required for org_invitation)
@@ -257,7 +314,7 @@ def build_email_job_config(
   }
 
   if token:
-    config["token"] = token
+    config["token_ref"] = _stash_email_token(token)
 
   if operation_id:
     config["operation_id"] = operation_id

--- a/robosystems/operations/extensions/materialize.py
+++ b/robosystems/operations/extensions/materialize.py
@@ -518,7 +518,10 @@ def _staging_sql(graph_id: str, entity_id: str, connstr: str) -> dict[str, str]:
       agent_type,
       name,
       legal_name,
-      tax_id,
+      -- Counterparty tax IDs reach the graph as last-4 only (Entity.tax_id
+      -- is the filer's public EIN and stays verbatim).
+      CASE WHEN coalesce(tax_id, '') = '' THEN NULL
+           ELSE '***' || right(tax_id, 4) END AS tax_id,
       registration_number,
       duns,
       lei,

--- a/tests/dagster/test_notifications.py
+++ b/tests/dagster/test_notifications.py
@@ -1,0 +1,155 @@
+"""send_email_job — the raw token never enters Dagster run config.
+
+Run config is persisted indefinitely in Dagster run storage and rendered in
+its UI; the platform DB holds only the token's hash. The job therefore
+carries an opaque reference and resolves it from Valkey at send time.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from dagster import build_op_context
+
+from robosystems.config.defaults import CacheDefaults
+from robosystems.dagster.jobs import notifications
+from robosystems.dagster.jobs.notifications import (
+  SendEmailConfig,
+  build_email_job_config,
+  send_email_op,
+)
+
+RAW_TOKEN = "raw-reset-token-that-must-not-persist"
+
+
+class FakeValkey:
+  def __init__(self) -> None:
+    self.store: dict[str, str] = {}
+    self.ttls: dict[str, int] = {}
+
+  def setex(self, key: str, ttl: int, value: str) -> None:
+    self.store[key] = value
+    self.ttls[key] = ttl
+
+  def get(self, key: str) -> str | None:
+    return self.store.get(key)
+
+  def delete(self, key: str) -> None:
+    self.store.pop(key, None)
+    self.ttls.pop(key, None)
+
+
+@pytest.fixture
+def valkey():
+  fake = FakeValkey()
+  with patch.object(notifications, "_token_store", return_value=fake):
+    yield fake
+
+
+def _op_config(run_config: dict) -> SendEmailConfig:
+  return SendEmailConfig(**run_config["ops"]["send_email_op"]["config"])
+
+
+def _ses(send_result: bool = True) -> MagicMock:
+  ses = MagicMock()
+  for name in (
+    "send_verification_email",
+    "send_password_reset_email",
+    "send_org_invitation_email",
+    "send_welcome_email",
+  ):
+    setattr(ses, name, AsyncMock(return_value=send_result))
+  return ses
+
+
+@pytest.mark.unit
+class TestRunConfigCarriesOnlyAReference:
+  def test_raw_token_absent_from_run_config(self, valkey):
+    run_config = build_email_job_config(
+      "password_reset", "u@example.com", "U", token=RAW_TOKEN
+    )
+
+    assert RAW_TOKEN not in json.dumps(run_config)
+    cfg = run_config["ops"]["send_email_op"]["config"]
+    assert cfg["token_ref"]
+    assert "token" not in cfg
+
+  def test_reference_parks_the_token_with_a_ttl(self, valkey):
+    run_config = build_email_job_config(
+      "email_verification", "u@example.com", "U", token=RAW_TOKEN
+    )
+
+    ref = run_config["ops"]["send_email_op"]["config"]["token_ref"]
+    key = f"email_token:{ref}"
+    assert valkey.store[key] == RAW_TOKEN
+    assert valkey.ttls[key] == CacheDefaults.EMAIL_TOKEN_REF_TTL
+
+  def test_no_token_means_no_reference(self, valkey):
+    run_config = build_email_job_config("welcome", "u@example.com", "U")
+
+    assert "token_ref" not in run_config["ops"]["send_email_op"]["config"]
+    assert valkey.store == {}
+
+  def test_config_schema_has_no_raw_token_field(self):
+    assert "token" not in SendEmailConfig.model_fields
+    assert "token_ref" in SendEmailConfig.model_fields
+
+
+@pytest.mark.unit
+class TestSendEmailOpResolvesTheReference:
+  def test_resolves_token_and_discards_it_after_send(self, valkey):
+    run_config = build_email_job_config(
+      "password_reset", "u@example.com", "U", token=RAW_TOKEN
+    )
+    ref = run_config["ops"]["send_email_op"]["config"]["token_ref"]
+    ses = _ses()
+
+    with patch("robosystems.operations.aws.ses.ses_service", ses):
+      result = send_email_op(context=build_op_context(), config=_op_config(run_config))
+
+    assert result["success"] is True
+    ses.send_password_reset_email.assert_awaited_once()
+    assert ses.send_password_reset_email.await_args.kwargs["token"] == RAW_TOKEN
+    assert f"email_token:{ref}" not in valkey.store
+
+  def test_expired_reference_fails_without_sending(self, valkey):
+    cfg = SendEmailConfig(
+      email_type="password_reset",
+      to_email="u@example.com",
+      user_name="U",
+      token_ref="no-longer-there",
+    )
+    ses = _ses()
+
+    with patch("robosystems.operations.aws.ses.ses_service", ses):
+      with pytest.raises(ValueError, match="expired or was already used"):
+        send_email_op(context=build_op_context(), config=cfg)
+
+    ses.send_password_reset_email.assert_not_awaited()
+
+  def test_send_failure_keeps_the_reference_for_retry(self, valkey):
+    run_config = build_email_job_config(
+      "org_invitation",
+      "u@example.com",
+      "U",
+      token=RAW_TOKEN,
+      org_name="Acme",
+    )
+    ref = run_config["ops"]["send_email_op"]["config"]["token_ref"]
+    ses = _ses(send_result=False)
+
+    with patch("robosystems.operations.aws.ses.ses_service", ses):
+      with pytest.raises(RuntimeError, match="Failed to send"):
+        send_email_op(context=build_op_context(), config=_op_config(run_config))
+
+    assert valkey.store[f"email_token:{ref}"] == RAW_TOKEN
+
+  def test_welcome_email_needs_no_reference(self, valkey):
+    run_config = build_email_job_config("welcome", "u@example.com", "U")
+    ses = _ses()
+
+    with patch("robosystems.operations.aws.ses.ses_service", ses):
+      result = send_email_op(context=build_op_context(), config=_op_config(run_config))
+
+    assert result["success"] is True
+    ses.send_welcome_email.assert_awaited_once()

--- a/tests/operations/extensions/test_materialize.py
+++ b/tests/operations/extensions/test_materialize.py
@@ -216,6 +216,17 @@ class TestREAStaging:
     assert "address" not in tables["Agent"]
     assert "metadata" not in tables["Agent"]
 
+  def test_agent_tax_id_masked_to_last_four(self):
+    """The graph never carries more than the last four of a counterparty
+    tax ID, whatever wrote the OLTP row — QuickBooks delivers it masked,
+    a native write may not. Entity.tax_id is the filer's public EIN and
+    stays verbatim."""
+    tables = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)
+    assert "'***' || right(tax_id, 4)" in tables["Agent"]
+    assert "AS tax_id" in tables["Agent"]
+    assert "right(tax_id, 4)" not in tables["Entity"]
+    assert "tax_id," in tables["Entity"]
+
   def test_event_table_sources_from_events_with_event_action(self):
     tables = _staging_sql(GRAPH_ID, ENTITY_ID, CONNSTR)
     assert "Event" in tables

--- a/tests/routers/orgs/test_invitations.py
+++ b/tests/routers/orgs/test_invitations.py
@@ -86,7 +86,10 @@ class TestCreateInvitation:
     assert email_config["to_email"] == "invitee@example.com"
     assert email_config["org_name"] == org.name
     assert email_config["inviter_name"] == test_user.name
-    assert email_config["token"]
+    # The raw invitation token is parked in Valkey; run config carries a
+    # reference only.
+    assert email_config["token_ref"]
+    assert "token" not in email_config
 
   async def test_member_cannot_invite(self, async_client, test_db, test_user):
     org = _make_org(test_db, test_user.id, OrgRole.MEMBER)


### PR DESCRIPTION
## Summary

Two small data-hygiene hardenings from the PII and data-classification review. Counterparty tax identifiers now reach the analytical graph as their last four characters only, whatever wrote the OLTP row, and the email notification job no longer embeds verification/reset/invitation tokens in its Dagster run config.

## Changes

- **`operations/extensions/materialize.py`** — the `Agent` staging projection masks `tax_id` to `***` + last-4 (empty → `NULL`). `Entity.tax_id` — the filer's own public EIN — is unchanged, as are its SEC-pipeline and export consumers. No graph schema change: the column name and type are the same, so existing tenants pick the masked value up at their next materialize with no per-graph migration.
- **`dagster/jobs/notifications.py`** — `build_email_job_config` parks the raw token in the AUTH Valkey DB under an opaque reference (`CacheDefaults.EMAIL_TOKEN_REF_TTL`, 15 min) and the run config carries only `token_ref`; `send_email_op` resolves it at send time and discards it after a successful send. A reference that has expired or already been used fails the op without sending, so a re-execution from the Dagster UI cannot resend a stale token. A failed send leaves the reference in place for the op's existing retry policy. The `token` field is removed from `SendEmailConfig` so the raw value cannot be placed in run config by any caller; all seven call sites go through the builder and are untouched.
- **`config/defaults.py`** — `EMAIL_TOKEN_REF_TTL`.
- **Tests** — `tests/dagster/test_notifications.py` (new): run config never contains the raw token, the reference resolves with the configured TTL, the op resolves-then-discards, an expired reference fails without sending, a send failure keeps the reference. `test_materialize.py` pins the mask on `Agent` and its absence on `Entity`. `test_invitations.py` updated for the new key.

Reviewers: the Valkey lookup in `_token_store()` is deliberately per-call rather than a cached client so it can be patched cleanly in tests; it mirrors `SSEEventStorage._get_sync_redis`.

## Breaking Changes

None. No REST, GraphQL, or operations-envelope shape changes; the OLTP `Agent.tax_id` column and its API responses are unchanged — only the graph projection is masked.

## Testing

- Pre-commit gate (ruff check + format + basedpyright) passed on commit.
- `uv run pytest` on `tests/dagster/test_notifications.py`, `tests/operations/extensions/test_materialize.py`, `tests/routers/auth/test_password_reset.py`, `tests/routers/auth/test_email_verification.py`, `tests/routers/orgs/test_invitations.py`, `tests/routers/user/test_user_profile.py` — 155 passed.
- Full `just test-all` not run in-session; CI runs it.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
