### PR TITLE
feat(operators): widen the read-only tool surface and add a per-question credit ceiling

### DIFF
--- a/robosystems/middleware/mcp/tools/manager.py
+++ b/robosystems/middleware/mcp/tools/manager.py
@@ -202,9 +202,10 @@ class GraphMCPTools:
       self.financial_statement_analysis_tool = FinancialStatementAnalysisTool(
         graph_client
       )
-      # OLTP-backed live statement — tenant entity graphs only. Skipped
-      # on shared repos (no OLTP tenant schema) and on read-only graphs.
-      if not self._is_shared_repository() and not read_only:
+      # OLTP-backed live statement — tenant entity graphs only. Skipped on
+      # shared repos (no OLTP tenant schema). A pure read, so it stays
+      # available on read-only surfaces (graph viewers, read-only operators).
+      if not self._is_shared_repository():
         self.live_financial_statement_tool = LiveFinancialStatementTool(graph_client)
 
       # Semantic enrichment tools (roboledger + manifest flag)
@@ -254,6 +255,8 @@ class GraphMCPTools:
     # Layer 2: Materialization — `materialize` + `get-graph-sync-status`.
     # User entity graphs only (shared repos use their own pipeline and
     # don't track staleness). `materialize` mirrors the REST body shape.
+    # The pair splits on read_only: sync status is a pure read and stays
+    # available on read-only surfaces; materialize is the write half.
     self.get_graph_sync_status_tool = None
     self.materialize_tool = None
     if (
@@ -261,10 +264,10 @@ class GraphMCPTools:
       and env.ROBOLEDGER_ENABLED
       and not self._is_shared_repository()
       and not self._is_subgraph()
-      and not read_only
     ):
       self.get_graph_sync_status_tool = GetGraphSyncStatusTool(graph_client)
-      self.materialize_tool = MaterializeTool(graph_client)
+      if not read_only:
+        self.materialize_tool = MaterializeTool(graph_client)
 
     # Connection write-policy — the outbound write-back opt-in. Platform-DB,
     # writable user graphs only: shared repos have no editable connections,
@@ -296,7 +299,11 @@ class GraphMCPTools:
     # Information Block read tools (get/list-information-block)
     self.get_information_block_tool = None
     self.list_information_blocks_tool = None
-    if self._has_extension("roboledger") and env.ROBOLEDGER_ENABLED and not read_only:
+    if (
+      self._has_extension("roboledger")
+      and env.ROBOLEDGER_ENABLED
+      and not self._is_shared_repository()
+    ):
       from .fiscal_calendar_tools import (
         BackfillPlanHistoryTool,
         ClosePeriodTool,
@@ -313,12 +320,18 @@ class GraphMCPTools:
       # `list-information-blocks` with block_type='schedule' and written
       # through the registrar-generated create/update/delete-information-block
       # ops; see `schedule_tools.py` for the full routing.
+      #
+      # The reads (period status, drafts, fiscal calendar) stay available on
+      # read-only surfaces; only the writes (close/reopen/backfill) require a
+      # writable graph. All read the extensions OLTP DB, which has no schema
+      # for a shared repo — hence the shared-repository exclusion above.
       self.get_period_close_status_tool = GetPeriodCloseStatusTool(graph_client)
       self.list_period_drafts_tool = ListPeriodDraftsTool(graph_client)
       self.get_fiscal_calendar_tool = GetFiscalCalendarTool(graph_client)
-      self.close_period_tool = ClosePeriodTool(graph_client)
-      self.reopen_period_tool = ReopenPeriodTool(graph_client)
-      self.backfill_plan_history_tool = BackfillPlanHistoryTool(graph_client)
+      if not read_only:
+        self.close_period_tool = ClosePeriodTool(graph_client)
+        self.reopen_period_tool = ReopenPeriodTool(graph_client)
+        self.backfill_plan_history_tool = BackfillPlanHistoryTool(graph_client)
 
     # Information Block reads stay available on read-only *tenant* graphs (no
     # read_only guard) but are excluded on shared repos: they read the
@@ -405,7 +418,11 @@ class GraphMCPTools:
     self.get_unmapped_elements_tool = None
     self.suggest_mapping_tool = None
     self.get_mapping_summary_tool = None
-    if self._has_extension("roboledger") and env.ROBOLEDGER_ENABLED and not read_only:
+    if (
+      self._has_extension("roboledger")
+      and env.ROBOLEDGER_ENABLED
+      and not self._is_shared_repository()
+    ):
       from .taxonomy_tools import (
         GetMappingSummaryTool,
         GetUnmappedElementsTool,
@@ -413,6 +430,10 @@ class GraphMCPTools:
         SuggestMappingTool,
       )
 
+      # All four are extensions-OLTP reads (suggest-mapping computes its
+      # suggestions heuristically — no writes, no AI), so they stay available
+      # on read-only surfaces; the shared-repo exclusion is because the OLTP
+      # DB has no per-graph schema for a shared repository.
       self.list_mapping_structures_tool = ListMappingStructuresTool(graph_client)
       self.get_unmapped_elements_tool = GetUnmappedElementsTool(graph_client)
       self.suggest_mapping_tool = SuggestMappingTool(graph_client)

--- a/robosystems/models/api/graphs/operator.py
+++ b/robosystems/models/api/graphs/operator.py
@@ -87,6 +87,17 @@ class OperatorRequest(BaseModel):
   )
   enable_rag: bool = Field(True, description="Enable RAG context enrichment")
   stream: bool = Field(False, description="Enable streaming response")
+  max_credits: float | None = Field(
+    None,
+    gt=0,
+    le=100_000,
+    description=(
+      "Per-question credit ceiling. Once the run's consumed credits reach "
+      "this number, no further tool step starts and the operator answers "
+      "from what it has (the wrap-up itself may carry the total slightly "
+      "past the ceiling). Omit for the mode's default step-bounded behavior."
+    ),
+  )
 
   class Config:
     json_schema_extra = {

--- a/robosystems/operations/operators/implementations/cypher.py
+++ b/robosystems/operations/operators/implementations/cypher.py
@@ -49,10 +49,10 @@ class CypherOperator(Operator):
 
   # Read-only tool allowlist. The loop intersects this with the tools the
   # graph actually exposes (generic graphs get only schema + cypher; SEC and
-  # roboledger graphs also get example queries, element resolution, GraphQL,
-  # and document search). Write tools are never included. The two orientation
-  # tools are normally prefetched into the system prompt and withheld from
-  # the loop; they stay listed for the fallback when that prefetch fails.
+  # roboledger graphs also get the curated and OLTP reads below). Write tools
+  # are never included. The two orientation tools are normally prefetched
+  # into the system prompt and withheld from the loop; they stay listed for
+  # the fallback when that prefetch fails.
   READ_ONLY_TOOLS = [
     "get-graph-schema",
     "read-graph-cypher",
@@ -62,7 +62,56 @@ class CypherOperator(Operator):
     "resolve-element",
     "search-documents",
     "get-document-section",
+    # Curated financial reads — routed ahead of raw Cypher for statement,
+    # balance, and pivot questions (see CURATED TOOLS in the system prompt).
+    "live-financial-statement",
+    "financial-statement-analysis",
+    "build-fact-grid",
+    # Period workflow and freshness reads
+    "get-fiscal-calendar",
+    "get-period-close-status",
+    "list-period-drafts",
+    "get-graph-sync-status",
+    "get-close-playbook",
+    # Chart-of-accounts mapping reads
+    "list-mapping-structures",
+    "get-unmapped-elements",
+    "get-mapping-summary",
+    "suggest-mapping",
+    # Tenant entity/OLTP reads
+    "list-subgraphs",
+    "get-information-block",
+    "list-information-blocks",
+    "get-agent",
+    "list-agents",
+    "agent-activity",
+    "get-event-block",
+    "list-event-blocks",
+    "get-event-handler",
+    "list-event-handlers",
+    "get-document",
+    "list-documents",
+    "recall",
   ]
+
+  # The subset worth calling out in the system prompt as preferred over raw
+  # Cypher, with the one-line routing hint for each.
+  CURATED_TOOL_HINTS: dict[str, str] = {
+    "live-financial-statement": (
+      "current income statement / balance sheet / trial balance straight "
+      "from the live ledger — the right first call for expense, revenue, "
+      "and balance questions"
+    ),
+    "financial-statement-analysis": (
+      "financial statement analysis over the reported (materialized) facts"
+    ),
+    "build-fact-grid": (
+      "multidimensional pivots over the fact hypercube (by account, period, dimension)"
+    ),
+    "get-fiscal-calendar": "fiscal periods, close status, and the close target",
+    "get-period-close-status": "close readiness for a specific period",
+    "get-graph-sync-status": "source-connection data freshness",
+  }
 
   spec = OperatorSpec(
     name="Cypher Operator",
@@ -142,6 +191,8 @@ class CypherOperator(Operator):
     if orientation is not None:
       tool_names = [t for t in tool_names if t not in _ORIENTATION_TOOLS]
 
+    curated_tools = [t for t in self.CURATED_TOOL_HINTS if t in available_tools]
+
     system = self._build_system_prompt(
       max_results,
       output_mode,
@@ -149,6 +200,7 @@ class CypherOperator(Operator):
       has_document_search,
       max_iterations,
       orientation,
+      curated_tools,
     )
 
     result = await run_tool_loop(
@@ -160,6 +212,7 @@ class CypherOperator(Operator):
       temperature=0.3,
       operator_type="cypher",
       operation_description="Cypher query loop",
+      max_credits=self._get_max_credits(ctx),
     )
 
     await ctx.progress.report("Done", percent=100)
@@ -173,6 +226,7 @@ class CypherOperator(Operator):
         "rows": rows,
         "result_count": len(rows),
         "hit_step_limit": result.hit_cap,
+        "hit_credit_ceiling": result.hit_credit_ceiling,
         "loop_iterations": result.iterations,
       },
       # De-dupe preserving order (a tool may be called several times).
@@ -227,6 +281,7 @@ class CypherOperator(Operator):
     has_document_search: bool = False,
     tool_turns: int = 6,
     orientation: dict[str, str] | None = None,
+    curated_tools: list[str] | None = None,
   ) -> str:
     if is_shared:
       # Shared repository (e.g. SEC): thousands of filers, so the selective
@@ -255,9 +310,19 @@ class CypherOperator(Operator):
       )
 
     if orientation is not None:
+      first_move = (
+        "Call a curated tool where one fits (see CURATED TOOLS below); "
+        "otherwise write a read-only Cypher query and run it with "
+        "`read-graph-cypher`. Act on your first turn — no orientation calls "
+        "are needed."
+        if curated_tools
+        else "Write a read-only Cypher query and run it with "
+        "`read-graph-cypher` on your first turn — no orientation calls are "
+        "needed."
+      )
       workflow = f"""WORKFLOW:
 1. The GRAPH SCHEMA and (when present) EXAMPLE QUERIES sections at the end of this prompt are authoritative for this graph — plan directly from them and never guess labels or properties they don't show. (Purely qualitative/narrative questions may go straight to document search — see below.)
-2. Write a read-only Cypher query and run it with `read-graph-cypher` on your first turn — no orientation calls are needed.
+2. {first_move}
 3. If a query errors or returns nothing useful, read the error, fix the query, and try again — don't repeat a failing query unchanged.
 4. When you have the answer, respond in natural language.
 
@@ -289,6 +354,15 @@ CYPHER RULES:
 
 LEDGER DATA (only when the schema has Entry / Transaction / LineItem nodes):
 - The graph keeps cancelled/replaced rows for audit. When counting or summing ledger data, restrict to live rows using the materialized `is_live` boolean — it exists on every spine node (`Entry`, `LineItem`, `Event`, `Transaction`) and is the one rule to remember: `WHERE e.is_live`, `WHERE li.is_live`, `WHERE ev.is_live`, `WHERE t.is_live`. For balances/debit-credit sums, aggregate through live Entry/LineItem (`e.is_live`, ⇔ status = 'posted'), not by summing Transaction.amount. `is_live` keeps open obligations (pending/committed/fulfilled events); for a specific realized set, filter `status` explicitly.
+"""
+    if curated_tools:
+      hints = "\n".join(
+        f"- `{name}`: {self.CURATED_TOOL_HINTS[name]}" for name in curated_tools
+      )
+      prompt += f"""
+CURATED TOOLS (prefer these over raw Cypher when one answers the question — they encode the accounting semantics you would otherwise reconstruct by hand):
+{hints}
+Reach for `read-graph-cypher` when no curated tool fits, or to drill into specifics a curated result doesn't show.
 """
     if has_document_search:
       if is_shared:
@@ -340,8 +414,24 @@ EXAMPLE QUERIES (working patterns for this graph — copy and adapt rather than 
       OperatorMode.EXTENDED: 500,
     }.get(mode, 100)
 
+  @staticmethod
+  def _get_max_credits(ctx: OperatorContext) -> float | None:
+    """Caller-chosen per-question credit ceiling, from the request context.
+
+    Tenant-supplied, so anything non-numeric or non-positive is ignored
+    rather than trusted to shape the loop.
+    """
+    raw = ctx.extra.get("max_credits")
+    if raw is None:
+      return None
+    try:
+      value = float(raw)
+    except (TypeError, ValueError):
+      return None
+    return value if value > 0 else None
+
   def _calculate_confidence(self, result: ToolLoopResult) -> float:
-    if result.hit_cap:
+    if result.hit_cap or result.hit_credit_ceiling:
       return 0.5
     if result.rows:
       return 0.9

--- a/robosystems/operations/operators/tool_loop.py
+++ b/robosystems/operations/operators/tool_loop.py
@@ -47,6 +47,12 @@ _ANSWER_NOW = (
   "results gathered so far. Do not request any more tools."
 )
 
+_ANSWER_NOW_CREDITS = (
+  "You've reached the credit limit set for this question. Answer the original "
+  "question now using the results gathered so far. Do not request any more "
+  "tools."
+)
+
 # The nudge keeps the tool definitions (the transcript carries tool_use
 # blocks, which the API requires tools for) but forbids further calls, so
 # the final turn is guaranteed to be text rather than a dropped tool_use.
@@ -63,6 +69,7 @@ class ToolLoopResult:
   tools_called: list[str] = field(default_factory=list)
   iterations: int = 0  # model calls made, including the nudge if any
   hit_cap: bool = False  # stopped at max_iterations rather than by the model
+  hit_credit_ceiling: bool = False  # stopped by the caller's max_credits
   error_retries: int = 0  # uncharged turns granted for all-error tool results
 
 
@@ -100,6 +107,7 @@ async def run_tool_loop(
   operator_type: str | None = None,
   operation_description: str = "Tool-use loop",
   max_error_retries: int = DEFAULT_MAX_ERROR_RETRIES,
+  max_credits: float | None = None,
 ) -> ToolLoopResult:
   """Run a bounded tool-use loop and return the model's final answer.
 
@@ -112,6 +120,13 @@ async def run_tool_loop(
   one further turn nudges the model to answer from what it has with tool use
   disabled, so the loop always costs at most
   ``max_iterations + max_error_retries + 1`` model calls.
+
+  ``max_credits`` is a soft per-run ceiling checked between model calls
+  against the run's accumulated spend (`TrackedAIClient.total_credits`): once
+  reached, no further tool turn starts and the model is nudged to answer from
+  what it has — so the wrap-up turn itself can carry the total somewhat past
+  the ceiling, but a runaway run stops at a number the caller chose rather
+  than at the iteration cap.
   """
   tools = await ctx.tools.get_tool_schemas(tool_names)
   if not tools:
@@ -133,9 +148,20 @@ async def run_tool_loop(
   tool_turns = 0  # round-trips charged against max_iterations
   error_retries = 0  # uncharged round-trips granted so far
   model_calls = 0
+  hit_ceiling = False
   step = 60 // max(max_iterations, 1)
 
   while tool_turns < max_iterations:
+    # Between-calls credit check: the first call always runs (its cost is
+    # unknowable up front and the pre-flight already gated the run).
+    if (
+      max_credits is not None
+      and model_calls > 0
+      and getattr(ctx.ai, "total_credits", 0.0) >= max_credits
+    ):
+      hit_ceiling = True
+      break
+
     await ctx.progress.report(
       "Thinking..." if model_calls == 0 else f"Working (step {model_calls + 1})...",
       percent=min(20 + tool_turns * step, 85),
@@ -234,20 +260,26 @@ async def run_tool_loop(
     else:
       error_retries += 1
 
-  # Iteration cap reached. Nudge for a final answer, appending the nudge to
-  # the trailing user turn (avoids a second consecutive user message). Keep
-  # `tools` defined so the tool_use/tool_result transcript stays valid, but
-  # disable tool choice so the answer can't come back as a tool_use block
-  # that nobody would execute.
+  # Iteration cap or credit ceiling reached. Nudge for a final answer,
+  # appending the nudge to the trailing user turn (a second consecutive user
+  # message would be rejected). Keep `tools` defined so the tool_use/
+  # tool_result transcript stays valid, but disable tool choice so the answer
+  # can't come back as a tool_use block that nobody would execute.
+  answer_now = _ANSWER_NOW_CREDITS if hit_ceiling else _ANSWER_NOW
   final_messages = list(messages)
   last = final_messages[-1]
-  if last.role == "user" and isinstance(last.content, list):
-    final_messages[-1] = AIMessage(
-      role="user",
-      content=[*last.content, {"type": "text", "text": _ANSWER_NOW}],
-    )
+  if last.role == "user":
+    if isinstance(last.content, list):
+      final_messages[-1] = AIMessage(
+        role="user",
+        content=[*last.content, {"type": "text", "text": answer_now}],
+      )
+    else:
+      final_messages[-1] = AIMessage(
+        role="user", content=f"{last.content}\n\n{answer_now}"
+      )
   else:
-    final_messages.append(AIMessage(role="user", content=_ANSWER_NOW))
+    final_messages.append(AIMessage(role="user", content=answer_now))
 
   final = await ctx.ai.create_message(
     messages=final_messages,
@@ -267,6 +299,7 @@ async def run_tool_loop(
     cypher=last_cypher,
     tools_called=tools_called,
     iterations=model_calls + 1,
-    hit_cap=True,
+    hit_cap=not hit_ceiling,
+    hit_credit_ceiling=hit_ceiling,
     error_retries=error_retries,
   )

--- a/robosystems/routers/graphs/operator/execute.py
+++ b/robosystems/routers/graphs/operator/execute.py
@@ -98,6 +98,14 @@ def _check_operator_post_enabled():
     )
 
 
+def _request_context(request: OperatorRequest) -> dict | None:
+  """The free-form context dict handed to the operator as ctx.extra, with the
+  typed per-question credit ceiling folded in when the caller set one."""
+  if request.max_credits is None:
+    return request.context
+  return {**(request.context or {}), "max_credits": request.max_credits}
+
+
 def _convert_operator_mode(mode: OperatorMode | None) -> BaseOperatorMode:
   """Convert API OperatorMode to base OperatorMode."""
   if mode is None:
@@ -241,7 +249,7 @@ async def auto_operator(
       "message": request.message,
       "mode": request.mode.value if request.mode else "standard",
       "history": history,
-      "context": request.context,
+      "context": _request_context(request),
       "enable_rag": request.enable_rag,
       "force_extended_analysis": request.force_extended_analysis,
     }
@@ -395,7 +403,7 @@ async def specific_operator(
       "message": request.message,
       "mode": request.mode.value if request.mode else "standard",
       "history": history,
-      "context": request.context,
+      "context": _request_context(request),
       "enable_rag": request.enable_rag,
       "force_extended_analysis": request.force_extended_analysis,
     }

--- a/tests/middleware/mcp/tools/test_manager_helpers.py
+++ b/tests/middleware/mcp/tools/test_manager_helpers.py
@@ -148,8 +148,11 @@ class TestGetToolDefinitionHelpers:
     assert tools.graphql_query_tool is not None
     assert {"get-graphql-schema", "query-graphql"} <= names
 
-  def test_live_statement_tool_absent_on_read_only(self, mock_client):
-    """Read-only graphs must NOT get the OLTP live-statement tool."""
+  def test_read_only_tenant_keeps_the_read_half_of_each_pair(self, mock_client):
+    """Pure reads that were historically bundled with their write siblings —
+    live statement, sync status, the period workflow, the mapping reads —
+    stay available on a read-only surface (graph viewers, read-only
+    operators); only the writes require a writable graph."""
     with (
       patch.object(GraphMCPTools, "_should_include_semantic_tools", return_value=False),
       patch("robosystems.middleware.mcp.tools.manager.env") as mock_env,
@@ -157,13 +160,58 @@ class TestGetToolDefinitionHelpers:
       mock_env.MCP_WORKSPACE_ENABLED = False
       mock_env.MCP_SUBGRAPH_OPS_ENABLED = False
       mock_env.FACT_GRID_ENABLED = False
+      mock_env.ROBOLEDGER_ENABLED = True
       tools = GraphMCPTools(
         mock_client, schema_extensions=["roboledger"], read_only=True
       )
 
-    # Analysis tool stays (read-only is fine for graph-backed reads)
     assert tools.financial_statement_analysis_tool is not None
+    assert tools.live_financial_statement_tool is not None
+    assert tools.get_graph_sync_status_tool is not None
+    assert tools.get_fiscal_calendar_tool is not None
+    assert tools.get_period_close_status_tool is not None
+    assert tools.list_period_drafts_tool is not None
+    assert tools.list_mapping_structures_tool is not None
+    assert tools.get_unmapped_elements_tool is not None
+    assert tools.get_mapping_summary_tool is not None
+    assert tools.suggest_mapping_tool is not None
+
+    # The write siblings stay off.
+    assert tools.materialize_tool is None
+    assert tools.close_period_tool is None
+    assert tools.reopen_period_tool is None
+    assert tools.backfill_plan_history_tool is None
+    assert tools.set_write_policy_tool is None
+    assert tools.sync_connection_tool is None
+    assert tools.bind_text_block_tool is None
+
+  def test_split_oltp_reads_stay_off_shared_repos(self, mock_client):
+    """The unbundled reads are extensions-OLTP-backed, and the OLTP DB has no
+    per-graph schema for a shared repo — the new gates must exclude SEC even
+    though read_only no longer does."""
+    mock_client.graph_id = "sec"
+    with (
+      patch.object(GraphMCPTools, "_should_include_semantic_tools", return_value=False),
+      patch.object(GraphMCPTools, "_is_shared_repository", return_value=True),
+      patch("robosystems.middleware.mcp.tools.manager.env") as mock_env,
+    ):
+      mock_env.MCP_WORKSPACE_ENABLED = False
+      mock_env.MCP_SUBGRAPH_OPS_ENABLED = False
+      mock_env.FACT_GRID_ENABLED = False
+      mock_env.ROBOLEDGER_ENABLED = True
+      tools = GraphMCPTools(
+        mock_client, schema_extensions=["roboledger"], read_only=True
+      )
+
     assert tools.live_financial_statement_tool is None
+    assert tools.get_graph_sync_status_tool is None
+    assert tools.get_fiscal_calendar_tool is None
+    assert tools.get_period_close_status_tool is None
+    assert tools.list_period_drafts_tool is None
+    assert tools.list_mapping_structures_tool is None
+    assert tools.get_unmapped_elements_tool is None
+    assert tools.get_mapping_summary_tool is None
+    assert tools.suggest_mapping_tool is None
 
   def test_oltp_read_tools_absent_on_shared_repo(self, mock_client):
     """Roboledger OLTP read tools (information blocks, agents, event handlers,
@@ -511,8 +559,9 @@ class TestTaxonomyToolRegistration:
     assert "create-mapping-association" in tool_names
     assert "get-mapping-summary" in tool_names
 
-  def test_taxonomy_tools_not_in_readonly(self, mock_client):
-    """Taxonomy tools should NOT appear for read-only graphs."""
+  def test_taxonomy_reads_advertised_on_readonly_but_writes_are_not(self, mock_client):
+    """The mapping READS stay available on read-only graphs; the registrar
+    write tools require a writable surface."""
     with (
       patch.object(GraphMCPTools, "_should_include_semantic_tools", return_value=False),
       patch("robosystems.middleware.mcp.tools.manager.env") as mock_env,
@@ -530,7 +579,9 @@ class TestTaxonomyToolRegistration:
 
     definitions = tools.get_tool_definitions_as_dict()
     tool_names = {d["name"] for d in definitions}
-    assert "get-unmapped-elements" not in tool_names
+    assert "get-unmapped-elements" in tool_names
+    assert "suggest-mapping" in tool_names
+    assert "get-mapping-summary" in tool_names
     assert "create-mapping-association" not in tool_names
 
   def test_taxonomy_tools_not_without_extension(self, mock_client):

--- a/tests/models/api/test_operator_models.py
+++ b/tests/models/api/test_operator_models.py
@@ -91,6 +91,14 @@ class TestOperatorRequest:
     with pytest.raises(ValidationError):
       OperatorRequest(message="")
 
+  def test_max_credits_bounds(self):
+    """The per-question credit ceiling must be a positive, sane number."""
+    assert OperatorRequest(message="ok").max_credits is None
+    assert OperatorRequest(message="ok", max_credits=250).max_credits == 250
+    for bad in (0, -1, 100_001):
+      with pytest.raises(ValidationError):
+        OperatorRequest(message="ok", max_credits=bad)
+
   def test_history_is_bounded_in_size_and_content(self):
     too_many = [
       OperatorMessage(role="user", content="q")

--- a/tests/operations/operators/test_cypher_orientation.py
+++ b/tests/operations/operators/test_cypher_orientation.py
@@ -145,3 +145,59 @@ async def test_oversized_orientation_is_truncated_deterministically():
   text = CypherOperator._serialize_orientation(big)
   assert len(text) <= 48000 + len("\n… [truncated]")
   assert text.endswith("[truncated]")
+
+
+async def test_curated_tools_are_routed_ahead_of_cypher():
+  """Where the graph exposes the curated financial reads, the prompt routes
+  statement/balance/period questions to them first, and the loop offers
+  them."""
+  tools = _tools(
+    [
+      "get-graph-schema",
+      "read-graph-cypher",
+      "live-financial-statement",
+      "get-fiscal-calendar",
+    ],
+    {"get-graph-schema": SCHEMA},
+  )
+  kwargs = await _run(tools)
+
+  system = kwargs["system"]
+  assert "CURATED TOOLS" in system
+  assert "`live-financial-statement`" in system
+  assert "`get-fiscal-calendar`" in system
+  # Hints only for tools this graph actually exposes.
+  assert "`build-fact-grid`" not in system
+  assert "Call a curated tool where one fits" in system
+  assert "live-financial-statement" in kwargs["tool_names"]
+
+
+async def test_no_curated_section_without_curated_tools():
+  tools = _tools(
+    ["get-graph-schema", "read-graph-cypher"],
+    {"get-graph-schema": SCHEMA},
+  )
+  kwargs = await _run(tools)
+  assert "CURATED TOOLS" not in kwargs["system"]
+
+
+async def test_max_credits_reaches_the_loop_and_garbage_is_ignored():
+  tools = _tools(
+    ["get-graph-schema", "read-graph-cypher"],
+    {"get-graph-schema": SCHEMA},
+  )
+  with patch(
+    "robosystems.operations.operators.implementations.cypher.run_tool_loop",
+    AsyncMock(return_value=_loop_result()),
+  ) as loop:
+    ctx = _ctx(tools)
+    ctx.extra["max_credits"] = 25
+    await CypherOperator().run(ctx)
+  assert loop.await_args.kwargs["max_credits"] == 25.0
+
+  # Tenant-supplied garbage must not shape the loop.
+  assert CypherOperator._get_max_credits(_ctx(tools)) is None
+  for bad in ("abc", -5, 0, None, {"x": 1}):
+    ctx = _ctx(tools)
+    ctx.extra["max_credits"] = bad
+    assert CypherOperator._get_max_credits(ctx) is None, bad

--- a/tests/operations/operators/test_tool_loop.py
+++ b/tests/operations/operators/test_tool_loop.py
@@ -409,6 +409,69 @@ async def test_mixed_turn_with_one_success_is_charged():
   assert ai.create_message.call_args_list[1].kwargs["tool_choice"] == {"type": "none"}
 
 
+async def test_credit_ceiling_stops_the_loop_between_calls():
+  """Once accumulated spend reaches max_credits, no further tool turn starts;
+  the model is nudged to answer from what it has, with the credit-limit
+  wording rather than the step-limit one."""
+  ai = MagicMock()
+  ai.total_credits = 50.0
+  ai.create_message = AsyncMock(
+    side_effect=[
+      _tool_use("t1", "read-graph-cypher", query="MATCH (n) RETURN n LIMIT 1"),
+      _final("best effort within budget"),
+    ]
+  )
+  tools = _tools_mock(call_results=[[{"n": 1}]])
+  ctx = _ctx(ai, tools)
+
+  result = await run_tool_loop(
+    ctx,
+    system="s",
+    tool_names=["read-graph-cypher"],
+    max_iterations=5,
+    max_tokens=100,
+    max_credits=10.0,
+  )
+
+  assert result.hit_credit_ceiling is True
+  assert result.hit_cap is False
+  assert result.text == "best effort within budget"
+  assert ai.create_message.await_count == 2  # first turn + the nudge only
+  final_kwargs = ai.create_message.call_args_list[1].kwargs
+  assert final_kwargs["tool_choice"] == {"type": "none"}
+  last_user = final_kwargs["messages"][-1]
+  assert any(
+    isinstance(b, dict)
+    and b.get("type") == "text"
+    and "credit limit" in b.get("text", "")
+    for b in last_user.content
+  )
+
+
+async def test_first_model_call_runs_even_over_the_ceiling():
+  """The first call's cost is unknowable up front (the pre-flight gates the
+  run); the ceiling is checked between calls, so a model that answers on its
+  first turn is unaffected by a tiny ceiling."""
+  ai = MagicMock()
+  ai.total_credits = 999.0
+  ai.create_message = AsyncMock(side_effect=[_final("direct answer")])
+  tools = _tools_mock(call_results=[])
+  ctx = _ctx(ai, tools)
+
+  result = await run_tool_loop(
+    ctx,
+    system="s",
+    tool_names=["read-graph-cypher"],
+    max_iterations=5,
+    max_tokens=100,
+    max_credits=1.0,
+  )
+
+  assert result.text == "direct answer"
+  assert result.hit_credit_ceiling is False
+  assert ai.create_message.await_count == 1
+
+
 async def test_every_model_call_requests_conversation_caching():
   """The transcript grows monotonically, so every call — loop turns and the
   nudge alike — marks the trailing turn for caching; the next call reads the


### PR DESCRIPTION
## Summary

Completes Phase 2 of the operator console hardening: splits read from write in the MCP tool manager so read-only surfaces get every pure read, widens the Cypher operator's allowlist accordingly with the system prompt routing statement/balance/period questions to the curated tools first, and adds a per-question `max_credits` ceiling to the operator request. Stacked on #1289 (prompt caching) — deliberately, since the ~25KB of added tool definitions ride under the system cache breakpoint that PR introduces.

## Changes

- **`robosystems/middleware/mcp/tools/manager.py`** — four gate blocks split on read vs write: `live-financial-statement`, `get-graph-sync-status`, the period-workflow reads (`get-fiscal-calendar`, `get-period-close-status`, `list-period-drafts`), and the four mapping reads (`list-mapping-structures`, `get-unmapped-elements`, `get-mapping-summary`, `suggest-mapping` — all extensions-OLTP reads, no writes, no AI) now construct on read-only surfaces. Their write siblings (`materialize`, `close-period`/`reopen-period`/`backfill-plan-history`, the registrar mapping writes) still require a writable graph. The unbundled OLTP-backed reads gain an explicit shared-repository exclusion — previously provided only implicitly by the read-only gate — so nothing new is advertised on `sec`. This is a legibility fix for MCP graph viewers independent of the operator.
- **`robosystems/operations/operators/implementations/cypher.py`** — `READ_ONLY_TOOLS` widens from 8 to 34 names (curated financial reads, period/freshness reads, mapping reads, tenant OLTP reads, document reads, `recall`); a `CURATED TOOLS` prompt section, built only from tools the graph actually exposes, routes statement/balance/period questions to `live-financial-statement`, `financial-statement-analysis`, `build-fact-grid`, and the fiscal-calendar/close-status/sync-status reads before raw Cypher; the workflow's first move reflects that. `hit_credit_ceiling` joins the result metadata and lowers confidence like the step cap.
- **`robosystems/operations/operators/tool_loop.py`** — `max_credits`: a soft ceiling checked between model calls against `TrackedAIClient.total_credits`; once reached, no further tool turn starts and the model is nudged (with credit-limit wording) to answer from what it has. The first call always runs — its cost is unknowable up front and the pre-flight already gates the run. The nudge path now also handles a trailing string-content user turn.
- **`robosystems/models/api/graphs/operator.py` / `routers/graphs/operator/execute.py`** — `max_credits` on `OperatorRequest` (positive, capped at 100k), folded into the operator context on both execution paths.

## Breaking Changes

None. `max_credits` is additive and optional — an SDK regen opportunity, generated tier. Read-only MCP viewers on roboledger tenants will see the nine read tools appear; no previously available tool moves or changes shape.

## Testing

- `just test` — full unit suite passed (14,060 passed, 43 skipped).
- `just test-code` — ruff, format, basedpyright, cf-lint all clean.
- New/updated tests: the manager read/write split on read-only tenants and its shared-repo exclusions (two gating tests that pinned the old bundling were deliberately flipped); curated-tool routing built only from exposed tools; ceiling stop between calls with the credit-limit nudge; first-call-always-runs; tenant-supplied garbage `max_credits` ignored; request-model bounds.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
