### PR TITLE
hotfix(waf): scope the body SQLi match away from the SQL query surface (1.11.5)

### DIFF
--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -491,6 +491,7 @@ Those three are the whole stack — per-rule CloudWatch metrics are emitted by t
 4. **SizeRestrictions** - block oversized payloads (413 response)
 5. **GeoBlocking** - optional: block non-US/CA traffic (403 response)
 6. **AWSManagedRulesCommonRuleSet** - optional: AWS managed rules
+7. **BlockSqliBody** - SQL injection in the request body, everywhere except the SQL query surface (`/query/sql`), which carries SQL by contract (403 response)
 
 **Exports**:
 - `{StackName}-WebACLId`, `-WebACLArn`

--- a/cloudformation/waf.yaml
+++ b/cloudformation/waf.yaml
@@ -123,7 +123,8 @@ Resources:
             CloudWatchMetricsEnabled: true
             MetricName: RateLimitPerIP
 
-        # Rule 3: Block common attack patterns (SQL injection, XSS)
+        # Rule 3: Block common attack patterns (SQL injection, XSS). Body SQLi
+        # lives in rule 3b so the SQL query surface can be exempted from it.
         - Name: BlockCommonAttacks
           Priority: 3
           Statement:
@@ -133,16 +134,6 @@ Resources:
                 - SqliMatchStatement:
                     FieldToMatch:
                       AllQueryArguments: {}
-                    TextTransformations:
-                      - Priority: 0
-                        Type: URL_DECODE
-                      - Priority: 1
-                        Type: HTML_ENTITY_DECODE
-                # SQL Injection - Request Body
-                - SqliMatchStatement:
-                    FieldToMatch:
-                      Body:
-                        OversizeHandling: CONTINUE
                     TextTransformations:
                       - Priority: 0
                         Type: URL_DECODE
@@ -194,6 +185,46 @@ Resources:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true
             MetricName: BlockCommonAttacks
+
+        # Rule 3b: SQL injection in the request body, everywhere except the SQL
+        # query surface. /v1/graphs/{g}/query/sql carries user SQL by contract;
+        # its controls are the SELECT-only validator and the sandboxed
+        # read-only DuckDB connection, so a body SQLi signature there only
+        # rejects legitimate statements. Query arguments, the URI path and the
+        # body XSS match (rule 3) still apply to that path.
+        - Name: BlockSqliBody
+          Priority: 7
+          Statement:
+            AndStatement:
+              Statements:
+                - NotStatement:
+                    Statement:
+                      ByteMatchStatement:
+                        FieldToMatch:
+                          UriPath: {}
+                        PositionalConstraint: ENDS_WITH
+                        SearchString: /query/sql
+                        TextTransformations:
+                          - Priority: 0
+                            Type: LOWERCASE
+                - SqliMatchStatement:
+                    FieldToMatch:
+                      Body:
+                        OversizeHandling: CONTINUE
+                    TextTransformations:
+                      - Priority: 0
+                        Type: URL_DECODE
+                      - Priority: 1
+                        Type: HTML_ENTITY_DECODE
+          Action:
+            Block:
+              CustomResponse:
+                ResponseCode: 403
+                CustomResponseBodyKey: CommonAttackBlocked
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: BlockSqliBody
 
         # Rule 4: Size restrictions (prevent large payload attacks)
         - Name: SizeRestrictions


### PR DESCRIPTION
## Summary

Release-branch twin of #1298 — the same two commits cherry-picked onto `release/1.11.5` so the WAF change reaches prod on the next release-branch deploy without waiting for a release. Reviewed on #1298; this PR exists so CI runs on the exact ref the deploy will use.

## Changes

- `cloudformation/waf.yaml` — body SQLi match moves to its own `BlockSqliBody` rule that excludes `/query/sql` (see #1298).
- `cloudformation/README.md` — rule list entry.

## Breaking Changes

None

## Testing

Identical commits to #1298 (`cf-lint` clean, capacity checked there). Post-deploy: the spec §5 re-walk against prod.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.