### PR TITLE
fix(mcp): keep the authored tool descriptions; carry the SEC query rules on the surface

### DIFF
--- a/robosystems/adapters/base.py
+++ b/robosystems/adapters/base.py
@@ -46,6 +46,13 @@ class SharedRepositoryManifest:
   # falls back to generating instructions from the graph's live tool surface.
   agent_instructions: str | None = None
 
+  # Query guidance appended to `read-graph-cypher`'s tool description for this
+  # repository: the data-model rules a raw Cypher query must honour to return
+  # a correct number (consolidation, period shape, deduplication). The tool
+  # description is the one place every MCP client reads — `agent_instructions`
+  # is the routing layer, and client-side skills reach only our own Claude.
+  cypher_query_guidance: str | None = None
+
   # Status
   status: str = "available"  # available, coming_soon
 

--- a/robosystems/adapters/sec/manifest.py
+++ b/robosystems/adapters/sec/manifest.py
@@ -44,8 +44,37 @@ SEC_MANIFEST = SharedRepositoryManifest(
     # not served: the replica stack carries `sec` only, master reads are off,
     # and the master is parked at desired 0, so every read for it fails. Do not
     # restore this line until a read actually succeeds against that graph.
+    "- Raw Cypher on this graph has four rules that decide whether a number is "
+    "right: `Fact {has_dimensions: false}` for consolidated totals, "
+    "`Element.canonical_concept` over a single qname, a pinned `Period` shape "
+    "(`duration_type` for flows, `period_type: 'instant'` for balances), and "
+    "`RETURN DISTINCT` anchored on the Entity. `read-graph-cypher`'s "
+    "description spells them out.\n"
     "- This is shared public data: period close, chart-of-accounts mapping, and "
     "all write operations are unavailable here."
+  ),
+  cypher_query_guidance=(
+    "**SEC DATA RULES — a query that ignores these returns a plausible wrong "
+    "number:**\n"
+    "- Consolidated vs dimensional: `Fact {has_dimensions: false}` is the "
+    "consolidated total; `true` is a segment / geography / member breakdown. "
+    "Mixing them double-counts.\n"
+    "- Canonical concepts over qnames: filter `Element.canonical_concept` "
+    "('revenue', 'net_income', 'total_assets', ...) rather than one qname — "
+    "filers tag the same concept differently (us-gaap:Revenues vs "
+    "us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax). "
+    "`resolve-element` maps a concept to its qnames.\n"
+    "- Period shape: income-statement and cash-flow facts are durations — pin "
+    "`Period {duration_type: 'annual'}` (or 'quarterly'); balance-sheet facts "
+    "are `Period {period_type: 'instant'}`. Quarterly, year-to-date and annual "
+    "figures share end dates, so an unpinned period mixes them.\n"
+    "- Anchor on the Entity (`{ticker: ...}` or CIK) or a Report first and reach "
+    "`Structure`, `Element` or `Period` last — ~53k filings share a "
+    "`Structure.canonical_type`, and leading with it scans them all. Always "
+    "`LIMIT`.\n"
+    "- `RETURN DISTINCT`: a fact is restated in later filings and sits in more "
+    "than one FactSet, so an un-deduplicated result repeats rows.\n"
+    "- `get-example-queries` carries these as working patterns; run it first."
   ),
   rate_limits={
     "starter": {

--- a/robosystems/middleware/mcp/README.md
+++ b/robosystems/middleware/mcp/README.md
@@ -83,6 +83,15 @@ manifest (`agent_instructions`); tenant graphs get a generated one. It names
 tool *families* rather than restating schemas, because it occupies the agent's
 context for the whole session.
 
+The handler (`routers/graphs/mcp/handlers.py`) prepends a one-line graph scope
+to the core tools' authored descriptions and never replaces them. A shared
+repository's manifest can also carry `cypher_query_guidance`, appended to
+`read-graph-cypher`'s description: the data-model rules a raw query must honour
+to return a correct number (for SEC: consolidation, canonical concepts, period
+shape, deduplication). The tool description is the one place every MCP client
+reads — `instructions` is routing, and client-side skills reach only our own
+Claude.
+
 ### Layer 1 — core, always available
 
 | Tool | Description |

--- a/robosystems/routers/graphs/mcp/handlers.py
+++ b/robosystems/routers/graphs/mcp/handlers.py
@@ -125,6 +125,34 @@ async def validate_mcp_access(
     )
 
 
+# Core tools whose authored description gets the graph scope prepended.
+SCOPED_TOOL_NAMES = ("read-graph-cypher", "get-graph-schema")
+
+
+def _graph_scope_line(graph_id: str, is_shared_repo: bool) -> str:
+  if is_shared_repo:
+    return f"**GRAPH:** shared repository `{graph_id}` — public, read-only data."
+  return f"**GRAPH:** private graph `{graph_id}`."
+
+
+def _graph_info_tool_definition(graph_id: str, is_shared_repo: bool) -> dict[str, Any]:
+  kind = "shared repository" if is_shared_repo else "private graph"
+  return {
+    "name": "get-graph-info",
+    "description": (
+      f"Basic facts about {kind} `{graph_id}`: graph id, approximate node "
+      "count, node labels, relationship types, and whether it is read-only.\n\n"
+      "**WHEN TO USE:**\n"
+      "- To confirm which graph you are connected to and what it holds before "
+      "`get-graph-schema`\n"
+      "- To size a query from the node count and label list without reading the "
+      "full schema\n\n"
+      "**RETURNS:** A small JSON object. Takes no arguments."
+    ),
+    "inputSchema": {"type": "object", "properties": {}},
+  }
+
+
 class MCPHandler:
   """Handle MCP protocol operations using Graph API with proper lifecycle management."""
 
@@ -203,49 +231,43 @@ class MCPHandler:
     return "ladybug"
 
   async def get_tools(self) -> list[dict[str, Any]]:
-    """Get available MCP tools with backend-specific customizations."""
+    """Get available MCP tools, scoped to this graph.
+
+    The authored descriptions are kept whole: the core tools get a one-line
+    graph scope prepended, and a shared repository's manifest can append
+    query guidance to ``read-graph-cypher``. Replacing the description with
+    the scope sentence deletes the prompt every MCP client writes its query
+    from — on the SEC graph that produced plausible, wrong revenue series.
+    """
     self._ensure_not_closed()
     await self._ensure_initialized()
     assert self.mcp_tools is not None, "MCP tools not initialized"
-    tools = self.mcp_tools.get_tool_definitions_as_dict()
+    tools = [dict(tool) for tool in self.mcp_tools.get_tool_definitions_as_dict()]
 
-    from robosystems.config.shared_repositories import is_shared_repository_or_subgraph
-
-    is_shared_repo = is_shared_repository_or_subgraph(self.graph_id)
-    backend_name = "Graph Database"
-
-    for tool in tools:
-      cypher_tool_names = ["read-graph-cypher"]
-      schema_tool_names = ["get-graph-schema"]
-
-      if tool["name"] in cypher_tool_names:
-        if is_shared_repo:
-          tool["description"] = (
-            f"Execute a Cypher query on shared {self.graph_id.upper()} repository with public data (via {backend_name})"
-          )
-        else:
-          tool["description"] = (
-            f"Execute a Cypher query on private graph {self.graph_id} (via {backend_name})"
-          )
-      elif tool["name"] in schema_tool_names:
-        if is_shared_repo:
-          tool["description"] = (
-            f"List all node types, attributes and relationships in shared {self.graph_id.upper()} repository (via {backend_name})"
-          )
-        else:
-          tool["description"] = (
-            f"List all node types, attributes and relationships in private graph {self.graph_id} (via {backend_name})"
-          )
-
-    graph_type = "shared repository" if is_shared_repo else "private graph"
-    tools.append(
-      {
-        "name": "get-graph-info",
-        "description": f"Get basic information about {graph_type} {self.graph_id} (via {backend_name})",
-        "inputSchema": {"type": "object", "properties": {}},
-      }
+    from robosystems.config.shared_repositories import (
+      get_manifest,
+      is_shared_repository_or_subgraph,
+      resolve_shared_repository_parent,
     )
 
+    is_shared_repo = is_shared_repository_or_subgraph(self.graph_id)
+    scope = _graph_scope_line(self.graph_id, is_shared_repo)
+
+    query_guidance: str | None = None
+    if is_shared_repo:
+      try:
+        manifest = get_manifest(resolve_shared_repository_parent(self.graph_id))
+      except ValueError:
+        manifest = None
+      query_guidance = getattr(manifest, "cypher_query_guidance", None)
+
+    for tool in tools:
+      if tool["name"] in SCOPED_TOOL_NAMES:
+        tool["description"] = f"{scope}\n\n{tool['description']}"
+      if tool["name"] == "read-graph-cypher" and query_guidance:
+        tool["description"] = f"{tool['description']}\n\n{query_guidance}"
+
+    tools.append(_graph_info_tool_definition(self.graph_id, is_shared_repo))
     return tools
 
   def get_instructions(self, tools: list[dict[str, Any]]) -> str | None:

--- a/tests/routers/graphs/test_mcp_handlers.py
+++ b/tests/routers/graphs/test_mcp_handlers.py
@@ -56,6 +56,21 @@ async def mcp_handler(mock_repository):
     return handler
 
 
+def _core_definitions() -> list[dict]:
+  return [
+    {
+      "name": "read-graph-cypher",
+      "description": "AUTHORED CYPHER GUIDANCE",
+      "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+      "name": "get-graph-schema",
+      "description": "AUTHORED SCHEMA GUIDANCE",
+      "inputSchema": {"type": "object", "properties": {}},
+    },
+  ]
+
+
 class TestMCPHandler:
   """Test MCPHandler functionality."""
 
@@ -210,6 +225,67 @@ class TestMCPHandler:
       assert any(expected in name for name in tool_names), (
         f"Expected tool {expected} not found"
       )
+
+  @pytest.mark.asyncio
+  async def test_get_tools_keeps_the_authored_descriptions(self, mcp_handler):
+    """The scope line is prepended and the authored prompt survives.
+    Replacing it with the scope sentence is what handed clients a plausible
+    wrong query."""
+    mcp_handler.mcp_tools.get_tool_definitions_as_dict = Mock(
+      return_value=_core_definitions()
+    )
+
+    tools = {tool["name"]: tool for tool in await mcp_handler.get_tools()}
+
+    cypher = tools["read-graph-cypher"]["description"]
+    assert cypher.startswith("**GRAPH:** private graph `test_graph`")
+    assert "AUTHORED CYPHER GUIDANCE" in cypher
+    assert "has_dimensions" not in cypher
+    schema = tools["get-graph-schema"]["description"]
+    assert schema.startswith("**GRAPH:** private graph `test_graph`")
+    assert "AUTHORED SCHEMA GUIDANCE" in schema
+    info = tools["get-graph-info"]["description"]
+    assert "node labels" in info and "relationship types" in info
+
+  @pytest.mark.asyncio
+  async def test_get_tools_shared_repo_appends_the_manifest_query_guidance(
+    self, mcp_handler
+  ):
+    """On the SEC graph the consolidation rules ride on the tool description,
+    the one surface every MCP client reads."""
+    mcp_handler.graph_id = "sec"
+    mcp_handler.mcp_tools.get_tool_definitions_as_dict = Mock(
+      return_value=_core_definitions()
+    )
+
+    tools = {tool["name"]: tool for tool in await mcp_handler.get_tools()}
+
+    cypher = tools["read-graph-cypher"]["description"]
+    assert cypher.startswith("**GRAPH:** shared repository `sec`")
+    assert "AUTHORED CYPHER GUIDANCE" in cypher
+    for rule in (
+      "has_dimensions: false",
+      "canonical_concept",
+      "duration_type",
+      "period_type: 'instant'",
+      "RETURN DISTINCT",
+    ):
+      assert rule in cypher, rule
+    assert "has_dimensions" not in tools["get-graph-schema"]["description"]
+    assert "shared repository `sec`" in tools["get-graph-info"]["description"]
+
+  @pytest.mark.asyncio
+  async def test_get_tools_does_not_grow_descriptions_across_calls(self, mcp_handler):
+    """Prepending must not accumulate if the manager ever hands back the same
+    dicts, and the manager's own definitions stay untouched."""
+    definitions = _core_definitions()
+    mcp_handler.mcp_tools.get_tool_definitions_as_dict = Mock(return_value=definitions)
+
+    first = await mcp_handler.get_tools()
+    second = await mcp_handler.get_tools()
+
+    assert first == second
+    assert definitions[0]["description"] == "AUTHORED CYPHER GUIDANCE"
 
   @pytest.mark.asyncio
   async def test_execute_streaming_tool(self, mcp_handler, mock_repository):


### PR DESCRIPTION
## Summary

`MCPHandler.get_tools()` overwrote the authored descriptions of `read-graph-cypher` and `get-graph-schema` with a single scope sentence on every graph, shared and tenant, discarding the WHEN-TO-USE / NOTES / worked-pattern guidance each client writes its Cypher from. Reproduced live on `sec`: a textbook query written from the degraded description returned eight rows all stamped the same date — segment facts, restatements and cumulative figures blended into what reads as a quarterly revenue trend. The guidance that fixes it lived only in `get-example-queries` (pull-only) and the client-side `sec-filing-analysis` skill, which reaches only our own Claude; on ChatGPT, Cursor, Docker, VS Code, Glama and Grok there is no skill. The tool description is the one surface every client reads, so this PR keeps the authored text and puts the SEC rules on it.

## Changes

**`robosystems/routers/graphs/mcp/handlers.py`**
- `get_tools()` prepends a one-line graph scope (`**GRAPH:** shared repository `sec` — public, read-only data.` / `**GRAPH:** private graph `kg…`.`) to the two core tools instead of replacing their descriptions. Tool dicts are copied before mutation.
- For a shared repository, the manifest's new `cypher_query_guidance` is appended to `read-graph-cypher`'s description (resolved the same way `get_instructions()` resolves `agent_instructions`).
- `get-graph-info` gets a real description: what it returns (graph id, approximate node count, node labels, relationship types, read-only flag), when to use it, no arguments. Schema unchanged.

**`robosystems/adapters/base.py`** — `SharedRepositoryManifest.cypher_query_guidance: str | None = None`, with a comment on why the tool description (not `agent_instructions`, not a skill) is where this knowledge has to live.

**`robosystems/adapters/sec/manifest.py`**
- `cypher_query_guidance`: the six rules — `has_dimensions: false` for consolidated totals; `Element.canonical_concept` over a single qname (with the `us-gaap:Revenues` vs `…ExcludingAssessedTax` example and the `resolve-element` pointer); pinned period shape (`duration_type` for flows, `period_type: 'instant'` for balances — quarterly/YTD/annual share end dates); anchor on Entity/Report first, `Structure`/`Element`/`Period` last, always `LIMIT`; `RETURN DISTINCT` because restated facts sit in more than one FactSet; run `get-example-queries` first. Wording mirrors the skill's "Rules of the road" so the server and the skill teach the same thing.
- `agent_instructions` NOTES gains a one-line pointer to those rules.

**Docs**: `middleware/mcp/README.md` paragraph on the scope-prepend rule and `cypher_query_guidance`.

**Tests** (`tests/routers/graphs/test_mcp_handlers.py`): the authored text survives on a tenant graph and carries no SEC rules; on `sec` the scope line, the authored text and each rule are present, and the rules are on the Cypher tool only; two `get_tools()` calls yield identical output and leave the manager's definitions untouched.

**Reviewer note — directory listings.** No tool is added or removed (the `sec` surface stays at 10 tools, the invariant the open reviews captured). OpenAI treats a definition change as a new version, but the v1.0.0 review is still pending, so there is no published definition to diverge from; the reviewer sees this text. Noted in the listings runbook.

## Breaking Changes

None. No REST/GraphQL/operation surface changes; the manifest field is additive with a `None` default.

## Testing

- `just test-code` — passed (ruff, format, basedpyright, cf-lint).
- `uv run pytest tests/routers/graphs/test_mcp_handlers.py tests/routers/graphs/mcp tests/middleware/mcp tests/adapters/sec tests/config` — 2,769 passed, 13 skipped, including the three new tests.
- Full `just test-all` unit run: not run in this session.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
