### PR TITLE
docs(operators): BaseOperator no longer drives any shipped operator

### DIFF
--- a/robosystems/operations/operators/base.py
+++ b/robosystems/operations/operators/base.py
@@ -5,7 +5,10 @@ Two protocols coexist:
 - ``Operator`` / ``OperatorSpec`` / ``OperatorResult`` — the unified protocol.
   Write new operators against this one.
 - ``BaseOperator`` / ``OperatorMetadata`` / ``OperatorResponse`` — the older
-  protocol still driving ``AnalystOperator`` and the orchestrator.
+  protocol. No shipped operator extends ``BaseOperator`` any more
+  (``AnalystOperator`` and ``MappingOperator`` are both ``Operator``); it stays
+  exported for its own tests, and the orchestrator still answers in
+  ``OperatorResponse``.
 
 "Operator" is the AI-executor concept (Claude/MCP), distinct from the REA
 ``Agent`` (counterparty) modeled in ``models/extensions/roboledger/agent.py``.
@@ -265,8 +268,10 @@ class OperatorResponse:
 
 
 class BaseOperator(ABC):
-  """Base class for the older operator protocol, used by ``AnalystOperator``
-  and the orchestrator. New operators inherit from :class:`Operator`.
+  """Base class for the older operator protocol. No shipped operator extends
+  it — ``AnalystOperator`` and ``MappingOperator`` are both :class:`Operator`,
+  which is what new operators inherit from; this stays for its own tests and
+  the orchestrator's ``OperatorResponse``.
   """
 
   def __init__(


### PR DESCRIPTION
## Summary

Follow-up to #1308, from its review. Two docstrings in `operations/operators/base.py` said the older protocol was "still driving `AnalystOperator` and the orchestrator". Neither is true of `BaseOperator`: `AnalystOperator` and `MappingOperator` both extend `Operator`, and the orchestrator only uses the protocol's `OperatorResponse`. The claim predates #1308 (it said the same of `CypherOperator`); the rename carried it forward mechanically.

## Changes

- `operations/operators/base.py` — the module docstring and the `BaseOperator` class docstring now say what is true: no shipped operator extends `BaseOperator`; it stays exported for its own tests, and the orchestrator still answers in `OperatorResponse`. Docstrings only; no code change.

## Breaking Changes

None.

## Testing

- `uv run pytest tests/operations/operators/test_operator_base.py tests/operations/operators/test_operator_base_full.py` — 47 passed.
- `just test-code` — all checks passed (ruff, format, basedpyright 0 errors, cf-lint).
- `just test-all` — not run; docstring-only change.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
