### PR TITLE
fix(graph-api): require the cluster key except on /health

### DIFF
--- a/robosystems/graph_api/app.py
+++ b/robosystems/graph_api/app.py
@@ -223,16 +223,7 @@ def create_app() -> FastAPI:
         }
       }
 
-      exempt_paths = {
-        "/health",
-        "/status",
-        "/info",
-        "/metrics",
-        "/openapi.json",
-        "/docs",
-        "/redoc",
-        "/",
-      }
+      exempt_paths = {"/health"}
       for path, methods in openapi_schema["paths"].items():
         if path not in exempt_paths:
           for method in methods.values():
@@ -314,7 +305,7 @@ def create_app() -> FastAPI:
 
   app.include_router(health.router)  # /health for load balancer health checks
   app.include_router(info.router)  # /info for cluster info
-  app.include_router(metrics.router)  # /metrics for monitoring systems
+  app.include_router(metrics.router)  # /metrics (cluster key in prod/staging)
 
   # Database routers
   app.include_router(databases.management.router)

--- a/robosystems/graph_api/middleware/auth.py
+++ b/robosystems/graph_api/middleware/auth.py
@@ -2,7 +2,7 @@
 Authentication middleware for Graph API with environment-based security.
 
 Provides API key authentication for production/staging environments while
-allowing unrestricted access in development and from bastion hosts.
+allowing unrestricted access in development.
 """
 
 import time
@@ -21,20 +21,11 @@ class GraphAuthMiddleware(BaseHTTPMiddleware):
   """API key authentication for the Graph API.
 
   Enforced in production and staging only; development runs unauthenticated.
-  Health, docs and metrics paths are always exempt so probes and the ALB do
-  not need a key. Repeated failures from one IP are locked out.
+  ``/health`` is the only exempt path so ALB and container probes do not
+  need a key. Repeated failures from one IP are locked out.
   """
 
-  EXEMPT_PATHS = {
-    "/health",
-    "/status",
-    "/info",
-    "/metrics",
-    "/openapi.json",
-    "/docs",
-    "/redoc",
-    "/",
-  }
+  EXEMPT_PATHS = frozenset({"/health"})
 
   def __init__(self, app, api_key: str | None = None, key_type: str = "writer"):
     super().__init__(app)

--- a/robosystems/middleware/mcp/client.py
+++ b/robosystems/middleware/mcp/client.py
@@ -644,10 +644,9 @@ class GraphMCPClient:
         Dictionary with graph statistics
     """
     try:
-      # Get API info
-      response = await self.client.get(f"{self.api_base_url}/info")
-      response.raise_for_status()
-      api_info = response.json()
+      # Cluster probe rides GraphClient so it carries X-Graph-API-Key in
+      # prod/staging the same way every other Graph API call does.
+      api_info = await self.graph_client.get_info()
 
       # Get table information from database
       node_labels = []

--- a/tests/graph_api/test_auth_middleware.py
+++ b/tests/graph_api/test_auth_middleware.py
@@ -48,6 +48,27 @@ class TestLadybugAuthMiddleware:
       call_next.assert_called_with(mock_request)
 
   @pytest.mark.asyncio
+  async def test_cluster_probes_require_key_in_prod(self, mock_app, mock_request):
+    """Cluster inventory and metrics are not ALB probes — they need the key."""
+    with patch("robosystems.graph_api.middleware.auth.env") as mock_env:
+      mock_env.ENVIRONMENT = "prod"
+      mock_env.GRAPH_API_KEY = None
+
+      middleware = LadybugAuthMiddleware(mock_app, api_key="secret-key")
+      call_next = AsyncMock(return_value=JSONResponse({"status": "ok"}))
+
+      for path in ("/info", "/metrics", "/openapi.json", "/docs", "/redoc", "/"):
+        mock_request.url.path = path
+        mock_request.headers = Headers({})
+        response = await middleware.dispatch(mock_request, call_next)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED, path
+        call_next.assert_not_called()
+
+      mock_request.url.path = "/health"
+      response = await middleware.dispatch(mock_request, call_next)
+      assert response.status_code == 200
+
+  @pytest.mark.asyncio
   async def test_middleware_development_bypass(self, mock_app, mock_request):
     """Test that authentication is bypassed in development."""
     with patch("robosystems.graph_api.middleware.auth.env") as mock_env:

--- a/tests/middleware/mcp/test_client.py
+++ b/tests/middleware/mcp/test_client.py
@@ -187,14 +187,13 @@ class TestGraphMCPClient:
   @pytest.mark.unit
   async def test_get_graph_info(self, mock_async_graph_client, mock_httpx_client):
     """Test graph info retrieval (optimized, no relationship counts)."""
-    # Mock API info response
-    info_response = MagicMock()
-    info_response.raise_for_status = MagicMock()
-    info_response.json.return_value = {
-      "database_path": "/path/to/db",
-      "read_only": True,
-      "uptime_seconds": 3600,
-    }
+    mock_async_graph_client.get_info = AsyncMock(
+      return_value={
+        "database_path": "/path/to/db",
+        "read_only": True,
+        "uptime_seconds": 3600,
+      }
+    )
 
     # Mock the queries responses - no relationship counts for performance
     query_responses = [
@@ -211,7 +210,6 @@ class TestGraphMCPClient:
       ],
     ]
 
-    mock_httpx_client.get.return_value = info_response
     mock_async_graph_client.query.side_effect = [
       {"data": response, "execution_time_ms": 10} for response in query_responses
     ]
@@ -224,6 +222,7 @@ class TestGraphMCPClient:
       client.graph_client = mock_async_graph_client
 
       info = await client.get_graph_info()
+      mock_async_graph_client.get_info.assert_awaited_once()
 
       assert info["graph_id"] == "test"
       assert info["total_nodes"] == 150  # Sum of Entity (100) + Report (50)


### PR DESCRIPTION
## Summary

Require the Graph API cluster key on every route except `/health`, matching the documented contract. Load-balancer and container probes stay unauthenticated; everything else uses the key the platform client already sends.

## Changes

- `graph_api/middleware/auth.py` — exempt only `/health` in prod/staging (dev still unauthenticated).
- `graph_api/app.py` — OpenAPI security scheme matches that exemption.
- `middleware/mcp/client.py` — cluster probe goes through `GraphClient` so it carries the key.
- Tests pin the exemption and the prod deny on non-health cluster routes.

## Breaking Changes

None for the public API / SDKs. Graph API callers in prod/staging that hit non-health routes without `X-Graph-API-Key` (or Bearer) will get 401. The platform Graph client and the volume-monitor Lambda already send the key.

## Testing

`uv run pytest tests/graph_api/test_auth_middleware.py tests/middleware/mcp/test_client.py tests/graph_api/routers/test_info.py tests/graph_api/routers/test_metrics.py tests/graph_api/routers/test_health.py` — 77 passed. Pre-commit (ruff + basedpyright) passed on commit. `just test-all` not run.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
