### PR TITLE
chore(deps): dev client floor to 1.12.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # RoboSystems client for demo and testing.
-    "robosystems-client>=1.12.0,<2.0",
+    "robosystems-client>=1.12.2,<2.0",
     # Testing framework
     "pytest>=9.0.0,<10.0",
     "pytest-asyncio>=1.4.0,<2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3822,7 +3822,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.34.2,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=15.0.0,<16.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = ">=1.12.0,<2.0" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = ">=1.12.2,<2.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3848,7 +3848,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "1.12.0"
+version = "1.12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3856,9 +3856,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/c0/9e7fd68367a343602925185e144e0ad4004c97ef8c27c7de350c49bf4f5c/robosystems_client-1.12.0.tar.gz", hash = "sha256:3a1920fe69e7472120a1de28d3ff03a780d3db6dd0874b3b7ce9ee508d3239fc", size = 546608, upload-time = "2026-08-27T03:10:58.485Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/ff/925f36c63ff05001865dd122a970bc3e8673a0995fafd96a6c7ca536bd3a/robosystems_client-1.12.2.tar.gz", hash = "sha256:7d55fdd2625fabe195cff28372e29ed33174d8473e5a83d700a6393f4e6bc5f0", size = 549582, upload-time = "2026-08-29T05:46:55.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/32/777615816a24ee3ef0d667fc450d867f920d4360fa76e5da8edf624dd401/robosystems_client-1.12.0-py3-none-any.whl", hash = "sha256:abad04811c4c8ce9fd802444da56ccbc870e4633c0f9197c952bdf88f4cfeead", size = 1272429, upload-time = "2026-08-27T03:10:56.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e2/da364a1e41c0356f1646f273c67ece528e1dfb81e637e8c5dc453a8f9d54/robosystems_client-1.12.2-py3-none-any.whl", hash = "sha256:bc03926b0c932c0f817074b8e405c37161080043533c563894d0b06e665a24db", size = 1279738, upload-time = "2026-08-29T05:46:53.041Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adopt `robosystems-client` 1.12.2 in the dev dependency group (the client is used only by the demo scripts under `examples/`). The release carries the regenerated operator endpoint docs for the `analyst` rename (#1308) and removes three POC facade methods (`analyze_financials` / `research` / `rag`) that nothing here called.

## Changes

- `pyproject.toml` — dev floor `robosystems-client>=1.12.0,<2.0` → `>=1.12.2,<2.0`, matching the convention from the 1.12.0 bump (`a4c6307a`).
- `uv.lock` — resolves to 1.12.2.

No application code changed; the client is not a runtime dependency of the API.

## Breaking Changes

None.

## Testing

- `just test-code` — ruff, format, basedpyright, cf-lint all clean.
- `just test-all` — not run; dependency floor and lockfile only, and the client is dev-group-only.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
