### PR TITLE
fix(operators): a cancelled run stops calling the model

### DIFF
--- a/robosystems/operations/operators/implementations/cypher.py
+++ b/robosystems/operations/operators/implementations/cypher.py
@@ -227,6 +227,7 @@ class CypherOperator(Operator):
         "result_count": len(rows),
         "hit_step_limit": result.hit_cap,
         "hit_credit_ceiling": result.hit_credit_ceiling,
+        "cancelled": result.cancelled,
         "loop_iterations": result.iterations,
       },
       # De-dupe preserving order (a tool may be called several times).
@@ -431,6 +432,8 @@ EXAMPLE QUERIES (working patterns for this graph — copy and adapt rather than 
     return value if value > 0 else None
 
   def _calculate_confidence(self, result: ToolLoopResult) -> float:
+    if result.cancelled:
+      return 0.0
     if result.hit_cap or result.hit_credit_ceiling:
       return 0.5
     if result.rows:

--- a/robosystems/operations/operators/tool_loop.py
+++ b/robosystems/operations/operators/tool_loop.py
@@ -70,6 +70,7 @@ class ToolLoopResult:
   iterations: int = 0  # model calls made, including the nudge if any
   hit_cap: bool = False  # stopped at max_iterations rather than by the model
   hit_credit_ceiling: bool = False  # stopped by the caller's max_credits
+  cancelled: bool = False  # the operation was cancelled; no answer was composed
   error_retries: int = 0  # uncharged turns granted for all-error tool results
 
 
@@ -152,6 +153,22 @@ async def run_tool_loop(
   step = 60 // max(max_iterations, 1)
 
   while tool_turns < max_iterations:
+    # A cancel lands on the operation store and nothing else in this loop
+    # would ever see it: on the worker the run kept calling the model after
+    # the client was told "cancelled". Checked before every call, including
+    # the first, so a run cancelled while it waited in the queue spends
+    # nothing. No wrap-up call either — the caller asked for silence.
+    if await ctx.progress.is_cancelled():
+      return ToolLoopResult(
+        text="Cancelled before an answer was reached.",
+        rows=last_rows,
+        cypher=last_cypher,
+        tools_called=tools_called,
+        iterations=model_calls,
+        cancelled=True,
+        error_retries=error_retries,
+      )
+
     # Between-calls credit check: the first call always runs (its cost is
     # unknowable up front and the pre-flight already gated the run).
     if (

--- a/robosystems/worker/consumer.py
+++ b/robosystems/worker/consumer.py
@@ -23,6 +23,7 @@ import redis.exceptions
 
 from robosystems.config.valkey_registry import ValkeyDatabase, create_async_redis_client
 from robosystems.middleware.otel.setup import get_tracer
+from robosystems.middleware.sse.event_storage import OperationStatus
 from robosystems.middleware.sse.operation_manager import (
   OperationManager,
   get_operation_manager,
@@ -164,6 +165,14 @@ async def _process_task(
   if handler_cls is None:
     logger.error(f"Unknown task type: {task_type}, task_id={task_id}")
     await manager.fail_operation(task_id, error=f"Unknown task type: {task_type}")
+    await queue.lrem(inflight_key, 1, task_json)
+    return
+
+  # Cancelled while it waited in the queue: the operation is already
+  # terminal, so running it would only spend credits on a result the
+  # status ladder will refuse to record.
+  if await manager.get_operation_status(task_id) == OperationStatus.CANCELLED:
+    logger.info(f"Skipping cancelled task: {task_type} ({task_id})")
     await queue.lrem(inflight_key, 1, task_json)
     return
 

--- a/tests/operations/operators/test_tool_loop.py
+++ b/tests/operations/operators/test_tool_loop.py
@@ -548,3 +548,57 @@ async def test_orientation_tool_results_escape_the_default_cap():
     ai.create_message.call_args_list[2].kwargs["messages"]
   )
   assert "truncated" in rows_blocks[-1]["content"]
+
+
+async def test_cancel_between_calls_stops_the_loop_without_a_wrap_up_call():
+  """A cancel lands on the operation store; the loop must consult it before
+  every call. Once seen, no further model call is made — not even the nudge.
+  On the worker this used to run to completion behind a 'cancelled' status."""
+  ai = MagicMock()
+  ai.total_credits = 0.0
+  ai.create_message = AsyncMock(
+    side_effect=[
+      _tool_use("t1", "read-graph-cypher", query="MATCH (n) RETURN n LIMIT 1"),
+      _final("should never be composed"),
+    ]
+  )
+  tools = _tools_mock(call_results=[[{"n": 1}]])
+  ctx = _ctx(ai, tools)
+  ctx.progress = MagicMock()
+  ctx.progress.report = AsyncMock()
+  ctx.progress.is_cancelled = AsyncMock(side_effect=[False, True])
+
+  result = await run_tool_loop(
+    ctx,
+    system="s",
+    tool_names=["read-graph-cypher"],
+    max_iterations=5,
+    max_tokens=100,
+  )
+
+  assert result.cancelled is True
+  assert result.hit_cap is False
+  assert result.hit_credit_ceiling is False
+  assert ai.create_message.await_count == 1
+  assert result.iterations == 1
+  assert result.tools_called == ["read-graph-cypher"]
+  assert result.rows == [{"n": 1}]
+
+
+async def test_a_run_cancelled_while_queued_spends_nothing():
+  ai = MagicMock()
+  ai.total_credits = 0.0
+  ai.create_message = AsyncMock(side_effect=[_final("never")])
+  tools = _tools_mock(call_results=[])
+  ctx = _ctx(ai, tools)
+  ctx.progress = MagicMock()
+  ctx.progress.report = AsyncMock()
+  ctx.progress.is_cancelled = AsyncMock(return_value=True)
+
+  result = await run_tool_loop(
+    ctx, system="s", tool_names=["read-graph-cypher"], max_iterations=5, max_tokens=100
+  )
+
+  assert result.cancelled is True
+  assert result.iterations == 0
+  ai.create_message.assert_not_awaited()

--- a/tests/worker/test_consumer.py
+++ b/tests/worker/test_consumer.py
@@ -364,3 +364,24 @@ async def test_paused_task_is_neither_completed_nor_failed(
   # It still leaves the inflight list and the worker is cleaned up
   mock_queue.lrem.assert_called_once()
   mock_cleanup.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("robosystems.worker.consumer.cleanup_connections")
+@patch("robosystems.worker.consumer.get_tracer")
+async def test_task_cancelled_while_queued_is_skipped(
+  mock_tracer, mock_cleanup, mock_manager, mock_queue
+):
+  """A cancel that landed while the task waited: never executed, never
+  completed or failed, still removed from inflight."""
+  from robosystems.middleware.sse.event_storage import OperationStatus
+
+  mock_manager.get_operation_status = AsyncMock(return_value=OperationStatus.CANCELLED)
+
+  await _call_process_task(_make_task_data(), mock_queue, mock_manager)
+
+  mock_manager.mark_running.assert_not_called()
+  mock_manager.complete_operation.assert_not_called()
+  mock_manager.fail_operation.assert_not_called()
+  mock_queue.lrem.assert_called_once()
+  mock_cleanup.assert_not_called()


### PR DESCRIPTION
## Summary

Found in the post-hotfix prod walk of the worker execution home (#1291/#1293): cancelling an operator run (`DELETE /v1/operations/{id}`) flipped the status to `cancelled` for the client, but the worker kept running the tool loop to completion — 22 more seconds and seven more billed model calls on the cancelled question. The Cypher loop never consulted cancellation; only the MappingOperator did. This closes that, plus the queued case.

## Changes

- `operations/operators/tool_loop.py`: `run_tool_loop` checks `ctx.progress.is_cancelled()` before every model call — including the first, so a run cancelled while it waited in the queue spends nothing — and returns a `cancelled=True` result without the wrap-up ("answer now") call. `ToolLoopResult.cancelled` added.
- `operations/operators/implementations/cypher.py`: `cancelled` in the result metadata; confidence 0.0 for a cancelled run.
- `worker/consumer.py`: a task whose operation is already `cancelled` at pickup is skipped (removed from inflight, never executed) rather than run into a result the status ladder refuses to record anyway.
- Tests: loop cancels between calls with no nudge; a run cancelled while queued makes zero calls; the consumer skips a pre-cancelled task.

On the API path `CallbackProgress.is_cancelled` is always `False`, so nothing changes for the orchestrator/test contexts.

## Breaking Changes

None. Additive `cancelled` key in the Cypher operator's result metadata.

## Testing

- `tests/operations/operators/test_tool_loop.py`, `tests/worker/test_consumer.py`, `tests/operations/operators/test_cypher_orientation.py`, `tests/operations/operators/test_unified_operator.py`: 53 passed; ruff/format/basedpyright clean on the touched files.
- Reproduced on prod before the fix (op `op_01M13CYZ75WYAMZ3YN2KF7N0AA`: cancelled at +4s, worker completed at +22s with 7 billed calls); not re-run on prod — this rides the next release, the console has no cancel control for operator runs yet.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
