### PR TITLE
fix(waf): scope the body SQLi match away from the SQL query surface

### DIFF
--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -491,6 +491,7 @@ Those three are the whole stack — per-rule CloudWatch metrics are emitted by t
 4. **SizeRestrictions** - block oversized payloads (413 response)
 5. **GeoBlocking** - optional: block non-US/CA traffic (403 response)
 6. **AWSManagedRulesCommonRuleSet** - optional: AWS managed rules
+7. **BlockSqliBody** - SQL injection in the request body, everywhere except the SQL query surface (`/query/sql`), which carries SQL by contract (403 response)
 
 **Exports**:
 - `{StackName}-WebACLId`, `-WebACLArn`

--- a/cloudformation/waf.yaml
+++ b/cloudformation/waf.yaml
@@ -123,7 +123,8 @@ Resources:
             CloudWatchMetricsEnabled: true
             MetricName: RateLimitPerIP
 
-        # Rule 3: Block common attack patterns (SQL injection, XSS)
+        # Rule 3: Block common attack patterns (SQL injection, XSS). Body SQLi
+        # lives in rule 3b so the SQL query surface can be exempted from it.
         - Name: BlockCommonAttacks
           Priority: 3
           Statement:
@@ -133,16 +134,6 @@ Resources:
                 - SqliMatchStatement:
                     FieldToMatch:
                       AllQueryArguments: {}
-                    TextTransformations:
-                      - Priority: 0
-                        Type: URL_DECODE
-                      - Priority: 1
-                        Type: HTML_ENTITY_DECODE
-                # SQL Injection - Request Body
-                - SqliMatchStatement:
-                    FieldToMatch:
-                      Body:
-                        OversizeHandling: CONTINUE
                     TextTransformations:
                       - Priority: 0
                         Type: URL_DECODE
@@ -194,6 +185,46 @@ Resources:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true
             MetricName: BlockCommonAttacks
+
+        # Rule 3b: SQL injection in the request body, everywhere except the SQL
+        # query surface. /v1/graphs/{g}/query/sql carries user SQL by contract;
+        # its controls are the SELECT-only validator and the sandboxed
+        # read-only DuckDB connection, so a body SQLi signature there only
+        # rejects legitimate statements. Query arguments, the URI path and the
+        # body XSS match (rule 3) still apply to that path.
+        - Name: BlockSqliBody
+          Priority: 7
+          Statement:
+            AndStatement:
+              Statements:
+                - NotStatement:
+                    Statement:
+                      ByteMatchStatement:
+                        FieldToMatch:
+                          UriPath: {}
+                        PositionalConstraint: ENDS_WITH
+                        SearchString: /query/sql
+                        TextTransformations:
+                          - Priority: 0
+                            Type: LOWERCASE
+                - SqliMatchStatement:
+                    FieldToMatch:
+                      Body:
+                        OversizeHandling: CONTINUE
+                    TextTransformations:
+                      - Priority: 0
+                        Type: URL_DECODE
+                      - Priority: 1
+                        Type: HTML_ENTITY_DECODE
+          Action:
+            Block:
+              CustomResponse:
+                ResponseCode: 403
+                CustomResponseBodyKey: CommonAttackBlocked
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: BlockSqliBody
 
         # Rule 4: Size restrictions (prevent large payload attacks)
         - Name: SizeRestrictions


### PR DESCRIPTION
## Summary

`POST /v1/graphs/{graph_id}/query/sql` carries user SQL by contract, and the WAF's request-body SQL-injection match rejected most legitimate statements on it with the generic `403 Request blocked due to security rules` — a WAF response that never reaches the API, so it carries no `request_id` and leaves no server-side trace. The surface documented in the wiki (`Querying-the-Analytical-Graph` → SQL Over Staging) and the SDKs' `executeSql` was effectively unavailable in deployed environments while working locally (no WAF). The endpoint's controls are its own: the SELECT-only single-statement validator and the sandboxed read-only DuckDB connection (external access off, one staging file per graph).

## Changes

- `cloudformation/waf.yaml` — the body `SqliMatchStatement` moves out of `BlockCommonAttacks` into its own rule, **`BlockSqliBody`** (priority 7), wrapped in `AND(NOT(UriPath ENDS_WITH /query/sql), …)`. Unchanged on every path including the SQL one: the query-argument and URI-path SQLi matches, the body XSS match, size restrictions, rate limiting, and the managed rule set. Same custom 403 response; new per-rule metric `BlockSqliBody` (nothing alarms on `BlockCommonAttacks`, so no alarm change).
- `cloudformation/README.md` — rule list gains the new rule.

Ships with the next deploy of each environment (`deploy-api.yml` updates the WAF stack on every deploy when `WAF_ENABLED_<ENV>` is true). Frontend side: robosystems-app #342 already moved the Data Lake sample buttons to statement shapes that pass either way.

## Breaking Changes

None

## Testing

- `just cf-lint waf` clean.
- `aws wafv2 check-capacity`: new rule 52 WCU vs 40 removed — net +12 on an ACL at 955/1500.
- Probed the live rule with unauthenticated requests (the WAF decides before auth, so its 403 vs the API's 401 is a side-effect-free oracle): the false positive is specific to bodies that *are* SQL — the same statement text embedded in a document, memory, journal-entry description, text block, operator message or Cypher literal already passes. Cypher and GraphQL bodies pass on every shape tried. The exemption is therefore the whole fix, not a first entry in a list.
- Post-deploy check (spec §5): re-run the projection/aggregate/catalog statements against staging then prod; confirm SQLi in query arguments and in non-SQL bodies still blocks under `BlockCommonAttacks` / `BlockSqliBody` via `wafv2 get-sampled-requests`.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.