### PR TITLE
fix(operators): guard the wrap-up call against a cancel at the cap

### DIFF
--- a/robosystems/operations/operators/tool_loop.py
+++ b/robosystems/operations/operators/tool_loop.py
@@ -277,11 +277,25 @@ async def run_tool_loop(
     else:
       error_retries += 1
 
-  # Iteration cap or credit ceiling reached. Nudge for a final answer,
-  # appending the nudge to the trailing user turn (a second consecutive user
-  # message would be rejected). Keep `tools` defined so the tool_use/
-  # tool_result transcript stays valid, but disable tool choice so the answer
-  # can't come back as a tool_use block that nobody would execute.
+  # Iteration cap or credit ceiling reached. The wrap-up below is the loop's
+  # only other model call, and hitting the cap is exactly when a run has been
+  # going long enough for a client to cancel — so it gets the same guard.
+  if await ctx.progress.is_cancelled():
+    return ToolLoopResult(
+      text="Cancelled before an answer was reached.",
+      rows=last_rows,
+      cypher=last_cypher,
+      tools_called=tools_called,
+      iterations=model_calls,
+      cancelled=True,
+      error_retries=error_retries,
+    )
+
+  # Nudge for a final answer, appending the nudge to the trailing user turn
+  # (a second consecutive user message would be rejected). Keep `tools`
+  # defined so the tool_use/tool_result transcript stays valid, but disable
+  # tool choice so the answer can't come back as a tool_use block that nobody
+  # would execute.
   answer_now = _ANSWER_NOW_CREDITS if hit_ceiling else _ANSWER_NOW
   final_messages = list(messages)
   last = final_messages[-1]

--- a/tests/operations/operators/test_tool_loop.py
+++ b/tests/operations/operators/test_tool_loop.py
@@ -602,3 +602,36 @@ async def test_a_run_cancelled_while_queued_spends_nothing():
   assert result.cancelled is True
   assert result.iterations == 0
   ai.create_message.assert_not_awaited()
+
+
+async def test_cancel_at_the_cap_skips_the_wrap_up_call():
+  """The post-loop nudge is the loop's only other model call; a cancel that
+  lands as the cap is hit must stop it too."""
+  ai = MagicMock()
+  ai.total_credits = 0.0
+  ai.create_message = AsyncMock(
+    side_effect=[
+      _tool_use("t1", "read-graph-cypher", query="MATCH (n) RETURN n LIMIT 1"),
+      _final("the nudge answer that must not be requested"),
+    ]
+  )
+  tools = _tools_mock(call_results=[[{"n": 1}]])
+  ctx = _ctx(ai, tools)
+  ctx.progress = MagicMock()
+  ctx.progress.report = AsyncMock()
+  # Not cancelled at the top of the only iteration; cancelled by the time the
+  # cap is reached and the wrap-up would run.
+  ctx.progress.is_cancelled = AsyncMock(side_effect=[False, True])
+
+  result = await run_tool_loop(
+    ctx,
+    system="s",
+    tool_names=["read-graph-cypher"],
+    max_iterations=1,
+    max_tokens=100,
+  )
+
+  assert result.cancelled is True
+  assert result.hit_cap is False
+  assert ai.create_message.await_count == 1
+  assert result.rows == [{"n": 1}]


### PR DESCRIPTION
## Summary

Follow-up to #1294 (merged before this landed on it). The review there found the one call the cancel guard didn't cover: after the loop exits via the iteration cap or the credit ceiling, the "answer now" wrap-up call ran unconditionally — so a cancel landing exactly as a run hit its cap still billed one more model call. The wrap-up now sits behind the same `is_cancelled` check and early return as the in-loop call.

## Changes

- `operations/operators/tool_loop.py`: cancel check before the post-loop wrap-up call; returns `cancelled=True` with the rows gathered so far and no further model call.
- `tests/operations/operators/test_tool_loop.py`: reaches the cap with a cancel pending and asserts a single model call.

## Breaking Changes

None.

## Testing

`tests/operations/operators/test_tool_loop.py`: 16 passed; ruff/format/basedpyright clean.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
