### PR TITLE
fix(operators): give worker-run operators the full tool surface (1.11.5 hotfix)

### DIFF
--- a/robosystems/middleware/mcp/tools/taxonomy_tools.py
+++ b/robosystems/middleware/mcp/tools/taxonomy_tools.py
@@ -20,9 +20,10 @@ operations anyway, and that is load-bearing rather than duplication.
 **There are two dispatchers, and only one of them knows about the
 registrar.** `GraphMCPTools.call_tool` resolves registrar tools first
 (Layer 0), so a remote MCP client never reaches the class. But
-`DirectToolAccess` — the worker path, used by `MappingOperator` and hence
-by `auto-map-elements` — instantiates tool classes in process and calls
-`.execute()` on them directly, never consulting the registrar at all.
+`DirectToolAccess` — the in-process dispatcher (tests and any caller that
+instantiates tool classes by hand; the worker adapter no longer does, it
+dispatches through `GraphMCPTools` like the API path) — calls `.execute()`
+on tool classes directly, never consulting the registrar at all.
 
 So "the registrar publishes this name" does **not** imply "this class is
 dead". Check `operations/operators/tool_access.py` before deleting a tool
@@ -401,10 +402,11 @@ class CreateMappingAssociationTool:
   operation, and that is deliberate rather than duplication: the two serve
   different dispatchers. On the MCP wire, ``GraphMCPTools.call_tool``
   resolves registrar tools at Layer 0, so *this* class is not what a remote
-  client reaches. On the worker path, ``DirectToolAccess`` instantiates tool
-  classes in process and executes them directly — it never consults the
-  registrar — so this class is the live write path for ``auto-map-elements``
-  and every MappingOperator run.
+  client reaches — and since the worker adapter dispatches through
+  ``GraphMCPTools`` too (``HttpToolAccess``, on both the API and worker
+  paths), neither is it what a MappingOperator run reaches. It is the live
+  write path only for ``DirectToolAccess``, which instantiates tool classes
+  in process and executes them directly without consulting the registrar.
 
   Consequence worth keeping: the ``mark_graph_stale`` call below is not
   redundant with the spec's ``mark_stale_reason``. That only fires on the

--- a/robosystems/operations/operators/adapters/worker.py
+++ b/robosystems/operations/operators/adapters/worker.py
@@ -1,9 +1,10 @@
 """Worker execution adapter — runs operators in worker context.
 
-Builds an OperatorContext from `DirectToolAccess` (in-process tool classes, no
-HTTP), `FactoryCreditConsumer` (a session per call), and
-`OperationManagerProgress` (SSE progress + cancellation). Reached through the
-`OperatorWorkerTask` bridge in `worker_task.py`.
+Builds an OperatorContext from `HttpToolAccess` (the full GraphMCPTools
+surface, gated by the operator's `read_only` flag), `FactoryCreditConsumer`
+(a session per call), and `OperationManagerProgress` (SSE progress +
+cancellation). Reached through the `OperatorWorkerTask` bridge in
+`worker_task.py`.
 """
 
 from __future__ import annotations
@@ -23,7 +24,7 @@ from robosystems.operations.operators.credit_consumer import FactoryCreditConsum
 from robosystems.operations.operators.credit_preflight import enforce_operator_credits
 from robosystems.operations.operators.operator_context import OperatorContext
 from robosystems.operations.operators.progress import OperationManagerProgress
-from robosystems.operations.operators.tool_access import DirectToolAccess
+from robosystems.operations.operators.tool_access import HttpToolAccess
 from robosystems.operations.operators.tracked_ai import TrackedAIClient
 
 if TYPE_CHECKING:
@@ -74,7 +75,12 @@ async def run_operator_worker(
   finally:
     preflight_session.close()
 
-  tools = DirectToolAccess(graph_id, user_id=user_id)
+  # The full GraphMCPTools surface, gated by the operator's read_only flag —
+  # the same tool access the API path used. DirectToolAccess only reports
+  # tool classes registered by hand, so a model-driven loop on it sees no
+  # tools at all: on the first worker deploy the Cypher operator narrated
+  # "Tool: get-graph-schema" as text and stopped.
+  tools = HttpToolAccess(graph_id, read_only=operator.spec.read_only, user_id=user_id)
   ai_client = get_ai_client()
   credit_consumer = FactoryCreditConsumer()
 

--- a/robosystems/operations/operators/implementations/mapping/operator.py
+++ b/robosystems/operations/operators/implementations/mapping/operator.py
@@ -12,8 +12,9 @@ Candidates are narrowed by the CoA element's EFS trait and (for
 assets/liabilities) its liquidity trait, so the AI chooses among a tight,
 section-correct candidate set rather than guessing current-vs-noncurrent.
 
-Uses the same MCP tool classes as cowork (Claude Desktop) — instantiated
-in-process via DirectToolAccess.
+Uses the same MCP tools as cowork (Claude Desktop): the adapter's tool access
+(`HttpToolAccess` on both the API and worker paths) hands `get_tool_instance`
+back as a name-bound handle that dispatches through `GraphMCPTools`.
 """
 
 from __future__ import annotations

--- a/tests/operations/operators/test_credit_preflight.py
+++ b/tests/operations/operators/test_credit_preflight.py
@@ -171,7 +171,7 @@ class TestAdaptersRunThePreflight:
         side_effect=InsufficientOperatorCreditsError("Test Operator", 10.0, 1.0),
       ),
       patch.object(worker, "SessionFactory"),
-      patch.object(worker, "DirectToolAccess") as tool_access,
+      patch.object(worker, "HttpToolAccess") as tool_access,
       patch.object(worker, "get_ai_client"),
       patch.object(worker, "TrackedAIClient"),
       patch.object(worker, "FactoryCreditConsumer"),

--- a/tests/operations/operators/test_worker_adapter.py
+++ b/tests/operations/operators/test_worker_adapter.py
@@ -50,7 +50,7 @@ def _patched_adapter(stack: ExitStack, tracked: MagicMock, tools: MagicMock) -> 
   ):
     stack.enter_context(patch.object(adapter, name))
   stack.enter_context(patch.object(adapter, "SessionFactory", return_value=MagicMock()))
-  stack.enter_context(patch.object(adapter, "DirectToolAccess", return_value=tools))
+  stack.enter_context(patch.object(adapter, "HttpToolAccess", return_value=tools))
   stack.enter_context(patch.object(adapter, "TrackedAIClient", return_value=tracked))
 
 
@@ -145,3 +145,35 @@ async def test_worker_task_without_operator_type_fails_rather_than_completing():
 
   with pytest.raises(ValueError, match="operator_type"):
     await task.execute()
+
+
+@pytest.mark.asyncio
+async def test_worker_uses_the_full_tool_surface_gated_by_read_only():
+  """The model-driven loop needs the tools a graph actually exposes.
+
+  DirectToolAccess only reports tool classes registered by hand, so a loop
+  operator on it saw no tools at all in prod (it narrated a tool call as
+  text). The worker builds HttpToolAccess with the operator's read_only flag,
+  exactly as the API path did.
+  """
+  operator = _operator(OperatorResult(content="ok"))
+  tools = MagicMock()
+  tools.close = AsyncMock()
+
+  with ExitStack() as stack:
+    _patched_adapter(stack, _tracked_ai(), tools)
+    http_access = stack.enter_context(
+      patch.object(adapter, "HttpToolAccess", return_value=tools)
+    )
+    await adapter.run_operator_worker(
+      operator=operator,
+      task_id="op_01TEST",
+      graph_id=GRAPH_ID,
+      user_id=USER_ID,
+      params={"operator_type": "cypher", "query": "q"},
+      manager=AsyncMock(),
+    )
+
+  http_access.assert_called_once_with(GRAPH_ID, read_only=True, user_id=USER_ID)
+  ctx = operator.run.call_args[0][0]
+  assert ctx.tools is tools

--- a/tests/operations/operators/test_write_role_gate.py
+++ b/tests/operations/operators/test_write_role_gate.py
@@ -126,7 +126,7 @@ class TestAdaptersEnforceBeforeToolAccess:
         "enforce_operator_write_role",
         side_effect=HTTPException(status_code=403, detail="read-only"),
       ),
-      patch.object(worker, "DirectToolAccess") as tool_access,
+      patch.object(worker, "HttpToolAccess") as tool_access,
       patch.object(worker, "get_ai_client"),
       patch.object(worker, "TrackedAIClient"),
       patch.object(worker, "FactoryCreditConsumer"),


### PR DESCRIPTION
**Release-branch twin of #1292** (same commit, cherry-picked onto `release/1.11.5` for the hotfix deploy; #1292 carries it to `main` for the next release).

## Summary

Hotfix for the worker execution home shipped in #1291 (v1.11.5): operators running on the worker had no tools. The worker adapter built `DirectToolAccess`, whose `get_tool_schemas` only reports tool classes registered by hand, so the Cypher loop's read-only allowlist resolved to an empty tool list and no orientation — on prod the model narrated `Tool: get-graph-schema` as text and stopped after one call (1,083-token prefix, 3.4 credits, no answer). Same change is opened against `release/1.11.5` for the hotfix deploy.

## Changes

- `operations/operators/adapters/worker.py`: build `HttpToolAccess(graph_id, read_only=operator.spec.read_only, user_id=…)` — the full `GraphMCPTools` surface gated by the operator's flag, exactly what the API path used. The MappingOperator's `get_tool_instance` handles dispatch through the same path, as they already did on the API path since #1103.
- Docstrings in `taxonomy_tools.py` and `mapping/operator.py` that described `DirectToolAccess` as the worker path now say what is true; the class itself stays (in-process dispatcher for tests).
- Tests: adapter test pins `HttpToolAccess` with `read_only=True` for a read-only operator; the two gate tests that patched the old class follow.

## Breaking Changes

None.

## Testing

- `tests/operations/operators`, `tests/routers/graphs/test_operator_router.py`, `tests/middleware/mcp/tools`, `tests/worker`: 603 passed; ruff/format/basedpyright clean on the touched files.
- Local end-to-end through the worker (the check the original PR lacked): `POST /operator/cypher` on the demo graph → 202 → completed in 12s with 2 model calls, 30,252 cached prefix tokens (tools + orientation present), a correct answer via `live-financial-statement`. Before the fix the same run made 1 call with a 1k prefix and no answer.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
