### PR TITLE
feat(operators): harden the tool loop and schema payload for the console operator

### DIFF
--- a/robosystems/middleware/mcp/client.py
+++ b/robosystems/middleware/mcp/client.py
@@ -358,7 +358,8 @@ class GraphMCPClient:
       tables_query = "CALL SHOW_TABLES() RETURN id, name, type, comment"
       tables_result = await self.execute_query(tables_query)
 
-      schema_info = []
+      nodes: list[dict[str, Any]] = []
+      relationships: list[dict[str, Any]] = []
 
       for table in tables_result:
         table_name = table.get("name", "")
@@ -372,18 +373,17 @@ class GraphMCPClient:
           # Prefer the curated property map for well-known nodes (nice
           # ordering); for everything else introspect the real columns from
           # the catalog so the schema isn't reported as a misleading guess.
-          sample_properties = self._get_common_properties(table_name)
-          if sample_properties is None:
-            sample_properties = await self._introspect_node_properties(table_name)
+          properties = self._get_common_properties(table_name)
+          if properties is None:
+            properties = await self._introspect_node_properties(table_name)
 
-          schema_info.append(
+          nodes.append(
             {
               "label": table_name,
               "type": "node",
               "comment": table_comment,
               "description": self._get_node_description(table_name),
-              "sample_properties": sample_properties,
-              "common_properties": sample_properties,
+              "properties": properties,
             }
           )
 
@@ -391,7 +391,7 @@ class GraphMCPClient:
           # Infer relationship details without querying table structure
           from_node, to_node = self._infer_relationship_nodes(table_name)
 
-          schema_info.append(
+          relationships.append(
             {
               "label": table_name,
               "type": "relationship",
@@ -401,6 +401,14 @@ class GraphMCPClient:
               "description": self._get_relationship_description(table_name),
             }
           )
+
+      # Nodes first, then relationships, each alphabetical: the model reads
+      # the labels before the edges that join them, and the payload is
+      # byte-stable across calls (a prerequisite for prompt caching) rather
+      # than following catalog insertion order.
+      nodes.sort(key=lambda entry: entry["label"])
+      relationships.sort(key=lambda entry: entry["label"])
+      schema_info = nodes + relationships
 
       logger.info(f"Retrieved schema for {len(schema_info)} tables")
       return schema_info
@@ -443,7 +451,9 @@ class GraphMCPClient:
         "calendar_period_key",
       ],
       "Element": ["name", "qname", "balance", "item_type", "is_numeric", "is_abstract"],
-      "Transaction": ["date", "amount", "description", "type", "transaction_id"],
+      # The ledger spine (Transaction / Entry / LineItem / Event) is deliberately
+      # absent: those tables carry the live-row filter (`is_live`, `status`)
+      # a curated list would omit, so they are introspected from the catalog.
       "Account": ["name", "number", "type", "balance", "parent_account_id"],
       "User": ["id", "name", "email", "is_active", "created_at"],
       "Connection": ["provider", "status", "last_sync", "realm_id", "connection_id"],
@@ -542,8 +552,27 @@ class GraphMCPClient:
     return descriptions.get(rel_name, f"{rel_name} relationship in the graph")
 
   def _infer_relationship_nodes(self, rel_name: str) -> tuple[str, str]:
-    """Infer source and target nodes from relationship name (base + roboledger only)."""
-    # Complete relationship mappings for base + roboledger extension
+    """Resolve a relationship's source and target node labels.
+
+    The declared schema (base + every extension) is authoritative for the
+    platform's own relationships — several don't follow the naming patterns
+    below (``ENTRY_FROM_SCHEDULE`` targets ``Structure``; the ``EVENT_*``
+    verbs are neither HAS nor OWNS nor RELATES_TO). Name-pattern inference
+    remains the fallback for custom graphs that add their own tables.
+    """
+    try:
+      from robosystems.schemas.loader import get_schema_loader
+
+      declared = get_schema_loader().get_relationship_schema(rel_name)
+    except (
+      Exception
+    ) as e:  # pragma: no cover - never let a loader fault break schema retrieval
+      logger.warning(f"Declared-schema lookup failed for {rel_name}: {e}")
+      declared = None
+    if declared is not None:
+      return (declared.from_node, declared.to_node)
+
+    # Legacy hand map, kept for graphs whose extensions were not discoverable.
     known_relationships = {
       # Base relationships
       "ELEMENT_HAS_LABEL": ("Element", "Label"),

--- a/robosystems/operations/operators/ai_client.py
+++ b/robosystems/operations/operators/ai_client.py
@@ -121,16 +121,20 @@ class AIClient:
     model: str | None = None,
     operator_type: str | None = None,
     tools: list[dict[str, Any]] | None = None,
+    tool_choice: dict[str, Any] | None = None,
   ) -> AIResponse:
     """Send one Bedrock request.
 
     `tools` takes Anthropic tool definitions (name/description/input_schema);
     with them the model may stop with reason "tool_use" and return tool_use
-    blocks in `AIResponse.content_blocks`.
+    blocks in `AIResponse.content_blocks`. `tool_choice` is the Anthropic
+    tool_choice object (e.g. ``{"type": "none"}`` to keep the tool definitions
+    — required while the transcript carries tool_use blocks — but forbid
+    further calls). Only meaningful alongside `tools`.
     """
     model_id = self._get_model_id(model, operator_type)
     return await self._bedrock_create_message(
-      messages, system, max_tokens, temperature, model_id, tools
+      messages, system, max_tokens, temperature, model_id, tools, tool_choice
     )
 
   def _invoke_model_sync(
@@ -150,6 +154,7 @@ class AIClient:
     temperature: float,
     model: str,
     tools: list[dict[str, Any]] | None = None,
+    tool_choice: dict[str, Any] | None = None,
   ) -> AIResponse:
     message_dicts = [{"role": msg.role, "content": msg.content} for msg in messages]
 
@@ -164,6 +169,8 @@ class AIClient:
       request_body["system"] = system
     if tools:
       request_body["tools"] = tools
+      if tool_choice:
+        request_body["tool_choice"] = tool_choice
 
     # botocore is synchronous and a model call can take minutes; run it on a
     # worker thread so the event loop — shared by every tenant on this task —

--- a/robosystems/operations/operators/implementations/cypher.py
+++ b/robosystems/operations/operators/implementations/cypher.py
@@ -104,7 +104,10 @@ class CypherOperator(Operator):
   async def run(self, ctx: OperatorContext) -> OperatorResult:
     limits = OperatorConfig.get_mode_limits(ctx.mode.value)
     max_results = self._get_max_results(ctx.mode)
-    # One iteration per allowed tool call, plus a final answer turn.
+    # `max_tools + 1` tool-calling turns. The ceiling has been this since the
+    # loop's first version (every mode's budget was tuned against it); the
+    # natural final answer is not a tool turn and costs nothing, and a turn
+    # whose tool calls all fail is uncharged — see run_tool_loop.
     max_iterations = int(limits.get("max_tools", 5)) + 1
     max_tokens = int(limits.get("max_output_tokens", 4000))
     output_mode = "answer" if ctx.extra.get("output_mode") == "answer" else "narrative"

--- a/robosystems/operations/operators/implementations/cypher.py
+++ b/robosystems/operations/operators/implementations/cypher.py
@@ -24,7 +24,11 @@ from robosystems.operations.operators.base import (
 )
 from robosystems.operations.operators.operator_context import OperatorContext
 from robosystems.operations.operators.operator_registry import register_operator
-from robosystems.operations.operators.tool_loop import ToolLoopResult, run_tool_loop
+from robosystems.operations.operators.tool_loop import (
+  DEFAULT_MAX_ERROR_RETRIES,
+  ToolLoopResult,
+  run_tool_loop,
+)
 
 
 @register_operator("cypher")
@@ -117,7 +121,7 @@ class CypherOperator(Operator):
     has_document_search = "search-documents" in available_tools
 
     system = self._build_system_prompt(
-      max_results, output_mode, is_shared, has_document_search
+      max_results, output_mode, is_shared, has_document_search, max_iterations
     )
 
     result = await run_tool_loop(
@@ -155,6 +159,7 @@ class CypherOperator(Operator):
     output_mode: str,
     is_shared: bool,
     has_document_search: bool = False,
+    tool_turns: int = 6,
   ) -> str:
     if is_shared:
       # Shared repository (e.g. SEC): thousands of filers, so the selective
@@ -188,8 +193,10 @@ WORKFLOW:
 1. For any question that needs the fact graph, call `get-graph-schema` first to discover node labels, relationships, and properties — never guess the schema. (Purely qualitative/narrative questions may skip straight to document search — see below.)
 2. If `get-example-queries` is available, use it for working query patterns tuned to this graph.
 3. Write a read-only Cypher query and run it with `read-graph-cypher`.
-4. If a query errors or returns nothing useful, read the error, fix the query, and try again. You have a limited number of steps, so be efficient — don't repeat a failing query unchanged.
+4. If a query errors or returns nothing useful, read the error, fix the query, and try again — don't repeat a failing query unchanged.
 5. When you have the answer, respond in natural language.
+
+STEP BUDGET: you have {tool_turns} tool-calling turns before you must answer from what you have. A turn whose tool calls all fail is not charged (up to {DEFAULT_MAX_ERROR_RETRIES} times), so a corrected retry is free — but plan to reach `read-graph-cypher` within the first three turns.
 
 CYPHER RULES:
 - Read-only only: MATCH, WHERE, WITH, RETURN, ORDER BY, LIMIT. Never CREATE, SET, DELETE, MERGE, or DROP.

--- a/robosystems/operations/operators/tool_loop.py
+++ b/robosystems/operations/operators/tool_loop.py
@@ -25,10 +25,32 @@ if TYPE_CHECKING:
 # for the caller/frontend, which paginates.
 _MAX_TOOL_RESULT_CHARS = 12000
 
+# Orientation tools are the exception: a truncated schema or example set is
+# worse than none, because the model then plans queries against
+# relationships it never saw. A tenant schema with the ledger spine runs
+# 20-30k chars, so these get a cap well above the largest real payload and
+# only a pathological graph truncates.
+_ORIENTATION_TOOL_RESULT_CHARS = 48000
+_TOOL_RESULT_CHAR_CAPS: dict[str, int] = {
+  "get-graph-schema": _ORIENTATION_TOOL_RESULT_CHARS,
+  "get-example-queries": _ORIENTATION_TOOL_RESULT_CHARS,
+}
+
+# A turn whose tool calls ALL fail is not charged against the tool budget, up
+# to this many times per run. Error feedback is the point of the loop, and
+# charging a budgeted turn for a syntax error starves quick mode of the one
+# retry it needs to recover.
+DEFAULT_MAX_ERROR_RETRIES = 2
+
 _ANSWER_NOW = (
   "You've reached the step limit. Answer the original question now using the "
   "results gathered so far. Do not request any more tools."
 )
+
+# The nudge keeps the tool definitions (the transcript carries tool_use
+# blocks, which the API requires tools for) but forbids further calls, so
+# the final turn is guaranteed to be text rather than a dropped tool_use.
+_NO_MORE_TOOLS: dict[str, Any] = {"type": "none"}
 
 
 @dataclass
@@ -39,15 +61,17 @@ class ToolLoopResult:
   rows: list[dict[str, Any]] | None = None  # last read-graph-cypher result set
   cypher: str | None = None  # the query that produced ``rows``
   tools_called: list[str] = field(default_factory=list)
-  iterations: int = 0
+  iterations: int = 0  # model calls made, including the nudge if any
   hit_cap: bool = False  # stopped at max_iterations rather than by the model
+  error_retries: int = 0  # uncharged turns granted for all-error tool results
 
 
-def _serialize_tool_result(result: Any) -> str:
-  """JSON-encode a tool result for feedback, capped in size."""
+def _serialize_tool_result(result: Any, tool_name: str | None = None) -> str:
+  """JSON-encode a tool result for feedback, capped in size per tool."""
+  cap = _TOOL_RESULT_CHAR_CAPS.get(tool_name or "", _MAX_TOOL_RESULT_CHARS)
   text = json.dumps(result, default=str)
-  if len(text) > _MAX_TOOL_RESULT_CHARS:
-    text = text[:_MAX_TOOL_RESULT_CHARS] + f"\n… [truncated; {len(text)} chars total]"
+  if len(text) > cap:
+    text = text[:cap] + f"\n… [truncated; {len(text)} chars total]"
   return text
 
 
@@ -75,15 +99,19 @@ async def run_tool_loop(
   temperature: float = 0.3,
   operator_type: str | None = None,
   operation_description: str = "Tool-use loop",
+  max_error_retries: int = DEFAULT_MAX_ERROR_RETRIES,
 ) -> ToolLoopResult:
   """Run a bounded tool-use loop and return the model's final answer.
 
   The model gets the read-only tools named by ``tool_names``, intersected with
   what the graph actually exposes, and iterates: call tools → observe results
   (errors included) → answer in natural language. ``max_iterations`` caps the
-  round-trips that may call tools; on hitting the cap one further turn nudges
-  the model to answer from what it has, so the loop always costs at most
-  ``max_iterations + 1`` model calls.
+  round-trips that may call tools. A round-trip whose tool calls all failed is
+  not charged against that cap, up to ``max_error_retries`` times, so a bad
+  query costs the model a correction rather than a step. On hitting the cap
+  one further turn nudges the model to answer from what it has with tool use
+  disabled, so the loop always costs at most
+  ``max_iterations + max_error_retries + 1`` model calls.
   """
   tools = await ctx.tools.get_tool_schemas(tool_names)
   if not tools:
@@ -102,12 +130,15 @@ async def run_tool_loop(
   last_rows: list[dict[str, Any]] | None = None
   last_cypher: str | None = None
 
+  tool_turns = 0  # round-trips charged against max_iterations
+  error_retries = 0  # uncharged round-trips granted so far
+  model_calls = 0
   step = 60 // max(max_iterations, 1)
 
-  for iteration in range(max_iterations):
+  while tool_turns < max_iterations:
     await ctx.progress.report(
-      "Thinking..." if iteration == 0 else f"Working (step {iteration + 1})...",
-      percent=min(20 + iteration * step, 85),
+      "Thinking..." if model_calls == 0 else f"Working (step {model_calls + 1})...",
+      percent=min(20 + tool_turns * step, 85),
     )
 
     response = await ctx.ai.create_message(
@@ -119,6 +150,7 @@ async def run_tool_loop(
       operation_description=operation_description,
       tools=tools,
     )
+    model_calls += 1
 
     # No tool call means the model is answering — done.
     if response.stop_reason != "tool_use":
@@ -127,13 +159,15 @@ async def run_tool_loop(
         rows=last_rows,
         cypher=last_cypher,
         tools_called=tools_called,
-        iterations=iteration + 1,
+        iterations=model_calls,
+        error_retries=error_retries,
       )
 
     # Replay the assistant turn (text + tool_use blocks) verbatim.
     messages.append(AIMessage(role="assistant", content=response.content_blocks))
 
     tool_results: list[dict[str, Any]] = []
+    turn_succeeded = False
     for block in response.content_blocks:
       if block.get("type") != "tool_use":
         continue
@@ -178,20 +212,29 @@ async def run_tool_loop(
         result = {"error": str(e)}
         is_error = True
 
+      if not is_error:
+        turn_succeeded = True
       tool_results.append(
         {
           "type": "tool_result",
           "tool_use_id": tool_use_id,
-          "content": _serialize_tool_result(result),
+          "content": _serialize_tool_result(result, name),
           "is_error": is_error,
         }
       )
 
     messages.append(AIMessage(role="user", content=tool_results))
 
+    if turn_succeeded or error_retries >= max_error_retries:
+      tool_turns += 1
+    else:
+      error_retries += 1
+
   # Iteration cap reached. Nudge for a final answer, appending the nudge to
   # the trailing user turn (avoids a second consecutive user message). Keep
-  # `tools` defined so the tool_use/tool_result transcript stays valid.
+  # `tools` defined so the tool_use/tool_result transcript stays valid, but
+  # disable tool choice so the answer can't come back as a tool_use block
+  # that nobody would execute.
   final_messages = list(messages)
   last = final_messages[-1]
   if last.role == "user" and isinstance(last.content, list):
@@ -210,6 +253,7 @@ async def run_tool_loop(
     operator_type=operator_type,
     operation_description=operation_description,
     tools=tools,
+    tool_choice=_NO_MORE_TOOLS if tools else None,
   )
   return ToolLoopResult(
     text=final.content
@@ -217,6 +261,7 @@ async def run_tool_loop(
     rows=last_rows,
     cypher=last_cypher,
     tools_called=tools_called,
-    iterations=max_iterations,
+    iterations=model_calls + 1,
     hit_cap=True,
+    error_retries=error_retries,
   )

--- a/robosystems/operations/operators/tracked_ai.py
+++ b/robosystems/operations/operators/tracked_ai.py
@@ -64,6 +64,7 @@ class TrackedAIClient:
     operator_type: str | None = None,
     operation_description: str = "Operator AI call",
     tools: list[dict[str, Any]] | None = None,
+    tool_choice: dict[str, Any] | None = None,
   ) -> AIResponse:
     """Call the model and consume credits for it.
 
@@ -89,6 +90,7 @@ class TrackedAIClient:
       model=model,
       operator_type=operator_type,
       tools=tools,
+      tool_choice=tool_choice,
     )
 
     self.total_tokens["input"] += response.input_tokens

--- a/tests/middleware/mcp/test_client.py
+++ b/tests/middleware/mcp/test_client.py
@@ -146,11 +146,12 @@ class TestGraphMCPClient:
     """Test schema retrieval (no counts for performance)."""
     # Mock responses - schema no longer fetches counts
     query_responses = [
-      # SHOW_TABLES response only
+      # SHOW_TABLES response only — deliberately NOT nodes-first or
+      # alphabetical, to check get_schema imposes its own order.
       [
-        {"name": "Entity", "type": "NODE"},
-        {"name": "Report", "type": "NODE"},
         {"name": "HAS_REPORT", "type": "REL"},
+        {"name": "Report", "type": "NODE"},
+        {"name": "Entity", "type": "NODE"},
       ],
     ]
 
@@ -166,6 +167,9 @@ class TestGraphMCPClient:
       schema = await client.get_schema()
 
       assert len(schema) == 3
+      # Nodes first, then relationships, each alphabetical — byte-stable
+      # output regardless of catalog insertion order.
+      assert [s["label"] for s in schema] == ["Entity", "Report", "HAS_REPORT"]
       # Check node tables
       entity_schema = next(s for s in schema if s["label"] == "Entity")
       assert entity_schema["type"] == "node"
@@ -628,7 +632,7 @@ class TestGraphMCPConfigurableSchema:
       custom1 = next(s for s in schema if s["label"] == "CustomTable1")
       assert custom1["type"] == "node"
       assert "count" not in custom1
-      assert custom1["sample_properties"] == ["identifier", "label"]
+      assert custom1["properties"] == ["identifier", "label"]
 
       custom2 = next(s for s in schema if s["label"] == "CustomTable2")
       assert custom2["type"] == "node"

--- a/tests/middleware/mcp/test_client_extended.py
+++ b/tests/middleware/mcp/test_client_extended.py
@@ -359,6 +359,13 @@ class TestSchemaInference:
     # the catalog instead of emitting a misleading generic guess.
     assert client._get_common_properties("UnknownNode") is None
 
+  def test_ledger_spine_is_introspected_not_curated(self):
+    """Transaction/Entry/LineItem carry the live-row columns (is_live,
+    status) a curated hint list omitted, so they must come from the catalog."""
+    client = _create_client()
+    for label in ("Transaction", "Entry", "LineItem", "Event"):
+      assert client._get_common_properties(label) is None
+
   @pytest.mark.asyncio
   async def test_introspect_node_properties_uses_catalog(self):
     client = _create_client()
@@ -430,6 +437,38 @@ class TestSchemaInference:
     from_node, to_node = client._infer_relationship_nodes("SOME_UNKNOWN_TYPE")
     assert from_node == "Unknown"
     assert to_node == "Unknown"
+
+  def test_infer_relationship_nodes_prefers_the_declared_schema(self):
+    """Platform relationships resolve from the declared schema, including the
+    ones no naming heuristic could guess: ENTRY_FROM_SCHEDULE targets a
+    Structure, and the Event verbs are neither HAS nor OWNS nor RELATES_TO."""
+    client = _create_client()
+    assert client._infer_relationship_nodes("ENTRY_FROM_SCHEDULE") == (
+      "Entry",
+      "Structure",
+    )
+    assert client._infer_relationship_nodes("EVENT_TRIGGERS_TRANSACTION") == (
+      "Event",
+      "Transaction",
+    )
+    assert client._infer_relationship_nodes("EVENT_INVOLVES_AGENT") == (
+      "Event",
+      "Agent",
+    )
+    assert client._infer_relationship_nodes("ENTITY_HAS_EVENT") == ("Entity", "Event")
+
+  def test_infer_relationship_nodes_survives_a_loader_fault(self):
+    """A declared-schema lookup failure degrades to the name heuristics
+    rather than breaking schema retrieval."""
+    client = _create_client()
+    with patch(
+      "robosystems.schemas.loader.get_schema_loader",
+      side_effect=RuntimeError("extensions not importable"),
+    ):
+      assert client._infer_relationship_nodes("COMPANY_HAS_PRODUCT") == (
+        "Company",
+        "Product",
+      )
 
 
 @pytest.mark.unit

--- a/tests/operations/operators/test_tool_loop.py
+++ b/tests/operations/operators/test_tool_loop.py
@@ -230,13 +230,19 @@ async def test_hits_iteration_cap_then_forces_a_final_answer():
   )
 
   assert result.hit_cap is True
-  assert result.iterations == 2
+  # `iterations` counts model calls: 2 loop turns + the forced-final turn.
+  assert result.iterations == 3
+  assert result.error_retries == 0
   assert result.text == "Best-effort answer from what I gathered."
-  # 2 loop iterations + 1 forced-final turn.
   assert ai.create_message.await_count == 3
 
   final_kwargs = ai.create_message.call_args_list[2].kwargs
   assert final_kwargs["tools"]  # transcript stays valid
+  # ...but the nudge forbids further tool use, so the answer can't come back
+  # as a tool_use block the loop would have to drop.
+  assert final_kwargs["tool_choice"] == {"type": "none"}
+  # Loop turns carry no tool_choice — the model decides.
+  assert ai.create_message.call_args_list[0].kwargs.get("tool_choice") is None
   # The answer-now nudge is appended to the trailing user turn (no second
   # consecutive user message).
   last_user = final_kwargs["messages"][-1]
@@ -286,3 +292,168 @@ async def test_unadvertised_tool_is_refused_without_dispatch():
   assert len(blocks) == 1
   assert blocks[0]["is_error"] is True
   assert "not available" in blocks[0]["content"]
+
+
+async def test_all_error_turn_is_not_charged_against_the_tool_budget():
+  """A turn whose tool calls all fail costs the model a correction, not a
+  step: with a budget of TWO turns, error → fixed query → answer must complete
+  normally. Charging the error would spend both turns before the answer and
+  force the nudge (hit_cap) instead."""
+  ai = MagicMock()
+  ai.create_message = AsyncMock(
+    side_effect=[
+      _tool_use("t1", "read-graph-cypher", query="MATCH bad syntax"),
+      _tool_use("t2", "read-graph-cypher", query="MATCH (e:Entity) RETURN e LIMIT 1"),
+      _final("Fixed and answered."),
+    ]
+  )
+  rows = [{"e": 1}]
+  tools = _tools_mock(call_results=[ValueError("Invalid Cypher near 'bad'"), rows])
+  ctx = _ctx(ai, tools)
+
+  result = await run_tool_loop(
+    ctx,
+    system="s",
+    tool_names=["read-graph-cypher"],
+    max_iterations=2,
+    max_tokens=100,
+  )
+
+  assert result.hit_cap is False
+  assert result.text == "Fixed and answered."
+  assert result.rows == rows
+  assert result.error_retries == 1
+  assert result.iterations == 3
+  # No nudge was needed, so no call carried a tool_choice.
+  assert all(
+    c.kwargs.get("tool_choice") is None for c in ai.create_message.call_args_list
+  )
+
+
+async def test_error_retry_budget_is_bounded():
+  """Uncharged retries are capped by max_error_retries; past that an
+  all-error turn is charged like any other, so a model that never fixes its
+  query still hits the cap and gets nudged."""
+  ai = MagicMock()
+  ai.create_message = AsyncMock(
+    side_effect=[
+      _tool_use("t1", "read-graph-cypher", query="MATCH bad"),
+      _tool_use("t2", "read-graph-cypher", query="MATCH still bad"),
+      _final("I couldn't get a working query."),
+    ]
+  )
+  tools = _tools_mock(call_results=[ValueError("bad"), ValueError("still bad")])
+  ctx = _ctx(ai, tools)
+
+  result = await run_tool_loop(
+    ctx,
+    system="s",
+    tool_names=["read-graph-cypher"],
+    max_iterations=1,
+    max_tokens=100,
+    max_error_retries=1,
+  )
+
+  # 1 free retry + 1 charged turn + the nudge = 3 model calls.
+  assert ai.create_message.await_count == 3
+  assert result.hit_cap is True
+  assert result.error_retries == 1
+  assert result.rows is None
+  assert ai.create_message.call_args_list[2].kwargs["tool_choice"] == {"type": "none"}
+
+
+async def test_mixed_turn_with_one_success_is_charged():
+  """A turn is only free when EVERY tool call in it failed — one success
+  means the model got usable information and the turn counts."""
+  ai = MagicMock()
+  mixed = AIResponse(
+    content="",
+    model="m",
+    input_tokens=10,
+    output_tokens=5,
+    stop_reason="tool_use",
+    content_blocks=[
+      {
+        "type": "tool_use",
+        "id": "t1",
+        "name": "read-graph-cypher",
+        "input": {"query": "bad"},
+      },
+      {
+        "type": "tool_use",
+        "id": "t2",
+        "name": "read-graph-cypher",
+        "input": {"query": "ok"},
+      },
+    ],
+  )
+  ai.create_message = AsyncMock(side_effect=[mixed, _final("answer")])
+  tools = _tools_mock(call_results=[ValueError("bad"), [{"n": 1}]])
+  ctx = _ctx(ai, tools)
+
+  result = await run_tool_loop(
+    ctx,
+    system="s",
+    tool_names=["read-graph-cypher"],
+    max_iterations=1,
+    max_tokens=100,
+  )
+
+  # Charged: the single budgeted turn is spent, so the next call is the
+  # tool-disabled nudge. Had the turn been free, the loop would have made a
+  # normal second call with no tool_choice and finished without hit_cap.
+  assert result.error_retries == 0
+  assert result.hit_cap is True
+  assert result.text == "answer"
+  assert ai.create_message.await_count == 2
+  assert ai.create_message.call_args_list[1].kwargs["tool_choice"] == {"type": "none"}
+
+
+def _two_tools_mock(call_results: list) -> MagicMock:
+  tools = MagicMock()
+  tools.get_tool_schemas = AsyncMock(
+    return_value=[
+      {"name": "get-graph-schema", "description": "schema", "input_schema": {}},
+      {"name": "read-graph-cypher", "description": "cypher", "input_schema": {}},
+    ]
+  )
+  tools.call_tool = AsyncMock(side_effect=call_results)
+  return tools
+
+
+async def test_orientation_tool_results_escape_the_default_cap():
+  """A 20k-char schema is fed back whole (a truncated schema hides the
+  relationships the model needs), while a 20k-char query result is still
+  capped at the default — the console paginates rows, the model doesn't
+  need them all."""
+  ai = MagicMock()
+  ai.create_message = AsyncMock(
+    side_effect=[
+      _tool_use("t1", "get-graph-schema"),
+      _tool_use("t2", "read-graph-cypher", query="MATCH (n) RETURN n LIMIT 500"),
+      _final("done"),
+    ]
+  )
+  big_schema = [{"label": f"Node{i}", "properties": ["x" * 40] * 4} for i in range(100)]
+  big_rows = [{"n": "y" * 100} for _ in range(200)]
+  tools = _two_tools_mock(call_results=[big_schema, big_rows])
+  ctx = _ctx(ai, tools)
+
+  await run_tool_loop(
+    ctx,
+    system="s",
+    tool_names=["get-graph-schema", "read-graph-cypher"],
+    max_iterations=5,
+    max_tokens=100,
+  )
+
+  schema_block = _tool_result_blocks(
+    ai.create_message.call_args_list[1].kwargs["messages"]
+  )[0]
+  assert "truncated" not in schema_block["content"]
+  assert len(schema_block["content"]) > 12000
+
+  rows_blocks = _tool_result_blocks(
+    ai.create_message.call_args_list[2].kwargs["messages"]
+  )
+  assert "truncated" in rows_blocks[-1]["content"]

--- a/tests/operations/test_ai_client.py
+++ b/tests/operations/test_ai_client.py
@@ -458,6 +458,55 @@ class TestAIClientCreateMessage:
     assert "tools" not in request_body
 
   @pytest.mark.unit
+  async def test_create_message_sends_tool_choice_alongside_tools(self):
+    """tool_choice rides in the request body with the tools it constrains —
+    the tool loop's final nudge uses {"type": "none"} to keep the transcript
+    valid while forbidding another tool_use turn."""
+    client, mock_bedrock = _make_ai_client()
+    from robosystems.operations.operators.ai_client import AIMessage
+
+    response_body = {
+      "content": [{"type": "text", "text": "final"}],
+      "usage": {"input_tokens": 10, "output_tokens": 5},
+      "stop_reason": "end_turn",
+    }
+    mock_body = MagicMock()
+    mock_body.read.return_value = json.dumps(response_body).encode()
+    mock_bedrock.invoke_model.return_value = {"body": mock_body}
+
+    tools = [{"name": "t", "description": "d", "input_schema": {"type": "object"}}]
+    await client.create_message(
+      messages=[AIMessage(role="user", content="answer now")],
+      tools=tools,
+      tool_choice={"type": "none"},
+    )
+    request_body = json.loads(mock_bedrock.invoke_model.call_args[1]["body"])
+    assert request_body["tools"] == tools
+    assert request_body["tool_choice"] == {"type": "none"}
+
+  @pytest.mark.unit
+  async def test_tool_choice_without_tools_is_dropped(self):
+    """tool_choice is meaningless (and rejected by the API) without tools."""
+    client, mock_bedrock = _make_ai_client()
+    from robosystems.operations.operators.ai_client import AIMessage
+
+    response_body = {
+      "content": [{"type": "text", "text": "hi"}],
+      "usage": {"input_tokens": 10, "output_tokens": 5},
+      "stop_reason": "end_turn",
+    }
+    mock_body = MagicMock()
+    mock_body.read.return_value = json.dumps(response_body).encode()
+    mock_bedrock.invoke_model.return_value = {"body": mock_body}
+
+    await client.create_message(
+      messages=[AIMessage(role="user", content="hi")],
+      tool_choice={"type": "none"},
+    )
+    request_body = json.loads(mock_bedrock.invoke_model.call_args[1]["body"])
+    assert "tool_choice" not in request_body
+
+  @pytest.mark.unit
   async def test_create_message_formats_messages_correctly(self):
     """Test that messages are formatted into the correct dict structure."""
     client, mock_bedrock = _make_ai_client()


### PR DESCRIPTION
## Summary

Hardens the AI Operator's tool loop and schema payload so the console operator answers ledger questions instead of exhausting its step budget on orientation. Measured against prod today: a `quick`-mode ledger question ran 3 turns, hit the step limit, spent 114 credits, and returned zero rows plus a Cypher query for the user to run themselves — because the tenant schema (20–30k chars) was truncated at the 12k feedback cap, the one failed Cypher call burned a budgeted turn, and the forced-final nudge could still come back as a `tool_use` block that was silently dropped. First unit of `specs/ai-operators/operator-console-hardening.md` (Phase 1, API side); the console change (`standard` mode + history) follows in `robosystems-core`.

## Changes

- **`operations/operators/tool_loop.py`**
  - Per-tool feedback caps: `get-graph-schema` and `get-example-queries` escape the 12k default (48k), so the model sees the whole schema; query results stay capped.
  - Uncharged error retries: a turn whose tool calls *all* fail is not charged against `max_iterations`, up to `max_error_retries` (default 2). A mixed turn with one success is charged. Total model calls remain bounded at `max_iterations + max_error_retries + 1`.
  - The step-limit nudge sends `tool_choice: {"type": "none"}` — tools stay defined so the tool_use/tool_result transcript is valid, but the final turn is guaranteed to be text. Verified live against Bedrock `InvokeModel` with Sonnet 4.6.
  - `ToolLoopResult.iterations` now consistently counts model calls (including the nudge); new `error_retries` field.
- **`operations/operators/ai_client.py`, `tracked_ai.py`** — thread `tool_choice` through to the Bedrock request body (only alongside `tools`).
- **`operations/operators/implementations/cypher.py`** — the system prompt states the concrete step budget for the mode and that a corrected retry is free, replacing "you have a limited number of steps".
- **`middleware/mcp/client.py`** (the `get-graph-schema` payload)
  - Relationship endpoints resolve from the declared schema (`robosystems.schemas.loader`) before falling back to the name heuristics: 19 of 54 platform relationships were reported as `Unknown → Unknown` (all the `EVENT_*` verbs, `ENTRY_FROM_SCHEDULE`, `FACT_SET_CONTAINS_FACT`, `REPORT_USES_TAXONOMY`, the roboinvestor set) and 4 were mis-guessed (`DIMENSION_HAS_AXIS_ELEMENT → AxisElement`).
  - The ledger spine (`Transaction`) is no longer hand-curated — it is introspected from the catalog like `Entry`/`LineItem`, so `is_live`/`status` appear (the curated list omitted the live-row filter the prompt tells the model to use).
  - Output is nodes-first then relationships, each alphabetical (byte-stable across calls — a prerequisite for the prompt-caching spec), and the duplicated `sample_properties`/`common_properties` pair collapses to `properties`.

Reviewers: the retry accounting in `run_tool_loop` (`turn_succeeded` / `error_retries`) is the piece to read closely.

## Breaking Changes

None to the REST/GraphQL/operations surface. The `get-graph-schema` MCP tool's JSON payload renames `sample_properties`/`common_properties` → `properties` on node entries; nothing programmatic consumes those keys (checked across the three frontend apps, `robosystems-core`, both SDK facades, and this repo) — the payload is read by models.

## Testing

- `just test-code` — passes (ruff, format, basedpyright, cf-lint).
- Targeted: `tests/middleware/mcp`, `tests/operations/operators`, `tests/operations/test_ai_client.py`, `tests/routers/graphs/test_operator*.py` — 1044 + 27 passed. New tests cover the uncharged retry, the bounded retry budget, the charged mixed turn, the per-tool cap, `tool_choice` in the request body (and dropped without tools), declared-schema endpoint resolution with the loader-fault fallback, ledger-spine introspection, and nodes-first ordering.
- Full `just test-all` not run in-session.
- Live: Bedrock `InvokeModel` probe confirming `tool_choice: none` returns `end_turn` text on `us.anthropic.claude-sonnet-4-6`.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
