### PR TITLE
refactor(operators): rename the cypher operator to analyst, keep cypher as an alias

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,7 +296,7 @@ robosystems/
 4. **Two-database split**: Platform (`robosystems`) for IAM/billing/metadata; extensions (`extensions`) for per-graph OLTP. Different `DeclarativeBase` classes, independent migration histories, same shared RDS instance
 5. **Credit-based AI billing**: Only AI operations (Anthropic/OpenAI) consume credits; database operations are free
 6. **Graph backend**: LadybugDB (`GRAPH_BACKEND_TYPE=ladybug`)
-7. **Two `Agent` concepts, disambiguated**: `Agent` (REA party — customer/vendor/employee counterparty) lives in `models/extensions/roboledger/agent.py` and is the canonical ontology term. The AI executor layer (Claude/MCP-driven) is named **Operator** throughout the codebase: `routers/graphs/operator/`, `operations/operators/`, classes like `CypherOperator` / `MappingOperator`, endpoint `/v1/graphs/{g}/operator`. Marketing-facing copy can still say "AI agent" / "AI assistant" — that's decoupled from internal naming.
+7. **Two `Agent` concepts, disambiguated**: `Agent` (REA party — customer/vendor/employee counterparty) lives in `models/extensions/roboledger/agent.py` and is the canonical ontology term. The AI executor layer (Claude/MCP-driven) is named **Operator** throughout the codebase: `routers/graphs/operator/`, `operations/operators/`, classes like `AnalystOperator` / `MappingOperator`, endpoint `/v1/graphs/{g}/operator`. Marketing-facing copy can still say "AI agent" / "AI assistant" — that's decoupled from internal naming.
 
 ## Testing
 

--- a/robosystems/config/README.md
+++ b/robosystems/config/README.md
@@ -146,7 +146,7 @@ from robosystems.config import BedrockModel, OperatorConfig, OperatorExecutionMo
 
 OperatorConfig.get_bedrock_model_id()                          # default (Sonnet 4.6)
 OperatorConfig.get_bedrock_model_id(model=BedrockModel.SONNET_4_5)
-OperatorConfig.get_bedrock_model_id(operator_type="cypher")    # honors OPERATOR_MODEL_OVERRIDES
+OperatorConfig.get_bedrock_model_id(operator_type="analyst")   # honors OPERATOR_MODEL_OVERRIDES
 
 profile = OperatorConfig.get_execution_profile(OperatorExecutionMode.STANDARD)
 # max_tool_calls=5, timeout_seconds=60, max_input_tokens=100_000

--- a/robosystems/config/operators.py
+++ b/robosystems/config/operators.py
@@ -139,12 +139,12 @@ class OperatorConfig:
   # Allows different operators to use different models if needed
   OPERATOR_MODEL_OVERRIDES: dict[str, BedrockModel] = {
     # Example: "financial": BedrockModel.SONNET_4_5,
-    # Example: "cypher": BedrockModel.SONNET_4,
+    # Example: "analyst": BedrockModel.SONNET_4,
   }
 
   # Orchestrator Configuration
   ORCHESTRATOR_CONFIG = {
-    "fallback_operator": "cypher",
+    "fallback_operator": "analyst",
     "confidence_threshold": 0.7,
     "max_routing_attempts": 3,
     "enable_rag": False,
@@ -153,7 +153,7 @@ class OperatorConfig:
 
   # Operator Capabilities Configuration
   OPERATOR_CAPABILITIES = {
-    "cypher": {
+    "analyst": {
       "supported_modes": ["quick", "standard", "extended", "streaming"],
       "requires_credits": True,
       "max_concurrent_requests": 10,

--- a/robosystems/operations/README.md
+++ b/robosystems/operations/README.md
@@ -32,7 +32,7 @@ Every operation on the platform is one of four shapes, and the shape determines 
 | `event_block/` | Cross-domain Event Block registry, engine, and Python handlers |
 | `roboledger/` | RoboLedger domain kernel — `reads/`, `commands/`, `views/`, plus `fiscal_calendar/`, `reports/`, `schedules/`, `fact_set.py` |
 | `roboinvestor/` | RoboInvestor domain kernel — `reads/`, `commands/` |
-| `operators/` | AI Operator system (`CypherOperator`, `MappingOperator`) — see [its README](operators/README.md) |
+| `operators/` | AI Operator system (`AnalystOperator`, `MappingOperator`) — see [its README](operators/README.md) |
 | `graph/` | Platform graph lifecycle: creation, subscriptions, credits, pricing, tiers, subgraphs, deprovisioning, storage reclaim, backup/ingestion under `engine/`, worker tasks under `tasks/` |
 | `extensions/` | OLTP→OLAP materialization (`materialize.py`, `loader.py`, `staleness.py`) |
 | `billing/` | Subscription billing lifecycle shared by routers and off-boarding |

--- a/robosystems/operations/operators/README.md
+++ b/robosystems/operations/operators/README.md
@@ -4,7 +4,7 @@ AI executors: Claude-via-MCP running against a graph, for natural-language query
 
 ## Naming: Operator is not Agent
 
-**"Operator" is the AI-executor concept.** It is deliberately distinct from **`Agent`**, the REA counterparty model in `models/extensions/roboledger/agent.py` — a customer, vendor, or employee. `Agent` is the canonical ontology term and it is not available for the AI layer, so everything in the executor layer is named Operator: this package, `routers/graphs/operator/`, `CypherOperator`, `MappingOperator`, and the endpoint `/v1/graphs/{graph_id}/operator`.
+**"Operator" is the AI-executor concept.** It is deliberately distinct from **`Agent`**, the REA counterparty model in `models/extensions/roboledger/agent.py` — a customer, vendor, or employee. `Agent` is the canonical ontology term and it is not available for the AI layer, so everything in the executor layer is named Operator: this package, `routers/graphs/operator/`, `AnalystOperator`, `MappingOperator`, and the endpoint `/v1/graphs/{graph_id}/operator`.
 
 This is the most confusable naming in the repo. When you read `Agent`, it is a business counterparty; when you read `Operator`, it is an AI executor.
 
@@ -63,7 +63,7 @@ Import the module in `implementations/__init__.py` so the decorator runs.
 
 | Operator | Context | Purpose |
 | -------- | ------- | ------- |
-| `cypher` | Worker, `run_operator_worker()` — queued by `POST /v1/graphs/{g}/operator[/cypher]` | Natural language → Cypher graph queries |
+| `analyst` (alias: `cypher`, its former name) | Worker, `run_operator_worker()` — queued by `POST /v1/graphs/{g}/operator[/analyst]` | Natural-language questions over the graph — curated financial reads, documents, memory, GraphQL, read-only Cypher as the fallback |
 | `mapping` | Worker, `run_operator_worker()` — queued by `auto-map-elements` and the QuickBooks first sync | Autonomous CoA → US GAAP taxonomy mapping |
 
 ## Module layout
@@ -83,7 +83,7 @@ Import the module in `implementations/__init__.py` so the decorator runs.
 | `adapters/api.py` | `run_operator_api()` — builds an in-process context (the orchestrator's `route_query` and tests; no endpoint runs an operator in the API process) |
 | `adapters/worker.py` | `run_operator_worker()` — builds the context for worker tasks and returns the response envelope |
 | `adapters/worker_task.py` | `@register_task("operator")` bridge into the worker consumer |
-| `implementations/` | `cypher.py`, `mapping/` (operator, prompt, constants) |
+| `implementations/` | `analyst.py`, `mapping/` (operator, prompt, constants) |
 
 ## Execution paths
 

--- a/robosystems/operations/operators/adapters/worker.py
+++ b/robosystems/operations/operators/adapters/worker.py
@@ -78,7 +78,7 @@ async def run_operator_worker(
   # The full GraphMCPTools surface, gated by the operator's read_only flag —
   # the same tool access the API path used. DirectToolAccess only reports
   # tool classes registered by hand, so a model-driven loop on it sees no
-  # tools at all: on the first worker deploy the Cypher operator narrated
+  # tools at all: on the first worker deploy the analyst operator narrated
   # "Tool: get-graph-schema" as text and stopped.
   tools = HttpToolAccess(graph_id, read_only=operator.spec.read_only, user_id=user_id)
   ai_client = get_ai_client()

--- a/robosystems/operations/operators/base.py
+++ b/robosystems/operations/operators/base.py
@@ -5,7 +5,7 @@ Two protocols coexist:
 - ``Operator`` / ``OperatorSpec`` / ``OperatorResult`` — the unified protocol.
   Write new operators against this one.
 - ``BaseOperator`` / ``OperatorMetadata`` / ``OperatorResponse`` — the older
-  protocol still driving ``CypherOperator`` and the orchestrator.
+  protocol still driving ``AnalystOperator`` and the orchestrator.
 
 "Operator" is the AI-executor concept (Claude/MCP), distinct from the REA
 ``Agent`` (counterparty) modeled in ``models/extensions/roboledger/agent.py``.
@@ -265,7 +265,7 @@ class OperatorResponse:
 
 
 class BaseOperator(ABC):
-  """Base class for the older operator protocol, used by ``CypherOperator``
+  """Base class for the older operator protocol, used by ``AnalystOperator``
   and the orchestrator. New operators inherit from :class:`Operator`.
   """
 

--- a/robosystems/operations/operators/implementations/__init__.py
+++ b/robosystems/operations/operators/implementations/__init__.py
@@ -3,7 +3,7 @@
 Importing this module registers all operators in the operator_registry.
 """
 
-from robosystems.operations.operators.implementations import cypher
+from robosystems.operations.operators.implementations import analyst
 from robosystems.operations.operators.implementations.mapping import operator as mapping
 
-__all__ = ["cypher", "mapping"]
+__all__ = ["analyst", "mapping"]

--- a/robosystems/operations/operators/implementations/analyst.py
+++ b/robosystems/operations/operators/implementations/analyst.py
@@ -1,13 +1,18 @@
-"""CypherOperator — natural-language querying of the graph.
+"""AnalystOperator — natural-language questions answered from the graph.
 
-Drives a bounded tool-use loop (`run_tool_loop`): the schema and example
-queries are fetched up front into the (cached) system prompt, the model
-writes read-only Cypher against them, sees query errors and retries, then
-answers in natural language. Seeing its own errors is the point — a
+Registered as ``analyst``; ``cypher`` is kept as an alias, the name it
+shipped under when Cypher was its only tool. Drives a bounded tool-use loop
+(`run_tool_loop`) over the graph's read-only surface: curated financial
+reads (live statements, fact grids, close status, mapping state), document
+search, semantic memory, GraphQL, and read-only Cypher as the general
+fallback. The schema and example queries are fetched up front into the
+(cached) system prompt and the memories most similar to the question into
+the user turn; the model then calls tools, sees its own errors and retries,
+and answers in natural language. Seeing its own errors is the point — a
 single-shot pipeline that generates one query and formats whatever comes
-back fails on questions this handles. The last non-empty result set is
-returned as structured ``rows`` so the console renders a real table instead
-of scraping the prose.
+back fails on questions this handles. The last non-empty Cypher result set
+is returned as structured ``rows`` so the console renders a real table
+instead of scraping the prose.
 """
 
 from __future__ import annotations
@@ -50,9 +55,9 @@ _RECALL_K = 5
 _MAX_MEMORY_CHARS = 800
 
 
-@register_operator("cypher")
-class CypherOperator(Operator):
-  """Answers a question by writing and running read-only Cypher."""
+@register_operator("analyst")
+class AnalystOperator(Operator):
+  """Answers a question from the graph's read-only tool surface."""
 
   # Read-only tool allowlist. The loop intersects this with the tools the
   # graph actually exposes (generic graphs get only schema + cypher; SEC and
@@ -121,8 +126,11 @@ class CypherOperator(Operator):
   }
 
   spec = OperatorSpec(
-    name="Cypher Operator",
-    description="Answers natural-language questions by querying the graph with Cypher",
+    name="Analyst Operator",
+    description=(
+      "Answers natural-language questions over the graph: curated financial "
+      "reads, documents, memory, GraphQL, and read-only Cypher as the fallback"
+    ),
     capabilities=[
       OperatorCapability.RAG_SEARCH,
       OperatorCapability.ENTITY_ANALYSIS,
@@ -221,8 +229,8 @@ class CypherOperator(Operator):
       max_iterations=max_iterations,
       max_tokens=max_tokens,
       temperature=0.3,
-      operator_type="cypher",
-      operation_description="Cypher query loop",
+      operator_type="analyst",
+      operation_description="Analyst tool loop",
       max_credits=self._get_max_credits(ctx),
     )
 
@@ -271,7 +279,7 @@ class CypherOperator(Operator):
       return orientation
     except Exception as e:
       logger.warning(
-        "Cypher operator orientation prefetch failed on %s; "
+        "Analyst operator orientation prefetch failed on %s; "
         "falling back to tool-driven orientation: %s",
         ctx.graph_id,
         e,
@@ -295,7 +303,7 @@ class CypherOperator(Operator):
       )
     except Exception as e:
       logger.warning(
-        "Cypher operator memory prefetch failed on %s: %s", ctx.graph_id, e
+        "Analyst operator memory prefetch failed on %s: %s", ctx.graph_id, e
       )
       return None
     if not isinstance(result, dict) or "error" in result:
@@ -408,7 +416,7 @@ STEP BUDGET: you have {tool_turns} tool-calling turns before you must answer fro
       ", and you do NOT need `get-graph-schema` first" if orientation is None else ""
     )
 
-    prompt = f"""You are a graph database analyst for RoboSystems. You answer the user's question by querying a LadybugDB graph with read-only Cypher.
+    prompt = f"""You are a financial-graph analyst for RoboSystems. You answer the user's question from a LadybugDB graph with the tools offered: curated reads where one fits, documents and memory where the graph has them, and read-only Cypher for everything else.
 
 {workflow}
 

--- a/robosystems/operations/operators/operator_registry.py
+++ b/robosystems/operations/operators/operator_registry.py
@@ -15,6 +15,16 @@ from robosystems.operations.operators.base import Operator
 _OPERATORS: dict[str, type[Operator]] = {}
 _adapter_operators_loaded: list[bool] = []
 
+# Former names. An operator's registry key is public surface — the URL
+# segment, the `operator_type` in queued tasks and stored operations, and
+# whatever client code hardcoded — so a rename keeps the old key resolving
+# here rather than breaking those. A direct registration always beats an
+# alias, and the listing shows canonical names only.
+_ALIASES: dict[str, str] = {
+  # The analyst shipped as `cypher` when Cypher was its only tool.
+  "cypher": "analyst",
+}
+
 
 def register_operator(operator_type: str):
   """Register an Operator class under `operator_type`.
@@ -23,8 +33,8 @@ def register_operator(operator_type: str):
 
   Example::
 
-      @register_operator("cypher")
-      class CypherOperator(Operator):
+      @register_operator("analyst")
+      class AnalystOperator(Operator):
           spec = OperatorSpec(...)
           async def run(self, ctx): ...
   """
@@ -42,13 +52,20 @@ def register_operator(operator_type: str):
   return decorator
 
 
+def resolve_operator_type(operator_type: str) -> str:
+  """Map a former name to its canonical registry key; unknown names pass through."""
+  if operator_type in _OPERATORS:
+    return operator_type
+  return _ALIASES.get(operator_type, operator_type)
+
+
 def get_operator(operator_type: str) -> Operator:
-  """Instantiate a registered operator, or raise KeyError.
+  """Instantiate a registered operator (by canonical name or alias), or raise KeyError.
 
   A fresh instance per call — operators are stateless, and their per-run state
   lives on the `OperatorContext` the adapter injects.
   """
-  cls = _OPERATORS.get(operator_type)
+  cls = _OPERATORS.get(resolve_operator_type(operator_type))
   if cls is None:
     registered = ", ".join(_OPERATORS.keys()) or "(none)"
     raise KeyError(
@@ -59,7 +76,7 @@ def get_operator(operator_type: str) -> Operator:
 
 def get_operator_class(operator_type: str) -> type[Operator] | None:
   """Get the operator class without instantiation."""
-  return _OPERATORS.get(operator_type)
+  return _OPERATORS.get(resolve_operator_type(operator_type))
 
 
 def list_operators() -> dict[str, dict[str, Any]]:
@@ -91,8 +108,8 @@ def _serialize_scope(scope: Any) -> dict[str, str] | None:
 
 
 def is_registered(operator_type: str) -> bool:
-  """Check if an operator type is registered."""
-  return operator_type in _OPERATORS
+  """Check if an operator type (canonical or alias) is registered."""
+  return resolve_operator_type(operator_type) in _OPERATORS
 
 
 def load_adapter_operators() -> None:

--- a/robosystems/operations/operators/tool_loop.py
+++ b/robosystems/operations/operators/tool_loop.py
@@ -2,7 +2,7 @@
 
 The model chooses which read-only MCP tools to call; every tool error comes
 back as an ``is_error`` tool_result so it can correct itself and retry. The
-loop is the shared harness behind `CypherOperator` and any other read/analysis
+loop is the shared harness behind `AnalystOperator` and any other read/analysis
 operator — the Claude-via-MCP tool loop run in-process on Bedrock, with
 per-call credit tracking supplied by `TrackedAIClient`.
 """

--- a/robosystems/routers/graphs/operator/execute.py
+++ b/robosystems/routers/graphs/operator/execute.py
@@ -52,6 +52,7 @@ from robosystems.operations.operators.credit_preflight import (
 from robosystems.operations.operators.operator_registry import (
   get_operator,
   list_operators,
+  resolve_operator_type,
 )
 from robosystems.operations.operators.orchestrator import (
   OperatorOrchestrator,
@@ -273,6 +274,9 @@ async def _dispatch(
   db: Session,
 ) -> OperatorResponse | JSONResponse:
   """Gate, enqueue, and answer — 202 with links, or 200 under a sync wait."""
+  # A former name resolves here so the queued task and `operator_used` carry
+  # the canonical one.
+  operator_type = resolve_operator_type(operator_type)
   operator = get_operator(operator_type)
   base_mode = (
     BaseOperatorMode.EXTENDED
@@ -348,10 +352,12 @@ async def list_operators_endpoint(
   response_model=OperatorResponse,
   summary="Auto-select Operator for Query",
   description=(
-    "Routes to the best operator for your query. Operators: `cypher` "
-    "(answers natural-language questions by querying the graph; supports "
-    "`quick`, `standard`, `extended`) and `mapping` (autonomous Chart of "
-    "Accounts → rs-gaap mapping; roboledger graphs only, `extended` only). "
+    "Routes to the best operator for your query. Operators: `analyst` "
+    "(answers natural-language questions over the graph — curated financial "
+    "reads, documents, memory, and read-only Cypher; supports `quick`, "
+    "`standard`, `extended`; `cypher` is accepted as its former name) and "
+    "`mapping` (autonomous Chart of Accounts → rs-gaap mapping; roboledger "
+    "graphs only, `extended` only). "
     "`GET /v1/graphs/{graph_id}/operator` lists what is registered. Credits "
     "are consumed by actual token usage, not a fixed price per mode. "
     "The run executes on the background worker: the default answer is 202 "
@@ -415,14 +421,14 @@ async def get_operator_metadata(
   ),
   operator_type: str = Path(
     ...,
-    description="Operator type identifier (e.g., 'financial', 'research', 'rag')",
+    description="Operator type identifier (e.g., 'analyst', 'mapping')",
     pattern="^[a-zA-Z][a-zA-Z0-9_]{2,32}$",
   ),
   _current_user: User = Depends(get_current_user_with_graph),
   _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
 ) -> OperatorMetadataResponse:
   operators = list_operators()
-  metadata = operators.get(operator_type)
+  metadata = operators.get(resolve_operator_type(operator_type))
 
   if not metadata:
     raise HTTPException(status_code=404, detail=f"Operator '{operator_type}' not found")
@@ -435,10 +441,11 @@ async def get_operator_metadata(
   response_model=OperatorResponse,
   summary="Execute Specific Operator",
   description=(
-    "Available: `cypher` (natural-language questions answered by querying the "
-    "graph; RAG retrieval is one of its capabilities, not a separate operator) "
-    "and `mapping` (Chart of Accounts → rs-gaap mapping, roboledger graphs "
-    "only). `GET /v1/graphs/{graph_id}/operator` lists what is registered. "
+    "Available: `analyst` (natural-language questions over the graph — "
+    "curated financial reads, documents, memory, and read-only Cypher; RAG "
+    "retrieval is one of its capabilities, not a separate operator; `cypher` "
+    "is accepted as its former name) and `mapping` (Chart of Accounts → "
+    "rs-gaap mapping, roboledger graphs only). `GET /v1/graphs/{graph_id}/operator` lists what is registered. "
     "The run executes on the background worker: the default answer is 202 "
     "with the operation's `_links` (stream, status, cancel); `?mode=sync` "
     "waits up to 50s and answers 200 with the result."

--- a/tests/config/test_operators.py
+++ b/tests/config/test_operators.py
@@ -49,7 +49,7 @@ class TestGetBedrockModelId:
 
   def test_agent_type_override(self):
     # Currently empty overrides, so it falls through to default
-    model_id = OperatorConfig.get_bedrock_model_id(operator_type="cypher")
+    model_id = OperatorConfig.get_bedrock_model_id(operator_type="analyst")
     assert isinstance(model_id, str)
 
   def test_agent_override_takes_precedence(self):
@@ -108,7 +108,7 @@ class TestGetOperatorCapabilities:
   """Tests for OperatorConfig.get_operator_capabilities."""
 
   def test_known_agent(self):
-    caps = OperatorConfig.get_operator_capabilities("cypher")
+    caps = OperatorConfig.get_operator_capabilities("analyst")
     assert "supported_modes" in caps
     assert "requires_credits" in caps
     assert "max_concurrent_requests" in caps

--- a/tests/operations/operators/test_analyst_prefetch.py
+++ b/tests/operations/operators/test_analyst_prefetch.py
@@ -1,4 +1,4 @@
-"""CypherOperator prefetches — schema/examples in the system prefix, memories
+"""AnalystOperator prefetches — schema/examples in the system prefix, memories
 in the user turn.
 
 Schema and example queries are deterministic per graph, so the operator
@@ -22,7 +22,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from robosystems.operations.operators.base import OperatorMode
-from robosystems.operations.operators.implementations.cypher import CypherOperator
+from robosystems.operations.operators.implementations.analyst import AnalystOperator
 from robosystems.operations.operators.operator_context import OperatorContext
 from robosystems.operations.operators.progress import NoOpProgress
 from robosystems.operations.operators.tool_loop import ToolLoopResult
@@ -75,10 +75,10 @@ def _loop_result() -> ToolLoopResult:
 async def _run(tools: MagicMock):
   """Run the operator with the loop patched out; return the loop's kwargs."""
   with patch(
-    "robosystems.operations.operators.implementations.cypher.run_tool_loop",
+    "robosystems.operations.operators.implementations.analyst.run_tool_loop",
     AsyncMock(return_value=_loop_result()),
   ) as loop:
-    await CypherOperator().run(_ctx(tools))
+    await AnalystOperator().run(_ctx(tools))
   return loop.await_args.kwargs
 
 
@@ -99,7 +99,7 @@ async def test_orientation_is_prefetched_into_the_system_prompt():
   # ...and the loop no longer offers them.
   assert kwargs["tool_names"] == [
     t
-    for t in CypherOperator.READ_ONLY_TOOLS
+    for t in AnalystOperator.READ_ONLY_TOOLS
     if t not in ("get-graph-schema", "get-example-queries")
   ]
 
@@ -116,7 +116,7 @@ async def test_prefetch_failure_falls_back_to_tool_driven_orientation():
 
   assert "GRAPH SCHEMA" not in kwargs["system"]
   assert "call `get-graph-schema` first" in kwargs["system"]
-  assert kwargs["tool_names"] == CypherOperator.READ_ONLY_TOOLS
+  assert kwargs["tool_names"] == AnalystOperator.READ_ONLY_TOOLS
 
 
 async def test_error_dict_schema_falls_back():
@@ -129,7 +129,7 @@ async def test_error_dict_schema_falls_back():
   kwargs = await _run(tools)
 
   assert "GRAPH SCHEMA" not in kwargs["system"]
-  assert kwargs["tool_names"] == CypherOperator.READ_ONLY_TOOLS
+  assert kwargs["tool_names"] == AnalystOperator.READ_ONLY_TOOLS
 
 
 async def test_graph_without_examples_gets_schema_only():
@@ -148,7 +148,7 @@ async def test_graph_without_examples_gets_schema_only():
 
 async def test_oversized_orientation_is_truncated_deterministically():
   big = [{"label": "N" * 1000} for _ in range(100)]
-  text = CypherOperator._serialize_orientation(big)
+  text = AnalystOperator._serialize_orientation(big)
   assert len(text) <= 48000 + len("\n… [truncated]")
   assert text.endswith("[truncated]")
 
@@ -193,20 +193,20 @@ async def test_max_credits_reaches_the_loop_and_garbage_is_ignored():
     {"get-graph-schema": SCHEMA},
   )
   with patch(
-    "robosystems.operations.operators.implementations.cypher.run_tool_loop",
+    "robosystems.operations.operators.implementations.analyst.run_tool_loop",
     AsyncMock(return_value=_loop_result()),
   ) as loop:
     ctx = _ctx(tools)
     ctx.extra["max_credits"] = 25
-    await CypherOperator().run(ctx)
+    await AnalystOperator().run(ctx)
   assert loop.await_args.kwargs["max_credits"] == 25.0
 
   # Tenant-supplied garbage must not shape the loop.
-  assert CypherOperator._get_max_credits(_ctx(tools)) is None
+  assert AnalystOperator._get_max_credits(_ctx(tools)) is None
   for bad in ("abc", -5, 0, None, {"x": 1}):
     ctx = _ctx(tools)
     ctx.extra["max_credits"] = bad
-    assert CypherOperator._get_max_credits(ctx) is None, bad
+    assert AnalystOperator._get_max_credits(ctx) is None, bad
 
 
 # ── Semantic memory prefetch ─────────────────────────────────────────────
@@ -302,7 +302,7 @@ async def test_graph_without_recall_gets_no_memory_prefetch():
 
 def test_oversized_memories_are_capped_per_hit():
   hits = [{"id": str(i), "text": "x" * 5000, "tags": None} for i in range(5)]
-  message = CypherOperator._build_user_message("q", hits)
+  message = AnalystOperator._build_user_message("q", hits)
   assert message is not None
   assert message.count("x" * 800 + "…") == 5
   assert "x" * 801 not in message

--- a/tests/operations/operators/test_orchestrator.py
+++ b/tests/operations/operators/test_orchestrator.py
@@ -77,7 +77,7 @@ class TestOrchestratorConfig:
     assert config.enable_rag is False
     assert config.enable_caching is False
     assert config.enable_fallback is True
-    assert config.fallback_operator == "cypher"
+    assert config.fallback_operator == "analyst"
 
 
 # ── Mock agents for testing ──────────────────────────────────────────────────

--- a/tests/operations/operators/test_unified_operator.py
+++ b/tests/operations/operators/test_unified_operator.py
@@ -285,6 +285,43 @@ class TestOperatorRegistry:
     with pytest.raises(KeyError, match="not registered"):
       get_operator("nonexistent")
 
+  def test_former_name_resolves_to_the_canonical_operator(self):
+    """`cypher` is the name the analyst shipped under; stored operator_type
+    values (queued tasks, saved operations, client code) keep resolving, and
+    the listing shows canonical names only."""
+    from robosystems.operations.operators.operator_registry import (
+      is_registered,
+      resolve_operator_type,
+    )
+
+    @register_operator("analyst")
+    class Analyst(Operator):
+      spec = OperatorSpec(name="Analyst", description="a", capabilities=[])
+
+      async def run(self, ctx):
+        return OperatorResult(content="a")
+
+    assert resolve_operator_type("cypher") == "analyst"
+    assert isinstance(get_operator("cypher"), Analyst)
+    assert is_registered("cypher")
+    assert "cypher" not in list_operators()
+    assert resolve_operator_type("nonexistent") == "nonexistent"
+
+  def test_direct_registration_beats_the_alias(self):
+    from robosystems.operations.operators.operator_registry import (
+      resolve_operator_type,
+    )
+
+    @register_operator("cypher")
+    class Legacy(Operator):
+      spec = OperatorSpec(name="Legacy", description="l", capabilities=[])
+
+      async def run(self, ctx):
+        return OperatorResult(content="l")
+
+    assert resolve_operator_type("cypher") == "cypher"
+    assert isinstance(get_operator("cypher"), Legacy)
+
   def test_list_agents(self):
     @register_operator("test_a")
     class A(Operator):

--- a/tests/operations/operators/test_worker_adapter.py
+++ b/tests/operations/operators/test_worker_adapter.py
@@ -23,7 +23,7 @@ USER_ID = "usr_test123"
 def _operator(result: OperatorResult) -> MagicMock:
   operator = MagicMock()
   operator.spec = OperatorSpec(
-    name="Cypher Operator",
+    name="Analyst Operator",
     description="test",
     capabilities=[OperatorCapability.CUSTOM],
     read_only=True,
@@ -76,7 +76,7 @@ async def test_run_operator_worker_returns_the_response_envelope():
       graph_id=GRAPH_ID,
       user_id=USER_ID,
       params={
-        "operator_type": "cypher",
+        "operator_type": "analyst",
         "query": "How many nodes?",
         "mode": "standard",
         "history": [{"role": "user", "content": "hi"}],
@@ -87,7 +87,7 @@ async def test_run_operator_worker_returns_the_response_envelope():
 
   # The envelope the endpoint and the SSE completion event hand to callers
   assert result["content"] == "42"
-  assert result["operator_used"] == "Cypher Operator"
+  assert result["operator_used"] == "Analyst Operator"
   assert result["mode_used"] == "standard"
   assert result["tokens_used"] == tracked.total_tokens
   assert result["confidence_score"] == 0.9
@@ -107,7 +107,7 @@ async def test_run_operator_worker_returns_the_response_envelope():
   assert ctx.query == "How many nodes?"
   assert ctx.history == [{"role": "user", "content": "hi"}]
   assert ctx.extra["max_credits"] == 50
-  assert ctx.extra["operator_type"] == "cypher"
+  assert ctx.extra["operator_type"] == "analyst"
 
 
 @pytest.mark.asyncio
@@ -170,7 +170,7 @@ async def test_worker_uses_the_full_tool_surface_gated_by_read_only():
       task_id="op_01TEST",
       graph_id=GRAPH_ID,
       user_id=USER_ID,
-      params={"operator_type": "cypher", "query": "q"},
+      params={"operator_type": "analyst", "query": "q"},
       manager=AsyncMock(),
     )
 

--- a/tests/operations/operators/test_write_role_gate.py
+++ b/tests/operations/operators/test_write_role_gate.py
@@ -151,10 +151,10 @@ class TestRegisteredOperatorDeclarations:
   """
 
   def test_cypher_operator_is_read_only(self) -> None:
-    from robosystems.operations.operators.implementations.cypher import CypherOperator
+    from robosystems.operations.operators.implementations.analyst import AnalystOperator
 
-    assert CypherOperator.spec.read_only is True, (
-      "CypherOperator is viewer-accessible because READ_ONLY_TOOLS contains no "
+    assert AnalystOperator.spec.read_only is True, (
+      "AnalystOperator is viewer-accessible because READ_ONLY_TOOLS contains no "
       "write tool; adding one means this flag must go"
     )
 

--- a/tests/routers/graphs/test_operator_router.py
+++ b/tests/routers/graphs/test_operator_router.py
@@ -57,7 +57,7 @@ def _metadata(
 
 COMPLETED_RESULT = {
   "content": "Revenue was 1.2M",
-  "operator_used": "Cypher Operator",
+  "operator_used": "Analyst Operator",
   "mode_used": "standard",
   "metadata": {"credits_consumed": 116.7, "rows": [{"total": 1200000}]},
   "tokens_used": {"input": 4, "output": 600, "cache_read": 22881, "cache_write": 0},
@@ -213,6 +213,16 @@ class TestQueuedExecution:
     assert params["operator_type"] == "research"
     assert params["mode"] == "extended"
 
+  def test_former_operator_name_queues_the_canonical_one(self, client, mock_enqueue):
+    """`cypher` was the analyst's name until 2026-08; the path still works and
+    the queued task carries the canonical `analyst`."""
+    response = client.post(
+      f"/v1/graphs/{VALID_TEST_GRAPH_ID}/operator/cypher",
+      json={"message": "Total expenses in July?"},
+    )
+    assert response.status_code == 202
+    assert mock_enqueue.call_args[0][3]["operator_type"] == "analyst"
+
   def test_history_and_credit_ceiling_travel_with_the_task(self, client, mock_enqueue):
     response = client.post(
       f"/v1/graphs/{VALID_TEST_GRAPH_ID}/operator",
@@ -352,7 +362,7 @@ class TestSyncWait:
     assert response.status_code == 200
     data = response.json()
     assert data["content"] == "Revenue was 1.2M"
-    assert data["operator_used"] == "Cypher Operator"
+    assert data["operator_used"] == "Analyst Operator"
     assert data["mode_used"] == "standard"
     assert data["metadata"]["credits_consumed"] == 116.7
     assert data["tokens_used"]["cache_read"] == 22881

--- a/tests/routers/graphs/test_operator_subgraph_integration.py
+++ b/tests/routers/graphs/test_operator_subgraph_integration.py
@@ -48,7 +48,7 @@ def queued_worker():
 
   orchestrator = MagicMock()
   orchestrator.get_operator_recommendations.return_value = [
-    {"operator_type": "cypher", "confidence": 0.9}
+    {"operator_type": "analyst", "confidence": 0.9}
   ]
 
   with (

--- a/tests/routers/test_operations.py
+++ b/tests/routers/test_operations.py
@@ -351,7 +351,7 @@ class TestAwaitingInput:
         "task_type": "operator",
         "graph_id": "kg01234567890abcdef",
         "user_id": "usr_test123",
-        "params": {"operator_type": "cypher"},
+        "params": {"operator_type": "analyst"},
       },
       "requested_at": "2024-01-01T00:02:00Z",
     }

--- a/tests/worker/test_client.py
+++ b/tests/worker/test_client.py
@@ -335,7 +335,7 @@ async def test_requeue_task_pushes_the_same_operation_with_the_answer():
         "task_type": "operator",
         "graph_id": "kg0123456789abcdef",
         "user_id": "user_01TEST",
-        "params": {"operator_type": "cypher", "query": "close?"},
+        "params": {"operator_type": "analyst", "query": "close?"},
       },
       resume={"checkpoint": {"step": 2}, "input": {"approved": True}},
     )
@@ -347,7 +347,7 @@ async def test_requeue_task_pushes_the_same_operation_with_the_answer():
   assert data["task_id"] == "op_01PAUSED"
   assert data["task_type"] == "operator"
   assert data["attempt"] == 1
-  assert data["params"]["operator_type"] == "cypher"
+  assert data["params"]["operator_type"] == "analyst"
   assert data["params"]["resume"] == {
     "checkpoint": {"step": 2},
     "input": {"approved": True},


### PR DESCRIPTION
## Summary

The operator registered as `cypher` answers natural-language questions from a 34-tool read-only surface — curated statements and fact grids, close and mapping status, documents, memory (#1307), GraphQL — and its own prompt tells the model to reach for Cypher only when no curated tool fits. The name had outgrown it, and its self-description (spec, docstring, the prompt's opening line) still said "answers by writing Cypher", contradicting the routing two paragraphs later. This renames it to `analyst` and keeps `cypher` as a registry alias so nothing that stored or hardcoded the old name breaks.

## Changes

- `operations/operators/implementations/cypher.py` → `analyst.py` — `CypherOperator` → `AnalystOperator`, registered as `analyst`. Spec name/description, module docstring, and the system prompt's opening line now describe the operator as it is: curated reads where one fits, documents and memory where the graph has them, read-only Cypher for everything else. `operator_type` on its model calls and the loop's operation description follow. No change to the allowlist, the loop, or the structured `cypher`/`rows` output the console renders.
- `operations/operators/operator_registry.py` — **the part to look at.** New `_ALIASES = {"cypher": "analyst"}` and `resolve_operator_type()`; `get_operator`, `get_operator_class`, and `is_registered` resolve through it. A direct registration always beats an alias; `list_operators()` shows canonical names only.
- `routers/graphs/operator/execute.py` — `_dispatch` resolves the alias before enqueue so the queued task and `operator_used` carry the canonical name; the metadata endpoint resolves it too. Endpoint descriptions name `analyst` and note `cypher` is accepted as its former name. `POST /v1/graphs/{g}/operator/cypher` keeps working.
- `config/operators.py` — `fallback_operator` and the `OPERATOR_CAPABILITIES` key renamed.
- Docs — `CLAUDE.md`, the operators/operations/config READMEs, and docstring mentions in `base.py`, `tool_loop.py`, `adapters/worker.py`.
- Tests — `test_cypher_orientation.py` → `test_analyst_prefetch.py`; registry alias tests (former name resolves, listing stays canonical, direct registration wins); router test that `/operator/cypher` queues `operator_type == "analyst"`; string updates across the worker adapter, orchestrator, config, operations, and worker-client tests.

Not in this PR: no SDK facade or frontend hardcodes the literal (`operator_client.py` in the Python client passes `operator_type` through), so there is nothing to coordinate on the client side. The wiki's operator section is updated separately in the wiki repo.

## Breaking Changes

None. `cypher` remains accepted everywhere it was — URL segment, `operator_type` in requests, queued tasks, stored operations. Responses now report `operator_used: "Analyst Operator"` / `operator_type: "analyst"`; `GET /v1/graphs/{g}/operator` lists `analyst` instead of `cypher`. Generated-tier only; nothing in the SDK facades references the name.

## Testing

- `just test-all` — 14,207 passed, 42 skipped; ruff (one import-order auto-fix), format, basedpyright (0 errors), cf-lint all clean.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
