### PR TITLE
fix(reports): validate every rendered column and the live statement; report inconclusive instead of a vacuous pass

### DIFF
--- a/robosystems/middleware/mcp/tools/financial_statement_tools.py
+++ b/robosystems/middleware/mcp/tools/financial_statement_tools.py
@@ -62,6 +62,8 @@ class LiveFinancialStatementTool(BaseTool):
 
 **RETURNS:**
 Facts with element qnames, names, classifications, and values aligned with `periods` — current + prior (equal duration) for income_statement and balance_sheet, current only for cash_flow_statement. Abstract scaffolding rows and all-zero rows are filtered out; subtotals are kept and flagged `is_subtotal`. Capped at `limit` rows (default 1000 — the whole statement).
+
+`validation` is the guard-rail outcome for the rendered columns (`status`: passed | failed | inconclusive; `failures`; `warnings`). Read it before quoting a number: a `failed` status means the statement does not foot or balance, and a warning about 'Other operating capital, net' means the cash flow was made to foot by a reconciling plug — say so rather than presenting the figure as clean.
 """,
       "inputSchema": {
         "type": "object",

--- a/robosystems/models/api/extensions/reports.py
+++ b/robosystems/models/api/extensions/reports.py
@@ -253,9 +253,29 @@ class FactRowResponse(BaseModel):
 
 
 class ValidationCheckResponse(BaseModel):
-  """Aggregate result of running reporting rules over a structure."""
+  """Aggregate result of running reporting rules over a structure.
 
-  passed: bool = Field(..., description="True iff every rule produced zero failures.")
+  Every rule runs once per rendered period column; on a multi-column
+  statement each failure and warning is prefixed with the column it was
+  found in (``[Prior] …``).
+  """
+
+  passed: bool = Field(
+    ...,
+    description=(
+      "True iff at least one rule ran and every rule produced zero failures "
+      "on every rendered column. False when nothing was checked "
+      "(`status == 'inconclusive'`)."
+    ),
+  )
+  status: str = Field(
+    ...,
+    description=(
+      "`passed` — every rule ran on every column with zero failures; "
+      "`failed` — at least one rule failed; `inconclusive` — no validation "
+      "rules exist for this block type, so nothing was checked."
+    ),
+  )
   checks: list[str] = Field(
     ...,
     description="Names of rules that were evaluated.",
@@ -604,6 +624,14 @@ class LiveFinancialStatementResponse(BaseModel):
   )
   facts: list[LiveStatementFactRow]
   fact_count: int
+  validation: ValidationCheckResponse | None = Field(
+    None,
+    description=(
+      "Guard-rail outcome for the rendered columns — accounting equation, "
+      "net-income equation, totals footing, operating-plug size. Null only "
+      "when no structure rendered."
+    ),
+  )
   unmapped_count: int = 0
   truncated: bool = False
 

--- a/robosystems/models/api/information_block.py
+++ b/robosystems/models/api/information_block.py
@@ -937,6 +937,9 @@ class ValidationLite(BaseModel):
   model_config = ConfigDict(from_attributes=True)
 
   passed: bool = True
+  # ``passed`` | ``failed`` | ``inconclusive`` (no rules for the block type —
+  # nothing was checked, and ``passed`` is False rather than vacuously True).
+  status: str = "passed"
   checks: list[str] = Field(default_factory=list)
   failures: list[str] = Field(default_factory=list)
   warnings: list[str] = Field(default_factory=list)

--- a/robosystems/operations/information_block/statement.py
+++ b/robosystems/operations/information_block/statement.py
@@ -427,8 +427,12 @@ def _build_statement_rendering(
     hierarchy, period_balances, calculations, pre_signed=True
   )
 
-  # 7) Validation — guard-rail checks on the rendered rows.
-  validation_result = validate_report(block_type, rows)
+  # 7) Validation — guard-rail checks on every rendered column. Columns
+  # carry no display label here (the frontend formats the dates), so a
+  # finding names its column by period end.
+  validation_result = validate_report(
+    block_type, rows, period_labels=[p.end.isoformat() for p in periods]
+  )
 
   return RenderingLite(
     rows=[
@@ -450,6 +454,7 @@ def _build_statement_rendering(
     ],
     validation=ValidationLite(
       passed=validation_result.passed,
+      status=validation_result.status,
       checks=list(validation_result.checks),
       failures=list(validation_result.failures),
       warnings=list(validation_result.warnings),

--- a/robosystems/operations/roboledger/reads/reports.py
+++ b/robosystems/operations/roboledger/reads/reports.py
@@ -39,15 +39,16 @@ from robosystems.operations.roboledger.reads.fiscal_calendar import (
   get_fiscal_year_start_month,
 )
 from robosystems.operations.roboledger.reports.fact_grid import (
+  FactRow,
+  _compute_prior_period,
+  generate_report_facts,
+  render_structure_view,
+)
+from robosystems.operations.roboledger.reports.fact_grid import (
   PeriodSpec as FactPeriodSpec,
 )
 from robosystems.operations.roboledger.reports.fact_grid import (
   ReportFact as ReportFactData,
-)
-from robosystems.operations.roboledger.reports.fact_grid import (
-  _compute_prior_period,
-  generate_report_facts,
-  render_structure_view,
 )
 from robosystems.operations.roboledger.reports.guard_rails import validate_report
 from robosystems.operations.roboledger.reports.network_picker import (
@@ -875,7 +876,9 @@ def get_statement(
   if not grid.structure_id:
     raise StatementStructureNotFoundError(block_type)
 
-  validation = validate_report(block_type, grid.rows)
+  validation = validate_report(
+    block_type, grid.rows, period_labels=[p.label for p in grid.periods]
+  )
 
   # Drop XBRL is_abstract rows (presentation scaffolding — *Abstract,
   # *Table, *LineItems, *RollUp wrappers that aren't themselves reportable
@@ -899,6 +902,7 @@ def get_statement(
   validation_resp = (
     ValidationCheckResponse(
       passed=validation.passed,
+      status=validation.status,
       checks=validation.checks,
       failures=validation.failures,
       warnings=validation.warnings,
@@ -1031,6 +1035,7 @@ def get_live_financial_statement(
   - builds current+prior periods of matching duration
   - renders both columns, except on a cash flow statement, which renders
     the current period only (``rendered_period_indexes``)
+  - runs the guard rails over exactly the rendered columns (``validation``)
   - filters abstract scaffolding rows and all-zero rows
   - caps at ``limit`` rows (marking ``truncated=True`` when capped)
 
@@ -1052,6 +1057,15 @@ def get_live_financial_statement(
   )
   columns = rendered_period_indexes(statement_type, periods)
   rendered_periods = [periods[i] for i in columns]
+
+  # Validate what the reader sees: the full grid (subtotals foot against
+  # their children, so the all-zero rows filtered below still count), but
+  # only the rendered columns — the cash flow delta basis is not a statement.
+  validation = validate_report(
+    statement_type,
+    [_project_row(row, columns) for row in grid.rows],
+    period_labels=[p.label for p in rendered_periods],
+  )
 
   facts: list[LiveStatementFactRow] = []
   for row in grid.rows:
@@ -1100,6 +1114,28 @@ def get_live_financial_statement(
     ],
     facts=facts,
     fact_count=len(facts),
+    validation=ValidationCheckResponse(
+      passed=validation.passed,
+      status=validation.status,
+      checks=validation.checks,
+      failures=validation.failures,
+      warnings=validation.warnings,
+    ),
     unmapped_count=unmapped_count,
     truncated=truncated,
+  )
+
+
+def _project_row(row: FactRow, columns: list[int]) -> FactRow:
+  """Copy ``row`` keeping only the values at ``columns``, in that order."""
+  return FactRow(
+    element_id=row.element_id,
+    element_qname=row.element_qname,
+    element_name=row.element_name,
+    classification=row.classification,
+    balance_type=row.balance_type,
+    values=[row.values[i] if i < len(row.values) else None for i in columns],
+    is_subtotal=row.is_subtotal,
+    is_abstract=row.is_abstract,
+    depth=row.depth,
   )

--- a/robosystems/operations/roboledger/reports/guard_rails.py
+++ b/robosystems/operations/roboledger/reports/guard_rails.py
@@ -2,10 +2,17 @@
 
 Structural checks are deterministic arithmetic (hard failures).
 Semantic checks are pattern matching against known report structures (warnings).
+
+Every check runs once per rendered period column. A statement with a
+comparative column is two statements sharing one row layout, and a green
+result that inspected only the first column says nothing about the other —
+so on a multi-column statement each failure and warning names the column it
+was found in (``[Prior] Balance sheet does not balance …``).
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from .fact_grid import (
@@ -19,19 +26,52 @@ from .fact_grid import (
 # Rounding tolerance for balance checks (dollars)
 _TOLERANCE = 0.01
 
+STATUS_PASSED = "passed"
+STATUS_FAILED = "failed"
+STATUS_INCONCLUSIVE = "inconclusive"
+
 
 @dataclass
 class ValidationResult:
-  """Result of guard rail validation."""
+  """Result of guard rail validation.
+
+  ``status`` is the load-bearing field: ``passed`` (every rule ran on every
+  rendered column and produced zero failures), ``failed`` (at least one rule
+  failed), or ``inconclusive`` (no rule exists for the block type — nothing
+  was checked). ``passed`` is ``True`` only for ``status == "passed"``: a
+  statement nobody checked is not a statement that passed.
+  """
 
   passed: bool = True
+  status: str = STATUS_PASSED
   checks: list[str] = field(default_factory=list)
   failures: list[str] = field(default_factory=list)
   warnings: list[str] = field(default_factory=list)
 
 
-def validate_report(block_type: str, rows: list[FactRow]) -> ValidationResult:
+@dataclass(frozen=True)
+class _Column:
+  """One rendered period column: its index into ``FactRow.values`` + a name."""
+
+  index: int
+  label: str
+  # Empty on a single-column statement; "[<label>] " otherwise.
+  prefix: str
+
+
+_Validator = Callable[[list[FactRow], ValidationResult, _Column], None]
+
+
+def validate_report(
+  block_type: str,
+  rows: list[FactRow],
+  period_labels: list[str] | None = None,
+) -> ValidationResult:
   """Run structural and semantic validation for a rendered structure.
+
+  ``period_labels`` names the columns of ``rows[*].values`` (``Current`` /
+  ``Prior``, a period end date, …) so a finding on a comparative statement
+  says which column it belongs to. Missing labels fall back to ``column N``.
 
   `_check_totals_foot` (shared) is the load-bearing CF check: it verifies the
   net-change-in-cash line foots to Op + Inv + Fin and that each section foots
@@ -40,25 +80,86 @@ def validate_report(block_type: str, rows: list[FactRow]) -> ValidationResult:
   lives at the fact-bundle level in ``fact_grid._check_cash_flow_tie_out``,
   since the rendered CF rows carry no independent beginning/ending cash.
 
-  `equity_statement` and `comprehensive_income` remain unhandled until their
-  validators are added.
+  `equity_statement` and `comprehensive_income` have no validators yet, so
+  they come back ``inconclusive`` rather than vacuously passed.
   """
-  if block_type == "income_statement":
-    return _validate_income_statement(rows)
-  elif block_type == "balance_sheet":
-    return _validate_balance_sheet(rows)
-  elif block_type == "cash_flow_statement":
-    return _validate_cash_flow(rows)
-  return ValidationResult(checks=["no_validation_rules"])
+  validator = _VALIDATORS.get(block_type)
+  if validator is None:
+    return ValidationResult(
+      passed=False,
+      status=STATUS_INCONCLUSIVE,
+      checks=["no_validation_rules"],
+      warnings=[f"No validation rules exist for '{block_type}' — nothing was checked."],
+    )
+
+  result = ValidationResult()
+  columns = _columns(rows, period_labels)
+  empty_columns = _empty_column_indexes(rows, columns)
+  for column in columns:
+    validator(rows, result, column)
+    # A comparative column that is empty end to end is reported once by
+    # ``_check_comparative_data``; per-section zero warnings on it are noise.
+    if column.index == 0 or column.index not in empty_columns:
+      _check_zero_subtotals(rows, result, column)
+  _check_comparative_data(result, columns, empty_columns)
+
+  result.passed = not result.failures
+  result.status = STATUS_FAILED if result.failures else STATUS_PASSED
+  return result
+
+
+# ── Column helpers ────────────────────────────────────────────────────────
+
+
+def _columns(rows: list[FactRow], period_labels: list[str] | None) -> list[_Column]:
+  count = max((len(r.values) for r in rows), default=0) or 1
+  columns: list[_Column] = []
+  for index in range(count):
+    label = ""
+    if period_labels and index < len(period_labels):
+      label = period_labels[index] or ""
+    label = label or f"column {index + 1}"
+    prefix = "" if count == 1 else f"[{label}] "
+    columns.append(_Column(index=index, label=label, prefix=prefix))
+  return columns
+
+
+def _empty_column_indexes(rows: list[FactRow], columns: list[_Column]) -> set[int]:
+  return {
+    column.index
+    for column in columns
+    if all(_value(r, column.index) == 0.0 for r in rows)
+  }
+
+
+def _value(row: FactRow, col: int) -> float:
+  """The row's value in column ``col`` — ``None`` and missing read as zero."""
+  if col >= len(row.values):
+    return 0.0
+  return row.values[col] or 0.0
+
+
+def _note_check(result: ValidationResult, name: str) -> None:
+  """Record that a rule ran — once, however many columns it ran over."""
+  if name not in result.checks:
+    result.checks.append(name)
+
+
+def _fail(result: ValidationResult, message: str) -> None:
+  """Record a failure — deduplicated, so a column-independent finding (a
+  missing classification rollup) is stated once, not once per column."""
+  if message not in result.failures:
+    result.failures.append(message)
+  result.passed = False
 
 
 # ── Structural checks ─────────────────────────────────────────────────────
 
 
-def _validate_income_statement(rows: list[FactRow]) -> ValidationResult:
-  result = ValidationResult()
-
-  _check_totals_foot(rows, result)
+def _validate_income_statement(
+  rows: list[FactRow], result: ValidationResult, column: _Column
+) -> None:
+  _check_totals_foot(rows, result, column)
 
   # Structural: Net Income must reconcile against EVERY income-statement
   # line by natural balance — credit-nature lines (operating AND
@@ -70,7 +171,7 @@ def _validate_income_statement(rows: list[FactRow]) -> ValidationResult:
   # "Revenue minus Expenses" identity misses on a multi-step statement.
   # Keying on balance_type rather than classification makes contras
   # (e.g. sales returns) net correctly.
-  result.checks.append("net_income_equation")
+  _note_check(result, "net_income_equation")
 
   net_income_row = _net_income_row(rows)
 
@@ -83,7 +184,7 @@ def _validate_income_statement(rows: list[FactRow]) -> ValidationResult:
     # identity so it's excluded even if its is_subtotal flag is unset.
     if row.is_subtotal or row.is_abstract or row is net_income_row:
       continue
-    value = (row.values[0] or 0.0) if row.values else 0.0
+    value = _value(row, column.index)
     if row.balance_type == "credit":
       implied_ni += value
       credit_leaves += 1
@@ -98,65 +199,58 @@ def _validate_income_statement(rows: list[FactRow]) -> ValidationResult:
     # back to the top-most Revenue minus Expenses subtotals — the same approach
     # as the balance sheet, handling FAC's parallel subtotals + qname
     # inference.
-    revenue_row = _top_most_subtotal_for_classification(rows, "revenue")
-    expense_row = _top_most_subtotal_for_classification(rows, "expense")
+    revenue_row = _top_most_subtotal_for_classification(rows, "revenue", column.index)
+    expense_row = _top_most_subtotal_for_classification(rows, "expense", column.index)
     if revenue_row is None or expense_row is None:
       missing: list[str] = []
       if revenue_row is None:
         missing.append("revenue")
       if expense_row is None:
         missing.append("expense")
-      result.failures.append(
+      _fail(
+        result,
         "Income statement validation inconclusive: missing classification "
         f"rollups for {missing}. Wire FASB elementsOfFinancialStatements "
         "traits onto the structure's elements, or ensure at least one "
-        "subtotal row per classification is present."
+        "subtotal row per classification is present.",
       )
-      result.passed = False
       inconclusive = True
     else:
-      revenue = (revenue_row.values[0] or 0.0) if revenue_row.values else 0.0
-      expense = (expense_row.values[0] or 0.0) if expense_row.values else 0.0
-      implied_ni = revenue - expense
+      implied_ni = _value(revenue_row, column.index) - _value(expense_row, column.index)
   elif credit_leaves == 0:
     # Leaf detail present but no revenue/income line — can't reconcile.
-    result.failures.append(
+    _fail(
+      result,
       "Income statement validation inconclusive: no revenue/income line "
-      "found to reconcile Net Income against."
+      "found to reconcile Net Income against.",
     )
-    result.passed = False
     inconclusive = True
 
-  if not inconclusive:
-    if net_income_row is not None:
-      reported_ni = (net_income_row.values[0] or 0.0) if net_income_row.values else 0.0
-      diff = abs(reported_ni - implied_ni)
-      if diff > _TOLERANCE:
-        result.failures.append(
-          f"Net Income mismatch: reported '{net_income_row.element_name}' "
-          f"({reported_ni:.2f}) ≠ Σ(income − expense) ({implied_ni:.2f}), "
-          f"difference: {diff:.2f}"
-        )
-        result.passed = False
-    elif implied_ni != 0.0:
-      # Informational warning — not a failure. A missing NetIncome row
-      # is common in multi-step structures whose final line is
-      # "Income from Continuing Operations" or similar.
-      result.warnings.append(
-        f"No Net Income line found; implied NI = Σ(income − expense) = {implied_ni:.2f}"
+  if inconclusive:
+    return
+
+  if net_income_row is not None:
+    reported_ni = _value(net_income_row, column.index)
+    diff = abs(reported_ni - implied_ni)
+    if diff > _TOLERANCE:
+      _fail(
+        result,
+        f"{column.prefix}Net Income mismatch: reported "
+        f"'{net_income_row.element_name}' ({reported_ni:.2f}) ≠ "
+        f"Σ(income − expense) ({implied_ni:.2f}), difference: {diff:.2f}",
       )
-
-  # Semantic: check for zero-balance subtotals
-  _check_zero_subtotals(rows, result)
-
-  # Semantic: check for comparative data
-  _check_comparative_data(rows, result)
-
-  return result
+  elif implied_ni != 0.0:
+    # Informational warning — not a failure. A missing NetIncome row
+    # is common in multi-step structures whose final line is
+    # "Income from Continuing Operations" or similar.
+    result.warnings.append(
+      f"{column.prefix}No Net Income line found; implied NI = "
+      f"Σ(income − expense) = {implied_ni:.2f}"
+    )
 
 
 def _top_most_subtotal_for_classification(
-  rows: list[FactRow], classification: str
+  rows: list[FactRow], classification: str, col: int = 0
 ) -> FactRow | None:
   """Pick the highest-priority row matching ``classification``.
 
@@ -166,9 +260,9 @@ def _top_most_subtotal_for_classification(
   2. Among ties on depth, prefer the subtotal (Revenue rolled up across
      subcategories) over the leaf (a single Revenue line).
   3. Among ties on depth + subtotal-flag, prefer the larger absolute
-     value (zero-valued placeholder rows must not beat the real rollup —
-     see the FAC ``Temporary Equity`` tie scenario covered in
-     ``test_among_ties_at_same_depth_largest_value_wins``).
+     value in column ``col`` (zero-valued placeholder rows must not beat
+     the real rollup — see the FAC ``Temporary Equity`` tie scenario covered
+     in ``test_among_ties_at_same_depth_largest_value_wins``).
 
   Combined L+E rollups are skipped via the qname check (won't classify
   cleanly as either liability or equity).
@@ -195,8 +289,8 @@ def _top_most_subtotal_for_classification(
     if best is None:
       best = row
       continue
-    row_val = abs((row.values[0] or 0.0) if row.values else 0.0)
-    best_val = abs((best.values[0] or 0.0) if best.values else 0.0)
+    row_val = abs(_value(row, col))
+    best_val = abs(_value(best, col))
     if row.depth < best.depth:
       best = row
     elif row.depth == best.depth:
@@ -228,10 +322,10 @@ def _net_income_row(rows: list[FactRow]) -> FactRow | None:
   return candidates[0]
 
 
-def _validate_balance_sheet(rows: list[FactRow]) -> ValidationResult:
-  result = ValidationResult()
-
-  _check_totals_foot(rows, result)
+def _validate_balance_sheet(
+  rows: list[FactRow], result: ValidationResult, column: _Column
+) -> None:
+  _check_totals_foot(rows, result, column)
 
   # Structural: Assets = Liabilities + Equity.
   #
@@ -243,7 +337,7 @@ def _validate_balance_sheet(rows: list[FactRow]) -> ValidationResult:
   #
   # Classification falls back to qname-based inference (FAC, rs-gaap,
   # rs-gaap-type-subtype reference taxonomies often lack FASB element_traits).
-  result.checks.append("accounting_equation")
+  _note_check(result, "accounting_equation")
 
   # Reuses the IS validator's resolution chain (smallest depth → subtotal
   # over leaf → larger value) so a single-step BS variant where, for
@@ -251,7 +345,7 @@ def _validate_balance_sheet(rows: list[FactRow]) -> ValidationResult:
   # cleanly. See :func:`_top_most_subtotal_for_classification`.
   candidates: dict[str, FactRow] = {}
   for cls in ("asset", "liability", "equity"):
-    pick = _top_most_subtotal_for_classification(rows, cls)
+    pick = _top_most_subtotal_for_classification(rows, cls, column.index)
     if pick is not None:
       candidates[cls] = pick
 
@@ -262,42 +356,31 @@ def _validate_balance_sheet(rows: list[FactRow]) -> ValidationResult:
     # classifications the validator can't make any claim about the
     # equation. Report explicitly so callers don't read a phantom green
     # check as proof of correctness.
-    result.failures.append(
+    _fail(
+      result,
       "Balance sheet validation inconclusive: missing classification "
       f"rollups for {sorted(missing)}. Wire FASB elementsOfFinancialStatements "
       "traits onto the structure's elements, or ensure at least one "
-      "subtotal row per classification is present."
+      "subtotal row per classification is present.",
     )
-    result.passed = False
-  else:
-    total_assets = (
-      (candidates["asset"].values[0] or 0.0) if candidates["asset"].values else 0.0
-    )
-    total_liabilities = (
-      (candidates["liability"].values[0] or 0.0)
-      if candidates["liability"].values
-      else 0.0
-    )
-    total_equity = (
-      (candidates["equity"].values[0] or 0.0) if candidates["equity"].values else 0.0
-    )
-    diff = abs(total_assets - (total_liabilities + total_equity))
-    if diff > _TOLERANCE:
-      result.failures.append(
-        f"Balance sheet does not balance: Assets ({total_assets:.2f}) "
-        f"≠ Liabilities ({total_liabilities:.2f}) + Equity ({total_equity:.2f}), "
-        f"difference: {diff:.2f}"
-      )
-      result.passed = False
+    return
 
-  # Semantic checks
-  _check_zero_subtotals(rows, result)
-  _check_comparative_data(rows, result)
-
-  return result
+  total_assets = _value(candidates["asset"], column.index)
+  total_liabilities = _value(candidates["liability"], column.index)
+  total_equity = _value(candidates["equity"], column.index)
+  diff = abs(total_assets - (total_liabilities + total_equity))
+  if diff > _TOLERANCE:
+    _fail(
+      result,
+      f"{column.prefix}Balance sheet does not balance: Assets "
+      f"({total_assets:.2f}) ≠ Liabilities ({total_liabilities:.2f}) + "
+      f"Equity ({total_equity:.2f}), difference: {diff:.2f}",
+    )
 
 
-def _validate_cash_flow(rows: list[FactRow]) -> ValidationResult:
+def _validate_cash_flow(
+  rows: list[FactRow], result: ValidationResult, column: _Column
+) -> None:
   """Cash flow validation — structural footing of the rendered CF.
 
   `_check_totals_foot` verifies the net-change line foots to Op + Inv + Fin
@@ -306,20 +389,23 @@ def _validate_cash_flow(rows: list[FactRow]) -> ValidationResult:
   reconciliation against the balance sheet is a fact-bundle check
   (``fact_grid._check_cash_flow_tie_out``), not a per-statement one.
   """
-  result = ValidationResult()
+  _check_totals_foot(rows, result, column)
+  _check_operating_plug(rows, result, column)
 
-  _check_totals_foot(rows, result)
-  _check_zero_subtotals(rows, result)
-  _check_comparative_data(rows, result)
-  _check_operating_plug(rows, result)
 
-  return result
+_VALIDATORS: dict[str, _Validator] = {
+  "income_statement": _validate_income_statement,
+  "balance_sheet": _validate_balance_sheet,
+  "cash_flow_statement": _validate_cash_flow,
+}
 
 
 # ── Shared check helpers ──────────────────────────────────────────────────
 
 
-def _check_totals_foot(rows: list[FactRow], result: ValidationResult) -> None:
+def _check_totals_foot(
+  rows: list[FactRow], result: ValidationResult, column: _Column
+) -> None:
   """Verify that subtotal rows equal the sum of their children.
 
   ``_build_rows`` emits post-order — children first, then their parent
@@ -335,7 +421,7 @@ def _check_totals_foot(rows: list[FactRow], result: ValidationResult) -> None:
   the net-income equation. Value-less structural headers (abstract rows
   rendered with all-None values) are skipped outright.
   """
-  result.checks.append("totals_foot")
+  _note_check(result, "totals_foot")
 
   for idx, subtotal in enumerate(rows):
     if not subtotal.is_subtotal:
@@ -352,43 +438,45 @@ def _check_totals_foot(rows: list[FactRow], result: ValidationResult) -> None:
       if child.depth <= subtotal.depth:
         break
       if child.depth == subtotal.depth + 1:
-        child_sum += (child.values[0] or 0.0) if child.values else 0.0
+        child_sum += _value(child, column.index)
 
-    subtotal_val = (subtotal.values[0] or 0.0) if subtotal.values else 0.0
+    subtotal_val = _value(subtotal, column.index)
     diff = abs(subtotal_val - child_sum)
     if diff > _TOLERANCE and child_sum != 0.0:
       result.warnings.append(
-        f"Subtotal '{subtotal.element_name}' ({subtotal_val:.2f}) "
+        f"{column.prefix}Subtotal '{subtotal.element_name}' ({subtotal_val:.2f}) "
         f"does not match sum of children ({child_sum:.2f}), "
         f"difference: {diff:.2f}"
       )
 
 
-def _check_zero_subtotals(rows: list[FactRow], result: ValidationResult) -> None:
+def _check_zero_subtotals(
+  rows: list[FactRow], result: ValidationResult, column: _Column
+) -> None:
   """Warn about zero-balance subtotal sections."""
-  result.checks.append("zero_subtotals")
+  _note_check(result, "zero_subtotals")
   for row in rows:
-    val = (row.values[0] or 0.0) if row.values else 0.0
-    if row.is_subtotal and val == 0.0 and row.depth <= 1:
-      result.warnings.append(f"Section '{row.element_name}' has zero balance")
-
-
-def _check_comparative_data(rows: list[FactRow], result: ValidationResult) -> None:
-  """Warn if multi-period data has empty columns."""
-  result.checks.append("comparative_data")
-  if not rows or not rows[0].values or len(rows[0].values) < 2:
-    return
-  for col_idx in range(1, len(rows[0].values)):
-    all_zero = all(
-      (r.values[col_idx] if col_idx < len(r.values) else 0.0) == 0.0 for r in rows
-    )
-    if all_zero:
+    if row.is_subtotal and row.depth <= 1 and _value(row, column.index) == 0.0:
       result.warnings.append(
-        f"Period column {col_idx + 1} has no data — column will be empty"
+        f"{column.prefix}Section '{row.element_name}' has zero balance"
       )
 
 
-def _check_operating_plug(rows: list[FactRow], result: ValidationResult) -> None:
+def _check_comparative_data(
+  result: ValidationResult, columns: list[_Column], empty_columns: set[int]
+) -> None:
+  """Warn if multi-period data has empty columns."""
+  _note_check(result, "comparative_data")
+  for column in columns[1:]:
+    if column.index in empty_columns:
+      result.warnings.append(
+        f"Period '{column.label}' has no data — column will be empty"
+      )
+
+
+def _check_operating_plug(
+  rows: list[FactRow], result: ValidationResult, column: _Column
+) -> None:
   """Warn when the operating-CF reconciling plug is large vs operating cash.
 
   ``fact_grid._reconcile_operating_to_cash`` foots the indirect CF to actual
@@ -404,21 +492,20 @@ def _check_operating_plug(rows: list[FactRow], result: ValidationResult) -> None
   directly, so the row value ≈ the plug in practice. Warning-only — the CF still
   foots and renders.
   """
-  result.checks.append("operating_plug")
+  _note_check(result, "operating_plug")
   plug = next((r for r in rows if r.element_qname == _CF_RECONCILING_LEAF_QNAME), None)
   op = next((r for r in rows if r.element_qname == _CF_OPERATING_SUBTOTAL_QNAME), None)
   if plug is None or op is None:
     return
-  for col in range(len(plug.values)):
-    plug_val = (plug.values[col] or 0.0) if col < len(plug.values) else 0.0
-    if abs(plug_val) <= _TOLERANCE:
-      continue
-    op_val = (op.values[col] or 0.0) if col < len(op.values) else 0.0
-    if abs(op_val) < _TOLERANCE or abs(plug_val) > _CF_PLUG_WARN_RATIO * abs(op_val):
-      result.warnings.append(
-        f"Operating cash flow (period column {col + 1}) carries a large "
-        f"unattributed reconciling adjustment in 'Other operating capital, net' "
-        f"({plug_val:.2f} vs operating cash {op_val:.2f}) — likely an "
-        f"un-itemized non-cash item (gain/loss on disposal, etc.) or a flow "
-        f"misclassification; review."
-      )
+  plug_val = _value(plug, column.index)
+  if abs(plug_val) <= _TOLERANCE:
+    return
+  op_val = _value(op, column.index)
+  if abs(op_val) < _TOLERANCE or abs(plug_val) > _CF_PLUG_WARN_RATIO * abs(op_val):
+    result.warnings.append(
+      f"{column.prefix}Operating cash flow carries a large unattributed "
+      f"reconciling adjustment in 'Other operating capital, net' "
+      f"({plug_val:.2f} vs operating cash {op_val:.2f}) — likely an "
+      f"un-itemized non-cash item (gain/loss on disposal, etc.) or a flow "
+      f"misclassification; review."
+    )

--- a/tests/middleware/mcp/tools/test_financial_statement_tools.py
+++ b/tests/middleware/mcp/tools/test_financial_statement_tools.py
@@ -94,6 +94,58 @@ class TestLiveFinancialStatementToolExecute:
     assert "tip" in result  # empty results trigger the tip
 
   @pytest.mark.unit
+  async def test_validation_rides_the_payload(self):
+    """The guard-rail outcome reaches the model verbatim — it is the only
+    signal that a returned number does not foot."""
+    tool = LiveFinancialStatementTool(_make_client("kg_123"))
+    from robosystems.models.api.extensions.reports import (
+      LiveFinancialStatementResponse,
+      LiveStatementFactRow,
+      PeriodSpec,
+      ValidationCheckResponse,
+    )
+
+    mock_response = LiveFinancialStatementResponse(
+      graph_id="kg_123",
+      statement_type="balance_sheet",
+      periods=[
+        PeriodSpec(start=date(2026, 7, 1), end=date(2026, 7, 31), label="Current")
+      ],
+      facts=[
+        LiveStatementFactRow(qname="rs-gaap:Assets", name="Assets", values=[100.0])
+      ],
+      fact_count=1,
+      validation=ValidationCheckResponse(
+        passed=False,
+        status="failed",
+        checks=["accounting_equation"],
+        failures=["Balance sheet does not balance: Assets (100.00) ≠ …"],
+        warnings=[],
+      ),
+    )
+
+    cm = MagicMock()
+    cm.__enter__.return_value = MagicMock()
+    cm.__exit__.return_value = False
+
+    with (
+      patch(f"{MODULE}.extensions_session", return_value=cm),
+      patch(
+        f"{MODULE}.resolve_reporting_window",
+        return_value=(date(2026, 7, 1), date(2026, 7, 31)),
+      ),
+      patch(f"{MODULE}.get_live_financial_statement", return_value=mock_response),
+    ):
+      result = await tool.execute({"statement_type": "balance_sheet"})
+
+    assert result["validation"]["status"] == "failed"
+    assert result["validation"]["passed"] is False
+    assert result["validation"]["failures"] == [
+      "Balance sheet does not balance: Assets (100.00) ≠ …"
+    ]
+    assert "tip" not in result
+
+  @pytest.mark.unit
   async def test_default_limit_is_the_ceiling(self):
     """A real chart of accounts exceeds 50 non-zero rows routinely, and a
     cut statement's visible rows stop footing to its subtotals."""

--- a/tests/operations/information_block/test_statement_handlers.py
+++ b/tests/operations/information_block/test_statement_handlers.py
@@ -670,6 +670,7 @@ class TestRenderingComposesCalcsCrossStructure:
 
     assert rendering.validation is not None
     assert rendering.validation.passed is True
+    assert rendering.validation.status == "passed"
     assert not any("Net Income mismatch" in f for f in rendering.validation.failures)
 
   def test_non_arithmetic_block_keeps_envelope_associations(self) -> None:

--- a/tests/operations/roboledger/reads/test_reports_extra.py
+++ b/tests/operations/roboledger/reads/test_reports_extra.py
@@ -23,6 +23,9 @@ from robosystems.operations.roboledger.reads.reports import (
   resolve_reporting_window,
 )
 from robosystems.operations.roboledger.reports.fact_grid import (
+  FactRow,
+)
+from robosystems.operations.roboledger.reports.fact_grid import (
   PeriodSpec as FactPeriodSpec,
 )
 
@@ -554,3 +557,124 @@ class TestSavedCashFlowRendersCurrentOnly:
 
     assert resp is not None
     assert [p.label for p in resp.periods] == ["Current", "Prior"]
+
+
+def _fact_row(
+  name: str,
+  values: list[float | None],
+  *,
+  classification: str = "revenue",
+  balance_type: str | None = None,
+  is_subtotal: bool = False,
+  depth: int = 0,
+  qname: str | None = None,
+) -> FactRow:
+  return FactRow(
+    element_id=f"e_{name}",
+    element_qname=qname or f"rs-gaap:{name}",
+    element_name=name,
+    classification=classification,
+    balance_type=balance_type
+    or ("credit" if classification in ("revenue", "liability", "equity") else "debit"),
+    values=values,
+    is_subtotal=is_subtotal,
+    depth=depth,
+  )
+
+
+def _live(session, statement_type, grid):
+  with (
+    patch(
+      "robosystems.operations.roboledger.reads.reports.generate_adhoc_private_statement",
+      return_value=(grid, 0),
+    ),
+    patch(
+      "robosystems.operations.roboledger.reports.network_picker.load_primary_reporting_style",
+      return_value="025f5d48-12ce-5d65-b9eb-4f137a10ef06",
+    ),
+  ):
+    return get_live_financial_statement(
+      session,
+      graph_id="kg_test",
+      statement_type=statement_type,
+      period_start=date(2026, 7, 1),
+      period_end=date(2026, 7, 31),
+    )
+
+
+class TestLiveStatementValidation:
+  """The live statement — the surface the app renders and the MCP tool
+  returns — carries the guard-rail outcome for exactly its rendered columns."""
+
+  @pytest.mark.unit
+  def test_validation_runs_on_both_rendered_columns(self):
+    grid = MagicMock()
+    grid.rows = [
+      _fact_row("Assets", [100.0, 100.0], classification="asset", is_subtotal=True),
+      _fact_row(
+        "Liabilities", [40.0, 40.0], classification="liability", is_subtotal=True
+      ),
+      # Balances in Current, not in Prior.
+      _fact_row("Equity", [60.0, 55.0], classification="equity", is_subtotal=True),
+    ]
+    resp = _live(MagicMock(), "balance_sheet", grid)
+
+    assert resp.validation is not None
+    assert resp.validation.status == "failed"
+    assert resp.validation.passed is False
+    assert "accounting_equation" in resp.validation.checks
+    assert len(resp.validation.failures) == 1
+    assert resp.validation.failures[0].startswith(
+      "[Prior] Balance sheet does not balance"
+    )
+
+  @pytest.mark.unit
+  def test_clean_statement_passes(self):
+    grid = MagicMock()
+    grid.rows = [
+      _fact_row("Assets", [100.0, 90.0], classification="asset", is_subtotal=True),
+      _fact_row(
+        "Liabilities", [40.0, 30.0], classification="liability", is_subtotal=True
+      ),
+      _fact_row("Equity", [60.0, 60.0], classification="equity", is_subtotal=True),
+    ]
+    resp = _live(MagicMock(), "balance_sheet", grid)
+    assert resp.validation is not None
+    assert (resp.validation.status, resp.validation.passed) == ("passed", True)
+    assert resp.validation.failures == []
+
+  @pytest.mark.unit
+  def test_cash_flow_validates_only_the_rendered_column(self):
+    """The prior period rides the pivot as the delta basis and is not a
+    statement; its plug must not be reported against the rendered column."""
+    op = "rs-gaap:NetCashProvidedByUsedInOperatingActivities"
+    plug = "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet"
+    grid = MagicMock()
+    grid.rows = [
+      _fact_row("Operating", [1000.0, 100.0], qname=op),
+      # Quiet in Current (10%), loud in the basis column (500%).
+      _fact_row("OtherOperatingCapital", [100.0, 500.0], qname=plug),
+    ]
+    resp = _live(MagicMock(), "cash_flow_statement", grid)
+
+    assert [p.label for p in resp.periods] == ["Current"]
+    assert resp.validation is not None
+    assert resp.validation.status == "passed"
+    assert "operating_plug" in resp.validation.checks
+    assert not any("Other operating capital" in w for w in resp.validation.warnings)
+
+  @pytest.mark.unit
+  def test_cash_flow_plug_in_the_rendered_column_warns(self):
+    op = "rs-gaap:NetCashProvidedByUsedInOperatingActivities"
+    plug = "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet"
+    grid = MagicMock()
+    grid.rows = [
+      _fact_row("Operating", [-1391.39, 0.0], qname=op),
+      _fact_row("OtherOperatingCapital", [4153.73, 0.0], qname=plug),
+    ]
+    resp = _live(MagicMock(), "cash_flow_statement", grid)
+
+    assert resp.validation is not None
+    warnings = [w for w in resp.validation.warnings if "Other operating capital" in w]
+    assert len(warnings) == 1
+    assert "4153.73" in warnings[0] and "-1391.39" in warnings[0]

--- a/tests/operations/roboledger/reports/test_guard_rails.py
+++ b/tests/operations/roboledger/reports/test_guard_rails.py
@@ -479,10 +479,41 @@ class TestSemanticChecks:
     result = validate_report("income_statement", rows)
     assert any("no data" in w for w in result.warnings)
 
-  def test_unknown_report_type(self):
+  def test_unknown_report_type_is_inconclusive_not_passed(self):
+    """A block type with no rules was not checked — that is not a pass."""
     result = validate_report("unknown_type", [])
-    assert result.passed is True
+    assert result.passed is False
+    assert result.status == "inconclusive"
+    assert result.failures == []
     assert "no_validation_rules" in result.checks
+    assert any("nothing was checked" in w for w in result.warnings)
+
+  def test_equity_statement_is_inconclusive(self):
+    rows = [_row("Total Equity", 500.0, classification="equity", is_subtotal=True)]
+    result = validate_report("equity_statement", rows)
+    assert result.status == "inconclusive"
+    assert result.passed is False
+
+  def test_status_tracks_failures(self):
+    passing = validate_report(
+      "balance_sheet",
+      [
+        _row("Assets", 100.0, classification="asset", is_subtotal=True),
+        _row("Liabilities", 40.0, classification="liability", is_subtotal=True),
+        _row("Equity", 60.0, classification="equity", is_subtotal=True),
+      ],
+    )
+    assert (passing.status, passing.passed) == ("passed", True)
+
+    failing = validate_report(
+      "balance_sheet",
+      [
+        _row("Assets", 100.0, classification="asset", is_subtotal=True),
+        _row("Liabilities", 40.0, classification="liability", is_subtotal=True),
+        _row("Equity", 50.0, classification="equity", is_subtotal=True),
+      ],
+    )
+    assert (failing.status, failing.passed) == ("failed", False)
 
 
 class TestCashFlowOperatingPlug:
@@ -521,3 +552,152 @@ class TestCashFlowOperatingPlug:
       "cash_flow_statement", [_row("Operating", 1000.0, qname=self._OP)]
     )
     assert not any("Other operating capital" in w for w in result.warnings)
+
+
+class TestPerColumnValidation:
+  """Every rule runs on every rendered column, and names the column it fails in.
+
+  Before this, each structural check read ``values[0]`` only: the envelope
+  path (ascending sort) validated the oldest column and the saved-report
+  path validated ``Current`` — two surfaces, one boolean, different columns.
+  """
+
+  def _balance_sheet(self, current_equity: float, prior_equity: float):
+    return [
+      _row("Assets", 100.0, classification="asset", is_subtotal=True, prior=100.0),
+      _row(
+        "Liabilities", 40.0, classification="liability", is_subtotal=True, prior=40.0
+      ),
+      _row(
+        "Equity",
+        current_equity,
+        classification="equity",
+        is_subtotal=True,
+        prior=prior_equity,
+      ),
+    ]
+
+  def test_prior_column_imbalance_fails_and_names_the_column(self):
+    result = validate_report(
+      "balance_sheet",
+      self._balance_sheet(60.0, 55.0),
+      period_labels=["Current", "Prior"],
+    )
+    assert result.passed is False
+    assert result.status == "failed"
+    assert len(result.failures) == 1
+    assert result.failures[0].startswith("[Prior] Balance sheet does not balance")
+    assert "difference: 5.00" in result.failures[0]
+
+  def test_current_column_imbalance_names_current(self):
+    result = validate_report(
+      "balance_sheet",
+      self._balance_sheet(55.0, 60.0),
+      period_labels=["Current", "Prior"],
+    )
+    assert [f[: len("[Current]")] for f in result.failures] == ["[Current]"]
+
+  def test_both_columns_balanced_passes(self):
+    result = validate_report(
+      "balance_sheet",
+      self._balance_sheet(60.0, 60.0),
+      period_labels=["Current", "Prior"],
+    )
+    assert result.passed is True
+    assert result.failures == []
+
+  def test_missing_labels_fall_back_to_column_numbers(self):
+    result = validate_report("balance_sheet", self._balance_sheet(60.0, 55.0))
+    assert result.failures[0].startswith("[column 2] ")
+
+  def test_single_column_messages_carry_no_prefix(self):
+    rows = [
+      _row("Assets", 100.0, classification="asset", is_subtotal=True),
+      _row("Liabilities", 40.0, classification="liability", is_subtotal=True),
+      _row("Equity", 55.0, classification="equity", is_subtotal=True),
+    ]
+    result = validate_report("balance_sheet", rows, period_labels=["Current"])
+    assert result.failures[0].startswith("Balance sheet does not balance")
+
+  def test_checks_are_recorded_once_across_columns(self):
+    result = validate_report(
+      "balance_sheet",
+      self._balance_sheet(60.0, 60.0),
+      period_labels=["Current", "Prior"],
+    )
+    assert result.checks.count("accounting_equation") == 1
+    assert result.checks.count("totals_foot") == 1
+    assert result.checks.count("zero_subtotals") == 1
+    assert result.checks.count("comparative_data") == 1
+
+  def test_column_independent_inconclusive_failure_is_stated_once(self):
+    rows = [
+      _row("Assets", 100.0, classification="asset", is_subtotal=True, prior=90.0),
+    ]
+    result = validate_report("balance_sheet", rows, period_labels=["Current", "Prior"])
+    assert len(result.failures) == 1
+    assert "inconclusive" in result.failures[0]
+
+  def test_net_income_mismatch_in_prior_column_only(self):
+    rows = [
+      _row("Revenue", 1000.0, depth=1, qname="us-gaap:Revenues", prior=900.0),
+      _row("Cost", 700.0, classification="expense", depth=1, prior=600.0),
+      # Correct in Current (300), wrong in Prior (should be 300, reports 250).
+      _row("Net Income", 300.0, qname="us-gaap:NetIncomeLoss", prior=250.0),
+    ]
+    result = validate_report(
+      "income_statement", rows, period_labels=["Current", "Prior"]
+    )
+    assert result.passed is False
+    assert len(result.failures) == 1
+    assert result.failures[0].startswith("[Prior] Net Income mismatch")
+
+  def test_totals_foot_warning_names_the_column(self):
+    rows = [
+      _row("R&D", 200.0, classification="expense", depth=1, prior=200.0),
+      _row("SG&A", 200.0, classification="expense", depth=1, prior=200.0),
+      # Foots in Current (400), not in Prior (410 vs 400).
+      _row(
+        "Operating Expenses",
+        400.0,
+        classification="expense",
+        is_subtotal=True,
+        depth=0,
+        prior=410.0,
+      ),
+      _row("Revenue", 1000.0, depth=0, qname="us-gaap:Revenues", prior=1000.0),
+      _row("Net Income", 600.0, qname="us-gaap:NetIncomeLoss", prior=600.0),
+    ]
+    result = validate_report(
+      "income_statement", rows, period_labels=["Current", "Prior"]
+    )
+    foot = [w for w in result.warnings if "does not match" in w]
+    assert len(foot) == 1
+    assert foot[0].startswith("[Prior] Subtotal 'Operating Expenses'")
+
+  def test_empty_prior_column_is_reported_once_not_per_section(self):
+    rows = [
+      _row("Assets", 100.0, classification="asset", is_subtotal=True, prior=0.0),
+      _row(
+        "Liabilities", 40.0, classification="liability", is_subtotal=True, prior=None
+      ),
+      _row("Equity", 60.0, classification="equity", is_subtotal=True, prior=0.0),
+    ]
+    result = validate_report("balance_sheet", rows, period_labels=["Current", "Prior"])
+    assert result.passed is True
+    assert result.warnings == ["Period 'Prior' has no data — column will be empty"]
+
+  def test_operating_plug_warns_per_column(self):
+    op = "rs-gaap:NetCashProvidedByUsedInOperatingActivities"
+    plug = "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet"
+    rows = [
+      _row("Operating", 1000.0, qname=op, prior=100.0),
+      # 10% of operating in Current (quiet), 500% in Prior (loud).
+      _row("Other operating capital net", 100.0, qname=plug, prior=500.0),
+    ]
+    result = validate_report(
+      "cash_flow_statement", rows, period_labels=["Current", "Prior"]
+    )
+    plug_warnings = [w for w in result.warnings if "Other operating capital" in w]
+    assert len(plug_warnings) == 1
+    assert plug_warnings[0].startswith("[Prior] ")


### PR DESCRIPTION
## Summary

Two gaps in what a green validation result actually meant:

- **The live statement ran no validation.** `validate_report` had two call sites — the saved-report read and the IB envelope — and neither is the surface the app renders or the MCP `live-financial-statement` tool returns. `LiveFinancialStatementResponse` had no `validation` field, so the accounting equation, net-income equation, totals footing, and the operating-plug warning were all off on the primary surface. Concretely: a cash flow whose reconciling plug on `IncreaseDecreaseInOtherOperatingCapitalNet` was larger than operating cash rendered with no warning.
- **`passed: true` overstated what was checked.** Every structural check read `values[0]` only, so a comparative statement was validated on one column — the oldest on the envelope path (periods sort ascending), `Current` on the saved-report path — and both reported one unqualified boolean. And a block type with no rules (`equity_statement`) returned `passed=True, checks=["no_validation_rules"]`, which the close UI renders as a green "Validation Passed" badge.

## Changes

- `guard_rails.py` — every check runs once per rendered column; on a multi-column statement each failure/warning is prefixed with the column it was found in (`[Prior] Balance sheet does not balance …`). Checks are recorded once; column-independent findings (a missing classification rollup) are stated once. A comparative column that is empty end to end is reported once by `comparative_data` instead of per section. `validate_report` takes optional `period_labels`; missing labels fall back to `column N`.
- `ValidationResult` / `ValidationCheckResponse` / `ValidationLite` gain `status`: `passed | failed | inconclusive`. A block type with no rules returns `inconclusive` with `passed=False` and a warning saying nothing was checked — not a vacuous pass.
- `get_live_financial_statement` validates exactly the rendered columns (the cash flow delta basis is projected out first) and carries the result as `LiveFinancialStatementResponse.validation`; the MCP tool's description tells the model to read it before quoting a number.
- Saved-report and envelope paths pass column labels (`Current`/`Prior`; period end date on the envelope).

## Client contract

Additive on the generated tier — new `validation` field on `LiveFinancialStatementResponse`, new `status` on `ValidationCheckResponse` / `ValidationLite` (REST + GraphQL). Rides the next client minor. The one behavior change consumers can see: `passed` is now `false` for an equity statement (nothing was checked). Follow-on in `roboledger-app`: read `status` and render a neutral "Not validated" badge for `inconclusive`, and show `validation` on the live statements page.

## Tests

- `test_guard_rails.py` — per-column failures name the column; single-column messages unchanged; checks recorded once; column-independent inconclusive stated once; empty prior column reported once; operating plug per column; `status` tracks failures; equity/unknown types are `inconclusive` (the old test asserted the vacuous pass and was rewritten).
- `test_reports_extra.py` — live path validates both rendered columns, passes a clean statement, validates only the rendered CF column, and surfaces a plug larger than operating cash.
- `test_financial_statement_tools.py` — the MCP payload carries `validation`.
- `test_statement_handlers.py` — envelope passes `status` through.

`just test-code` clean; `tests/operations`, `tests/graphql`, `tests/routers/extensions`, `tests/models`, `tests/middleware/mcp` green.
