### PR TITLE
fix(reports): foot subtotals by calculation weight, not a plain sum

### DIFF
--- a/robosystems/operations/roboledger/reports/guard_rails.py
+++ b/robosystems/operations/roboledger/reports/guard_rails.py
@@ -159,7 +159,7 @@ def _fail(result: ValidationResult, message: str) -> None:
 def _validate_income_statement(
   rows: list[FactRow], result: ValidationResult, column: _Column
 ) -> None:
-  _check_totals_foot(rows, result, column)
+  _check_totals_foot(rows, result, column, sign_by_balance=True)
 
   # Structural: Net Income must reconcile against EVERY income-statement
   # line by natural balance — credit-nature lines (operating AND
@@ -325,7 +325,7 @@ def _net_income_row(rows: list[FactRow]) -> FactRow | None:
 def _validate_balance_sheet(
   rows: list[FactRow], result: ValidationResult, column: _Column
 ) -> None:
-  _check_totals_foot(rows, result, column)
+  _check_totals_foot(rows, result, column, sign_by_balance=True)
 
   # Structural: Assets = Liabilities + Equity.
   #
@@ -389,7 +389,10 @@ def _validate_cash_flow(
   reconciliation against the balance sheet is a fact-bundle check
   (``fact_grid._check_cash_flow_tie_out``), not a per-statement one.
   """
-  _check_totals_foot(rows, result, column)
+  # Cash-flow rows are cash-effect signed by ``_derive_cash_flow_facts`` and
+  # ``_reconcile_operating_to_cash`` — a section foots as a plain sum by
+  # construction, whatever balance type each element declares.
+  _check_totals_foot(rows, result, column, sign_by_balance=False)
   _check_operating_plug(rows, result, column)
 
 
@@ -404,7 +407,11 @@ _VALIDATORS: dict[str, _Validator] = {
 
 
 def _check_totals_foot(
-  rows: list[FactRow], result: ValidationResult, column: _Column
+  rows: list[FactRow],
+  result: ValidationResult,
+  column: _Column,
+  *,
+  sign_by_balance: bool,
 ) -> None:
   """Verify that subtotal rows equal the sum of their children.
 
@@ -414,6 +421,17 @@ def _check_totals_foot(
   or lower depth. Scanning FORWARD instead would foot each subtotal against
   the next section's children (e.g. 'Revenues' against Cost of Revenue's
   leaves), producing spurious warnings while skipping the real check.
+
+  ``sign_by_balance`` applies the XBRL calculation-weight rule: a child
+  whose balance type differs from its parent's enters with weight -1
+  (interest expense under Nonoperating Income, a contra under Revenues,
+  accumulated depreciation under PP&E net). Income-statement and
+  balance-sheet rows are natural-signed per element, so that is exactly
+  how the calc DAG produced the subtotal — a plain sum counted a 3,755.70
+  interest expense with the wrong sign and reported a 7,511.40 "difference"
+  on a subtotal that was right. Cash-flow rows are cash-effect signed and
+  foot as a plain sum, so that validator passes ``False``. A row with no
+  usable balance type enters with weight +1 either way.
 
   Calc-target subtotals with no presentation children (Gross Profit,
   Operating Income) have no preceding deeper rows and fall out via the
@@ -438,7 +456,9 @@ def _check_totals_foot(
       if child.depth <= subtotal.depth:
         break
       if child.depth == subtotal.depth + 1:
-        child_sum += _value(child, column.index)
+        child_sum += _child_weight(child, subtotal, sign_by_balance) * _value(
+          child, column.index
+        )
 
     subtotal_val = _value(subtotal, column.index)
     diff = abs(subtotal_val - child_sum)
@@ -448,6 +468,18 @@ def _check_totals_foot(
         f"does not match sum of children ({child_sum:.2f}), "
         f"difference: {diff:.2f}"
       )
+
+
+def _child_weight(child: FactRow, subtotal: FactRow, sign_by_balance: bool) -> float:
+  """Calculation weight of ``child`` under ``subtotal``: -1 when their balance
+  types differ, +1 when they agree or either is unknown."""
+  if not sign_by_balance:
+    return 1.0
+  parent = subtotal.balance_type
+  kid = child.balance_type
+  if parent not in ("credit", "debit") or kid not in ("credit", "debit"):
+    return 1.0
+  return 1.0 if kid == parent else -1.0
 
 
 def _check_zero_subtotals(

--- a/tests/operations/roboledger/reports/test_guard_rails.py
+++ b/tests/operations/roboledger/reports/test_guard_rails.py
@@ -448,6 +448,120 @@ class TestTotalsFoot:
     foot_warnings = [w for w in result.warnings if "does not match" in w]
     assert foot_warnings == []
 
+  def test_mixed_balance_children_foot_by_calc_weight(self):
+    """Harbinger FY2025, verbatim: the calc DAG subtracts the debit-nature
+    interest expense under the credit-nature nonoperating subtotal. A plain
+    sum reported a 7,511.40 difference on a subtotal that was right."""
+    rows = [
+      _row("Revenues", 96062.5, depth=1, qname="us-gaap:Revenues"),
+      _row(
+        "Investment Income, Interest",
+        250.87,
+        classification="revenue",
+        depth=2,
+        balance_type="credit",
+      ),
+      _row(
+        "Interest Expense",
+        3755.7,
+        classification="expense",
+        depth=2,
+        balance_type="debit",
+      ),
+      _row(
+        "Other Nonoperating Income (Expense)",
+        -979.62,
+        classification="revenue",
+        depth=2,
+        balance_type="credit",
+      ),
+      _row(
+        "Nonoperating Income (Expense)",
+        -4484.45,
+        classification="revenue",
+        is_subtotal=True,
+        depth=1,
+        balance_type="credit",
+      ),
+      _row("Net Income", 10612.03, depth=1, qname="us-gaap:NetIncomeLoss"),
+    ]
+    result = validate_report("income_statement", rows)
+    assert not any("does not match" in w for w in result.warnings)
+
+  def test_mixed_balance_children_still_flag_a_real_mismatch(self):
+    rows = [
+      _row("Interest Income", 250.87, depth=2, balance_type="credit"),
+      _row(
+        "Interest Expense",
+        3755.7,
+        classification="expense",
+        depth=2,
+        balance_type="debit",
+      ),
+      # Should be -3504.83; reports -3000.
+      _row(
+        "Nonoperating Income (Expense)",
+        -3000.0,
+        is_subtotal=True,
+        depth=1,
+        balance_type="credit",
+      ),
+    ]
+    result = validate_report("income_statement", rows)
+    foot = [w for w in result.warnings if "does not match" in w]
+    assert len(foot) == 1
+    assert "(-3000.00) does not match sum of children (-3504.83)" in foot[0]
+
+  def test_contra_revenue_under_revenues_foots(self):
+    rows = [
+      _row("Gross Sales", 1000.0, depth=1, balance_type="credit"),
+      _row("Sales Returns", 100.0, depth=1, balance_type="debit"),
+      _row("Revenues", 900.0, is_subtotal=True, depth=0, balance_type="credit"),
+    ]
+    result = validate_report("income_statement", rows)
+    assert not any("does not match" in w for w in result.warnings)
+
+  def test_contra_asset_under_net_ppe_foots(self):
+    rows = [
+      _row("PP&E Gross", 10000.0, classification="asset", depth=2),
+      _row(
+        "Accumulated Depreciation",
+        2500.0,
+        classification="asset",
+        depth=2,
+        balance_type="credit",
+      ),
+      _row("PP&E Net", 7500.0, classification="asset", is_subtotal=True, depth=1),
+      _row("Assets", 7500.0, classification="asset", is_subtotal=True, depth=0),
+      _row("Liabilities", 0.0, classification="liability", is_subtotal=True),
+      _row("Equity", 7500.0, classification="equity", is_subtotal=True),
+    ]
+    result = validate_report("balance_sheet", rows)
+    assert not any("does not match" in w for w in result.warnings)
+
+  def test_cash_flow_sections_foot_as_a_plain_sum(self):
+    """CF rows are cash-effect signed: net income (credit) and the
+    working-capital deltas add straight into the debit-nature operating
+    subtotal. Harbinger July 2026, verbatim."""
+    rows = [
+      _row("Net Income", -545.19, depth=2, balance_type="credit"),
+      _row("D&A", 205.32, classification="expense", depth=2, balance_type="debit"),
+      _row("Δ Receivables", -8279.54, depth=2, balance_type="credit"),
+      _row("Δ Prepaids", 2724.29, depth=2, balance_type="credit"),
+      _row("Δ Payables", 350.0, depth=2, balance_type="debit"),
+      _row("Other operating capital, net", 4153.73, depth=2, balance_type="debit"),
+      _row(
+        "Operating",
+        -1391.39,
+        is_subtotal=True,
+        depth=1,
+        balance_type="debit",
+        qname="rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+      ),
+    ]
+    result = validate_report("cash_flow_statement", rows)
+    assert not any("does not match" in w for w in result.warnings)
+
   def test_valueless_abstract_header_is_skipped(self):
     """A multi-subtotal abstract header renders value-less (all None) and
     must not warn when the backward scan reaches its depth-1 children."""


### PR DESCRIPTION
## Summary

`_check_totals_foot` summed a subtotal's presentation children with no regard to balance type. A debit-nature child under a credit-nature subtotal — interest expense under Nonoperating Income, a contra under Revenues, accumulated depreciation under PP&E net — was counted with the wrong sign, and the check reported a "difference" on a subtotal the calc DAG had computed correctly. Surfaced the moment #1303 started naming columns: on Harbinger's FY2025 income statement, `[2025-12-31] Subtotal 'Nonoperating Income (Expense)' (-4484.45) does not match sum of children (3026.95), difference: 7511.40` — exactly 2 × the 3,755.70 interest expense. The subtotal was right; the check was wrong.

## Change

- Income-statement and balance-sheet rows are natural-signed per element, so the foot check now applies XBRL's calculation-weight rule: a child whose balance type differs from its subtotal's enters with weight −1; agreeing or unknown balance types enter +1 (`_child_weight`).
- Cash-flow rows are cash-effect signed by `_derive_cash_flow_facts` / `_reconcile_operating_to_cash` and foot as a plain sum by construction, so `_validate_cash_flow` passes `sign_by_balance=False`.
- Warning-only either way; `passed` / `status` are unaffected.

## Tests

Five new cases in `test_guard_rails.py::TestTotalsFoot`: the Harbinger FY2025 nonoperating section verbatim (no warning), the same shape with a genuinely wrong subtotal (one warning, right numbers), contra-revenue under Revenues, accumulated depreciation under PP&E net, and Harbinger's July 2026 operating section footing as a plain sum on the cash flow.

`just test-code` clean; `tests/operations`, `tests/routers/extensions`, `tests/middleware/mcp` — 4,986 passed.