### PR TITLE
refactor(operators): remove the orchestrator response cache

### DIFF
--- a/robosystems/models/api/graphs/operator.py
+++ b/robosystems/models/api/graphs/operator.py
@@ -268,8 +268,6 @@ class OperatorMetricsResponse(BaseModel):
   average_response_time: float = Field(
     ..., description="Average response time in seconds"
   )
-  cache_hits: int = Field(0, description="Number of cache hits")
-  cache_misses: int = Field(0, description="Number of cache misses")
   errors: int = Field(0, description="Number of errors")
   timestamp: datetime = Field(
     default_factory=datetime.utcnow, description="Metrics timestamp"

--- a/robosystems/operations/operators/orchestrator.py
+++ b/robosystems/operations/operators/orchestrator.py
@@ -59,7 +59,6 @@ class OrchestratorConfig:
 
   routing_strategy: RoutingStrategy = RoutingStrategy.BEST_MATCH
   enable_rag: bool = False
-  enable_caching: bool = False
   enable_fallback: bool = True
   fallback_operator: str | None = None
   max_retries: int = 2
@@ -84,9 +83,8 @@ from robosystems.operations.operators.base import OperatorResponse  # noqa: E402
 class OperatorOrchestrator:
   """Selects and runs operators for one graph and user.
 
-  Instances hold routing state (round-robin position, per-operator metrics, an
-  optional response cache), so one orchestrator serves a conversation rather
-  than the whole process.
+  Instances hold routing state (round-robin position, per-operator metrics),
+  so one orchestrator serves a conversation rather than the whole process.
   """
 
   def __init__(
@@ -105,14 +103,9 @@ class OperatorOrchestrator:
       "total_queries": 0,
       "operator_usage": {},
       "total_response_time": 0.0,
-      "cache_hits": 0,
-      "cache_misses": 0,
       "errors": 0,
     }
 
-    self._cache: dict[str, OperatorResponse] | None = (
-      {} if config and config.enable_caching else None
-    )
     self._round_robin_index = 0
     self._schema_extensions: list[str] | None = None
 
@@ -170,32 +163,19 @@ class OperatorOrchestrator:
     history: list[dict[str, Any]] | None = None,
     context: dict[str, Any] | None = None,
     selection_criteria: OperatorSelectionCriteria | None = None,
-    force_extended: bool = False,
     stream_callback: Callable | None = None,
     ensemble_size: int | None = None,
   ) -> OperatorResponse:
     """Route a query to an operator and return its response.
 
-    An explicit `operator_type` bypasses routing entirely. `force_extended`
-    skips the cache in both directions, so a deliberate re-run is never served
-    a stale answer. Failures are returned as an error-bearing response rather
-    than raised — this is the boundary the API renders directly.
+    An explicit `operator_type` bypasses routing entirely. Failures are
+    returned as an error-bearing response rather than raised — this is the
+    boundary the API renders directly.
     """
     start_time = time.time()
     self._metrics["total_queries"] += 1
 
     try:
-      if self._cache is not None and not force_extended:
-        cache_key = self._get_cache_key(query, operator_type, mode)
-        if cache_key in self._cache:
-          self._metrics["cache_hits"] += 1
-          cached = self._cache[cache_key]
-          if cached.metadata is None:
-            cached.metadata = {}
-          cached.metadata["from_cache"] = True
-          return cached
-        self._metrics["cache_misses"] += 1
-
       context = context or {}
       if history:
         context["has_history"] = True
@@ -248,10 +228,6 @@ class OperatorOrchestrator:
         self._metrics["operator_usage"][operator_name] = {"calls": 0, "total_time": 0.0}
       self._metrics["operator_usage"][operator_name]["calls"] += 1
       self._metrics["operator_usage"][operator_name]["total_time"] += execution_time
-
-      if self._cache is not None and not force_extended:
-        cache_key = self._get_cache_key(query, operator_type, mode)
-        self._cache[cache_key] = response
 
       return response
 
@@ -666,15 +642,8 @@ class OperatorOrchestrator:
       "total_queries": self._metrics["total_queries"],
       "operator_usage": self._metrics["operator_usage"],
       "average_response_time": avg_time,
-      "cache_hits": self._metrics.get("cache_hits", 0),
-      "cache_misses": self._metrics.get("cache_misses", 0),
       "errors": self._metrics["errors"],
     }
-
-  def _get_cache_key(
-    self, query: str, operator_type: str | None, mode: OperatorMode
-  ) -> str:
-    return f"{operator_type or 'auto'}:{mode.value}:{hash(query)}"
 
   def _sum_tokens(self, responses: list[OperatorResponse]) -> dict[str, int]:
     total = {"input": 0, "output": 0}

--- a/tests/operations/operators/test_orchestrator.py
+++ b/tests/operations/operators/test_orchestrator.py
@@ -61,7 +61,6 @@ class TestOrchestratorConfig:
     config = OrchestratorConfig(
       routing_strategy=RoutingStrategy.CAPABILITY_BASED,
       enable_rag=True,
-      enable_caching=True,
       enable_fallback=True,
       fallback_operator="financial",
       max_retries=3,
@@ -75,7 +74,6 @@ class TestOrchestratorConfig:
     config = OrchestratorConfig()
     assert config.routing_strategy == RoutingStrategy.BEST_MATCH
     assert config.enable_rag is False
-    assert config.enable_caching is False
     assert config.enable_fallback is True
     assert config.fallback_operator == "analyst"
 
@@ -363,20 +361,6 @@ class TestOperatorOrchestrator:
       query="Stream this response", mode=OperatorMode.STREAMING
     )
     assert response.mode_used == OperatorMode.STREAMING
-
-  @pytest.mark.asyncio
-  async def test_caching_enabled(self, orchestrator):
-    orchestrator.config.enable_caching = True
-    orchestrator._cache = {}
-
-    response1 = await orchestrator.route_query(
-      query="Cached query", mode=OperatorMode.QUICK
-    )
-    response2 = await orchestrator.route_query(
-      query="Cached query", mode=OperatorMode.QUICK
-    )
-    assert response1.content == response2.content
-    assert response2.metadata.get("from_cache") is True
 
   @pytest.mark.asyncio
   async def test_load_balanced_routing(self, orchestrator):


### PR DESCRIPTION
## Summary

Removes the orchestrator's opt-in in-memory response cache. It was never enabled in production and could not have worked as written, but its key omitted the graph scope, which made it a trap for whoever switched it on next. The Bedrock prompt cache that carries the operators' actual cost savings lives in `AIClient` and is untouched.

## Changes

- `robosystems/operations/operators/orchestrator.py`
  - Drop `OrchestratorConfig.enable_caching`, the `_cache` dict, `_get_cache_key`, the read/write around `route_query`, and the `cache_hits` / `cache_misses` counters from `get_metrics()`.
  - Drop the `force_extended` parameter on `route_query` — it existed only to bypass this cache. (The API's `force_extended_analysis` is unrelated: it selects the mode at the router and is unchanged.)
  - Why removal rather than a better key: the cache was off by default, the one production constructor never enabled it, and `route_query` has no production caller (the router uses `get_operator_recommendations` and hands execution to the worker). The key also used `hash(str)`, which is salted per process, so no entry would have survived a worker boundary.
- `tests/operations/operators/test_orchestrator.py` — remove the `enable_caching` config assertions and the `test_caching_enabled` case.
- `robosystems/models/api/graphs/operator.py` — drop `cache_hits` / `cache_misses` from `OperatorMetricsResponse`, which mirrors `get_metrics()`. The model is exported but bound to no router, so it is absent from the OpenAPI spec and both SDKs (verified by grep of the generated clients).

Net −49 lines, no behavior change on any reachable path.

## Breaking Changes

None. Nothing here reaches the OpenAPI spec or either SDK tier; `OrchestratorConfig` and `route_query` are internal Python surface.

## Testing

- `just test-code` — all checks passed (ruff, format, basedpyright, cf-lint).
- `uv run pytest tests/operations/operators/ tests/routers/graphs/test_operator_router.py` — 240 passed; `tests/models/api/test_operator_models.py` + `test_orchestrator.py` re-run after the model change — 47 passed.
- `just test-all` not run in-session; the PR's `test / test` job passed on the first commit (10m49s) and is re-running on the second.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
