### PR TITLE
Tidy the demo surface: collapse Seattle Method recipes, make `just demo` the suite, de-essay the justfile

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -209,13 +209,13 @@ reconciled against his published figures (18/18 concepts; balance sheet balances
 at $14,450).
 
 ```bash
-just demo-seattle-method                      # new graph + every step
-just demo-seattle-method --graph <id>         # against an existing graph
-just demo-seattle-method --step <name>        # re-run a single step
-just demo-seattle-method --dry-run            # validate + report, no writes
+just demo-seattle-method                            # new graph + every step
+just demo-seattle-method --graph <id>               # against an existing graph
+just demo-seattle-method --dry-run                  # validate + report, no writes
 
-just demo-seattle-method-reconcile            # reconciliation report only
-just demo-seattle-method-create-report        # materialize the 4-statement report
+# Re-run one step against the cached graph (--help lists every step name)
+just demo-seattle-method --step reconcile           # reconciliation report only
+just demo-seattle-method --step create-report       # materialize the 4-statement report
 ```
 
 Artifacts land in `examples/seattle_method_demo/output/`: two markdown reports
@@ -237,16 +237,16 @@ reconcile line-for-line against the source pivot (22/23; balance sheet balances
 to $0.00; trial balance balances).
 
 ```bash
-just demo-world-online                          # new graph + every step
-just demo-world-online --graph <id>             # against an existing graph
-just demo-world-online --step <name>            # re-run a single step
-just demo-world-online --limit 50               # smoke-test on a GL subset
-just demo-world-online --dry-run                # validate + report, no writes
+just demo-world-online                                 # new graph + every step
+just demo-world-online --graph <id>                    # against an existing graph
+just demo-world-online --limit 50                      # smoke-test on a GL subset
+just demo-world-online --dry-run                       # validate + report, no writes
 
-just demo-world-online-reconcile                # pivot vs SummaryOfTransactions.csv
-just demo-world-online-create-report            # materialize the 4-statement report
-just demo-world-online-trial-balance            # render the trial balance
-just demo-world-online-statement-reconcile      # statement anchors vs the reference instance
+# Re-run one step against the cached graph (--help lists every step name)
+just demo-world-online --step reconcile                # pivot vs SummaryOfTransactions.csv
+just demo-world-online --step create-report            # materialize the 4-statement report
+just demo-world-online --step trial-balance            # render the trial balance
+just demo-world-online --step statement-reconcile      # statement anchors vs the reference instance
 ```
 
 ## Credentials

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,7 +20,7 @@ need AWS Bedrock configured; without it, use the default hardcoded mappings.
 ## Quick Start
 
 ```bash
-# Run the core three in sequence (roboledger → custom-graph → sec)
+# Run the whole suite in sequence. Long — the World Online GL ingest dominates.
 just demo
 
 # Or pick one
@@ -29,6 +29,20 @@ just demo-roboinvestor
 just demo-custom-graph
 just demo-sec --ticker NVDA --year 2025
 ```
+
+`just demo` runs `demo-user` first, so it is self-contained on a fresh
+checkout, and orders the rest so each demo can reuse what the previous one
+built — `demo-saas-startup` runs before `demo-roboinvestor`, which adopts the
+cached Cadence Labs graph as its issuer instead of provisioning a second one.
+Every demo caches its graph in `.local/config.json` under its own slot, so
+re-running is idempotent rather than additive.
+
+**The SEC demo is deliberately not in `just demo`.** It drops and recreates the
+whole local `sec` graph, which would silently discard a corpus that took hours
+to build or 35 GiB to download. Populate that graph on its own terms —
+`just sec-dump` for the prebuilt public dump, or the `sec-*` pipeline recipes to
+build it from scratch — and run `just demo-sec` by itself when you want the
+walkthrough.
 
 ## The Demos
 

--- a/examples/seattle_method_demo/README.md
+++ b/examples/seattle_method_demo/README.md
@@ -47,10 +47,12 @@ just demo-seattle-method --graph <id> --step reconcile          # mini reconcili
 just demo-seattle-method --graph <id> --step create-report      # rs-gaap 4-IB Report only
 just demo-seattle-method --graph <id> --step download-bundles   # export + validate + DataBook
 
-# Reconcile + create-report can also be run via their dedicated recipes
-# (handy when iterating on the markdown rendering without re-provisioning):
-just demo-seattle-method-reconcile <graph_id>
-just demo-seattle-method-create-report <graph_id>
+# --graph is optional on a single step: it falls back to the cached
+# seattle_method_test slot, so iterating on the markdown rendering needs
+# no graph id and no re-provisioning.
+just demo-seattle-method --step reconcile
+just demo-seattle-method --step reconcile --no-diff   # skip the published-instance diff
+just demo-seattle-method --step create-report
 ```
 
 ## What Gets Created

--- a/examples/seattle_method_demo/create_report.py
+++ b/examples/seattle_method_demo/create_report.py
@@ -19,9 +19,9 @@ Three steps:
 Prerequisites: ``just demo-seattle-method`` has run against the graph, so the
 CoA, mappings and journal entries are in place.
 
-Run it (the orchestrator runs this as step 8):
-    just demo-seattle-method-create-report <graph_id>
-    just demo-seattle-method-create-report          # cached graph slot
+Run it (step 8 of the orchestrator; --graph defaults to the cached slot):
+    just demo-seattle-method --step create-report
+    just demo-seattle-method --step create-report --graph <graph_id>
 
 Writes ``output/seattle-method-case-1-four-statements.md``.
 """

--- a/examples/seattle_method_demo/main.py
+++ b/examples/seattle_method_demo/main.py
@@ -321,7 +321,9 @@ def step_author_rollforwards(graph_id: str, dry_run: bool = False) -> None:
   print(f"  {action} {created} rollforward IB(s)")
 
 
-def step_reconcile(graph_id: str, dry_run: bool = False) -> None:
+def step_reconcile(
+  graph_id: str, dry_run: bool = False, no_diff: bool = False
+) -> None:
   """Step 7 — Reconcile against Charlie Hoffman's published mini facts.
 
   Writes ``output/seattle-method-case-1.md`` — the source-vocabulary
@@ -334,18 +336,17 @@ def step_reconcile(graph_id: str, dry_run: bool = False) -> None:
   if dry_run:
     print("  (dry-run — skipping reconcile)")
     return
-  result = subprocess.run(
-    [
-      "uv",
-      "run",
-      "python",
-      "-m",
-      "examples.seattle_method_demo.reconcile",
-      graph_id,
-    ],
-    cwd=str(REPO_ROOT),
-    check=False,
-  )
+  cmd = [
+    "uv",
+    "run",
+    "python",
+    "-m",
+    "examples.seattle_method_demo.reconcile",
+    graph_id,
+  ]
+  if no_diff:
+    cmd.append("--no-diff")
+  result = subprocess.run(cmd, cwd=str(REPO_ROOT), check=False)
   if result.returncode != 0:
     raise SystemExit(f"reconcile exited with code {result.returncode}")
 
@@ -414,6 +415,21 @@ def step_create_report(graph_id: str, dry_run: bool = False) -> None:
     raise SystemExit(f"create_report exited with code {result.returncode}")
 
 
+def _resolve_step_graph_id(cli_graph: str | None) -> str:
+  """Resolve the target graph for a single-step run.
+
+  An explicit ``--graph`` wins; otherwise fall back to the
+  ``seattle_method_test`` slot the provision step cached, so re-running one
+  step never requires remembering the id.
+  """
+  if cli_graph:
+    return cli_graph
+
+  from examples._common.config import require_cached_graph_id, require_config
+
+  return require_cached_graph_id(require_config(), DEMO_NAME, "just demo-seattle-method")
+
+
 # ── Step registry ────────────────────────────────────────────────────────
 
 STEPS = {
@@ -465,6 +481,11 @@ def main() -> None:
     action="store_true",
     help="Validate + report; do not write to the API.",
   )
+  parser.add_argument(
+    "--no-diff",
+    action="store_true",
+    help="reconcile step only: skip the diff against the published instance.",
+  )
   args = parser.parse_args()
 
   # Single-step mode.
@@ -476,13 +497,14 @@ def main() -> None:
       graph_id = fn()
       print(f"\nProvisioned graph: {graph_id}")
       print(f"To continue: --graph {graph_id} --step <next>")
+    elif args.step == "reconcile":
+      fn(
+        _resolve_step_graph_id(args.graph),
+        dry_run=args.dry_run,
+        no_diff=args.no_diff,
+      )
     else:
-      if not args.graph:
-        raise SystemExit(
-          f"--step {args.step} requires --graph <id> "
-          "(or run end-to-end without --step to provision one)."
-        )
-      fn(args.graph, dry_run=args.dry_run)
+      fn(_resolve_step_graph_id(args.graph), dry_run=args.dry_run)
     return
 
   # Full end-to-end run.

--- a/examples/seattle_method_demo/reconcile.py
+++ b/examples/seattle_method_demo/reconcile.py
@@ -21,9 +21,10 @@ pull step has fetched the reference instance. ``EXTENSIONS_DATABASE_URL`` must
 be set — the ``just`` recipe below loads it from ``.env.local``; export it
 yourself when invoking the module directly.
 
-Run it (the orchestrator runs this as step 7):
-    just demo-seattle-method-reconcile <graph_id>
-    just demo-seattle-method-reconcile <graph_id> --no-diff   # skip the diff
+Run it (step 7 of the orchestrator; --graph defaults to the cached slot):
+    just demo-seattle-method --step reconcile
+    just demo-seattle-method --step reconcile --graph <graph_id>
+    just demo-seattle-method --step reconcile --no-diff   # skip the diff
 
 Writes ``output/seattle-method-case-1.md``.
 """
@@ -59,8 +60,8 @@ EXPECTED_INSTANCE_PATH = (
 )
 # The filter engine needs a direct SQLAlchemy session, so
 # ``EXTENSIONS_DATABASE_URL`` must be in the process env. The
-# ``just demo-seattle-method-reconcile`` recipe loads ``.env.local``, which
-# sets it; export it yourself when invoking this module directly.
+# ``just demo-seattle-method`` recipe loads ``.env.local``, which sets it;
+# export it yourself when invoking this module directly.
 EXTENSIONS_DB_URL = os.environ.get("EXTENSIONS_DATABASE_URL")
 SAFE_GRAPH_ID = re.compile(r"^kg[a-zA-Z0-9_]+$")
 
@@ -287,7 +288,7 @@ def _open_session(graph_id: str) -> Session:
   if not EXTENSIONS_DB_URL:
     raise SystemExit(
       "EXTENSIONS_DATABASE_URL is not set. Run via "
-      "`just demo-seattle-method-reconcile <graph_id>` (which loads "
+      "`just demo-seattle-method --step reconcile` (which loads "
       ".env.local), or export the env var manually."
     )
   engine = create_engine(EXTENSIONS_DB_URL)

--- a/examples/seattle_method_world_online/README.md
+++ b/examples/seattle_method_world_online/README.md
@@ -32,12 +32,15 @@ just demo-world-online
 # Smoke-test the whole pipeline on a 50-entry subset first
 just demo-world-online --limit 50
 
-# Single step (after provisioning)
+# Single step (after provisioning). --graph is optional — it falls back to
+# the cached world_online_test slot.
 just demo-world-online --step ingest --graph <graph_id>
 
-# Re-run just the artifacts against an existing graph
-just demo-world-online-reconcile <graph_id>
-just demo-world-online-create-report <graph_id>
+# Re-run just the artifacts against the cached graph
+just demo-world-online --step reconcile
+just demo-world-online --step create-report
+just demo-world-online --step trial-balance
+just demo-world-online --step statement-reconcile
 ```
 
 ## What Gets Created

--- a/examples/seattle_method_world_online/create_report.py
+++ b/examples/seattle_method_world_online/create_report.py
@@ -22,9 +22,9 @@ movement over the full span.
 Prerequisites: ``just demo-world-online`` has loaded the CoA, seeded the
 mappings and ingested the GL.
 
-Run it (the orchestrator runs this as step 8):
-    just demo-world-online-create-report <graph_id>
-    just demo-world-online-create-report          # cached graph slot
+Run it (step 8 of the orchestrator; --graph defaults to the cached slot):
+    just demo-world-online --step create-report
+    just demo-world-online --step create-report --graph <graph_id>
 
 Writes ``output/world-online-four-statements.md``.
 """
@@ -186,8 +186,8 @@ number.
 ### Reproduce
 
 ```bash
-just demo-world-online                         # full pipeline
-just demo-world-online-create-report {graph_id}  # this report only
+just demo-world-online                        # full pipeline
+just demo-world-online --step create-report   # this report only
 ```
 """
   return body

--- a/examples/seattle_method_world_online/main.py
+++ b/examples/seattle_method_world_online/main.py
@@ -303,7 +303,9 @@ def step_author_rollforwards(graph_id: str, dry_run: bool = False) -> None:
   print(f"  {action} {created} rollforward IB(s)")
 
 
-def step_reconcile(graph_id: str, dry_run: bool = False) -> None:
+def step_reconcile(
+  graph_id: str, dry_run: bool = False, no_diff: bool = False
+) -> None:
   """Step 7 — reconcile the graph pivot against SummaryOfTransactions.csv."""
   print("─" * 70)
   print(f"Step 7 — reconcile vs SummaryOfTransactions.csv → graph {graph_id}")
@@ -311,18 +313,17 @@ def step_reconcile(graph_id: str, dry_run: bool = False) -> None:
   if dry_run:
     print("  (dry-run — skipping reconcile)")
     return
-  result = subprocess.run(
-    [
-      "uv",
-      "run",
-      "python",
-      "-m",
-      "examples.seattle_method_world_online.reconcile",
-      graph_id,
-    ],
-    cwd=str(REPO_ROOT),
-    check=False,
-  )
+  cmd = [
+    "uv",
+    "run",
+    "python",
+    "-m",
+    "examples.seattle_method_world_online.reconcile",
+    graph_id,
+  ]
+  if no_diff:
+    cmd.append("--no-diff")
+  result = subprocess.run(cmd, cwd=str(REPO_ROOT), check=False)
   if result.returncode != 0:
     raise SystemExit(f"reconcile exited with code {result.returncode}")
 
@@ -409,7 +410,9 @@ def step_download_bundles(graph_id: str, dry_run: bool = False) -> None:
     raise SystemExit(f"download_bundles exited with code {result.returncode}")
 
 
-def step_statement_reconcile(graph_id: str, dry_run: bool = False) -> None:
+def step_statement_reconcile(
+  graph_id: str, dry_run: bool = False, no_fetch: bool = False
+) -> None:
   """Step 11 — statement-level reconcile vs the published reference instance.
 
   Reads the four-statement anchor totals out of the JSON-LD bundle step 10
@@ -423,19 +426,33 @@ def step_statement_reconcile(graph_id: str, dry_run: bool = False) -> None:
   if dry_run:
     print("  (dry-run — skipping statement reconcile)")
     return
-  result = subprocess.run(
-    [
-      "uv",
-      "run",
-      "python",
-      "-m",
-      "examples.seattle_method_world_online.statement_reconcile",
-    ],
-    cwd=str(REPO_ROOT),
-    check=False,
-  )
+  cmd = [
+    "uv",
+    "run",
+    "python",
+    "-m",
+    "examples.seattle_method_world_online.statement_reconcile",
+  ]
+  if no_fetch:
+    cmd.append("--no-fetch")
+  result = subprocess.run(cmd, cwd=str(REPO_ROOT), check=False)
   if result.returncode != 0:
     raise SystemExit(f"statement_reconcile exited with code {result.returncode}")
+
+
+def _resolve_step_graph_id(cli_graph: str | None) -> str:
+  """Resolve the target graph for a single-step run.
+
+  An explicit ``--graph`` wins; otherwise fall back to the
+  ``world_online_test`` slot the provision step cached, so re-running one
+  step never requires remembering the id.
+  """
+  if cli_graph:
+    return cli_graph
+
+  from examples._common.config import require_cached_graph_id, require_config
+
+  return require_cached_graph_id(require_config(), DEMO_NAME, "just demo-world-online")
 
 
 # ── Step registry ──────────────────────────────────────────────────────────
@@ -483,6 +500,16 @@ def main() -> None:
   parser.add_argument(
     "--dry-run", action="store_true", help="Validate + report; no API writes."
   )
+  parser.add_argument(
+    "--no-diff",
+    action="store_true",
+    help="reconcile step only: print the graph pivot; skip the comparison.",
+  )
+  parser.add_argument(
+    "--no-fetch",
+    action="store_true",
+    help="statement-reconcile step only: use the cached reference instance.",
+  )
   args = parser.parse_args()
 
   # Single-step mode.
@@ -495,15 +522,15 @@ def main() -> None:
       print(f"\nProvisioned graph: {graph_id}")
       print(f"To continue: --graph {graph_id} --step <next>")
     else:
-      if not args.graph:
-        raise SystemExit(
-          f"--step {args.step} requires --graph <id> "
-          "(or run end-to-end without --step to provision one)."
-        )
+      graph_id = _resolve_step_graph_id(args.graph)
       if args.step == "ingest":
-        fn(args.graph, dry_run=args.dry_run, limit=args.limit)
+        fn(graph_id, dry_run=args.dry_run, limit=args.limit)
+      elif args.step == "reconcile":
+        fn(graph_id, dry_run=args.dry_run, no_diff=args.no_diff)
+      elif args.step == "statement-reconcile":
+        fn(graph_id, dry_run=args.dry_run, no_fetch=args.no_fetch)
       else:
-        fn(args.graph, dry_run=args.dry_run)
+        fn(graph_id, dry_run=args.dry_run)
     return
 
   # Full end-to-end run.

--- a/examples/seattle_method_world_online/reconcile.py
+++ b/examples/seattle_method_world_online/reconcile.py
@@ -29,9 +29,10 @@ Prerequisites: ``just demo-world-online`` has ingested the GL, and
 ``EXTENSIONS_DATABASE_URL`` is set — the ``just`` recipe loads it from
 ``.env.local``; export it yourself when invoking the module directly.
 
-Run it (the orchestrator runs this as step 7):
-    just demo-world-online-reconcile <graph_id>
-    just demo-world-online-reconcile <graph_id> --no-diff   # print the pivot only
+Run it (step 7 of the orchestrator; --graph defaults to the cached slot):
+    just demo-world-online --step reconcile
+    just demo-world-online --step reconcile --graph <graph_id>
+    just demo-world-online --step reconcile --no-diff   # print the pivot only
 
 Writes ``output/world-online-reconciliation.md``.
 """
@@ -124,7 +125,7 @@ def _open_session(graph_id: str) -> Iterator[Session]:
   if not EXTENSIONS_DB_URL:
     raise SystemExit(
       "EXTENSIONS_DATABASE_URL is not set. Run via "
-      "`just demo-world-online-reconcile <graph_id>` (which loads "
+      "`just demo-world-online --step reconcile` (which loads "
       ".env.local), or export the env var manually."
     )
   engine = create_engine(EXTENSIONS_DB_URL)
@@ -401,8 +402,8 @@ def render_markdown(
     "## How to reproduce",
     "",
     "```bash",
-    "just demo-world-online                       # full pipeline",
-    "just demo-world-online-reconcile <graph_id>  # this report only",
+    "just demo-world-online                     # full pipeline",
+    "just demo-world-online --step reconcile    # this report only",
     "```",
   ]
   return "\n".join(lines)

--- a/examples/seattle_method_world_online/statement_reconcile.py
+++ b/examples/seattle_method_world_online/statement_reconcile.py
@@ -22,9 +22,9 @@ published artifact is what gets reconciled — not an internal query behind it.
 Prerequisites: ``just demo-world-online`` has run through the download-bundles
 step, which writes ``output/world-online.jsonld``.
 
-Run it (the orchestrator runs this as step 11):
-    just demo-world-online-statement-reconcile
-    just demo-world-online-statement-reconcile --no-fetch   # use the cached reference
+Run it (step 11 of the orchestrator):
+    just demo-world-online --step statement-reconcile
+    just demo-world-online --step statement-reconcile --no-fetch   # cached reference
 
 Writes ``output/world-online-statement-reconciliation.md``.
 """
@@ -254,8 +254,8 @@ def render(graph_bundle: Path, rows: list[Row]) -> str:
     "## How to reproduce",
     "",
     "```bash",
-    "just demo-world-online                                 # full pipeline",
-    "just demo-world-online-statement-reconcile             # this report only",
+    "just demo-world-online                               # full pipeline",
+    "just demo-world-online --step statement-reconcile    # this report only",
     "```",
   ]
   return "\n".join(lines) + "\n"

--- a/examples/seattle_method_world_online/trial_balance.py
+++ b/examples/seattle_method_world_online/trial_balance.py
@@ -17,9 +17,9 @@ opening balances are included rather than assumed.
 
 Prerequisites: ``just demo-world-online`` has ingested the GL.
 
-Run it (the orchestrator runs this as step 9):
-    just demo-world-online-trial-balance <graph_id>
-    just demo-world-online-trial-balance          # cached graph slot
+Run it (step 9 of the orchestrator; --graph defaults to the cached slot):
+    just demo-world-online --step trial-balance
+    just demo-world-online --step trial-balance --graph <graph_id>
 
 Writes ``output/world-online-trial-balance.md``.
 """
@@ -150,7 +150,8 @@ def render(graph_id: str, rows: list) -> str:
     "### Reproduce",
     "",
     "```bash",
-    f"just demo-world-online-trial-balance {graph_id}",
+    "just demo-world-online                        # full pipeline",
+    f"just demo-world-online --step trial-balance --graph {graph_id}",
     "```",
   ]
   return "\n".join(lines)

--- a/justfile
+++ b/justfile
@@ -227,11 +227,16 @@ framework-validate *args="":
 
 ## Demo Scripts ##
 
-# Run all demos
+# Run all demos except SEC, in dependency order (long)
 demo:
+    @just demo-user
     @just demo-roboledger
+    @just demo-coffee-roaster
+    @just demo-saas-startup
+    @just demo-roboinvestor
     @just demo-custom-graph
-    @just demo-sec
+    @just demo-seattle-method
+    @just demo-world-online
 
 # Create or reuse demo user (uses shared .local/config.json)
 demo-user *args="":

--- a/justfile
+++ b/justfile
@@ -269,37 +269,13 @@ demo-roboinvestor *args="":
 demo-custom-graph *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.custom_graph_demo.main {{args}}
 
-# Run Seattle Method cross-taxonomy demo (Test Case 1 — Charlie Hoffman's mini, 14 JEs). Flags: --dry-run, --step <name>, --graph <id>
+# Run Seattle Method cross-taxonomy demo (Test Case 1 — Charlie Hoffman's mini, 14 JEs). Flags: --step <name> (re-run one step; see --help), --graph <id>, --dry-run, --no-diff
 demo-seattle-method *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.seattle_method_demo.main {{args}}
 
-# Render the Seattle Method reconciliation report for a graph after the main demo has run
-demo-seattle-method-reconcile *args="":
-    UV_ENV_FILE={{_local_env}} uv run python -m examples.seattle_method_demo.reconcile {{args}}
-
-# Materialize the Seattle Method 4-IB rs-gaap Report (BS / IS / CF / SE) for a graph after the main demo has run
-demo-seattle-method-create-report *args="":
-    UV_ENV_FILE={{_local_env}} uv run python -m examples.seattle_method_demo.create_report {{args}}
-
-# Run "The World Online" demo (Seattle Method MINI 2026 — Charlie Hoffman's 22,288-line GL). Flags: --dry-run, --step <name>, --graph <id>, --limit <n>
+# Run "The World Online" demo (Seattle Method MINI 2026 — Charlie Hoffman's 22,288-line GL). Flags: --step <name> (re-run one step; see --help), --graph <id>, --limit <n>, --dry-run, --no-diff, --no-fetch
 demo-world-online *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.seattle_method_world_online.main {{args}}
-
-# Render the World Online reconciliation report (mini pivot vs SummaryOfTransactions.csv) for a graph after the main demo has run
-demo-world-online-reconcile *args="":
-    UV_ENV_FILE={{_local_env}} uv run python -m examples.seattle_method_world_online.reconcile {{args}}
-
-# Materialize the World Online 4-statement rs-gaap Report (BS / IS / CF / SE) for a graph after the main demo has run
-demo-world-online-create-report *args="":
-    UV_ENV_FILE={{_local_env}} uv run python -m examples.seattle_method_world_online.create_report {{args}}
-
-# Render the World Online trial balance for a graph after the main demo has run
-demo-world-online-trial-balance *args="":
-    UV_ENV_FILE={{_local_env}} uv run python -m examples.seattle_method_world_online.trial_balance {{args}}
-
-# Statement-level reconcile of the World Online four-statement anchors vs Charlie's reference instance.xml (after the main demo has written the bundle)
-demo-world-online-statement-reconcile *args="":
-    UV_ENV_FILE={{_local_env}} uv run python -m examples.seattle_method_world_online.statement_reconcile {{args}}
 
 
 ## CI/CD ##

--- a/justfile
+++ b/justfile
@@ -41,7 +41,7 @@ stop profile="robosystems":
 teardown profile="robosystems":
     docker compose -f compose.yaml --profile {{profile}} down
 
-# Upgrade to the latest images - pulls published images, or rebuilds in build mode (scope="all" also refreshes postgres/valkey/opensearch)
+# Fetch latest images (or rebuild) and recreate what changed
 upgrade profile="robosystems" scope="":
     @bin/tools/upgrade.sh {{profile}} {{scope}}
 
@@ -59,7 +59,7 @@ restart profile="robosystems":
 restart-container container="worker":
     docker compose -f compose.yaml restart robosystems-{{container}}
 
-# Restart graph-api if it is running (it holds replaced .lbug files open) and wait until it is healthy
+# Restart graph-api if running and wait until it is healthy
 graph-api-restart:
     @[ -z "$(docker ps --filter name=^robosystems-graph-api$ -q)" ] || docker compose -f compose.yaml restart graph-api
     @[ -z "$(docker ps --filter name=^robosystems-graph-api$ -q)" ] || (curl -fs --retry 30 --retry-delay 2 --retry-all-errors -o /dev/null http://localhost:8001/health && echo "graph-api healthy")
@@ -133,10 +133,7 @@ test-all:
     @just cf-lint-all
     @just lint-actions
 
-# Run tests (exclude slow tests). Parallel across cores: each xdist worker
-# gets its own platform test database (tests/xdist_workers.py); `loadfile`
-# keeps a file's tests on one worker so module-scoped tenant schemas in the
-# shared extensions DB never race themselves.
+# Run tests, excluding slow ones — optional module path
 test module="":
     uv run pytest \
         {{ if module != "" { "tests/" + module } else { "" } }} \
@@ -185,11 +182,7 @@ format:
 typecheck module="":
     @uv run basedpyright {{ if module != "" { "robosystems/" + module } else { "" } }}
 
-# CloudFormation linting and validation
-# validate-template only accepts a template body up to 51,200 bytes. Templates
-# that deploy from S3 (api.yaml) are allowed to exceed that, so validate is
-# skipped for them rather than failing — cfn-lint above has no size limit and
-# does the static analysis that matters here.
+# Lint + validate one CloudFormation template
 cf-lint template:
     @uv run cfn-lint -t cloudformation/{{template}}.yaml
     @size=$(wc -c < cloudformation/{{template}}.yaml | tr -d ' '); \
@@ -203,16 +196,7 @@ cf-lint template:
 cf-lint-all:
     @uv run cfn-lint -t cloudformation/*.yaml
 
-# Lint GitHub Actions workflows and composite actions.
-#
-# GitHub does not validate a workflow file until it is triggered, so a malformed
-# expression is invisible until it breaks a run — and for a reusable workflow like
-# service-refresh.yml, the run it breaks is a deploy. Accepted pre-existing
-# findings are baselined in .github/actionlint.yaml, so any output here is new.
-#
-# shellcheck integration is off: it reports dozens of info-level SC2086 quoting
-# notes across workflows that predate this recipe, which would drown the errors
-# that actually invalidate a file. Run `just lint-actions-shell` to see them.
+# Lint GitHub Actions workflows and composite actions
 lint-actions:
     @uv run actionlint -shellcheck=
 
@@ -220,7 +204,7 @@ lint-actions:
 lint-actions-shell:
     @uv run actionlint
 
-# Validate the rs-gaap framework: structure + package integrity + CoA coverage (--summary terse, --coverage-only for just coverage)
+# Validate the rs-gaap framework: structure, package integrity, CoA coverage
 framework-validate *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m robosystems.scripts.framework_validate {{args}}
 
@@ -242,11 +226,11 @@ demo:
 demo-user *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.credentials.main {{args}}
 
-# Setup SEC repository demo (pass any flags: --ticker NVDA, --year 2025, --skip-queries, --subscribe-only, --plan starter)
+# Set up the SEC repository demo — load filings, subscribe, run queries
 demo-sec *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.sec_demo.main {{args}}
 
-# Create SEC subscription only (no data loading) - plan: sec-starter (default) | sec-advanced (5x rate limits, more credits)
+# Create the SEC subscription only, no data load
 demo-sec-subscribe plan="sec-starter":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.sec_demo.main --subscribe-only --plan {{plan}}
 
@@ -254,31 +238,31 @@ demo-sec-subscribe plan="sec-starter":
 demo-sec-query *args:
     UV_ENV_FILE={{_local_env}} uv run python -m examples.sec_demo.query_examples {{args}}
 
-# Run RoboLedger demo (flags: --skeleton (empty graph, no data), --ai (MappingOperator; needs Bedrock), --dry-run, [graph_id])
+# Run the RoboLedger demo — Cascade Advisory, the full accounting arc
 demo-roboledger *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.roboledger_demo.main {{args}}
 
-# Run Coffee Roaster showcase demo — Driftline Coffee (profitable-but-cash-poor). Flags: --ai (MappingOperator; needs Bedrock), --dry-run, [graph_id]
+# Run the Coffee Roaster showcase — Driftline, profitable but cash-poor
 demo-coffee-roaster *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.coffee_roaster_demo.main {{args}}
 
-# Run SaaS Startup showcase demo — Cadence Labs (burning cash, deferred-revenue runway). Flags: --ai (MappingOperator; needs Bedrock), --dry-run, [graph_id]
+# Run the SaaS Startup showcase — Cadence Labs, burn behind deferred revenue
 demo-saas-startup *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.saas_startup_demo.main {{args}}
 
-# Run RoboInvestor demo — Meridian Ventures Fund I, incl. the cross-graph report share (flags: --issuer <id>, --reload-issuer, --skip-share, --revoke, --dry-run, [graph_id])
+# Run the RoboInvestor demo — Meridian fund, incl. the cross-graph report share
 demo-roboinvestor *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.roboinvestor_demo.main {{args}}
 
-# Run custom graph demo end-to-end (pass any flags: --new-user, --new-graph, --skip-queries)
+# Run the custom graph demo end-to-end — your own schema
 demo-custom-graph *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.custom_graph_demo.main {{args}}
 
-# Run Seattle Method cross-taxonomy demo (Test Case 1 — Charlie Hoffman's mini, 14 JEs). Flags: --step <name> (re-run one step; see --help), --graph <id>, --dry-run, --no-diff
+# Run the Seattle Method cross-taxonomy demo — Charlie Hoffman's mini, 14 JEs
 demo-seattle-method *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.seattle_method_demo.main {{args}}
 
-# Run "The World Online" demo (Seattle Method MINI 2026 — Charlie Hoffman's 22,288-line GL). Flags: --step <name> (re-run one step; see --help), --graph <id>, --limit <n>, --dry-run, --no-diff, --no-fetch
+# Run The World Online demo — Seattle Method at scale, 22,288 GL lines
 demo-world-online *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m examples.seattle_method_world_online.main {{args}}
 
@@ -305,18 +289,10 @@ tunnel environment service="all":
 ## Bootstrap ##
 
 # Bootstrap AWS OIDC federation for GitHub Actions
-# Usage: just bootstrap [profile] [region]
-#   profile: AWS SSO profile name (default: robosystems-sso)
-#   region:  AWS region (default: us-east-1)
 bootstrap profile="robosystems-sso" region="us-east-1":
     @bin/setup/bootstrap.sh "{{profile}}" "{{region}}"
 
-# Re-apply the GitHub OIDC stack only (the deploy roles) — after editing
-# cloudformation/bootstrap-oidc.yaml. Previews the change set and asks before
-# applying; a stack that already matches the template is reported, not touched.
-# Refreshes AWS_ROLE_ARN / AWS_ACCOUNT_ID / AWS_REGION if they drifted. No ECR,
-# SES, secrets or other variables are touched.
-# Usage: just bootstrap-oidc [profile] [region]
+# Re-apply the GitHub OIDC stack only — previews the change set, asks before applying
 bootstrap-oidc profile="robosystems-sso" region="us-east-1":
     @bin/setup/bootstrap.sh --oidc "{{profile}}" "{{region}}"
 
@@ -328,16 +304,11 @@ setup-aws:
 setup-gha:
     @bin/setup/gha.sh
 
-# Bedrock local development setup (creates IAM user, updates .env)
-# Pass "rotate" to rotate the access key: just setup-bedrock rotate
+# Bedrock local dev setup — creates IAM user, updates .env; pass "rotate" to rotate the key
 setup-bedrock *args:
     @bin/setup/bedrock.sh {{ args }}
 
-# Apply the operational ECR image lifecycle policy (idempotent reconcile)
-# Single source of truth: bin/setup/ecr-lifecycle-policy.json (also applied by
-# bootstrap when the robust option is chosen). Use this recipe to reconcile the
-# live repo after editing that file, without re-running full bootstrap.
-# Usage: just bootstrap-ecr-lifecycle [repo] [region]
+# Reconcile the ECR image lifecycle policy from bin/setup/ecr-lifecycle-policy.json
 bootstrap-ecr-lifecycle repo="robosystems" region="us-east-1":
     @echo "Applying ECR lifecycle policy to {{repo}} ({{region}})..."
     @aws ecr put-lifecycle-policy \
@@ -418,12 +389,7 @@ gha-list-org filter="":
 
 ## Admin CLI ##
 
-# For staging/prod: start tunnel first with ./bin/tools/tunnels.sh <env> all
-# Examples: just admin dev stats                    (local dev, no tunnel needed)
-#           just admin prod stats                   (requires tunnel running)
-#           just admin prod subscriptions list
-#           just admin prod credits health
-# Admin CLI for remote administration via admin API — environment: dev | staging | prod
+# Admin CLI via the admin API — dev | staging | prod (staging/prod need a tunnel)
 admin environment="dev" *args="":
     UV_ENV_FILE={{_local_env}} uv run python -m robosystems.admin.cli -e {{environment}} {{args}}
 
@@ -517,12 +483,12 @@ duckdb-query graph_id query format="table":
 
 # --- Dump (the prebuilt corpus, no pipeline) ---
 
-# Download the public SEC .lbug dump from Hugging Face into data/lbug-dbs (~35 GiB down, ~128 GiB on disk), then restart graph-api if running
+# Download the public SEC .lbug dump from Hugging Face (~128 GiB), restart graph-api
 sec-dump *flags="":
     @just sec-dump-no-restart {{flags}}
     @just graph-api-restart
 
-# Same download without the graph-api restart (a running graph-api keeps serving the replaced file until restarted)
+# Same download, without the graph-api restart
 sec-dump-no-restart *flags="":
     UV_ENV_FILE={{_local_env}} uv run python -m robosystems.scripts.sec_dump {{flags}}
 
@@ -550,7 +516,6 @@ sec-download count="10" year="":
 
 # --- Phase 2: Process ---
 
-# Triggers sec_process runs for each quarter with pending files. Use --reset-errors to retry failed files.
 # Process pending SEC filings by quarter
 sec-process reset_errors="":
     UV_ENV_FILE={{_local_env}} uv run python -m robosystems.scripts.sec_pipeline process \
@@ -563,15 +528,13 @@ sec-materialize:
     @just sec-stage ""
     @just sec-materialize-graph
 
-# Use this to save 2+ hours of work that persists if materialization fails
-# Stage to persistent DuckDB only (decoupled Stage 1)
+# Stage SEC filings to persistent DuckDB only (decoupled Stage 1)
 sec-stage year="":
     UV_ENV_FILE={{_local_env}} uv run python -m robosystems.scripts.sec_pipeline stage \
         --graph-id sec \
         {{ if year != "" { "--year " + year } else { "" } }}
 
-# Use this to retry materialization without re-staging
-# Materialize graph from existing DuckDB staging (decoupled Stage 2)
+# Materialize the graph from existing DuckDB staging (decoupled Stage 2)
 sec-materialize-graph:
     UV_ENV_FILE={{_local_env}} uv run python -m robosystems.scripts.sec_pipeline materialize-graph \
         --graph-id sec
@@ -585,13 +548,7 @@ sec-index quarter:
 
 # --- Phase 5: Text Search Query ---
 
-# Examples:
-#   just search sec "revenue growth"
-#   just search sec "risk factors" --entity NVDA
-#   just search sec "inventory" --form-type 10-K --fiscal-year 2025
-#   just search sec "revenue" --size 3
-#   just search sec "revenue" --no-semantic
-# Search OpenSearch for filing text content (semantic search enabled by default)
+# Search OpenSearch for filing text content (semantic search on by default)
 search graph_id query *flags:
     UV_ENV_FILE={{_local_env}} uv run python -m robosystems.scripts.search_query \
         --graph-id {{graph_id}} \
@@ -653,7 +610,7 @@ clean-data:
     rm -rf ./data/valkey
     rm -rf ./.local/config.json
 
-# Full local reset — tears down containers, wipes local data (artifacts + lbug-dbs), then rebuilds the stack from scratch
+# Full local reset — tear down, wipe local data, rebuild the stack
 reset-local:
     @just teardown
     @just clean-data


### PR DESCRIPTION
Three related passes over the demo surface and the justfile. No production code touched — `examples/` and `justfile` only.

## 1. Collapse the Seattle Method sub-recipes onto `--step`

The two Seattle Method demos carried **eight** just recipes between them where every other demo carries one. Six duplicated a `--step` flag the orchestrators already exposed, and the set was arbitrary: 2 of 9 Seattle steps had a recipe, 5 of 11 World Online ones did, while `download-bundles` and `author-rollforwards` never got one despite being just as re-runnable.

Two gaps closed first, so nothing regresses at the command line:

- **`--step` now falls back to the cached graph slot** (`seattle_method_test` / `world_online_test`) instead of hard-requiring `--graph`, matching what the step scripts already do on their own. `just demo-world-online --step trial-balance` needs no graph id.
- **`--no-diff` and `--no-fetch` are forwarded** into the subprocess argv, following the precedent `--limit` already set for the ingest step. They were unreachable through `--step` before.

Eight recipes become two. Docs, module docstrings, and the "how to reproduce" footers the reports print now name the `--step` form.

## 2. `just demo` runs the whole suite

It ran three of nine demos. It now runs all but SEC, ordered so each demo reuses what the previous one built:

- `demo-user` first, so the suite is self-contained on a fresh checkout rather than failing on a missing `.local/config.json`.
- `demo-saas-startup` before `demo-roboinvestor` — the fund's issuer *is* the Cadence Labs scenario, and `ensure_issuer_graph` reuses the cached `saas_startup` slot, so this order adopts that graph instead of building a second ledger inline.

**SEC is deliberately excluded.** `demo-sec` drops and recreates the whole local `sec` graph with no opt-out, which would silently discard a corpus that cost hours to build or 35 GiB to download. Populate it on its own terms (`just sec-dump`, or the `sec-*` pipeline recipes) and run `just demo-sec` standalone. Everything left in the suite resets only its own graph slot, so **`just demo` is non-destructive and idempotent.**

## 3. De-essay the justfile

`just` renders the **last** comment line above a recipe as its description — so every line above it was invisible to `just --list` while still cluttering the file. Five recipes were written inverted (terse line last, essay above), so the listing only read correctly by luck.

12 multi-line blocks collapsed to one doc line each; 15 overlong one-liners shortened, most of which enumerated flags `--help` already lists and that drift as the scripts change. 192 → 149 comment lines.

Nothing load-bearing was lost — each removed block is already documented in more depth where it belongs:

| Removed from justfile | Already lives at |
| --- | --- |
| `test` xdist/loadfile isolation | `tests/README.md` |
| `lint-actions` rationale + baseline | `.github/actionlint.yaml` header |
| `cf-lint` 51,200-byte validate skip | `cloudformation/README.md` (and the recipe echoes it at runtime) |

The `bootstrap*` "Usage:" blocks were pure redundancy: `--list` already prints the parameters and their defaults from the signature.

## Verification

Run against the live local stack, not just parsed:

- `just demo-world-online --step trial-balance` — ran off the cached slot, still balances ($17,217,503.20 both sides, ✓)
- `just demo-seattle-method --step create-report` — full API path, Report materialized, all four statements rendered
- `just demo-world-online --step reconcile --no-diff` — flag forwarded, pivot only, ledger nets to $0.00 over 22,286 lines
- `just demo` — ran the chain; `demo-roboledger`, `demo-coffee-roaster`, `demo-saas-startup`, `demo-roboinvestor`, `demo-custom-graph` all green, and RoboInvestor logged `Reusing issuer graph`, confirming the ordering
- `just test` — 14,213 passed, 42 skipped
- `just test-code` — ruff + format + basedpyright, 0 errors
- `just --list` parses; no multi-line recipe comments and none over 100 chars remain

No tests or CI referenced any removed recipe.

## Behavior change worth naming

`--step statement-reconcile` now needs the cached slot where the old recipe needed no config at all. It only uses the id for the step banner, but I kept it consistent with the other steps — the precondition (having run the demo, which writes the bundle it reads) is one the docstring already stated.