### PR TITLE
fix(reports): a zero credit balance renders as $0.00, not -$0.00

### DIFF
--- a/robosystems/operations/roboledger/reports/fact_grid.py
+++ b/robosystems/operations/roboledger/reports/fact_grid.py
@@ -2811,7 +2811,8 @@ def _build_rows(
       # rolled-up sum of all descendants for parent nodes, so subtotal
       # rows get the correct aggregate instead of zeros.
       vals = [
-        computed_per_period[i].get(node.element_id, 0.0) for i in range(n_periods)
+        _unsigned_zero(computed_per_period[i].get(node.element_id, 0.0))
+        for i in range(n_periods)
       ]
     # A row is a subtotal if it aggregates other rows by either path:
     # (a) it has child summands in the disclosure DAG, or (b) it is a
@@ -2869,5 +2870,14 @@ def _natural_sign(net_balance: float, balance_type: str) -> float:
   and Net Income = Revenue - Expenses works correctly.
   """
   if balance_type == "credit":
-    return -net_balance
+    # A zero balance has no sign: ``-(0.0)`` is ``-0.0``, which compares
+    # equal to zero but formats as "-$0.00" on a statement.
+    return -net_balance if net_balance else 0.0
   return net_balance
+
+
+def _unsigned_zero(value: float | None) -> float | None:
+  """Normalize ``-0.0`` to ``0.0`` at the point rows leave the renderer, so
+  no sign-flipping path upstream (natural sign, cash-flow deltas, equity
+  reducers) can put "-$0.00" on a statement."""
+  return 0.0 if value == 0.0 else value

--- a/tests/operations/roboledger/reports/test_fact_grid.py
+++ b/tests/operations/roboledger/reports/test_fact_grid.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from datetime import date
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -54,6 +55,12 @@ class TestNaturalSign:
   def test_zero(self):
     assert _natural_sign(0.0, "debit") == 0.0
     assert _natural_sign(0.0, "credit") == 0.0
+
+  def test_zero_credit_balance_is_not_negative_zero(self):
+    # ``-0.0 == 0.0`` is True, so the equality above cannot see the sign;
+    # a zero Accounts Payable rendered as "-$0.00" on a live balance sheet.
+    result = _natural_sign(0.0, "credit")
+    assert math.copysign(1.0, result) == 1.0
 
 
 class TestComputePriorPeriod:
@@ -225,6 +232,41 @@ class TestBuildRows:
     assert rows[2].element_name == "Revenues"
     assert rows[2].values == [500.0]
     assert rows[2].is_subtotal is True
+
+  def test_zero_credit_leaf_carries_no_sign(self):
+    """A credit-normal leaf whose current balance is exactly zero (debits
+    equal credits) rendered as ``-0.0`` — "-$0.00" on the balance sheet —
+    while its prior-period value kept the row visible."""
+    hierarchy = [
+      _HierarchyNode(
+        element_id="ap",
+        qname="rs-gaap:AccountsPayableCurrent",
+        name="Accounts Payable, Current",
+        classification="liability",
+        balance_type="credit",
+        is_abstract=False,
+        depth=0,
+      )
+    ]
+    current = {
+      "ap": _Balance(
+        element_id="ap",
+        qname="rs-gaap:AccountsPayableCurrent",
+        name="Accounts Payable, Current",
+        classification="liability",
+        balance_type="credit",
+        total_debits=195.94,
+        total_credits=195.94,
+        net_balance=0.0,
+      )
+    }
+    prior = self._make_balances({"ap": 195.94})
+
+    rows = _build_rows(hierarchy, [current, prior], {})
+
+    assert len(rows) == 1
+    assert rows[0].values == [0.0, 195.94]
+    assert math.copysign(1.0, rows[0].values[0]) == 1.0
 
   def test_nested_hierarchy(self):
     """Two-level nesting: root → abstract parent → leaves."""


### PR DESCRIPTION
## Summary

On a live balance sheet, `Accounts Payable, Current` rendered as **−$0.00** when the account's debits exactly equalled its credits. The value leaving the API was a literal `-0.0`: `_natural_sign` negates credit-normal balances, and `-(0.0)` is `-0.0` — equal to zero for every comparison and filter in the renderer, but formatted with a sign by the app. Subtotals happened to come out clean because their rollup starts from an integer accumulator; leaf rows carried the raw value through.

## Changes

- **`operations/roboledger/reports/fact_grid.py`**
  - `_natural_sign` returns an unsigned `0.0` for a zero credit balance instead of negating it.
  - New `_unsigned_zero` applied where rows leave `_build_rows`, so no other sign-flipping path (cash-flow deltas, equity reducers) can reintroduce `-0.0` on a rendered row.
- **`tests/operations/roboledger/reports/test_fact_grid.py`** — two regressions that check the sign with `math.copysign` (the existing `test_zero` passed on `-0.0`, since `-0.0 == 0.0`): the helper directly, and a `_build_rows` case with a zero-balance credit leaf that stays visible because its prior period is non-zero — the exact shape seen on prod.

## Breaking Changes

None. Response shapes are unchanged; only a signed zero becomes an unsigned zero.

## Testing

- `just test` — full unit suite: 14,193 passed, 42 skipped (223 in the reports/reads modules specifically).
- `just test-code` — clean; re-run by the pre-commit hook.
- Reproduced from prod: `live-financial-statement` (balance sheet, YTD) on the Harbinger ledger returned `"values": [-0.0, 195.94]` for AP before the fix.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
