### PR TITLE
feat(alarms): page when any Dagster run fails

### DIFF
--- a/.github/workflows/deploy-dagster.yml
+++ b/.github/workflows/deploy-dagster.yml
@@ -148,7 +148,7 @@ on:
         type: string
         default: "false"
       aws_sns_alert_email:
-        description: "Email for worker alerts (e.g. DLQ depth); empty disables alarm notifications"
+        description: "Email for Dagster and worker alerts (run failures, DLQ depth, backup gaps, stalled-provisioning write-offs); empty disables alarm notifications"
         required: false
         type: string
         default: ""
@@ -347,6 +347,7 @@ jobs:
                 ParameterKey=BastionSecurityGroupId,ParameterValue=${{ inputs.bastion_sg_id }} \
                 ParameterKey=ApiSecurityGroupId,ParameterValue=${{ steps.resolve-api-sg.outputs.api_sg_id }} \
                 ParameterKey=ContainerInsightsEnabled,ParameterValue=${{ inputs.container_insights_enabled }} \
+                ParameterKey=SNSAlertEmail,ParameterValue=\"${{ inputs.aws_sns_alert_email }}\" \
                 ParameterKey=SharedRawBucketArn,ParameterValue=\"${{ inputs.shared_raw_bucket_arn }}\" \
                 ParameterKey=SharedProcessedBucketArn,ParameterValue=\"${{ inputs.shared_processed_bucket_arn }}\" \
                 ParameterKey=DeploymentBucketArn,ParameterValue=\"${{ inputs.deployment_bucket_arn }}\" \

--- a/cloudformation/dagster.yaml
+++ b/cloudformation/dagster.yaml
@@ -14,7 +14,7 @@ Parameters:
   SNSAlertEmail:
     Type: String
     Default: ""
-    Description: Email for Dagster alerts (e.g. backup coverage gaps); empty disables alarm notifications
+    Description: Email for Dagster alerts (run failures, backup coverage gaps, stalled-provisioning write-offs); empty disables alarm notifications
 
   # Infrastructure & Networking
   VpcId:
@@ -538,14 +538,17 @@ Resources:
                   - logs:DescribeLogStreams
                 Resource:
                   - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/robosystems/${Environment}/dagster:*"
-              # CloudWatch Metrics for instance monitoring and auto-scaling
+              # CloudWatch Metrics: instance monitoring and auto-scaling (Graph),
+              # run-failure detection (Dagster)
               - Effect: Allow
                 Action:
                   - cloudwatch:PutMetricData
                 Resource: "*"
                 Condition:
                   StringEquals:
-                    "cloudwatch:namespace": !Sub "RoboSystems/Graph/${Environment}"
+                    "cloudwatch:namespace":
+                      - !Sub "RoboSystems/Graph/${Environment}"
+                      - !Sub "RoboSystems/Dagster/${Environment}"
               # SES for transactional emails (verification, password reset, welcome)
               - Effect: Allow
                 Action:
@@ -1090,6 +1093,28 @@ Resources:
       AlarmName: !Sub robosystems-dagster-${Environment}-stalled-provisioning-write-off
       AlarmDescription: A paid subscription was written off after provisioning stalled - the customer has no resource and needs an operator
       MetricName: StalledProvisioningWriteOff
+      Namespace: !Sub RoboSystems/Dagster/${Environment}
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - !Ref DagsterAlertTopic
+      TreatMissingData: notBreaching
+
+  # Every customer-visible failure that is not "the API is down" runs through
+  # Dagster: QuickBooks sync, materialization, backups, invoicing, the SEC
+  # pipeline. run_failure_metric_sensor publishes one RunFailure point per
+  # failed run and this pages on any of them. A quiet day publishes nothing,
+  # so missing data is the healthy state.
+  DagsterRunFailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: HasAlertEmail
+    Properties:
+      AlarmName: !Sub robosystems-dagster-${Environment}-run-failure
+      AlarmDescription: A Dagster run failed - triage it in the Dagster UI before the work it carried (sync, materialization, backup, invoicing, SEC) goes stale
+      MetricName: RunFailure
       Namespace: !Sub RoboSystems/Dagster/${Environment}
       Statistic: Sum
       Period: 300

--- a/cloudformation/dagster.yaml
+++ b/cloudformation/dagster.yaml
@@ -1125,7 +1125,6 @@ Resources:
         - !Ref DagsterAlertTopic
       TreatMissingData: notBreaching
 
-
 Outputs:
   ClusterName:
     Description: Name of the ECS Cluster

--- a/robosystems/dagster/README.md
+++ b/robosystems/dagster/README.md
@@ -93,6 +93,7 @@ The instance-monitoring schedules are auto-enabled in staging and production onl
 | `invoice_subscription_renewal_sensor` | Invoice-billed subscriptions whose period ended |
 | `graph_usage_monitor_sensor` | Storage usage against tier limits (email alerts at 80% and 100%) |
 | `worker_inflight_reaper_sensor` | Stale `worker:inflight:*` keys in Valkey DB 6 — runs in the always-on daemon, so no cold start |
+| `run_failure_metric_sensor` | Every failed run in any job — publishes a `RunFailure` CloudWatch metric that `robosystems-dagster-{env}-run-failure` pages on; without it a failed run is visible only in the UI |
 | `scheduled_obligation_promotion_sensor` | Matured `schedule_entry_due` events per entity graph |
 
 **Platform sensors default to `RUNNING`;** the obligation promoter is the exception and defaults to `STOPPED`. **Every SEC adapter sensor and its schedule default to `STOPPED`** — enable them in the Dagster UI when you're ready for automated processing.

--- a/robosystems/dagster/definitions.py
+++ b/robosystems/dagster/definitions.py
@@ -111,6 +111,7 @@ from robosystems.dagster.sensors.invoice_billing import (
 from robosystems.dagster.sensors.materialization import (
   stale_graph_materialization_sensor,
 )
+from robosystems.dagster.sensors.run_failure import run_failure_metric_sensor
 from robosystems.dagster.sensors.usage_monitor import (
   graph_usage_monitor_sensor,
 )
@@ -282,6 +283,8 @@ all_sensors = [
   graph_usage_monitor_sensor,
   # Platform: Worker reliability
   worker_inflight_reaper_sensor,
+  # Platform: Run failure detection (every job, including the adapters')
+  run_failure_metric_sensor,
   # Extensions: period-boundary obligation promoter
   *_extensions_sensors,
   # Adapter: SEC pipeline

--- a/robosystems/dagster/sensors/run_failure.py
+++ b/robosystems/dagster/sensors/run_failure.py
@@ -1,0 +1,89 @@
+"""Dagster sensor that turns every failed run into a CloudWatch metric.
+
+Every customer-visible failure that is not "the API is down" runs through
+Dagster: QuickBooks sync, materialization, backups, invoicing, the SEC
+pipeline. Before this sensor a failed run was a red row in the Dagster UI
+and nothing else — a stage that failed two nights running went unnoticed
+for four days because nothing watched for it.
+
+One ``RunFailure`` data point per failed run goes to the
+``RoboSystems/Dagster/{environment}`` namespace the stack's other detectors
+already use, and ``DagsterRunFailureAlarm`` in ``cloudformation/dagster.yaml``
+pages on any non-zero sum. A second copy of the point carries a ``Job``
+dimension so the console can split failures by job; the alarm reads the
+dimensionless copy, because CloudWatch never aggregates a custom metric
+across dimensions.
+"""
+
+from typing import Any
+
+from dagster import (
+  DagsterRunStatus,
+  DefaultSensorStatus,
+  RunStatusSensorContext,
+  run_status_sensor,
+)
+
+from robosystems.config import env
+from robosystems.logger import get_logger
+
+logger = get_logger(__name__)
+
+METRIC_NAME = "RunFailure"
+
+
+def metric_namespace() -> str:
+  return f"RoboSystems/Dagster/{env.ENVIRONMENT}"
+
+
+def run_failure_metric_data(job_name: str) -> list[dict[str, Any]]:
+  """One dimensionless point for the alarm, one per-job point for triage."""
+  return [
+    {"MetricName": METRIC_NAME, "Value": 1, "Unit": "Count"},
+    {
+      "MetricName": METRIC_NAME,
+      "Dimensions": [{"Name": "Job", "Value": job_name}],
+      "Value": 1,
+      "Unit": "Count",
+    },
+  ]
+
+
+def publish_run_failure(job_name: str) -> None:
+  import boto3
+
+  boto3.client("cloudwatch").put_metric_data(
+    Namespace=metric_namespace(),
+    MetricData=run_failure_metric_data(job_name),
+  )
+
+
+@run_status_sensor(
+  run_status=DagsterRunStatus.FAILURE,
+  monitor_all_code_locations=True,
+  default_status=DefaultSensorStatus.RUNNING,
+  minimum_interval_seconds=60,
+  description=(
+    "Publishes a RunFailure CloudWatch metric for every failed run, in any "
+    "job, so the stack's alarm pages on work not completing."
+  ),
+)
+def run_failure_metric_sensor(context: RunStatusSensorContext) -> None:
+  run = context.dagster_run
+  job_name = run.job_name
+  message = f"DAGSTER RUN FAILED job={job_name} run_id={run.run_id}"
+  # The module logger reaches the daemon's CloudWatch stream; the tick log
+  # is what the Dagster UI shows against this sensor.
+  logger.error(message)
+  context.log.error(message)
+
+  if not env.is_aws_environment():
+    return
+
+  try:
+    publish_run_failure(job_name)
+  except Exception as e:
+    # The alarm treats missing data as healthy, so a publish that fails is
+    # silent downstream and the log line above is the only trace. Raising
+    # here would only add the publisher's failure to the one being reported.
+    logger.warning(f"Failed to publish {METRIC_NAME} for {job_name}: {e}")

--- a/tests/dagster/test_run_failure_sensor.py
+++ b/tests/dagster/test_run_failure_sensor.py
@@ -23,6 +23,17 @@ from robosystems.dagster.sensors.run_failure import (
 )
 
 
+def _env(environment: str) -> type[EnvConfig]:
+  """A stand-in for the sensor module's ``env`` with one ENVIRONMENT.
+
+  Patched in as a class so ``ENVIRONMENT`` and the real
+  ``is_aws_environment()`` classmethod resolve from the same place. Patching
+  the shared instance is not enough: an earlier test's monkeypatch can leave
+  an instance attribute shadowing the class one, and the two then disagree.
+  """
+  return type("StubEnv", (EnvConfig,), {"ENVIRONMENT": environment})
+
+
 def _failed_run_context(job_name: str = "backup_graph_job"):
   run = DagsterRun(job_name=job_name, run_id="run-1", status=DagsterRunStatus.FAILURE)
   event = DagsterEvent(
@@ -58,7 +69,7 @@ def test_alarm_point_is_dimensionless_and_triage_point_names_the_job():
 def test_failed_run_publishes_to_the_dagster_namespace():
   cloudwatch = MagicMock()
   with (
-    patch.object(EnvConfig, "ENVIRONMENT", "prod"),
+    patch("robosystems.dagster.sensors.run_failure.env", _env("prod")),
     patch("boto3.client", return_value=cloudwatch) as client,
   ):
     run_failure_metric_sensor(_failed_run_context("extensions_materialize_job"))
@@ -73,7 +84,7 @@ def test_failed_run_publishes_to_the_dagster_namespace():
 @pytest.mark.unit
 def test_no_cloudwatch_outside_aws():
   with (
-    patch.object(EnvConfig, "ENVIRONMENT", "dev"),
+    patch("robosystems.dagster.sensors.run_failure.env", _env("dev")),
     patch("boto3.client") as client,
   ):
     run_failure_metric_sensor(_failed_run_context())
@@ -86,7 +97,7 @@ def test_publish_error_never_fails_the_tick():
   cloudwatch = MagicMock()
   cloudwatch.put_metric_data.side_effect = RuntimeError("cloudwatch down")
   with (
-    patch.object(EnvConfig, "ENVIRONMENT", "staging"),
+    patch("robosystems.dagster.sensors.run_failure.env", _env("staging")),
     patch("boto3.client", return_value=cloudwatch),
   ):
     assert run_failure_metric_sensor(_failed_run_context()) is None

--- a/tests/dagster/test_run_failure_sensor.py
+++ b/tests/dagster/test_run_failure_sensor.py
@@ -1,0 +1,92 @@
+"""The run-failure sensor is the alarm behind "work not completing": one
+RunFailure point per failed run, in the namespace the stack alarms on, for
+every job — and its own errors never turn one failure into two."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from dagster import (
+  DagsterEvent,
+  DagsterEventType,
+  DagsterInstance,
+  DagsterRun,
+  DagsterRunStatus,
+  DefaultSensorStatus,
+  build_run_status_sensor_context,
+)
+
+from robosystems.config import EnvConfig
+from robosystems.dagster.sensors.run_failure import (
+  METRIC_NAME,
+  run_failure_metric_data,
+  run_failure_metric_sensor,
+)
+
+
+def _failed_run_context(job_name: str = "backup_graph_job"):
+  run = DagsterRun(job_name=job_name, run_id="run-1", status=DagsterRunStatus.FAILURE)
+  event = DagsterEvent(
+    event_type_value=DagsterEventType.RUN_FAILURE.value, job_name=job_name
+  )
+  return build_run_status_sensor_context(
+    sensor_name=run_failure_metric_sensor.name,
+    dagster_event=event,
+    dagster_instance=DagsterInstance.ephemeral(),
+    dagster_run=run,
+  )
+
+
+@pytest.mark.unit
+def test_registered_running_and_watching_every_job():
+  from robosystems.dagster.definitions import all_sensors
+
+  assert run_failure_metric_sensor in all_sensors
+  assert run_failure_metric_sensor.default_status == DefaultSensorStatus.RUNNING
+  assert run_failure_metric_sensor._monitor_all_code_locations is True  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.unit
+def test_alarm_point_is_dimensionless_and_triage_point_names_the_job():
+  points = run_failure_metric_data("sec_materialize")
+
+  assert points[0] == {"MetricName": METRIC_NAME, "Value": 1, "Unit": "Count"}
+  assert points[1]["Dimensions"] == [{"Name": "Job", "Value": "sec_materialize"}]
+  assert points[1]["Value"] == 1
+
+
+@pytest.mark.unit
+def test_failed_run_publishes_to_the_dagster_namespace():
+  cloudwatch = MagicMock()
+  with (
+    patch.object(EnvConfig, "ENVIRONMENT", "prod"),
+    patch("boto3.client", return_value=cloudwatch) as client,
+  ):
+    run_failure_metric_sensor(_failed_run_context("extensions_materialize_job"))
+
+  client.assert_called_once_with("cloudwatch")
+  cloudwatch.put_metric_data.assert_called_once_with(
+    Namespace="RoboSystems/Dagster/prod",
+    MetricData=run_failure_metric_data("extensions_materialize_job"),
+  )
+
+
+@pytest.mark.unit
+def test_no_cloudwatch_outside_aws():
+  with (
+    patch.object(EnvConfig, "ENVIRONMENT", "dev"),
+    patch("boto3.client") as client,
+  ):
+    run_failure_metric_sensor(_failed_run_context())
+
+  client.assert_not_called()
+
+
+@pytest.mark.unit
+def test_publish_error_never_fails_the_tick():
+  cloudwatch = MagicMock()
+  cloudwatch.put_metric_data.side_effect = RuntimeError("cloudwatch down")
+  with (
+    patch.object(EnvConfig, "ENVIRONMENT", "staging"),
+    patch("boto3.client", return_value=cloudwatch),
+  ):
+    assert run_failure_metric_sensor(_failed_run_context()) is None


### PR DESCRIPTION
## Summary

Nothing alarms when Dagster work fails to complete, and the Dagster stack's own alarms have never existed. This PR fixes both: `deploy-dagster.yml` now passes `SNSAlertEmail` to the Dagster stack (it was only ever passed to the worker stack, so the SNS topic and every `HasAlertEmail` alarm — including the stalled-provisioning write-off alarm — were never created), and a new `run_status_sensor` publishes a `RunFailure` CloudWatch metric for every failed run in any job, with one alarm on it.

## Changes

**Deploy workflow (`.github/workflows/deploy-dagster.yml`)**
- Add `ParameterKey=SNSAlertEmail` to the Dagster stack's parameter block, reading the same `aws_sns_alert_email` input the worker block already uses. Widen the input's description to cover both stacks.

**CloudFormation (`cloudformation/dagster.yaml`)**
- `DagsterTaskRole`: the `cloudwatch:PutMetricData` namespace condition becomes a list — `RoboSystems/Graph/${Environment}` (unchanged) plus `RoboSystems/Dagster/${Environment}`, the namespace the stack's two existing metric-filter detectors already alarm on.
- New `DagsterRunFailureAlarm` (`robosystems-dagster-${Environment}-run-failure`): `Sum` of `RunFailure` over 300s, `> 0`, `TreatMissingData: notBreaching`, action `DagsterAlertTopic`. Same shape as the neighbouring Dagster alarms and the worker DLQ-depth alarm.
- `SNSAlertEmail` parameter description lists what it now covers.

**Sensor (`robosystems/dagster/sensors/run_failure.py`, registered in `definitions.py`)**
- `run_failure_metric_sensor`: `@run_status_sensor(run_status=FAILURE, monitor_all_code_locations=True, default_status=RUNNING)`. Logs `DAGSTER RUN FAILED job=… run_id=…` (module logger → daemon CloudWatch stream; `context.log` → the tick log in the UI), then publishes two data points in one `put_metric_data`: a dimensionless `RunFailure=1` for the alarm, and a copy with a `Job` dimension for triage in the console. CloudWatch never aggregates a custom metric across dimensions, which is why the alarm reads the dimensionless one.
- Publishes only when `env.is_aws_environment()`; any publish error is logged at warning and never raised, so the publisher's own failure cannot turn one failed run into a second failure.
- Defaults to `RUNNING` — a detector that ships stopped is the gap this closes. Run-status sensors start from the cursor at enable time, so the deploy does not replay historical failures.
- `run_monitoring` is already enabled in `dagster_home/dagster_prod.yaml`, so a run whose Fargate Spot task is reclaimed does transition to FAILURE and is covered.

**Docs**: `robosystems/dagster/README.md` sensor table gains the row.

**Reviewer notes**
- Adding the parameter creates `DagsterAlertTopic` with an email subscription on the next Dagster deploy; the confirmation email must be clicked before anything delivers (see below).
- `monitor_all_code_locations=True` rather than `monitored_jobs=[…]`: the point is every job, including the SEC adapter's, and the list would rot.

## Breaking Changes

None. No API surface changes; nothing for the SDKs to regenerate.

## Testing

- `just test-code` — passed (ruff, format, basedpyright, cf-lint).
- `just cf-lint dagster` — clean.
- `uv run pytest tests/dagster` — 271 passed, including the five new tests in `tests/dagster/test_run_failure_sensor.py` (registered + `RUNNING` + all code locations; alarm point dimensionless, triage point carries the job; publishes to `RoboSystems/Dagster/prod`; no CloudWatch call outside AWS; a publish error never fails the tick).
- Full `just test-all` unit run: not run in this session.

**Post-deploy verification (owner, after the next Dagster deploy)**
1. Confirm the SNS subscription email for `robosystems-dagster-prod-alerts` — until then the topic delivers nothing.
2. Prove the delivery path with one forced transition: `aws cloudwatch set-alarm-state --alarm-name robosystems-dagster-prod-run-failure --state-value ALARM --state-reason "delivery test"`. A green alarm proves it exists; only a transition proves it works.
3. Prove the sensor→metric path once with a real failed run (any job launched with a bad partition/config that fails at execution), then check `RunFailure` in `RoboSystems/Dagster/prod`.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
