### PR TITLE
fix(reports): statements stop rendering the cash-flow delta basis

### DIFF
--- a/robosystems/middleware/mcp/tools/fact_grid_tool.py
+++ b/robosystems/middleware/mcp/tools/fact_grid_tool.py
@@ -40,7 +40,7 @@ class BuildFactGridTool:
   def get_tool_definition(self) -> dict[str, Any]:
     return {
       "name": "build-fact-grid",
-      "description": """Construct multidimensional fact grid from graph data. Retrieves facts based on elements, periods, and optional dimensions. Returns structured data with element names, values, and periods. Use include_summary=true to add aggregated statistics (count, total, avg, min, max) by element.
+      "description": """Construct multidimensional fact grid from graph data. Retrieves facts based on elements, periods, and optional dimensions. Returns structured data with element names, values, and periods. Use include_summary=true to add per-element statistics: count, min, max for every element, plus total and average for duration elements only — a balance summed or averaged across periods is not a balance, so instants (e.g. total_assets) omit both.
 
 **WHEN TO USE:**
 - When the user asks to compare specific financial metrics across periods or companies
@@ -127,7 +127,7 @@ For income statement items (revenue, net income), always specify period_type='an
           },
           "include_summary": {
             "type": "boolean",
-            "description": "Include summary statistics (count, total, avg, min, max) by element",
+            "description": "Include per-element statistics: count, min, max for every element; total and average for duration elements only (instants omit them — a balance summed across periods is not a balance).",
             "default": False,
           },
           "limit": {

--- a/robosystems/middleware/mcp/tools/financial_statement_tools.py
+++ b/robosystems/middleware/mcp/tools/financial_statement_tools.py
@@ -24,7 +24,7 @@ from robosystems.db.extensions import extensions_session
 from robosystems.middleware.operations import run_off_loop
 from robosystems.operations.roboledger.reads.reports import (
   ANALYSIS_STATEMENT_TYPES,
-  LIVE_STATEMENT_TYPES,
+  MCP_LIVE_STATEMENT_TYPES,
   CoaMappingNotFoundError,
   get_live_financial_statement,
   resolve_reporting_window,
@@ -51,18 +51,17 @@ class LiveFinancialStatementTool(BaseTool):
 - Only available on RoboLedger tenant entity graphs (not SEC shared repo)
 
 **PARAMETERS:**
-- `statement_type` (required) — one of the four below
+- `statement_type` (required) — one of the three below (a statement of equity is not offered here yet: the live path renders equity balances, not a rollforward)
 - income_statement — Revenue, expenses, net income
 - balance_sheet — Assets, liabilities, equity (instant periods)
-- equity_statement — Equity components and changes
-- cash_flow_statement — Operating (indirect: net income + non-cash add-backs + working-capital deltas), investing, financing. Investing/financing leaves resolve from each line's explicit flow tag when present, else from the mapped rs-gaap element's default-flow derivation arc — so untagged QB data renders too, provided the relevant accounts are mapped at the grain the arcs key on (e.g. PP&E Gross for capex). Needs ≥2 periods (current + prior) for the indirect deltas.
+- cash_flow_statement — Operating (indirect: net income + non-cash add-backs + working-capital deltas), investing, financing. Investing/financing leaves resolve from each line's explicit flow tag when present, else from the mapped rs-gaap element's default-flow derivation arc — so untagged QB data renders too, provided the relevant accounts are mapped at the grain the arcs key on (e.g. PP&E Gross for capex). Needs ≥2 periods (current + prior) for the indirect deltas, so the prior period is pivoted as the delta basis and only the current period is rendered.
 - Explicit `period_start` / `period_end` (YYYY-MM-DD) win over everything else
 - `period_type="annual"` + `fiscal_year=2025` → window anchored on the graph's FiscalCalendar
 - `period_type="quarterly"` → current calendar quarter
 - `period_type="instant"` / unset → current calendar month
 
 **RETURNS:**
-Facts with element qnames, names, classifications, values across current + prior periods (equal duration). Subtotal rows and all-zero rows are filtered out. Capped at `limit` rows.
+Facts with element qnames, names, classifications, and values aligned with `periods` — current + prior (equal duration) for income_statement and balance_sheet, current only for cash_flow_statement. Abstract scaffolding rows and all-zero rows are filtered out; subtotals are kept and flagged `is_subtotal`. Capped at `limit` rows (default 1000 — the whole statement).
 """,
       "inputSchema": {
         "type": "object",
@@ -70,7 +69,7 @@ Facts with element qnames, names, classifications, values across current + prior
           "statement_type": {
             "type": "string",
             "description": "Type of financial statement to generate",
-            "enum": list(LIVE_STATEMENT_TYPES),
+            "enum": list(MCP_LIVE_STATEMENT_TYPES),
           },
           "period_start": {
             "type": "string",
@@ -91,8 +90,8 @@ Facts with element qnames, names, classifications, values across current + prior
           },
           "limit": {
             "type": "integer",
-            "description": "Max fact rows returned",
-            "default": 50,
+            "description": "Max fact rows returned (1-1000). Leave at the default for a whole statement; a lower cap cuts rows while subtotals still reflect the full set.",
+            "default": 1000,
           },
         },
         "required": ["statement_type"],
@@ -109,11 +108,20 @@ Facts with element qnames, names, classifications, values across current + prior
     statement_type = (arguments.get("statement_type") or "").strip()
     if not statement_type:
       return {"error": "statement_type is required"}
-    if statement_type not in LIVE_STATEMENT_TYPES:
+    if statement_type == "equity_statement":
+      return {
+        "error": (
+          "equity_statement is not offered on this surface yet: the live "
+          "path renders equity balances, not a rollforward, so the result "
+          "would read as a statement it is not. Use balance_sheet for the "
+          "equity section."
+        ),
+      }
+    if statement_type not in MCP_LIVE_STATEMENT_TYPES:
       return {
         "error": (
           f"Unknown statement_type '{statement_type}'. "
-          f"Valid types: {', '.join(LIVE_STATEMENT_TYPES)}. "
+          f"Valid types: {', '.join(MCP_LIVE_STATEMENT_TYPES)}. "
           "For graph-backed (materialized / SEC) statements, see "
           "financial-statement-analysis."
         ),
@@ -123,7 +131,7 @@ Facts with element qnames, names, classifications, values across current + prior
     period_end = _parse_date(arguments.get("period_end"))
     period_type = arguments.get("period_type")
     fiscal_year = arguments.get("fiscal_year")
-    limit = max(1, min(int(arguments.get("limit", 50)), 1000))
+    limit = max(1, min(int(arguments.get("limit", 1000)), 1000))
 
     graph_id = self.client.graph_id
 
@@ -221,8 +229,8 @@ class FinancialStatementAnalysisTool(BaseTool):
           },
           "limit": {
             "type": "integer",
-            "description": "Max fact rows returned",
-            "default": 50,
+            "description": "Max fact rows returned (1-1000). Leave at the default for a whole statement; a lower cap cuts rows while subtotals still reflect the full set.",
+            "default": 1000,
           },
         },
         "required": ["statement_type"],
@@ -248,7 +256,7 @@ class FinancialStatementAnalysisTool(BaseTool):
     report_id = (arguments.get("report_id") or "").strip() or None
     fiscal_year = arguments.get("fiscal_year")
     period_type = arguments.get("period_type")
-    limit = max(1, min(int(arguments.get("limit", 50)), 1000))
+    limit = max(1, min(int(arguments.get("limit", 1000)), 1000))
 
     graph_id = self.client.graph_id
     is_shared = is_shared_repository_or_subgraph(graph_id)

--- a/robosystems/models/api/extensions/reports.py
+++ b/robosystems/models/api/extensions/reports.py
@@ -528,6 +528,15 @@ class ReportBundleDownloadResponse(BaseModel):
   generation_count: int = Field(
     ..., description="Bundle generation number stamped on the Report."
   )
+  omitted_content: list[str] = Field(
+    default_factory=list,
+    description=(
+      "Content the Report carries that this flavor does not. "
+      "``disclosure_notes``: the XBRL 2.1 zip ships statements only — "
+      "tenant-authored disclosure notes render on screen and ride the "
+      "JSON-LD and holon flavors, but are excluded from this file."
+    ),
+  )
 
 
 # ── Live financial statement (OLTP) ──────────────────────────────────────────
@@ -539,7 +548,9 @@ class LiveFinancialStatementRequest(BaseModel):
   statement_type: str = Field(
     ...,
     description=(
-      "income_statement | balance_sheet | cash_flow_statement | equity_statement"
+      "income_statement | balance_sheet | cash_flow_statement | equity_statement. "
+      "``equity_statement`` is provisional — equity balances, not a rollforward "
+      "— and is not offered on the MCP surface until it articulates."
     ),
   )
   period_start: date | None = Field(
@@ -554,7 +565,16 @@ class LiveFinancialStatementRequest(BaseModel):
   fiscal_year: int | None = Field(
     None, description="Fiscal year for annual window (anchored on FiscalCalendar)"
   )
-  limit: int = Field(50, ge=1, le=1000, description="Max fact rows returned")
+  limit: int = Field(
+    1000,
+    ge=1,
+    le=1000,
+    description=(
+      "Max fact rows returned. Defaults to the ceiling so a statement is "
+      "never cut mid-section — visible rows would stop footing to visible "
+      "subtotals. Lower it only for a preview."
+    ),
+  )
 
 
 class LiveStatementFactRow(BaseModel):
@@ -573,7 +593,15 @@ class LiveFinancialStatementResponse(BaseModel):
 
   graph_id: str
   statement_type: str
-  periods: list[PeriodSpec]
+  periods: list[PeriodSpec] = Field(
+    ...,
+    description=(
+      "Rendered columns, aligned with each row's ``values``. Current and "
+      "prior for income_statement and balance_sheet; current only for "
+      "cash_flow_statement — the prior period is pivoted as the "
+      "indirect-method delta basis and not rendered."
+    ),
+  )
   facts: list[LiveStatementFactRow]
   fact_count: int
   unmapped_count: int = 0
@@ -602,7 +630,7 @@ class FinancialStatementAnalysisRequest(BaseModel):
     None, description="Filter by fiscal year focus when auto-resolving the report"
   )
   period_type: str | None = Field(None, description="annual | quarterly | instant")
-  limit: int = Field(50, ge=1, le=1000)
+  limit: int = Field(1000, ge=1, le=1000)
 
 
 class ResolvedReportInfo(BaseModel):

--- a/robosystems/models/api/views/view_response.py
+++ b/robosystems/models/api/views/view_response.py
@@ -92,9 +92,10 @@ class ViewResponse(BaseModel):
   summary: dict[str, ElementSummary] | None = Field(
     None,
     description=(
-      "Per-element aggregates, only when include_summary=true. Note that "
-      "`total` sums across every returned period, which is meaningful for "
-      "duration facts and not for instants. Overlapping duration windows "
+      "Per-element aggregates, only when include_summary=true. `total` and "
+      "`average` span every returned period, so they are present for "
+      "duration elements only — instants omit both (a balance summed across "
+      "periods is not a balance). Overlapping duration windows "
       "sharing a period_end (quarter + year-to-date) contribute only the "
       "narrowest window, so a quarter is never double-counted inside its "
       "own YTD figure."

--- a/robosystems/models/api/views/view_response.py
+++ b/robosystems/models/api/views/view_response.py
@@ -36,8 +36,20 @@ class FactRecord(BaseModel):
 
 class ElementSummary(BaseModel):
   count: int = Field(..., description="Number of facts for this element")
-  total: float = Field(..., description="Sum of values across the returned facts")
-  average: float = Field(..., description="Mean value across the returned facts")
+  total: float | None = Field(
+    None,
+    description=(
+      "Sum of values across the returned facts. Duration elements only — "
+      "a balance summed across periods is not a balance, so instants omit it."
+    ),
+  )
+  average: float | None = Field(
+    None,
+    description=(
+      "Mean value across the returned facts. Duration elements only; "
+      "omitted for instants."
+    ),
+  )
   min: float = Field(..., description="Minimum value across the returned facts")
   max: float = Field(..., description="Maximum value across the returned facts")
 

--- a/robosystems/operations/roboledger/reads/reports.py
+++ b/robosystems/operations/roboledger/reads/reports.py
@@ -78,6 +78,16 @@ LIVE_STATEMENT_TYPES: tuple[str, ...] = (
   "equity_statement",
 )
 
+# The subset offered to an AI operator. ``equity_statement`` stays servable
+# on REST (the app's Statement of Equity tab) but is not advertised on the
+# MCP surface until it articulates: today it renders equity balances, not a
+# rollforward, and a model reading two rows under a passing validation
+# presents them as the statement — on a live tenant a capital contribution
+# appeared nowhere in it.
+MCP_LIVE_STATEMENT_TYPES: tuple[str, ...] = tuple(
+  t for t in LIVE_STATEMENT_TYPES if t != "equity_statement"
+)
+
 # Statement types accepted by the graph-backed analysis path. The graph
 # hypercube carries cash-flow facts from XBRL filings, so it's valid here.
 ANALYSIS_STATEMENT_TYPES: tuple[str, ...] = (
@@ -548,6 +558,11 @@ def _materialize_and_presign_xbrl(
     content_type="application/zip",
     format=flavor.value,
     generation_count=generation_count,
+    # The emitter strips tenant-authored notes on every generation
+    # (``xbrl_21._strip_disclosure_content``); a property of the flavor, so
+    # it is declared on cache hits too. The file is valid and would
+    # otherwise be silently incomplete next to the notes shown on screen.
+    omitted_content=["disclosure_notes"],
   )
 
 
@@ -774,6 +789,10 @@ def get_statement(
     report_def.comparative,
     report_def.periods,
   )
+  # A comparative or multi-period report pivots every period, but the
+  # earliest column of a cash flow statement is the delta basis, not a
+  # statement — same rule as the live path.
+  periods = [periods[i] for i in rendered_period_indexes(block_type, periods)]
 
   if not periods:
     return StatementResponse(
@@ -974,6 +993,28 @@ def build_current_and_prior_periods(start: date, end: date) -> list[FactPeriodSp
   ]
 
 
+def rendered_period_indexes(
+  statement_type: str, periods: list[FactPeriodSpec]
+) -> list[int]:
+  """Column indexes a statement renders, in the order ``periods`` was built.
+
+  Every period renders, except the earliest on a cash flow statement when
+  two or more were pivoted. The indirect method derives working-capital
+  deltas and the cash reconciliation from period-over-period balance
+  changes, so ``_derive_cash_flow_facts`` / ``_reconcile_operating_to_cash``
+  populate every period but the first — it rides the pivot only as the
+  delta basis. Rendered, that column is a fully formed statement that
+  foots and is economically wrong (net income and add-backs, no deltas, no
+  cash tie). The close-time stamp already keeps only the close month's
+  facts (``statement_sets``); this applies the same rule on the read paths.
+  """
+  indexes = list(range(len(periods)))
+  if statement_type != "cash_flow_statement" or len(periods) < 2:
+    return indexes
+  earliest = min(indexes, key=lambda i: periods[i].end)
+  return [i for i in indexes if i != earliest]
+
+
 def get_live_financial_statement(
   session: Session,
   *,
@@ -981,14 +1022,16 @@ def get_live_financial_statement(
   statement_type: str,
   period_start: date,
   period_end: date,
-  limit: int = 50,
+  limit: int = 1000,
   reporting_style_id: str | None = None,
 ) -> LiveFinancialStatementResponse:
   """Generate an OLTP-backed ad-hoc statement and format the response.
 
   Thin wrapper around ``generate_adhoc_private_statement`` that:
   - builds current+prior periods of matching duration
-  - filters subtotal rows and all-zero rows
+  - renders both columns, except on a cash flow statement, which renders
+    the current period only (``rendered_period_indexes``)
+  - filters abstract scaffolding rows and all-zero rows
   - caps at ``limit`` rows (marking ``truncated=True`` when capped)
 
   ``reporting_style_id`` resolves the reporting entity's active Style. When
@@ -1007,6 +1050,8 @@ def get_live_financial_statement(
     periods=periods,
     reporting_style_id=reporting_style_id,
   )
+  columns = rendered_period_indexes(statement_type, periods)
+  rendered_periods = [periods[i] for i in columns]
 
   facts: list[LiveStatementFactRow] = []
   for row in grid.rows:
@@ -1025,14 +1070,19 @@ def get_live_financial_statement(
     # Disclosure DAG, but their value is the calc-DAG result the reader
     # most wants to see. The UI distinguishes them via the `is_subtotal`
     # flag on the response.
-    if not any(v != 0.0 for v in row.values):
+    values = (
+      row.values
+      if len(rendered_periods) == len(periods)
+      else [row.values[i] for i in columns]
+    )
+    if not any(v != 0.0 for v in values):
       continue
     facts.append(
       LiveStatementFactRow(
         qname=row.element_qname,
         name=row.element_name,
         trait=row.classification,
-        values=row.values,
+        values=values,
         depth=row.depth,
         is_subtotal=row.is_subtotal,
       )
@@ -1045,7 +1095,9 @@ def get_live_financial_statement(
   return LiveFinancialStatementResponse(
     graph_id=graph_id,
     statement_type=statement_type,
-    periods=[PeriodSpec(start=p.start, end=p.end, label=p.label) for p in periods],
+    periods=[
+      PeriodSpec(start=p.start, end=p.end, label=p.label) for p in rendered_periods
+    ],
     facts=facts,
     fact_count=len(facts),
     unmapped_count=unmapped_count,

--- a/robosystems/operations/roboledger/views/fact_grid_builder.py
+++ b/robosystems/operations/roboledger/views/fact_grid_builder.py
@@ -32,8 +32,12 @@ def summarize_by_element(facts: list[dict[str, Any]]) -> dict[str, dict[str, flo
   """Per-element aggregates over the returned facts.
 
   Shared by the REST and MCP surfaces so both report the same numbers.
-  `total` sums across every returned period — meaningful for duration facts,
-  not for instants (summing a balance across time is not a balance).
+  `total` and `average` span every returned period, so they are emitted for
+  duration facts only. A balance is a point-in-time measure: summed or
+  averaged across periods it yields a figure that looks authoritative and
+  means nothing, and a model reading the field quotes it. Instants (no
+  `period_start`, or an explicit `period_type` of `instant`) carry
+  `count` / `min` / `max` only.
 
   Overlapping duration windows that share a `period_end` (a 10-Q reports the
   same element for both the quarter and the year-to-date window ending the
@@ -48,6 +52,7 @@ def summarize_by_element(facts: list[dict[str, Any]]) -> dict[str, dict[str, flo
   # is the narrowest window ending that day. Instants have no period_start
   # and arrive one-per-end after dedup, so they pass through unchanged.
   narrowest: dict[tuple[str, Any, Any], tuple[str, float]] = {}
+  instant_elements: set[str] = set()
   for fact in facts:
     element = fact.get("element_id")
     value = fact.get("value")
@@ -55,6 +60,8 @@ def summarize_by_element(facts: list[dict[str, Any]]) -> dict[str, dict[str, flo
       continue
     key = (str(element), fact.get("entity_ticker"), fact.get("period_end"))
     start = str(fact.get("period_start") or "")
+    if not start or fact.get("period_type") == "instant":
+      instant_elements.add(str(element))
     prev = narrowest.get(key)
     if prev is None or start > prev[0]:
       narrowest[key] = (start, float(value))
@@ -64,13 +71,13 @@ def summarize_by_element(facts: list[dict[str, Any]]) -> dict[str, dict[str, flo
     by_element.setdefault(element, []).append(value)
 
   for element, values in by_element.items():
-    summary[element] = {
-      "count": len(values),
-      "total": sum(values),
-      "average": sum(values) / len(values),
-      "min": min(values),
-      "max": max(values),
-    }
+    stats: dict[str, float] = {"count": len(values)}
+    if element not in instant_elements:
+      stats["total"] = sum(values)
+      stats["average"] = sum(values) / len(values)
+    stats["min"] = min(values)
+    stats["max"] = max(values)
+    summary[element] = stats
 
   return summary
 

--- a/tests/middleware/mcp/test_tools.py
+++ b/tests/middleware/mcp/test_tools.py
@@ -223,6 +223,7 @@ class TestBuildFactGridTool:
       {
         "element_id": "us-gaap:Revenues",
         "element_name": "Revenues",
+        "period_start": "2024-01-01",
         "period_end": "2024-12-31",
         "value": 1000.0,
         "unit": "USD",
@@ -230,6 +231,7 @@ class TestBuildFactGridTool:
       {
         "element_id": "us-gaap:Revenues",
         "element_name": "Revenues",
+        "period_start": "2023-01-01",
         "period_end": "2023-12-31",
         "value": 2000.0,
         "unit": "USD",
@@ -237,6 +239,7 @@ class TestBuildFactGridTool:
       {
         "element_id": "us-gaap:CostOfRevenue",
         "element_name": "CostOfRevenue",
+        "period_start": "2024-01-01",
         "period_end": "2024-12-31",
         "value": 500.0,
         "unit": "USD",

--- a/tests/middleware/mcp/test_tools.py
+++ b/tests/middleware/mcp/test_tools.py
@@ -263,3 +263,49 @@ class TestBuildFactGridTool:
     assert result["summary"]["us-gaap:Revenues"]["count"] == 2
     assert result["summary"]["us-gaap:Revenues"]["total"] == 3000.0
     assert result["summary"]["us-gaap:CostOfRevenue"]["total"] == 500.0
+
+  async def test_include_summary_omits_total_for_instants(self, mock_graph_client):
+    """A balance summed across periods is not a balance, and a model reading
+    `total` quotes it. Instants (no period_start) carry count/min/max only;
+    the tool description says so."""
+    tool = BuildFactGridTool(mock_graph_client)
+
+    facts = [
+      {
+        "element_id": "us-gaap:Assets",
+        "element_name": "Assets",
+        "period_start": None,
+        "period_end": "2024-12-31",
+        "value": 1000.0,
+        "unit": "USD",
+      },
+      {
+        "element_id": "us-gaap:Assets",
+        "element_name": "Assets",
+        "period_start": None,
+        "period_end": "2023-12-31",
+        "value": 900.0,
+        "unit": "USD",
+      },
+    ]
+
+    with patch(
+      "robosystems.middleware.mcp.tools.fact_grid_tool.query_fact_grid",
+      new_callable=AsyncMock,
+      return_value=(facts, False),
+    ):
+      result = await tool.execute(
+        {
+          "elements": ["us-gaap:Assets"],
+          "periods": ["2024-12-31", "2023-12-31"],
+          "include_summary": True,
+        }
+      )
+
+    assert result["summary"]["us-gaap:Assets"] == {
+      "count": 2,
+      "min": 900.0,
+      "max": 1000.0,
+    }
+    description = tool.get_tool_definition()["description"]
+    assert "duration elements only" in description

--- a/tests/middleware/mcp/tools/test_financial_statement_tools.py
+++ b/tests/middleware/mcp/tools/test_financial_statement_tools.py
@@ -46,7 +46,15 @@ class TestLiveFinancialStatementToolDefinition:
     assert "income_statement" in enum
     assert "balance_sheet" in enum
     assert "cash_flow_statement" in enum
-    assert "equity_statement" in enum
+    # Served on REST for the app's tab, not offered to an operator until it
+    # articulates — today it is equity balances, not a rollforward.
+    assert "equity_statement" not in enum
+
+  @pytest.mark.unit
+  def test_limit_defaults_to_the_whole_statement(self):
+    tool = LiveFinancialStatementTool(_make_client())
+    d = tool.get_tool_definition()
+    assert d["inputSchema"]["properties"]["limit"]["default"] == 1000
 
 
 @pytest.mark.asyncio
@@ -84,6 +92,47 @@ class TestLiveFinancialStatementToolExecute:
     assert result["statement_type"] == "income_statement"
     assert result["fact_count"] == 0
     assert "tip" in result  # empty results trigger the tip
+
+  @pytest.mark.unit
+  async def test_default_limit_is_the_ceiling(self):
+    """A real chart of accounts exceeds 50 non-zero rows routinely, and a
+    cut statement's visible rows stop footing to its subtotals."""
+    tool = LiveFinancialStatementTool(_make_client("kg_123"))
+    from robosystems.models.api.extensions.reports import (
+      LiveFinancialStatementResponse,
+    )
+
+    mock_response = LiveFinancialStatementResponse(
+      graph_id="kg_123",
+      statement_type="balance_sheet",
+      periods=[],
+      facts=[],
+      fact_count=0,
+    )
+    cm = MagicMock()
+    cm.__enter__.return_value = MagicMock()
+    cm.__exit__.return_value = False
+
+    with (
+      patch(f"{MODULE}.extensions_session", return_value=cm),
+      patch(
+        f"{MODULE}.resolve_reporting_window",
+        return_value=(date(2026, 4, 1), date(2026, 4, 30)),
+      ),
+      patch(
+        f"{MODULE}.get_live_financial_statement", return_value=mock_response
+      ) as live,
+    ):
+      await tool.execute({"statement_type": "balance_sheet"})
+
+    assert live.call_args.kwargs["limit"] == 1000
+
+  @pytest.mark.unit
+  async def test_equity_statement_is_refused_with_a_reason(self):
+    tool = LiveFinancialStatementTool(_make_client())
+    result = await tool.execute({"statement_type": "equity_statement"})
+    assert "rollforward" in result["error"]
+    assert "balance_sheet" in result["error"]
 
   @pytest.mark.unit
   async def test_missing_statement_type(self):

--- a/tests/operations/roboledger/reads/test_report_download.py
+++ b/tests/operations/roboledger/reads/test_report_download.py
@@ -168,6 +168,8 @@ class TestJsonLd:
     assert resp.content_type == "application/ld+json"
     assert resp.format == "jsonld"
     assert resp.generation_count == 3
+    # JSON-LD carries the disclosure notes; nothing is omitted.
+    assert resp.omitted_content == []
     # Presigns the bucket/key parsed from the stored bundle_url.
     _, kwargs = s3.generate_presigned_url.call_args
     assert kwargs["bucket"] == "bkt"
@@ -209,6 +211,10 @@ class TestXbrl:
     # Cache hit → never rebuilds or uploads.
     build.assert_not_called()
     s3.upload_bytes.assert_not_called()
+    # The emitter strips tenant-authored notes on every generation, so the
+    # omission is declared on a cache hit too — the file is valid and would
+    # otherwise be silently incomplete next to the notes shown on screen.
+    assert resp.omitted_content == ["disclosure_notes"]
 
   @pytest.mark.unit
   def test_cache_miss_materializes_then_presigns(self):
@@ -228,6 +234,7 @@ class TestXbrl:
       resp = get_report_download_url(session, "kg1", "rpt_1", flavor="xbrl-2.1")
 
     assert resp is not None
+    assert resp.omitted_content == ["disclosure_notes"]
     build.assert_called_once()
     serialize.assert_called_once()
     _, up_kwargs = s3.upload_bytes.call_args

--- a/tests/operations/roboledger/reads/test_reports_extra.py
+++ b/tests/operations/roboledger/reads/test_reports_extra.py
@@ -19,7 +19,11 @@ from robosystems.operations.roboledger.reads.reports import (
   build_current_and_prior_periods,
   get_live_financial_statement,
   get_statement,
+  rendered_period_indexes,
   resolve_reporting_window,
+)
+from robosystems.operations.roboledger.reports.fact_grid import (
+  PeriodSpec as FactPeriodSpec,
 )
 
 
@@ -370,3 +374,183 @@ class TestGetStatementNumericFilter:
 
     src = inspect.getsource(get_statement)
     assert "rf.fact_type = 'Numeric'" in src
+
+
+class TestRenderedPeriodIndexes:
+  """The earliest period of a cash flow pivot is the indirect-method delta
+  basis, not a statement. ``_derive_cash_flow_facts`` and
+  ``_reconcile_operating_to_cash`` populate every period but the first, so
+  rendered it foots and is wrong — on a live tenant the comparative month
+  showed 2.19x the balance-sheet cash movement. The close-time stamp already
+  keeps only the close month (``statement_sets``); the read paths apply the
+  same rule here."""
+
+  @pytest.mark.unit
+  def test_cash_flow_drops_the_earliest_period(self):
+    periods = build_current_and_prior_periods(date(2026, 7, 1), date(2026, 7, 31))
+    assert rendered_period_indexes("cash_flow_statement", periods) == [0]
+
+  @pytest.mark.unit
+  def test_drops_by_date_not_position(self):
+    """Multi-period reports store periods in authored order; the basis is
+    whichever ends first, wherever it sits."""
+    periods = [
+      FactPeriodSpec(start=date(2026, 5, 1), end=date(2026, 5, 31), label="May"),
+      FactPeriodSpec(start=date(2026, 7, 1), end=date(2026, 7, 31), label="Jul"),
+      FactPeriodSpec(start=date(2026, 6, 1), end=date(2026, 6, 30), label="Jun"),
+    ]
+    assert rendered_period_indexes("cash_flow_statement", periods) == [1, 2]
+
+  @pytest.mark.unit
+  @pytest.mark.parametrize(
+    "statement_type", ["income_statement", "balance_sheet", "equity_statement"]
+  )
+  def test_other_statements_render_every_period(self, statement_type):
+    periods = build_current_and_prior_periods(date(2026, 7, 1), date(2026, 7, 31))
+    assert rendered_period_indexes(statement_type, periods) == [0, 1]
+
+  @pytest.mark.unit
+  def test_single_period_cash_flow_is_left_alone(self):
+    periods = [
+      FactPeriodSpec(start=date(2026, 7, 1), end=date(2026, 7, 31), label="Jul")
+    ]
+    assert rendered_period_indexes("cash_flow_statement", periods) == [0]
+
+
+class TestLiveCashFlowRendersCurrentOnly:
+  @pytest.mark.unit
+  def test_prior_column_is_pivoted_but_not_rendered(self):
+    session = MagicMock()
+
+    def _row(name, values):
+      r = MagicMock()
+      r.element_qname = f"rs-gaap:{name}"
+      r.element_name = name
+      r.classification = "monetary"
+      r.values = values
+      r.depth = 0
+      r.is_subtotal = False
+      r.is_abstract = False
+      return r
+
+    mock_grid = MagicMock()
+    mock_grid.rows = [
+      _row("NetIncomeLoss", [1_000.0, 900.0]),
+      # Derived only for the current column — the basis period has none.
+      _row("IncreaseDecreaseInAccountsReceivable", [-250.0, None]),
+      # Non-zero only in the basis column: nothing to render.
+      _row("PaymentsToAcquirePropertyPlantAndEquipment", [0.0, -400.0]),
+    ]
+
+    with (
+      patch(
+        "robosystems.operations.roboledger.reads.reports.generate_adhoc_private_statement",
+        return_value=(mock_grid, 0),
+      ) as generate,
+      patch(
+        "robosystems.operations.roboledger.reports.network_picker.load_primary_reporting_style",
+        return_value="025f5d48-12ce-5d65-b9eb-4f137a10ef06",
+      ),
+    ):
+      resp = get_live_financial_statement(
+        session,
+        graph_id="kg_test",
+        statement_type="cash_flow_statement",
+        period_start=date(2026, 7, 1),
+        period_end=date(2026, 7, 31),
+      )
+
+    # Both periods reach the generator — the prior month is the delta basis.
+    pivoted = generate.call_args.kwargs["periods"]
+    assert [p.label for p in pivoted] == ["Current", "Prior"]
+    # Only the current period is rendered, and every row is one column wide.
+    assert [p.label for p in resp.periods] == ["Current"]
+    assert resp.periods[0].end == date(2026, 7, 31)
+    assert [f.name for f in resp.facts] == [
+      "NetIncomeLoss",
+      "IncreaseDecreaseInAccountsReceivable",
+    ]
+    assert [f.values for f in resp.facts] == [[1_000.0], [-250.0]]
+
+  @pytest.mark.unit
+  def test_income_statement_still_renders_both(self):
+    session = MagicMock()
+    r = MagicMock()
+    r.element_qname = "rs-gaap:Revenues"
+    r.element_name = "Revenues"
+    r.classification = "monetary"
+    r.values = [500.0, 450.0]
+    r.depth = 0
+    r.is_subtotal = False
+    r.is_abstract = False
+    mock_grid = MagicMock()
+    mock_grid.rows = [r]
+
+    with (
+      patch(
+        "robosystems.operations.roboledger.reads.reports.generate_adhoc_private_statement",
+        return_value=(mock_grid, 0),
+      ),
+      patch(
+        "robosystems.operations.roboledger.reports.network_picker.load_primary_reporting_style",
+        return_value="025f5d48-12ce-5d65-b9eb-4f137a10ef06",
+      ),
+    ):
+      resp = get_live_financial_statement(
+        session,
+        graph_id="kg_test",
+        statement_type="income_statement",
+        period_start=date(2026, 7, 1),
+        period_end=date(2026, 7, 31),
+      )
+
+    assert [p.label for p in resp.periods] == ["Current", "Prior"]
+    assert resp.facts[0].values == [500.0, 450.0]
+
+
+class TestSavedCashFlowRendersCurrentOnly:
+  """``get_statement`` on a comparative report: the persisted facts for the
+  prior period are the delta basis, so a cash flow renders one column."""
+
+  def _report(self, comparative: bool):
+    report = MagicMock()
+    report.id = "rpt_01"
+    report.period_start = date(2026, 7, 1)
+    report.period_end = date(2026, 7, 31)
+    report.comparative = comparative
+    report.periods = None
+    return report
+
+  @pytest.mark.unit
+  def test_comparative_cash_flow_renders_the_current_period(self):
+    session = MagicMock()
+    session.get.return_value = self._report(comparative=True)
+    session.execute.return_value = iter([])
+
+    resp = get_statement(
+      session,
+      graph_id="kg_test",
+      report_id="rpt_01",
+      block_type="cash_flow_statement",
+      reporting_style_id="style_01",
+    )
+
+    assert resp is not None
+    assert [p.label for p in resp.periods] == ["Current"]
+
+  @pytest.mark.unit
+  def test_comparative_balance_sheet_renders_both(self):
+    session = MagicMock()
+    session.get.return_value = self._report(comparative=True)
+    session.execute.return_value = iter([])
+
+    resp = get_statement(
+      session,
+      graph_id="kg_test",
+      report_id="rpt_01",
+      block_type="balance_sheet",
+      reporting_style_id="style_01",
+    )
+
+    assert resp is not None
+    assert [p.label for p in resp.periods] == ["Current", "Prior"]

--- a/tests/operations/roboledger/views/test_fact_grid_builder.py
+++ b/tests/operations/roboledger/views/test_fact_grid_builder.py
@@ -210,18 +210,30 @@ class TestFactGridBuilder:
 class TestSummarizeByElement:
   def test_aggregates_per_element(self):
     facts = [
-      _fact("us-gaap:Assets", "Assets", 1000000, "2024-12-31"),
-      _fact("us-gaap:Assets", "Assets", 1500000, "2023-12-31"),
+      _fact(
+        "us-gaap:Revenues",
+        "Revenues",
+        1000000,
+        "2024-12-31",
+        period_start="2024-01-01",
+      ),
+      _fact(
+        "us-gaap:Revenues",
+        "Revenues",
+        1500000,
+        "2023-12-31",
+        period_start="2023-01-01",
+      ),
       _fact("us-gaap:Cash", "Cash", 100000, "2024-12-31"),
     ]
 
     summary = summarize_by_element(facts)
 
-    assert summary["us-gaap:Assets"]["count"] == 2
-    assert summary["us-gaap:Assets"]["total"] == 2500000
-    assert summary["us-gaap:Assets"]["average"] == 1250000
-    assert summary["us-gaap:Assets"]["min"] == 1000000
-    assert summary["us-gaap:Assets"]["max"] == 1500000
+    assert summary["us-gaap:Revenues"]["count"] == 2
+    assert summary["us-gaap:Revenues"]["total"] == 2500000
+    assert summary["us-gaap:Revenues"]["average"] == 1250000
+    assert summary["us-gaap:Revenues"]["min"] == 1000000
+    assert summary["us-gaap:Revenues"]["max"] == 1500000
     assert summary["us-gaap:Cash"]["count"] == 1
 
   def test_keyed_on_qname_not_local_name(self):
@@ -322,7 +334,56 @@ class TestSummarizeByElement:
     summary = summarize_by_element(facts)
 
     assert summary["us-gaap:Assets"]["count"] == 2
-    assert summary["us-gaap:Assets"]["total"] == 1900
+    assert summary["us-gaap:Assets"]["min"] == 900
+    assert summary["us-gaap:Assets"]["max"] == 1000
 
   def test_empty_input(self):
     assert summarize_by_element([]) == {}
+
+
+class TestSummarizeInstants:
+  """A balance is a point in time. Summed or averaged across periods it is a
+  number that looks authoritative and means nothing — and this is the field
+  a model quotes. Instants keep count / min / max only."""
+
+  def test_instants_omit_total_and_average(self):
+    facts = [
+      _fact("us-gaap:Assets", "Assets", 1_000_000, "2024-12-31"),
+      _fact("us-gaap:Assets", "Assets", 1_500_000, "2023-12-31"),
+    ]
+
+    summary = summarize_by_element(facts)
+
+    assert summary["us-gaap:Assets"] == {
+      "count": 2,
+      "min": 1_000_000,
+      "max": 1_500_000,
+    }
+
+  def test_explicit_instant_period_type_is_honoured(self):
+    facts = [
+      {
+        **_fact("us-gaap:Cash", "Cash", 100, "2024-12-31", period_start="2024-12-31"),
+        "period_type": "instant",
+      },
+    ]
+
+    summary = summarize_by_element(facts)
+
+    assert "total" not in summary["us-gaap:Cash"]
+    assert "average" not in summary["us-gaap:Cash"]
+
+  def test_durations_keep_the_aggregates(self):
+    facts = [
+      _fact(
+        "us-gaap:Revenues", "Revenues", 300, "2024-12-31", period_start="2024-10-01"
+      ),
+      _fact(
+        "us-gaap:Revenues", "Revenues", 200, "2024-09-30", period_start="2024-07-01"
+      ),
+    ]
+
+    summary = summarize_by_element(facts)
+
+    assert summary["us-gaap:Revenues"]["total"] == 500
+    assert summary["us-gaap:Revenues"]["average"] == 250

--- a/tests/routers/extensions/roboledger/test_views.py
+++ b/tests/routers/extensions/roboledger/test_views.py
@@ -241,6 +241,7 @@ class TestBuildFactGridOperation:
       {
         "element_id": "us-gaap:Revenues",
         "element_name": "Revenues",
+        "period_start": "2024-01-01",
         "period_end": "2024-12-31",
         "value": 1000.0,
         "unit": "USD",
@@ -248,6 +249,7 @@ class TestBuildFactGridOperation:
       {
         "element_id": "us-gaap:Revenues",
         "element_name": "Revenues",
+        "period_start": "2023-01-01",
         "period_end": "2023-12-31",
         "value": 2000.0,
         "unit": "USD",
@@ -255,6 +257,7 @@ class TestBuildFactGridOperation:
       {
         "element_id": "us-gaap:CostOfRevenue",
         "element_name": "CostOfRevenue",
+        "period_start": "2024-01-01",
         "period_end": "2024-12-31",
         "value": 500.0,
         "unit": "USD",


### PR DESCRIPTION
## Summary

Four correctness fixes on the statement and fact-grid read surfaces, all of the same kind: a number that looked authoritative and wasn't. The largest is the comparative column of every live cash flow statement — the indirect method derives working-capital deltas and the cash tie from period-over-period balance changes, so the earliest period of a cash flow pivot is the delta basis, not a statement. It rendered net income and add-backs with no deltas and no cash reconciliation, footed, and was wrong (on a live tenant the comparative month showed more than twice the balance-sheet cash movement). The close-time stamp already keeps only the close month; the live and saved-report read paths now apply the same rule.

## Changes

**Cash flow renders the current period only** (`operations/roboledger/reads/reports.py`)
- New `rendered_period_indexes(statement_type, periods)`: every period renders except the earliest on a `cash_flow_statement` when two or more were pivoted. Chosen by date, not position, so multi-period saved reports in authored order drop the right column.
- `get_live_financial_statement` still pivots `[Current, Prior]` (the prior month is the delta basis) but renders one column for cash flow; income statement and balance sheet are unchanged. The all-zero filter runs on the rendered values, so a row non-zero only in the basis column no longer appears.
- `get_statement` (saved reports) applies the same rule after `build_periods`, so a `comparative=True` report's cash flow renders one column. The persisted prior-period facts are untouched.
- `LiveFinancialStatementResponse.periods` documents the shape. The roboledger-app statements page maps `periods` and `row.values` generically, so a one-column cash flow renders without a client change.

**`limit` defaults to the whole statement** (`models/api/extensions/reports.py`, `middleware/mcp/tools/financial_statement_tools.py`)
- `LiveFinancialStatementRequest.limit` and both MCP financial-statement tools default to the 1000 ceiling instead of 50. A real chart of accounts exceeds 50 non-zero rows routinely, and a cut statement's visible rows stop footing to its subtotals; the app sends no `limit`.

**`equity_statement` leaves the MCP surface** (`reads/reports.py`, `financial_statement_tools.py`)
- New `MCP_LIVE_STATEMENT_TYPES` (the four minus `equity_statement`) drives the tool's enum and validation. It is still served on REST for the app's Statement of Equity tab. The live path renders equity balances, not a rollforward, and a model reading two rows under a passing validation presents them as the statement; the tool now refuses it with that reason and points at `balance_sheet`.
- The tool description also stops claiming subtotal rows are filtered out — they are kept and flagged `is_subtotal` — and states that cash flow renders the current period only.

**XBRL download declares what it omits** (`models/api/extensions/reports.py`, `reads/reports.py`)
- `ReportBundleDownloadResponse.omitted_content: list[str]` (default `[]`). The XBRL 2.1 presign sets `["disclosure_notes"]`: the emitter strips tenant-authored notes on every generation (`xbrl_21._strip_disclosure_content`), so the file was valid and silently incomplete next to the notes shown on screen. Declared on cache hits too, since it is a property of the flavor.

**Fact-grid summaries stop summing balances across time** (`operations/roboledger/views/fact_grid_builder.py`, `models/api/views/view_response.py`)
- `summarize_by_element` emitted `total` and `average` for instants — its own docstring conceded that summing a balance across periods is not a balance, and both the REST view and the MCP tool surfaced the figure unqualified. Instants (no `period_start`, or an explicit `period_type` of `instant` — verified against how the SEC graph stores them) now carry `count` / `min` / `max` only. `ElementSummary.total` / `.average` become optional to match.

**Tests**
- New: `rendered_period_indexes` (date-not-position, single period, other statement types untouched), live and saved cash flow render one column while both periods reach the generator, instants omit aggregates, MCP enum/limit/equity refusal, `omitted_content` on both flavors and on a cache hit.
- Corrected rather than preserved: two fixtures that built duration facts without a `period_start`, and one that asserted a `total` on `Assets`.

Reviewers: the one judgment call is `rendered_period_indexes` on `get_statement` — it trims the rendered periods, not the persisted facts, so an XBRL/JSON-LD export of a comparative report still carries the prior period's authored facts (net income etc. are legitimate facts on their own). A correct comparative cash flow column would need a three-period pivot; that is a follow-up, not this PR.

## Breaking Changes

None to the stable tier (facades, integration-template emit path).

Generated-tier changes, riding a client minor (SDK regen opportunity — all additive or loosening):
- `LiveFinancialStatementRequest.limit` default 50 → 1000 (range unchanged).
- `LiveFinancialStatementResponse.periods` is one entry for `cash_flow_statement` (two for the others, as before).
- `ElementSummary.total` / `average` become nullable.
- `ReportBundleDownloadResponse.omitted_content` added.
- MCP `live-financial-statement`: `statement_type` enum drops `equity_statement`; `limit` default 1000. Directory-listing note: the tool list is unchanged, so no resubmission on the channels that key on it; the OpenAI portal treats a definition change as a new version, and its review is still pending, so the definitions are not yet locked.

## Testing

- `uv run pytest tests/operations/roboledger tests/middleware/mcp tests/routers/extensions tests/graphql tests/models tests/operations/serialization` — 3,162 passed.
- `just test-code` — ruff, format, basedpyright all clean.
- Full `just test-all` not run in-session (the local run halts on a known test-order pyarrow issue unrelated to this change); CI runs the full suite.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
