### PR TITLE
fix(demos): stop transaction streams double-booking schedule periods

### DIFF
--- a/examples/_scenario/engine.py
+++ b/examples/_scenario/engine.py
@@ -85,6 +85,23 @@ def month_windows(start: date, months: int) -> list[tuple[date, date]]:
   ]
 
 
+def schedule_owned_from(months: int) -> int:
+  """First offset whose schedule-covered entries the Schedule block owns.
+
+  ``months - 2`` — the close target. Provisioning closes offsets
+  ``0 .. months - 3`` and leaves the close target (``months - 2``) and the
+  current month (``months - 1``) open; a Schedule created afterwards voids
+  its obligations for the closed range as historical and keeps the rest
+  ``pending``. So from this offset onward the obligation register is the
+  sole source of depreciation and prepaid amortization, and the
+  transaction stream must not book them: booking both makes every open
+  obligation a duplicate of an entry that is already posted, which
+  double-counts on draft and turns the close gate's blocker into one that
+  can only be cleared by voiding the obligation.
+  """
+  return max(months - 2, 0)
+
+
 # ---------------------------------------------------------------------------
 # Curve builders — author driver curves as intent, not 16 literals
 # ---------------------------------------------------------------------------
@@ -372,7 +389,9 @@ def _emit_capex(cx: CapexItem, start: date, months: int) -> list[Txn]:
     )
   monthly = cx.cost // cx.life_months
   first = 0 if cx.in_opening else cx.purchase_offset + 1
-  for off in range(max(first, 0), months):
+  # Stops at the close target: the depreciation Schedule owns every period
+  # from there on (see `schedule_owned_from`).
+  for off in range(max(first, 0), schedule_owned_from(months)):
     d = month_date(start, off, 31)
     out.append(
       (
@@ -399,7 +418,9 @@ def _emit_prepaid(pp: PrepaidItem, start: date, months: int) -> list[Txn]:
       )
     )
   monthly = pp.cost // pp.life_months
-  last = min(pp.purchase_offset + pp.life_months, months)
+  # Same boundary as depreciation: the amortization Schedule owns the close
+  # target onward (see `schedule_owned_from`).
+  last = min(pp.purchase_offset + pp.life_months, schedule_owned_from(months))
   for off in range(max(pp.purchase_offset, 0), last):
     out.append(
       (

--- a/examples/roboledger_demo/data.py
+++ b/examples/roboledger_demo/data.py
@@ -22,6 +22,17 @@ from datetime import date
 
 DEMO_MONTHS = 16  # rolling window of synthetic data
 
+# First offset whose schedule-covered entries the Schedule blocks own.
+# `initialize_fiscal_calendar` sets closed_through to the month before last,
+# leaving the close target (offset DEMO_MONTHS - 2) and the current month
+# open; `create_schedules` then tags its facts for the closed range
+# `historical` and leaves the rest in scope, so from this offset onward the
+# obligation register is the sole source of depreciation and the stream must
+# not book it. Booking both makes each open obligation a duplicate of an
+# already-posted entry, and the close silently doubles the expense.
+# Mirrors `schedule_owned_from` in examples/_scenario/engine.py.
+SCHEDULE_OWNED_FROM = DEMO_MONTHS - 2
+
 
 def add_months(d: date, months: int) -> date:
   """Return the first day of the month that is `months` after d."""
@@ -491,16 +502,18 @@ def _monthly_transactions(start: date, offset: int) -> list[tuple]:
   # starts depreciating the month after purchase (offset 0); Office
   # Furniture ($1,500 cost / 60 mo = $25/mo) starts after offset 2.
   # Posting DR 7000 Depreciation Expense / CR 1350 Accumulated Depreciation.
-  # The synthetic history posts these directly so the loaded books already
-  # balance; a tenant running the schedule workflow gets the identical
-  # posting from close-period instead.
+  # The closed history posts these directly so the loaded books already
+  # balance. From SCHEDULE_OWNED_FROM on, the schedule workflow supplies the
+  # identical posting at close-period, so the stream stops — the two must
+  # never both book the same month.
   dep_lines: list[tuple[str, int, int]] = []
-  if offset >= 1:
-    dep_lines.append(("7000", 133_33, 0))
-    dep_lines.append(("1350", 0, 133_33))
-  if offset >= 3:
-    dep_lines.append(("7000", 25_00, 0))
-    dep_lines.append(("1350", 0, 25_00))
+  if offset < SCHEDULE_OWNED_FROM:
+    if offset >= 1:
+      dep_lines.append(("7000", 133_33, 0))
+      dep_lines.append(("1350", 0, 133_33))
+    if offset >= 3:
+      dep_lines.append(("7000", 25_00, 0))
+      dep_lines.append(("1350", 0, 25_00))
   if dep_lines:
     # Collapse to one balanced entry: sum DR 7000 / sum CR 1350.
     total_dr = sum(d for c, d, _ in dep_lines if c == "7000")


### PR DESCRIPTION
## Summary

Three RoboLedger demos booked depreciation and prepaid amortization into their transaction stream for every month of the rolling window, while also creating Schedule blocks covering those same periods. Provisioning closes offsets `0..months-3` and leaves the close target and the current month open, so the Schedule voided its obligations for the closed range as historical and left the rest `pending` — against periods whose entries were already posted. Every open obligation was a duplicate.

This bounds the stream at the close target in both generators, so the transaction stream owns the closed history and the obligation register owns everything from the close target on.

The two failure modes differed, and the second is the reason this went unnoticed:

- **Driftline (coffee roaster) and Cadence Labs (SaaS startup)** — drafting the obligations would double-count, so the only correct way to clear the close gate was to void them. The demo's close beat (draft → approve → post → close) could not be run on either.
- **Cascade Advisory (roboledger)** — the close *succeeded* and silently booked July depreciation twice, $316.66 against a true $158.33. No blocker, no warning, just a wrong number.

## Changes

**`examples/_scenario/engine.py`** — shared engine behind the two showcase demos

- New `schedule_owned_from(months)` → `months - 2`, the close-target offset. The helper names that boundary in one place, next to `month_windows` and `trailing_year`, which already encode the same convention.
- `_emit_capex` — depreciation stops at `schedule_owned_from(months)` instead of running through `months`.
- `_emit_prepaid` — amortization's `last` offset is bounded the same way.

**`examples/roboledger_demo/data.py`** — Cascade has its own hand-rolled generator, not the shared engine

- New `SCHEDULE_OWNED_FROM = DEMO_MONTHS - 2`, mirroring the helper above (this demo already mirrors rather than imports `add_months` / `get_demo_start_date`).
- `_monthly_transactions` — the depreciation block is bounded by it.
- Corrected the comment that described the stream and the schedule workflow as an either/or; nothing enforced that, and both were booking.

Worth a close look: the boundary is an offset derived from the month count, the same derivation each demo uses to decide which periods it closes. If those ever disagree the duplicate comes straight back, which is why the reasoning lives in the helper/constant docstring rather than at the call sites.

Cascade's four prepaid schedules were always genuine — nothing in its stream amortizes `1200`/`1210`/`1220` — so only the two depreciation schedules were duplicated there.

No platform code changed. `roboinvestor`, `custom_graph`, `seattle_method`, `world_online`, and `sec` have no fiscal-calendar or schedule machinery at all and are unaffected.

## Breaking Changes

None. No API surface, GraphQL schema, operations envelope, or REST shape is touched, so there is no SDK impact in either tier.

Note for whoever re-seeds: existing demo graphs still hold the duplicated entries and cannot be repaired in place (`reset_demo` is local-only by design). They need fresh graphs off this branch.

## Testing

- `just test-code` — passed after each commit (ruff, format, basedpyright, cf-lint all clean).
- Full unit suite (`just test-all`) not run; this change touches only `examples/`.
- Verified end to end against a local stack instead, by re-seeding each demo and walking the whole close cadence:

  | | Driftline | Cadence Labs | Cascade Advisory |
  | --- | --- | --- | --- |
  | gate before close | `pending_obligations`, 3 pending, 0 stranded | `pending_obligations`, 4 pending, 0 stranded | `pending_obligations`, 5 pending, 0 stranded |
  | schedule-covered entries already in the close-target month | 0 | 0 | 0 |
  | `promote-obligations` (dispatch) | 3 classified, 3 dispatched, 0 errors | 4 / 4 / 0 | 5 / 5 / 0 |
  | drafts | 3, $2,471.42, balanced | 4, $6,388.88, balanced | 5, $333.33 |
  | `close-period 2026-07` | 3 posted, rules 3 pass / 0 fail | 4 posted, rules 4 pass / 0 fail | 5 posted, rules 5 pass / 0 fail |
  | statements | stamped, 19 pass / 0 fail | stamped, 19 pass / 0 fail | stamped, 18 pass / 0 fail |
  | after | `closed_through=2026-07` | same | same |

- Ledger inspection at the boundary on all three: the last closed month is booked from the stream, the close-target month from the schedule, each exactly once. Cascade's July depreciation lands at $158.33, not $316.66.
- Before the fix, the same walk on Cascade produced the two duplicate drafts sitting alongside the already-posted `Depreciation - July 2026` — that run is what established the double-count rather than inferring it.
- All three `--dry-run` validations still balance (383, 509, and 232 transactions).

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
