### PR TITLE
feat(operators): enable prompt caching and move orientation into the system prefix

### DIFF
--- a/robosystems/middleware/mcp/tools/manager.py
+++ b/robosystems/middleware/mcp/tools/manager.py
@@ -202,9 +202,10 @@ class GraphMCPTools:
       self.financial_statement_analysis_tool = FinancialStatementAnalysisTool(
         graph_client
       )
-      # OLTP-backed live statement — tenant entity graphs only. Skipped
-      # on shared repos (no OLTP tenant schema) and on read-only graphs.
-      if not self._is_shared_repository() and not read_only:
+      # OLTP-backed live statement — tenant entity graphs only. Skipped on
+      # shared repos (no OLTP tenant schema). A pure read, so it stays
+      # available on read-only surfaces (graph viewers, read-only operators).
+      if not self._is_shared_repository():
         self.live_financial_statement_tool = LiveFinancialStatementTool(graph_client)
 
       # Semantic enrichment tools (roboledger + manifest flag)
@@ -254,6 +255,8 @@ class GraphMCPTools:
     # Layer 2: Materialization — `materialize` + `get-graph-sync-status`.
     # User entity graphs only (shared repos use their own pipeline and
     # don't track staleness). `materialize` mirrors the REST body shape.
+    # The pair splits on read_only: sync status is a pure read and stays
+    # available on read-only surfaces; materialize is the write half.
     self.get_graph_sync_status_tool = None
     self.materialize_tool = None
     if (
@@ -261,10 +264,10 @@ class GraphMCPTools:
       and env.ROBOLEDGER_ENABLED
       and not self._is_shared_repository()
       and not self._is_subgraph()
-      and not read_only
     ):
       self.get_graph_sync_status_tool = GetGraphSyncStatusTool(graph_client)
-      self.materialize_tool = MaterializeTool(graph_client)
+      if not read_only:
+        self.materialize_tool = MaterializeTool(graph_client)
 
     # Connection write-policy — the outbound write-back opt-in. Platform-DB,
     # writable user graphs only: shared repos have no editable connections,
@@ -296,7 +299,11 @@ class GraphMCPTools:
     # Information Block read tools (get/list-information-block)
     self.get_information_block_tool = None
     self.list_information_blocks_tool = None
-    if self._has_extension("roboledger") and env.ROBOLEDGER_ENABLED and not read_only:
+    if (
+      self._has_extension("roboledger")
+      and env.ROBOLEDGER_ENABLED
+      and not self._is_shared_repository()
+    ):
       from .fiscal_calendar_tools import (
         BackfillPlanHistoryTool,
         ClosePeriodTool,
@@ -313,12 +320,18 @@ class GraphMCPTools:
       # `list-information-blocks` with block_type='schedule' and written
       # through the registrar-generated create/update/delete-information-block
       # ops; see `schedule_tools.py` for the full routing.
+      #
+      # The reads (period status, drafts, fiscal calendar) stay available on
+      # read-only surfaces; only the writes (close/reopen/backfill) require a
+      # writable graph. All read the extensions OLTP DB, which has no schema
+      # for a shared repo — hence the shared-repository exclusion above.
       self.get_period_close_status_tool = GetPeriodCloseStatusTool(graph_client)
       self.list_period_drafts_tool = ListPeriodDraftsTool(graph_client)
       self.get_fiscal_calendar_tool = GetFiscalCalendarTool(graph_client)
-      self.close_period_tool = ClosePeriodTool(graph_client)
-      self.reopen_period_tool = ReopenPeriodTool(graph_client)
-      self.backfill_plan_history_tool = BackfillPlanHistoryTool(graph_client)
+      if not read_only:
+        self.close_period_tool = ClosePeriodTool(graph_client)
+        self.reopen_period_tool = ReopenPeriodTool(graph_client)
+        self.backfill_plan_history_tool = BackfillPlanHistoryTool(graph_client)
 
     # Information Block reads stay available on read-only *tenant* graphs (no
     # read_only guard) but are excluded on shared repos: they read the
@@ -405,7 +418,11 @@ class GraphMCPTools:
     self.get_unmapped_elements_tool = None
     self.suggest_mapping_tool = None
     self.get_mapping_summary_tool = None
-    if self._has_extension("roboledger") and env.ROBOLEDGER_ENABLED and not read_only:
+    if (
+      self._has_extension("roboledger")
+      and env.ROBOLEDGER_ENABLED
+      and not self._is_shared_repository()
+    ):
       from .taxonomy_tools import (
         GetMappingSummaryTool,
         GetUnmappedElementsTool,
@@ -413,6 +430,10 @@ class GraphMCPTools:
         SuggestMappingTool,
       )
 
+      # All four are extensions-OLTP reads (suggest-mapping computes its
+      # suggestions heuristically — no writes, no AI), so they stay available
+      # on read-only surfaces; the shared-repo exclusion is because the OLTP
+      # DB has no per-graph schema for a shared repository.
       self.list_mapping_structures_tool = ListMappingStructuresTool(graph_client)
       self.get_unmapped_elements_tool = GetUnmappedElementsTool(graph_client)
       self.suggest_mapping_tool = SuggestMappingTool(graph_client)

--- a/robosystems/models/api/graphs/operator.py
+++ b/robosystems/models/api/graphs/operator.py
@@ -87,6 +87,17 @@ class OperatorRequest(BaseModel):
   )
   enable_rag: bool = Field(True, description="Enable RAG context enrichment")
   stream: bool = Field(False, description="Enable streaming response")
+  max_credits: float | None = Field(
+    None,
+    gt=0,
+    le=100_000,
+    description=(
+      "Per-question credit ceiling. Once the run's consumed credits reach "
+      "this number, no further tool step starts and the operator answers "
+      "from what it has (the wrap-up itself may carry the total slightly "
+      "past the ceiling). Omit for the mode's default step-bounded behavior."
+    ),
+  )
 
   class Config:
     json_schema_extra = {

--- a/robosystems/operations/operators/ai_client.py
+++ b/robosystems/operations/operators/ai_client.py
@@ -132,6 +132,7 @@ class AIClient:
     operator_type: str | None = None,
     tools: list[dict[str, Any]] | None = None,
     tool_choice: dict[str, Any] | None = None,
+    cache_conversation: bool = False,
   ) -> AIResponse:
     """Send one Bedrock request.
 
@@ -141,10 +142,22 @@ class AIClient:
     tool_choice object (e.g. ``{"type": "none"}`` to keep the tool definitions
     — required while the transcript carries tool_use blocks — but forbid
     further calls). Only meaningful alongside `tools`.
+
+    `cache_conversation` adds a cache breakpoint on the trailing user turn.
+    Only worth it for multi-call loops over a growing transcript, where the
+    next call re-reads everything up to that turn; a single-shot caller would
+    pay the 1.25x cache-write premium with nothing ever reading the entry.
     """
     model_id = self._get_model_id(model, operator_type)
     return await self._bedrock_create_message(
-      messages, system, max_tokens, temperature, model_id, tools, tool_choice
+      messages,
+      system,
+      max_tokens,
+      temperature,
+      model_id,
+      tools,
+      tool_choice,
+      cache_conversation,
     )
 
   def _invoke_model_sync(
@@ -165,8 +178,28 @@ class AIClient:
     model: str,
     tools: list[dict[str, Any]] | None = None,
     tool_choice: dict[str, Any] | None = None,
+    cache_conversation: bool = False,
   ) -> AIResponse:
-    message_dicts = [{"role": msg.role, "content": msg.content} for msg in messages]
+    message_dicts: list[dict[str, Any]] = [
+      {"role": msg.role, "content": msg.content} for msg in messages
+    ]
+
+    if cache_conversation and message_dicts:
+      # Cache breakpoint on the trailing user turn. Markers are applied here
+      # at request build, never persisted into the caller's transcript — a
+      # marker left on every past turn would exceed the 4-breakpoint limit.
+      # The moved breakpoint still hits: the lookup resolves the longest
+      # previously cached prefix, so each call reads the entry the previous
+      # one wrote and extends it.
+      last = message_dicts[-1]
+      content = last["content"]
+      if isinstance(content, str):
+        content = [{"type": "text", "text": content}] if content else []
+      else:
+        content = list(content)
+      if content:
+        content[-1] = {**content[-1], "cache_control": {"type": "ephemeral"}}
+        message_dicts[-1] = {"role": last["role"], "content": content}
 
     request_body: dict[str, Any] = {
       "anthropic_version": "bedrock-2023-05-31",
@@ -184,7 +217,14 @@ class AIClient:
       request_body["thinking"] = {"type": "disabled"}
 
     if system:
-      request_body["system"] = system
+      # One cache breakpoint at the end of `system` caches the tool
+      # definitions and the system prompt together (the request renders
+      # tools -> system -> messages). Below Sonnet's 1,024-token minimum
+      # cacheable prefix the marker is accepted and silently caches nothing,
+      # which costs nothing extra.
+      request_body["system"] = [
+        {"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}
+      ]
     if tools:
       request_body["tools"] = tools
       if tool_choice:

--- a/robosystems/operations/operators/implementations/cypher.py
+++ b/robosystems/operations/operators/implementations/cypher.py
@@ -49,10 +49,10 @@ class CypherOperator(Operator):
 
   # Read-only tool allowlist. The loop intersects this with the tools the
   # graph actually exposes (generic graphs get only schema + cypher; SEC and
-  # roboledger graphs also get example queries, element resolution, GraphQL,
-  # and document search). Write tools are never included. The two orientation
-  # tools are normally prefetched into the system prompt and withheld from
-  # the loop; they stay listed for the fallback when that prefetch fails.
+  # roboledger graphs also get the curated and OLTP reads below). Write tools
+  # are never included. The two orientation tools are normally prefetched
+  # into the system prompt and withheld from the loop; they stay listed for
+  # the fallback when that prefetch fails.
   READ_ONLY_TOOLS = [
     "get-graph-schema",
     "read-graph-cypher",
@@ -62,7 +62,56 @@ class CypherOperator(Operator):
     "resolve-element",
     "search-documents",
     "get-document-section",
+    # Curated financial reads — routed ahead of raw Cypher for statement,
+    # balance, and pivot questions (see CURATED TOOLS in the system prompt).
+    "live-financial-statement",
+    "financial-statement-analysis",
+    "build-fact-grid",
+    # Period workflow and freshness reads
+    "get-fiscal-calendar",
+    "get-period-close-status",
+    "list-period-drafts",
+    "get-graph-sync-status",
+    "get-close-playbook",
+    # Chart-of-accounts mapping reads
+    "list-mapping-structures",
+    "get-unmapped-elements",
+    "get-mapping-summary",
+    "suggest-mapping",
+    # Tenant entity/OLTP reads
+    "list-subgraphs",
+    "get-information-block",
+    "list-information-blocks",
+    "get-agent",
+    "list-agents",
+    "agent-activity",
+    "get-event-block",
+    "list-event-blocks",
+    "get-event-handler",
+    "list-event-handlers",
+    "get-document",
+    "list-documents",
+    "recall",
   ]
+
+  # The subset worth calling out in the system prompt as preferred over raw
+  # Cypher, with the one-line routing hint for each.
+  CURATED_TOOL_HINTS: dict[str, str] = {
+    "live-financial-statement": (
+      "current income statement / balance sheet / trial balance straight "
+      "from the live ledger — the right first call for expense, revenue, "
+      "and balance questions"
+    ),
+    "financial-statement-analysis": (
+      "financial statement analysis over the reported (materialized) facts"
+    ),
+    "build-fact-grid": (
+      "multidimensional pivots over the fact hypercube (by account, period, dimension)"
+    ),
+    "get-fiscal-calendar": "fiscal periods, close status, and the close target",
+    "get-period-close-status": "close readiness for a specific period",
+    "get-graph-sync-status": "source-connection data freshness",
+  }
 
   spec = OperatorSpec(
     name="Cypher Operator",
@@ -142,6 +191,8 @@ class CypherOperator(Operator):
     if orientation is not None:
       tool_names = [t for t in tool_names if t not in _ORIENTATION_TOOLS]
 
+    curated_tools = [t for t in self.CURATED_TOOL_HINTS if t in available_tools]
+
     system = self._build_system_prompt(
       max_results,
       output_mode,
@@ -149,6 +200,7 @@ class CypherOperator(Operator):
       has_document_search,
       max_iterations,
       orientation,
+      curated_tools,
     )
 
     result = await run_tool_loop(
@@ -160,6 +212,7 @@ class CypherOperator(Operator):
       temperature=0.3,
       operator_type="cypher",
       operation_description="Cypher query loop",
+      max_credits=self._get_max_credits(ctx),
     )
 
     await ctx.progress.report("Done", percent=100)
@@ -173,6 +226,7 @@ class CypherOperator(Operator):
         "rows": rows,
         "result_count": len(rows),
         "hit_step_limit": result.hit_cap,
+        "hit_credit_ceiling": result.hit_credit_ceiling,
         "loop_iterations": result.iterations,
       },
       # De-dupe preserving order (a tool may be called several times).
@@ -227,6 +281,7 @@ class CypherOperator(Operator):
     has_document_search: bool = False,
     tool_turns: int = 6,
     orientation: dict[str, str] | None = None,
+    curated_tools: list[str] | None = None,
   ) -> str:
     if is_shared:
       # Shared repository (e.g. SEC): thousands of filers, so the selective
@@ -255,9 +310,19 @@ class CypherOperator(Operator):
       )
 
     if orientation is not None:
+      first_move = (
+        "Call a curated tool where one fits (see CURATED TOOLS below); "
+        "otherwise write a read-only Cypher query and run it with "
+        "`read-graph-cypher`. Act on your first turn — no orientation calls "
+        "are needed."
+        if curated_tools
+        else "Write a read-only Cypher query and run it with "
+        "`read-graph-cypher` on your first turn — no orientation calls are "
+        "needed."
+      )
       workflow = f"""WORKFLOW:
 1. The GRAPH SCHEMA and (when present) EXAMPLE QUERIES sections at the end of this prompt are authoritative for this graph — plan directly from them and never guess labels or properties they don't show. (Purely qualitative/narrative questions may go straight to document search — see below.)
-2. Write a read-only Cypher query and run it with `read-graph-cypher` on your first turn — no orientation calls are needed.
+2. {first_move}
 3. If a query errors or returns nothing useful, read the error, fix the query, and try again — don't repeat a failing query unchanged.
 4. When you have the answer, respond in natural language.
 
@@ -289,6 +354,15 @@ CYPHER RULES:
 
 LEDGER DATA (only when the schema has Entry / Transaction / LineItem nodes):
 - The graph keeps cancelled/replaced rows for audit. When counting or summing ledger data, restrict to live rows using the materialized `is_live` boolean — it exists on every spine node (`Entry`, `LineItem`, `Event`, `Transaction`) and is the one rule to remember: `WHERE e.is_live`, `WHERE li.is_live`, `WHERE ev.is_live`, `WHERE t.is_live`. For balances/debit-credit sums, aggregate through live Entry/LineItem (`e.is_live`, ⇔ status = 'posted'), not by summing Transaction.amount. `is_live` keeps open obligations (pending/committed/fulfilled events); for a specific realized set, filter `status` explicitly.
+"""
+    if curated_tools:
+      hints = "\n".join(
+        f"- `{name}`: {self.CURATED_TOOL_HINTS[name]}" for name in curated_tools
+      )
+      prompt += f"""
+CURATED TOOLS (prefer these over raw Cypher when one answers the question — they encode the accounting semantics you would otherwise reconstruct by hand):
+{hints}
+Reach for `read-graph-cypher` when no curated tool fits, or to drill into specifics a curated result doesn't show.
 """
     if has_document_search:
       if is_shared:
@@ -340,8 +414,24 @@ EXAMPLE QUERIES (working patterns for this graph — copy and adapt rather than 
       OperatorMode.EXTENDED: 500,
     }.get(mode, 100)
 
+  @staticmethod
+  def _get_max_credits(ctx: OperatorContext) -> float | None:
+    """Caller-chosen per-question credit ceiling, from the request context.
+
+    Tenant-supplied, so anything non-numeric or non-positive is ignored
+    rather than trusted to shape the loop.
+    """
+    raw = ctx.extra.get("max_credits")
+    if raw is None:
+      return None
+    try:
+      value = float(raw)
+    except (TypeError, ValueError):
+      return None
+    return value if value > 0 else None
+
   def _calculate_confidence(self, result: ToolLoopResult) -> float:
-    if result.hit_cap:
+    if result.hit_cap or result.hit_credit_ceiling:
       return 0.5
     if result.rows:
       return 0.9

--- a/robosystems/operations/operators/implementations/cypher.py
+++ b/robosystems/operations/operators/implementations/cypher.py
@@ -1,19 +1,23 @@
 """CypherOperator — natural-language querying of the graph.
 
-Drives a bounded tool-use loop (`run_tool_loop`): the model discovers the
-schema, writes read-only Cypher, sees query errors and retries, then answers in
-natural language. Seeing its own errors is the point — a single-shot pipeline
-that generates one query and formats whatever comes back fails on questions
-this handles. The last non-empty result set is returned as structured ``rows``
-so the console renders a real table instead of scraping the prose.
+Drives a bounded tool-use loop (`run_tool_loop`): the schema and example
+queries are fetched up front into the (cached) system prompt, the model
+writes read-only Cypher against them, sees query errors and retries, then
+answers in natural language. Seeing its own errors is the point — a
+single-shot pipeline that generates one query and formats whatever comes
+back fails on questions this handles. The last non-empty result set is
+returned as structured ``rows`` so the console renders a real table instead
+of scraping the prose.
 """
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from robosystems.config import OperatorConfig
 from robosystems.config.shared_repositories import is_shared_repository_or_subgraph
+from robosystems.logger import logger
 from robosystems.operations.operators.base import (
   ExecutionProfile,
   Operator,
@@ -30,6 +34,14 @@ from robosystems.operations.operators.tool_loop import (
   run_tool_loop,
 )
 
+# Orientation payloads are fetched up front and rendered into the system
+# prompt rather than left as tools for the model to call: schema and
+# examples are static per graph, so this removes two model calls per
+# question and puts both under the system cache breakpoint. The cap mirrors
+# the tool loop's orientation cap — only a pathological graph truncates.
+_ORIENTATION_TOOLS = ("get-graph-schema", "get-example-queries")
+_MAX_ORIENTATION_CHARS = 48000
+
 
 @register_operator("cypher")
 class CypherOperator(Operator):
@@ -38,7 +50,9 @@ class CypherOperator(Operator):
   # Read-only tool allowlist. The loop intersects this with the tools the
   # graph actually exposes (generic graphs get only schema + cypher; SEC and
   # roboledger graphs also get example queries, element resolution, GraphQL,
-  # and document search). Write tools are never included.
+  # and document search). Write tools are never included. The two orientation
+  # tools are normally prefetched into the system prompt and withheld from
+  # the loop; they stay listed for the fallback when that prefetch fails.
   READ_ONLY_TOOLS = [
     "get-graph-schema",
     "read-graph-cypher",
@@ -123,14 +137,24 @@ class CypherOperator(Operator):
     }
     has_document_search = "search-documents" in available_tools
 
+    orientation = await self._fetch_orientation(ctx, available_tools)
+    tool_names = self.READ_ONLY_TOOLS
+    if orientation is not None:
+      tool_names = [t for t in tool_names if t not in _ORIENTATION_TOOLS]
+
     system = self._build_system_prompt(
-      max_results, output_mode, is_shared, has_document_search, max_iterations
+      max_results,
+      output_mode,
+      is_shared,
+      has_document_search,
+      max_iterations,
+      orientation,
     )
 
     result = await run_tool_loop(
       ctx,
       system=system,
-      tool_names=self.READ_ONLY_TOOLS,
+      tool_names=tool_names,
       max_iterations=max_iterations,
       max_tokens=max_tokens,
       temperature=0.3,
@@ -156,6 +180,45 @@ class CypherOperator(Operator):
       confidence_score=self._calculate_confidence(result),
     )
 
+  async def _fetch_orientation(
+    self, ctx: OperatorContext, available_tools: set[str]
+  ) -> dict[str, str] | None:
+    """Fetch the schema (and examples, where the graph has them) up front.
+
+    Both payloads are deterministic per graph, so they belong in the cached
+    system prefix rather than in the transcript as tool results — the model
+    gets a complete schema instead of a truncated tool result, and skips the
+    orientation calls entirely. Returns None on any failure so the loop
+    falls back to tool-driven orientation.
+    """
+    if "get-graph-schema" not in available_tools:
+      return None
+    try:
+      schema = await ctx.tools.call_tool("get-graph-schema", {}, return_raw=True)
+      if isinstance(schema, dict) and "error" in schema:
+        return None
+      orientation = {"schema": self._serialize_orientation(schema)}
+      if "get-example-queries" in available_tools:
+        examples = await ctx.tools.call_tool("get-example-queries", {}, return_raw=True)
+        if not (isinstance(examples, dict) and "error" in examples):
+          orientation["examples"] = self._serialize_orientation(examples)
+      return orientation
+    except Exception as e:
+      logger.warning(
+        "Cypher operator orientation prefetch failed on %s; "
+        "falling back to tool-driven orientation: %s",
+        ctx.graph_id,
+        e,
+      )
+      return None
+
+  @staticmethod
+  def _serialize_orientation(payload: Any) -> str:
+    text = json.dumps(payload, default=str)
+    if len(text) > _MAX_ORIENTATION_CHARS:
+      text = text[:_MAX_ORIENTATION_CHARS] + "\n… [truncated]"
+    return text
+
   def _build_system_prompt(
     self,
     max_results: int,
@@ -163,6 +226,7 @@ class CypherOperator(Operator):
     is_shared: bool,
     has_document_search: bool = False,
     tool_turns: int = 6,
+    orientation: dict[str, str] | None = None,
   ) -> str:
     if is_shared:
       # Shared repository (e.g. SEC): thousands of filers, so the selective
@@ -190,16 +254,32 @@ class CypherOperator(Operator):
         "hypercube unless the question is about a published financial statement."
       )
 
-    prompt = f"""You are a graph database analyst for RoboSystems. You answer the user's question by querying a LadybugDB graph with read-only Cypher.
+    if orientation is not None:
+      workflow = f"""WORKFLOW:
+1. The GRAPH SCHEMA and (when present) EXAMPLE QUERIES sections at the end of this prompt are authoritative for this graph — plan directly from them and never guess labels or properties they don't show. (Purely qualitative/narrative questions may go straight to document search — see below.)
+2. Write a read-only Cypher query and run it with `read-graph-cypher` on your first turn — no orientation calls are needed.
+3. If a query errors or returns nothing useful, read the error, fix the query, and try again — don't repeat a failing query unchanged.
+4. When you have the answer, respond in natural language.
 
-WORKFLOW:
+STEP BUDGET: you have {tool_turns} tool-calling turns before you must answer from what you have. A turn whose tool calls all fail is not charged (up to {DEFAULT_MAX_ERROR_RETRIES} times), so a corrected retry is free — spend your turns on queries, not orientation."""
+    else:
+      workflow = f"""WORKFLOW:
 1. For any question that needs the fact graph, call `get-graph-schema` first to discover node labels, relationships, and properties — never guess the schema. (Purely qualitative/narrative questions may skip straight to document search — see below.)
 2. If `get-example-queries` is available, use it for working query patterns tuned to this graph.
 3. Write a read-only Cypher query and run it with `read-graph-cypher`.
 4. If a query errors or returns nothing useful, read the error, fix the query, and try again — don't repeat a failing query unchanged.
 5. When you have the answer, respond in natural language.
 
-STEP BUDGET: you have {tool_turns} tool-calling turns before you must answer from what you have. A turn whose tool calls all fail is not charged (up to {DEFAULT_MAX_ERROR_RETRIES} times), so a corrected retry is free — but plan to reach `read-graph-cypher` within the first three turns.
+STEP BUDGET: you have {tool_turns} tool-calling turns before you must answer from what you have. A turn whose tool calls all fail is not charged (up to {DEFAULT_MAX_ERROR_RETRIES} times), so a corrected retry is free — but plan to reach `read-graph-cypher` within the first three turns."""
+
+    # Stale once orientation is in the prompt and the tool isn't offered.
+    schema_skip_note = (
+      ", and you do NOT need `get-graph-schema` first" if orientation is None else ""
+    )
+
+    prompt = f"""You are a graph database analyst for RoboSystems. You answer the user's question by querying a LadybugDB graph with read-only Cypher.
+
+{workflow}
 
 CYPHER RULES:
 - Read-only only: MATCH, WHERE, WITH, RETURN, ORDER BY, LIMIT. Never CREATE, SET, DELETE, MERGE, or DROP.
@@ -214,20 +294,30 @@ LEDGER DATA (only when the schema has Entry / Transaction / LineItem nodes):
       if is_shared:
         # Shared repository (SEC): documents are filing sections, so the
         # vocabulary is filing-specific (risk factors, MD&A, item_1a/item_7).
-        prompt += """
+        prompt += f"""
 NARRATIVE DISCLOSURES (qualitative filing text — NOT in the Cypher fact graph):
-- Questions about risk factors, MD&A, business description, legal proceedings, competition, or other management commentary are answered from filing TEXT, not the XBRL facts. Cypher can't surface this — use `search-documents` (hybrid semantic search over filing sections), and you do NOT need `get-graph-schema` first.
+- Questions about risk factors, MD&A, business description, legal proceedings, competition, or other management commentary are answered from filing TEXT, not the XBRL facts. Cypher can't surface this — use `search-documents` (hybrid semantic search over filing sections){schema_skip_note}.
 - `search-documents` returns ranked snippets, each with a document_id. Call `get-document-section` with that id to read the full section before you answer. When the question names a section, narrow with the section filter (e.g. item_1a for risk factors, item_7 for MD&A).
 - A section may carry `xbrl_elements`; use `resolve-element` or `read-graph-cypher` to tie the narrative back to the reported numbers when the question needs both text and figures.
 """
       else:
         # Tenant graph (roboledger / custom): documents are the company's own
         # uploaded policies, procedures, and notes — not SEC filing sections.
-        prompt += """
+        prompt += f"""
 DOCUMENTS (qualitative written context — accounting policies, procedures, memos, notes — NOT in the Cypher fact graph):
-- Questions about this company's accounting policies, close procedures, memos, or other written context are answered from its uploaded DOCUMENTS, not the ledger facts. Cypher can't surface this — use `search-documents` (hybrid semantic search over this graph's documents), and you do NOT need `get-graph-schema` first.
+- Questions about this company's accounting policies, close procedures, memos, or other written context are answered from its uploaded DOCUMENTS, not the ledger facts. Cypher can't surface this — use `search-documents` (hybrid semantic search over this graph's documents){schema_skip_note}.
 - `search-documents` returns ranked snippets, each with a document_id. Call `get-document-section` with that id to read the full section before you answer.
 - When a question needs both the written policy and the reported figures, combine the two: search for the text, then query the ledger with `read-graph-cypher`.
+"""
+    if orientation is not None:
+      prompt += f"""
+GRAPH SCHEMA (authoritative — node types first, then relationships):
+{orientation["schema"]}
+"""
+      if "examples" in orientation:
+        prompt += f"""
+EXAMPLE QUERIES (working patterns for this graph — copy and adapt rather than writing traversals from scratch):
+{orientation["examples"]}
 """
     if output_mode == "answer":
       prompt += (

--- a/robosystems/operations/operators/tool_loop.py
+++ b/robosystems/operations/operators/tool_loop.py
@@ -47,6 +47,12 @@ _ANSWER_NOW = (
   "results gathered so far. Do not request any more tools."
 )
 
+_ANSWER_NOW_CREDITS = (
+  "You've reached the credit limit set for this question. Answer the original "
+  "question now using the results gathered so far. Do not request any more "
+  "tools."
+)
+
 # The nudge keeps the tool definitions (the transcript carries tool_use
 # blocks, which the API requires tools for) but forbids further calls, so
 # the final turn is guaranteed to be text rather than a dropped tool_use.
@@ -63,6 +69,7 @@ class ToolLoopResult:
   tools_called: list[str] = field(default_factory=list)
   iterations: int = 0  # model calls made, including the nudge if any
   hit_cap: bool = False  # stopped at max_iterations rather than by the model
+  hit_credit_ceiling: bool = False  # stopped by the caller's max_credits
   error_retries: int = 0  # uncharged turns granted for all-error tool results
 
 
@@ -100,6 +107,7 @@ async def run_tool_loop(
   operator_type: str | None = None,
   operation_description: str = "Tool-use loop",
   max_error_retries: int = DEFAULT_MAX_ERROR_RETRIES,
+  max_credits: float | None = None,
 ) -> ToolLoopResult:
   """Run a bounded tool-use loop and return the model's final answer.
 
@@ -112,6 +120,13 @@ async def run_tool_loop(
   one further turn nudges the model to answer from what it has with tool use
   disabled, so the loop always costs at most
   ``max_iterations + max_error_retries + 1`` model calls.
+
+  ``max_credits`` is a soft per-run ceiling checked between model calls
+  against the run's accumulated spend (`TrackedAIClient.total_credits`): once
+  reached, no further tool turn starts and the model is nudged to answer from
+  what it has — so the wrap-up turn itself can carry the total somewhat past
+  the ceiling, but a runaway run stops at a number the caller chose rather
+  than at the iteration cap.
   """
   tools = await ctx.tools.get_tool_schemas(tool_names)
   if not tools:
@@ -133,9 +148,20 @@ async def run_tool_loop(
   tool_turns = 0  # round-trips charged against max_iterations
   error_retries = 0  # uncharged round-trips granted so far
   model_calls = 0
+  hit_ceiling = False
   step = 60 // max(max_iterations, 1)
 
   while tool_turns < max_iterations:
+    # Between-calls credit check: the first call always runs (its cost is
+    # unknowable up front and the pre-flight already gated the run).
+    if (
+      max_credits is not None
+      and model_calls > 0
+      and getattr(ctx.ai, "total_credits", 0.0) >= max_credits
+    ):
+      hit_ceiling = True
+      break
+
     await ctx.progress.report(
       "Thinking..." if model_calls == 0 else f"Working (step {model_calls + 1})...",
       percent=min(20 + tool_turns * step, 85),
@@ -234,20 +260,26 @@ async def run_tool_loop(
     else:
       error_retries += 1
 
-  # Iteration cap reached. Nudge for a final answer, appending the nudge to
-  # the trailing user turn (avoids a second consecutive user message). Keep
-  # `tools` defined so the tool_use/tool_result transcript stays valid, but
-  # disable tool choice so the answer can't come back as a tool_use block
-  # that nobody would execute.
+  # Iteration cap or credit ceiling reached. Nudge for a final answer,
+  # appending the nudge to the trailing user turn (a second consecutive user
+  # message would be rejected). Keep `tools` defined so the tool_use/
+  # tool_result transcript stays valid, but disable tool choice so the answer
+  # can't come back as a tool_use block that nobody would execute.
+  answer_now = _ANSWER_NOW_CREDITS if hit_ceiling else _ANSWER_NOW
   final_messages = list(messages)
   last = final_messages[-1]
-  if last.role == "user" and isinstance(last.content, list):
-    final_messages[-1] = AIMessage(
-      role="user",
-      content=[*last.content, {"type": "text", "text": _ANSWER_NOW}],
-    )
+  if last.role == "user":
+    if isinstance(last.content, list):
+      final_messages[-1] = AIMessage(
+        role="user",
+        content=[*last.content, {"type": "text", "text": answer_now}],
+      )
+    else:
+      final_messages[-1] = AIMessage(
+        role="user", content=f"{last.content}\n\n{answer_now}"
+      )
   else:
-    final_messages.append(AIMessage(role="user", content=_ANSWER_NOW))
+    final_messages.append(AIMessage(role="user", content=answer_now))
 
   final = await ctx.ai.create_message(
     messages=final_messages,
@@ -267,6 +299,7 @@ async def run_tool_loop(
     cypher=last_cypher,
     tools_called=tools_called,
     iterations=model_calls + 1,
-    hit_cap=True,
+    hit_cap=not hit_ceiling,
+    hit_credit_ceiling=hit_ceiling,
     error_retries=error_retries,
   )

--- a/robosystems/operations/operators/tool_loop.py
+++ b/robosystems/operations/operators/tool_loop.py
@@ -149,6 +149,10 @@ async def run_tool_loop(
       operator_type=operator_type,
       operation_description=operation_description,
       tools=tools,
+      # The transcript grows monotonically across iterations, so a breakpoint
+      # on the trailing turn means every call from the second onward reads the
+      # previous call's cache entry and extends it.
+      cache_conversation=True,
     )
     model_calls += 1
 
@@ -254,6 +258,7 @@ async def run_tool_loop(
     operation_description=operation_description,
     tools=tools,
     tool_choice=_NO_MORE_TOOLS if tools else None,
+    cache_conversation=True,
   )
   return ToolLoopResult(
     text=final.content

--- a/robosystems/operations/operators/tracked_ai.py
+++ b/robosystems/operations/operators/tracked_ai.py
@@ -72,6 +72,7 @@ class TrackedAIClient:
     operation_description: str = "Operator AI call",
     tools: list[dict[str, Any]] | None = None,
     tool_choice: dict[str, Any] | None = None,
+    cache_conversation: bool = False,
   ) -> AIResponse:
     """Call the model and consume credits for it.
 
@@ -98,6 +99,7 @@ class TrackedAIClient:
       operator_type=operator_type,
       tools=tools,
       tool_choice=tool_choice,
+      cache_conversation=cache_conversation,
     )
 
     self.total_tokens["input"] += response.input_tokens

--- a/robosystems/routers/graphs/operator/execute.py
+++ b/robosystems/routers/graphs/operator/execute.py
@@ -98,6 +98,14 @@ def _check_operator_post_enabled():
     )
 
 
+def _request_context(request: OperatorRequest) -> dict | None:
+  """The free-form context dict handed to the operator as ctx.extra, with the
+  typed per-question credit ceiling folded in when the caller set one."""
+  if request.max_credits is None:
+    return request.context
+  return {**(request.context or {}), "max_credits": request.max_credits}
+
+
 def _convert_operator_mode(mode: OperatorMode | None) -> BaseOperatorMode:
   """Convert API OperatorMode to base OperatorMode."""
   if mode is None:
@@ -241,7 +249,7 @@ async def auto_operator(
       "message": request.message,
       "mode": request.mode.value if request.mode else "standard",
       "history": history,
-      "context": request.context,
+      "context": _request_context(request),
       "enable_rag": request.enable_rag,
       "force_extended_analysis": request.force_extended_analysis,
     }
@@ -395,7 +403,7 @@ async def specific_operator(
       "message": request.message,
       "mode": request.mode.value if request.mode else "standard",
       "history": history,
-      "context": request.context,
+      "context": _request_context(request),
       "enable_rag": request.enable_rag,
       "force_extended_analysis": request.force_extended_analysis,
     }

--- a/tests/middleware/mcp/tools/test_manager_helpers.py
+++ b/tests/middleware/mcp/tools/test_manager_helpers.py
@@ -148,8 +148,11 @@ class TestGetToolDefinitionHelpers:
     assert tools.graphql_query_tool is not None
     assert {"get-graphql-schema", "query-graphql"} <= names
 
-  def test_live_statement_tool_absent_on_read_only(self, mock_client):
-    """Read-only graphs must NOT get the OLTP live-statement tool."""
+  def test_read_only_tenant_keeps_the_read_half_of_each_pair(self, mock_client):
+    """Pure reads that were historically bundled with their write siblings —
+    live statement, sync status, the period workflow, the mapping reads —
+    stay available on a read-only surface (graph viewers, read-only
+    operators); only the writes require a writable graph."""
     with (
       patch.object(GraphMCPTools, "_should_include_semantic_tools", return_value=False),
       patch("robosystems.middleware.mcp.tools.manager.env") as mock_env,
@@ -157,13 +160,58 @@ class TestGetToolDefinitionHelpers:
       mock_env.MCP_WORKSPACE_ENABLED = False
       mock_env.MCP_SUBGRAPH_OPS_ENABLED = False
       mock_env.FACT_GRID_ENABLED = False
+      mock_env.ROBOLEDGER_ENABLED = True
       tools = GraphMCPTools(
         mock_client, schema_extensions=["roboledger"], read_only=True
       )
 
-    # Analysis tool stays (read-only is fine for graph-backed reads)
     assert tools.financial_statement_analysis_tool is not None
+    assert tools.live_financial_statement_tool is not None
+    assert tools.get_graph_sync_status_tool is not None
+    assert tools.get_fiscal_calendar_tool is not None
+    assert tools.get_period_close_status_tool is not None
+    assert tools.list_period_drafts_tool is not None
+    assert tools.list_mapping_structures_tool is not None
+    assert tools.get_unmapped_elements_tool is not None
+    assert tools.get_mapping_summary_tool is not None
+    assert tools.suggest_mapping_tool is not None
+
+    # The write siblings stay off.
+    assert tools.materialize_tool is None
+    assert tools.close_period_tool is None
+    assert tools.reopen_period_tool is None
+    assert tools.backfill_plan_history_tool is None
+    assert tools.set_write_policy_tool is None
+    assert tools.sync_connection_tool is None
+    assert tools.bind_text_block_tool is None
+
+  def test_split_oltp_reads_stay_off_shared_repos(self, mock_client):
+    """The unbundled reads are extensions-OLTP-backed, and the OLTP DB has no
+    per-graph schema for a shared repo — the new gates must exclude SEC even
+    though read_only no longer does."""
+    mock_client.graph_id = "sec"
+    with (
+      patch.object(GraphMCPTools, "_should_include_semantic_tools", return_value=False),
+      patch.object(GraphMCPTools, "_is_shared_repository", return_value=True),
+      patch("robosystems.middleware.mcp.tools.manager.env") as mock_env,
+    ):
+      mock_env.MCP_WORKSPACE_ENABLED = False
+      mock_env.MCP_SUBGRAPH_OPS_ENABLED = False
+      mock_env.FACT_GRID_ENABLED = False
+      mock_env.ROBOLEDGER_ENABLED = True
+      tools = GraphMCPTools(
+        mock_client, schema_extensions=["roboledger"], read_only=True
+      )
+
     assert tools.live_financial_statement_tool is None
+    assert tools.get_graph_sync_status_tool is None
+    assert tools.get_fiscal_calendar_tool is None
+    assert tools.get_period_close_status_tool is None
+    assert tools.list_period_drafts_tool is None
+    assert tools.list_mapping_structures_tool is None
+    assert tools.get_unmapped_elements_tool is None
+    assert tools.get_mapping_summary_tool is None
+    assert tools.suggest_mapping_tool is None
 
   def test_oltp_read_tools_absent_on_shared_repo(self, mock_client):
     """Roboledger OLTP read tools (information blocks, agents, event handlers,
@@ -511,8 +559,9 @@ class TestTaxonomyToolRegistration:
     assert "create-mapping-association" in tool_names
     assert "get-mapping-summary" in tool_names
 
-  def test_taxonomy_tools_not_in_readonly(self, mock_client):
-    """Taxonomy tools should NOT appear for read-only graphs."""
+  def test_taxonomy_reads_advertised_on_readonly_but_writes_are_not(self, mock_client):
+    """The mapping READS stay available on read-only graphs; the registrar
+    write tools require a writable surface."""
     with (
       patch.object(GraphMCPTools, "_should_include_semantic_tools", return_value=False),
       patch("robosystems.middleware.mcp.tools.manager.env") as mock_env,
@@ -530,7 +579,9 @@ class TestTaxonomyToolRegistration:
 
     definitions = tools.get_tool_definitions_as_dict()
     tool_names = {d["name"] for d in definitions}
-    assert "get-unmapped-elements" not in tool_names
+    assert "get-unmapped-elements" in tool_names
+    assert "suggest-mapping" in tool_names
+    assert "get-mapping-summary" in tool_names
     assert "create-mapping-association" not in tool_names
 
   def test_taxonomy_tools_not_without_extension(self, mock_client):

--- a/tests/models/api/test_operator_models.py
+++ b/tests/models/api/test_operator_models.py
@@ -91,6 +91,14 @@ class TestOperatorRequest:
     with pytest.raises(ValidationError):
       OperatorRequest(message="")
 
+  def test_max_credits_bounds(self):
+    """The per-question credit ceiling must be a positive, sane number."""
+    assert OperatorRequest(message="ok").max_credits is None
+    assert OperatorRequest(message="ok", max_credits=250).max_credits == 250
+    for bad in (0, -1, 100_001):
+      with pytest.raises(ValidationError):
+        OperatorRequest(message="ok", max_credits=bad)
+
   def test_history_is_bounded_in_size_and_content(self):
     too_many = [
       OperatorMessage(role="user", content="q")

--- a/tests/operations/operators/test_cypher_orientation.py
+++ b/tests/operations/operators/test_cypher_orientation.py
@@ -1,0 +1,147 @@
+"""CypherOperator orientation prefetch — schema/examples in the system prefix.
+
+Schema and example queries are deterministic per graph, so the operator
+fetches them once up front and renders them into the (cached) system prompt
+instead of leaving them as tools: the model gets a complete schema rather
+than a truncated tool result, and a standard question loses two orientation
+model calls. The tool-driven path survives as the fallback when the
+prefetch fails.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robosystems.operations.operators.base import OperatorMode
+from robosystems.operations.operators.implementations.cypher import CypherOperator
+from robosystems.operations.operators.operator_context import OperatorContext
+from robosystems.operations.operators.progress import NoOpProgress
+from robosystems.operations.operators.tool_loop import ToolLoopResult
+
+pytestmark = pytest.mark.asyncio
+
+SCHEMA = [
+  {"type": "node", "label": "Entity", "properties": [{"name": "name"}]},
+  {"type": "relationship", "label": "ENTITY_HAS_REPORT", "from": "Entity"},
+]
+EXAMPLES = [{"category": "exploration", "query": "MATCH (e:Entity) RETURN e LIMIT 5"}]
+
+
+def _tools(available: list[str], call_results: dict[str, object]) -> MagicMock:
+  tools = MagicMock()
+  tools.get_tool_schemas = AsyncMock(
+    return_value=[
+      {"name": name, "description": "d", "input_schema": {"type": "object"}}
+      for name in available
+    ]
+  )
+
+  async def call_tool(name, arguments, return_raw=False):
+    result = call_results[name]
+    if isinstance(result, Exception):
+      raise result
+    return result
+
+  tools.call_tool = AsyncMock(side_effect=call_tool)
+  return tools
+
+
+def _ctx(tools: MagicMock) -> OperatorContext:
+  return OperatorContext(
+    graph_id="kg_test",
+    user_id="u",
+    query="Total expenses in July?",
+    mode=OperatorMode.STANDARD,
+    history=[],
+    ai=MagicMock(),
+    tools=tools,
+    progress=NoOpProgress(),
+  )
+
+
+def _loop_result() -> ToolLoopResult:
+  return ToolLoopResult(text="answer", iterations=2)
+
+
+async def _run(tools: MagicMock):
+  """Run the operator with the loop patched out; return the loop's kwargs."""
+  with patch(
+    "robosystems.operations.operators.implementations.cypher.run_tool_loop",
+    AsyncMock(return_value=_loop_result()),
+  ) as loop:
+    await CypherOperator().run(_ctx(tools))
+  return loop.await_args.kwargs
+
+
+async def test_orientation_is_prefetched_into_the_system_prompt():
+  tools = _tools(
+    ["get-graph-schema", "get-example-queries", "read-graph-cypher"],
+    {"get-graph-schema": SCHEMA, "get-example-queries": EXAMPLES},
+  )
+  kwargs = await _run(tools)
+
+  system = kwargs["system"]
+  assert "GRAPH SCHEMA" in system
+  assert json.dumps(SCHEMA) in system
+  assert "EXAMPLE QUERIES" in system
+  assert json.dumps(EXAMPLES) in system
+  # The prompt no longer routes the model through the orientation tools...
+  assert "call `get-graph-schema` first" not in system
+  # ...and the loop no longer offers them.
+  assert kwargs["tool_names"] == [
+    t
+    for t in CypherOperator.READ_ONLY_TOOLS
+    if t not in ("get-graph-schema", "get-example-queries")
+  ]
+
+
+async def test_prefetch_failure_falls_back_to_tool_driven_orientation():
+  tools = _tools(
+    ["get-graph-schema", "get-example-queries", "read-graph-cypher"],
+    {
+      "get-graph-schema": RuntimeError("graph API down"),
+      "get-example-queries": EXAMPLES,
+    },
+  )
+  kwargs = await _run(tools)
+
+  assert "GRAPH SCHEMA" not in kwargs["system"]
+  assert "call `get-graph-schema` first" in kwargs["system"]
+  assert kwargs["tool_names"] == CypherOperator.READ_ONLY_TOOLS
+
+
+async def test_error_dict_schema_falls_back():
+  """Registrar-style tools report failure as {"error": ...} without raising —
+  that must not end up rendered into the prompt as a schema."""
+  tools = _tools(
+    ["get-graph-schema", "read-graph-cypher"],
+    {"get-graph-schema": {"error": "not ready"}},
+  )
+  kwargs = await _run(tools)
+
+  assert "GRAPH SCHEMA" not in kwargs["system"]
+  assert kwargs["tool_names"] == CypherOperator.READ_ONLY_TOOLS
+
+
+async def test_graph_without_examples_gets_schema_only():
+  """A generic graph exposes no get-example-queries; the schema section still
+  lands and no examples section is emitted."""
+  tools = _tools(
+    ["get-graph-schema", "read-graph-cypher"],
+    {"get-graph-schema": SCHEMA},
+  )
+  kwargs = await _run(tools)
+
+  assert "GRAPH SCHEMA" in kwargs["system"]
+  assert "EXAMPLE QUERIES (working patterns" not in kwargs["system"]
+  tools.call_tool.assert_awaited_once()
+
+
+async def test_oversized_orientation_is_truncated_deterministically():
+  big = [{"label": "N" * 1000} for _ in range(100)]
+  text = CypherOperator._serialize_orientation(big)
+  assert len(text) <= 48000 + len("\n… [truncated]")
+  assert text.endswith("[truncated]")

--- a/tests/operations/operators/test_cypher_orientation.py
+++ b/tests/operations/operators/test_cypher_orientation.py
@@ -145,3 +145,59 @@ async def test_oversized_orientation_is_truncated_deterministically():
   text = CypherOperator._serialize_orientation(big)
   assert len(text) <= 48000 + len("\n… [truncated]")
   assert text.endswith("[truncated]")
+
+
+async def test_curated_tools_are_routed_ahead_of_cypher():
+  """Where the graph exposes the curated financial reads, the prompt routes
+  statement/balance/period questions to them first, and the loop offers
+  them."""
+  tools = _tools(
+    [
+      "get-graph-schema",
+      "read-graph-cypher",
+      "live-financial-statement",
+      "get-fiscal-calendar",
+    ],
+    {"get-graph-schema": SCHEMA},
+  )
+  kwargs = await _run(tools)
+
+  system = kwargs["system"]
+  assert "CURATED TOOLS" in system
+  assert "`live-financial-statement`" in system
+  assert "`get-fiscal-calendar`" in system
+  # Hints only for tools this graph actually exposes.
+  assert "`build-fact-grid`" not in system
+  assert "Call a curated tool where one fits" in system
+  assert "live-financial-statement" in kwargs["tool_names"]
+
+
+async def test_no_curated_section_without_curated_tools():
+  tools = _tools(
+    ["get-graph-schema", "read-graph-cypher"],
+    {"get-graph-schema": SCHEMA},
+  )
+  kwargs = await _run(tools)
+  assert "CURATED TOOLS" not in kwargs["system"]
+
+
+async def test_max_credits_reaches_the_loop_and_garbage_is_ignored():
+  tools = _tools(
+    ["get-graph-schema", "read-graph-cypher"],
+    {"get-graph-schema": SCHEMA},
+  )
+  with patch(
+    "robosystems.operations.operators.implementations.cypher.run_tool_loop",
+    AsyncMock(return_value=_loop_result()),
+  ) as loop:
+    ctx = _ctx(tools)
+    ctx.extra["max_credits"] = 25
+    await CypherOperator().run(ctx)
+  assert loop.await_args.kwargs["max_credits"] == 25.0
+
+  # Tenant-supplied garbage must not shape the loop.
+  assert CypherOperator._get_max_credits(_ctx(tools)) is None
+  for bad in ("abc", -5, 0, None, {"x": 1}):
+    ctx = _ctx(tools)
+    ctx.extra["max_credits"] = bad
+    assert CypherOperator._get_max_credits(ctx) is None, bad

--- a/tests/operations/operators/test_tool_loop.py
+++ b/tests/operations/operators/test_tool_loop.py
@@ -409,6 +409,34 @@ async def test_mixed_turn_with_one_success_is_charged():
   assert ai.create_message.call_args_list[1].kwargs["tool_choice"] == {"type": "none"}
 
 
+async def test_every_model_call_requests_conversation_caching():
+  """The transcript grows monotonically, so every call — loop turns and the
+  nudge alike — marks the trailing turn for caching; the next call reads the
+  entry the previous one wrote."""
+  ai = MagicMock()
+  ai.create_message = AsyncMock(
+    side_effect=[
+      _tool_use("t1", "read-graph-cypher", query="MATCH (n) RETURN n LIMIT 1"),
+      _final("nudged answer"),
+    ]
+  )
+  tools = _tools_mock(call_results=[[{"n": 1}]])
+  ctx = _ctx(ai, tools)
+
+  await run_tool_loop(
+    ctx,
+    system="s",
+    tool_names=["read-graph-cypher"],
+    max_iterations=1,
+    max_tokens=100,
+  )
+
+  assert ai.create_message.await_count == 2  # one loop turn + the nudge
+  assert all(
+    c.kwargs["cache_conversation"] is True for c in ai.create_message.call_args_list
+  )
+
+
 def _two_tools_mock(call_results: list) -> MagicMock:
   tools = MagicMock()
   tools.get_tool_schemas = AsyncMock(

--- a/tests/operations/operators/test_tool_loop.py
+++ b/tests/operations/operators/test_tool_loop.py
@@ -409,6 +409,69 @@ async def test_mixed_turn_with_one_success_is_charged():
   assert ai.create_message.call_args_list[1].kwargs["tool_choice"] == {"type": "none"}
 
 
+async def test_credit_ceiling_stops_the_loop_between_calls():
+  """Once accumulated spend reaches max_credits, no further tool turn starts;
+  the model is nudged to answer from what it has, with the credit-limit
+  wording rather than the step-limit one."""
+  ai = MagicMock()
+  ai.total_credits = 50.0
+  ai.create_message = AsyncMock(
+    side_effect=[
+      _tool_use("t1", "read-graph-cypher", query="MATCH (n) RETURN n LIMIT 1"),
+      _final("best effort within budget"),
+    ]
+  )
+  tools = _tools_mock(call_results=[[{"n": 1}]])
+  ctx = _ctx(ai, tools)
+
+  result = await run_tool_loop(
+    ctx,
+    system="s",
+    tool_names=["read-graph-cypher"],
+    max_iterations=5,
+    max_tokens=100,
+    max_credits=10.0,
+  )
+
+  assert result.hit_credit_ceiling is True
+  assert result.hit_cap is False
+  assert result.text == "best effort within budget"
+  assert ai.create_message.await_count == 2  # first turn + the nudge only
+  final_kwargs = ai.create_message.call_args_list[1].kwargs
+  assert final_kwargs["tool_choice"] == {"type": "none"}
+  last_user = final_kwargs["messages"][-1]
+  assert any(
+    isinstance(b, dict)
+    and b.get("type") == "text"
+    and "credit limit" in b.get("text", "")
+    for b in last_user.content
+  )
+
+
+async def test_first_model_call_runs_even_over_the_ceiling():
+  """The first call's cost is unknowable up front (the pre-flight gates the
+  run); the ceiling is checked between calls, so a model that answers on its
+  first turn is unaffected by a tiny ceiling."""
+  ai = MagicMock()
+  ai.total_credits = 999.0
+  ai.create_message = AsyncMock(side_effect=[_final("direct answer")])
+  tools = _tools_mock(call_results=[])
+  ctx = _ctx(ai, tools)
+
+  result = await run_tool_loop(
+    ctx,
+    system="s",
+    tool_names=["read-graph-cypher"],
+    max_iterations=5,
+    max_tokens=100,
+    max_credits=1.0,
+  )
+
+  assert result.text == "direct answer"
+  assert result.hit_credit_ceiling is False
+  assert ai.create_message.await_count == 1
+
+
 async def test_every_model_call_requests_conversation_caching():
   """The transcript grows monotonically, so every call — loop turns and the
   nudge alike — marks the trailing turn for caching; the next call reads the

--- a/tests/operations/test_ai_client.py
+++ b/tests/operations/test_ai_client.py
@@ -368,7 +368,15 @@ class TestAIClientCreateMessage:
 
     call_args = mock_bedrock.invoke_model.call_args
     request_body = json.loads(call_args[1]["body"])
-    assert request_body["system"] == "You are a financial analyst."
+    # `system` is a content-block list carrying the cache breakpoint that
+    # caches tools + system together.
+    assert request_body["system"] == [
+      {
+        "type": "text",
+        "text": "You are a financial analyst.",
+        "cache_control": {"type": "ephemeral"},
+      }
+    ]
     assert result.content == "Response with system context."
 
   @pytest.mark.unit
@@ -505,6 +513,88 @@ class TestAIClientCreateMessage:
     )
     request_body = json.loads(mock_bedrock.invoke_model.call_args[1]["body"])
     assert "tool_choice" not in request_body
+
+  @pytest.mark.unit
+  async def test_cache_conversation_marks_the_trailing_turn(self):
+    """cache_conversation puts a cache breakpoint on the last block of the
+    trailing message — string content is wrapped into a text block — and the
+    caller's message objects are never mutated (a persisted marker on every
+    past turn would exceed the 4-breakpoint limit)."""
+    client, mock_bedrock = _make_ai_client()
+    from robosystems.operations.operators.ai_client import AIMessage
+
+    response_body = {
+      "content": [{"type": "text", "text": "hi"}],
+      "usage": {"input_tokens": 10, "output_tokens": 5},
+      "stop_reason": "end_turn",
+    }
+    mock_body = MagicMock()
+    mock_body.read.return_value = json.dumps(response_body).encode()
+    mock_bedrock.invoke_model.return_value = {"body": mock_body}
+
+    tool_result = {"type": "tool_result", "tool_use_id": "t1", "content": "[]"}
+    messages = [
+      AIMessage(role="user", content="question"),
+      AIMessage(role="assistant", content=[{"type": "tool_use", "id": "t1"}]),
+      AIMessage(role="user", content=[tool_result]),
+    ]
+
+    await client.create_message(messages=messages, cache_conversation=True)
+
+    request_body = json.loads(mock_bedrock.invoke_model.call_args[1]["body"])
+    sent = request_body["messages"]
+    # Only the trailing turn's last block carries the marker.
+    assert sent[-1]["content"][-1]["cache_control"] == {"type": "ephemeral"}
+    assert "cache_control" not in json.dumps(sent[:-1])
+    # The caller's block object was copied, not mutated.
+    assert "cache_control" not in tool_result
+
+  @pytest.mark.unit
+  async def test_cache_conversation_wraps_string_content(self):
+    client, mock_bedrock = _make_ai_client()
+    from robosystems.operations.operators.ai_client import AIMessage
+
+    response_body = {
+      "content": [{"type": "text", "text": "hi"}],
+      "usage": {"input_tokens": 10, "output_tokens": 5},
+      "stop_reason": "end_turn",
+    }
+    mock_body = MagicMock()
+    mock_body.read.return_value = json.dumps(response_body).encode()
+    mock_bedrock.invoke_model.return_value = {"body": mock_body}
+
+    await client.create_message(
+      messages=[AIMessage(role="user", content="just a question")],
+      cache_conversation=True,
+    )
+    request_body = json.loads(mock_bedrock.invoke_model.call_args[1]["body"])
+    assert request_body["messages"][-1]["content"] == [
+      {
+        "type": "text",
+        "text": "just a question",
+        "cache_control": {"type": "ephemeral"},
+      }
+    ]
+
+  @pytest.mark.unit
+  async def test_no_conversation_marker_by_default(self):
+    """Single-shot callers pay the cache-write premium with nothing ever
+    reading the entry — the trailing-turn marker is opt-in."""
+    client, mock_bedrock = _make_ai_client()
+    from robosystems.operations.operators.ai_client import AIMessage
+
+    response_body = {
+      "content": [{"type": "text", "text": "hi"}],
+      "usage": {"input_tokens": 10, "output_tokens": 5},
+      "stop_reason": "end_turn",
+    }
+    mock_body = MagicMock()
+    mock_body.read.return_value = json.dumps(response_body).encode()
+    mock_bedrock.invoke_model.return_value = {"body": mock_body}
+
+    await client.create_message(messages=[AIMessage(role="user", content="hi")])
+    request_body = json.loads(mock_bedrock.invoke_model.call_args[1]["body"])
+    assert request_body["messages"] == [{"role": "user", "content": "hi"}]
 
   @pytest.mark.unit
   async def test_cache_token_counts_are_parsed_from_usage(self):


### PR DESCRIPTION
## Summary

Enables prompt caching on the operator loop and restructures the Cypher operator so its orientation payloads live in the cached prefix. Measured on the real operator payload, the cached prefix is 92% of a first call and cache reads bill at 0.1× — combined with dropping two orientation model calls per question, a `standard` question's input bill falls by roughly two-thirds. Stacked on #1288, which must land first: it teaches the meter to see cache tokens, and enabling caching without it would leave most input tokens unbilled.

## Changes

- **`robosystems/operations/operators/ai_client.py`** — `system` is now sent as a content-block list with a `cache_control: ephemeral` breakpoint at its end, which caches the tool definitions and system prompt together (the request renders tools → system → messages). New opt-in `cache_conversation` flag adds a second breakpoint on the trailing user turn, applied at request build without mutating the caller's transcript — a persisted marker on every past turn would exceed the 4-breakpoint limit.
- **`robosystems/operations/operators/tool_loop.py`** — every loop call (nudge included) passes `cache_conversation=True`: the transcript grows monotonically, so each call reads the cache entry the previous one wrote and extends it.
- **`robosystems/operations/operators/tracked_ai.py`** — passes the flag through.
- **`robosystems/operations/operators/implementations/cypher.py`** — the operator prefetches `get-graph-schema` (and `get-example-queries` where the graph exposes it) once, renders both into the system prompt, and withholds those two tools from the loop; the prompt tells the model to write its first query on turn one. Both payloads are deterministic per graph, so the prefix stays byte-stable per (graph, mode) — the prerequisite for cache hits. On any prefetch failure the operator falls back to the previous tool-driven orientation, for which the two tools remain on the allowlist.

## Breaking Changes

None. No API surface or SDK change. Behavior change per `standard` question: ~2 fewer model calls, a complete (untruncated) schema in front of the model, and most input tokens billed at the cache-read rate from the second call onward.

## Testing

- `just test` — full unit suite passed (14,053 passed, 43 skipped).
- `just test-code` — ruff, format, basedpyright, cf-lint all clean.
- New tests: system rendered as a cached content block; trailing-turn marker placement, string-content wrapping, no caller-transcript mutation, and opt-in default-off; the loop passing the flag on every call; orientation prefetched into the prompt with the reduced tool list; fallback on prefetch failure and on `{"error": ...}` payloads; schema-only graphs; deterministic truncation.

Post-deploy verification is the CUR reconciliation (it matched to 0.1 credit pre-caching and must match after) plus asserting `cache_read_input_tokens > 0` on a live probe — a sub-minimum prefix silently caches nothing, so "the call succeeded" proves nothing.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
