### PR TITLE
chore(docs): stop hardcoding the SEC dump's per-snapshot sizes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ just lbug-query GRAPH_ID "CYPHER_QUERY"        # Direct LadybugDB query (bypass 
 just sec-load NVDA 2025    # Load company filings
 just sec-health            # SEC database health
 just sec-reset             # Reset SEC database
-just sec-dump              # Pull the public SEC .lbug dump from Hugging Face (~35 GiB down, ~128 GiB on disk)
+just sec-dump              # Pull the public SEC .lbug dump from Hugging Face (tens of GiB down, >100 GiB on disk)
 ```
 
 ### Demo Scripts

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Details: [Enterprise SSO & SCIM](https://github.com/RoboFinSystems/robosystems/w
 
 A curated knowledge graph of US public company financial data from SEC EDGAR XBRL filings. Runs on the shared LadybugDB tier, accessible via MCP tools, Cypher queries, and the AI Operator.
 
-The full corpus is also published monthly as one LadybugDB file on Hugging Face — [robosystems/sec-xbrl-knowledge-graphs](https://huggingface.co/datasets/robosystems/sec-xbrl-knowledge-graphs) (35 GiB download, 128 GiB on disk). `just sec-dump` pulls it into `data/lbug-dbs` for local Cypher, API, and MCP with no pipeline run; see the [SEC XBRL Pipeline](https://github.com/RoboFinSystems/robosystems/wiki/SEC-XBRL-Pipeline) wiki page.
+The full corpus is also published monthly as one LadybugDB file on Hugging Face — [robosystems/sec-xbrl-knowledge-graphs](https://huggingface.co/datasets/robosystems/sec-xbrl-knowledge-graphs) (tens of GiB to download, well over 100 GiB on disk; the dataset card carries each snapshot's exact sizes). `just sec-dump` pulls it into `data/lbug-dbs` for local Cypher, API, and MCP with no pipeline run; see the [SEC XBRL Pipeline](https://github.com/RoboFinSystems/robosystems/wiki/SEC-XBRL-Pipeline) wiki page.
 
 - **Pipeline**: EDGAR → Download → Process (Parquet) → Stage (DuckDB) → Enrich (Icebug+fastembed) → Materialize (LadybugDB) → Index + Embed (OpenSearch)
 - **Graph**: the base schema plus the `roboledger` extension — 20 node types and 41 relationship types modeling the full XBRL reporting hierarchy

--- a/justfile
+++ b/justfile
@@ -483,7 +483,7 @@ duckdb-query graph_id query format="table":
 
 # --- Dump (the prebuilt corpus, no pipeline) ---
 
-# Download the public SEC .lbug dump from Hugging Face (~128 GiB), restart graph-api
+# Download the public SEC .lbug dump from Hugging Face (tens of GiB down, >100 GiB on disk), restart graph-api
 sec-dump *flags="":
     @just sec-dump-no-restart {{flags}}
     @just graph-api-restart

--- a/robosystems/scripts/sec_dump.py
+++ b/robosystems/scripts/sec_dump.py
@@ -8,8 +8,13 @@ checksum is verified on the way through), lands ``sec.lbug`` in the graph
 directory the local stack mounts, and warns if the engine that wrote the file
 differs from the ``ladybug`` version pinned in this checkout.
 
+Both sizes — the archive and what it expands to — are read from the dataset at
+run time and checked against free space before each step, so no figure is
+repeated here; the dataset card carries the current ones. Expect tens of GiB to
+download and well over 100 GiB on disk.
+
 Usage:
-    just sec-dump                    # ~35 GiB download, ~128 GiB on disk afterwards
+    just sec-dump                    # see the dataset card for current sizes
     just sec-dump --force            # replace an existing data/lbug-dbs/sec.lbug
     just sec-dump --keep-archive     # keep the .zst after decompression
     just sec-dump-no-restart         # same, without the graph-api restart afterwards


### PR DESCRIPTION
## Summary

The SEC dump's archive and expanded sizes were written out in four places in this repo, and every one of them went stale with each new snapshot — the 2026-08-31 publish moved them from ~35/~128 GiB to ~39/~130 GiB. This replaces the exact figures with a bracket that survives corpus growth and points readers at the dataset card, which is the one place the numbers are already maintained per snapshot.

`robosystems/scripts/sec_dump.py` already reads both real sizes from the dataset at run time and gates the download and the decompression on free space against them, so the hardcoded numbers were duplication that no reader depended on being precise.

## Changes

- `robosystems/scripts/sec_dump.py` — drop the size figures from the usage block; add a docstring paragraph noting that both sizes are read from the dataset at run time and checked against free space, so none is repeated in the source.
- `justfile` — `sec-dump` recipe comment.
- `README.md` — SEC shared-repository section; now also says the dataset card carries each snapshot's exact sizes.
- `CLAUDE.md` — SEC quick-reference block.

All four now read *tens of GiB down, >100 GiB on disk*, which keeps the "this is not a laptop-minutes download" warning without a number that rots monthly.

No behavior change: nothing outside comments, a module docstring, and Markdown prose is touched.

## Breaking Changes

None. No API surface, no SDK-visible symbols, no runtime code paths.

## Testing

`just test-code` (ruff + format + basedpyright + cf-lint) — all checks passed, 0 errors / 0 warnings / 0 notes.

The unit-test half of `just test-all` was not run to completion: it needs the local Postgres, which was not up in this session, and all 14 collection errors were `psycopg2.OperationalError: connection refused` on `localhost:5432`. They are environmental and unrelated to this diff, which contains no executable code.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
