### PR TITLE
fix(graphs): suspend the graph inline on immediate delete-graph

### DIFF
--- a/robosystems/routers/graphs/operations.py
+++ b/robosystems/routers/graphs/operations.py
@@ -363,6 +363,7 @@ async def delete_graph_op(
     BillingSubscription,
     SubscriptionStatus,
   )
+  from robosystems.models.core.graph import Graph, GraphStatus
   from robosystems.models.core.graph.graph_user import GraphUser
   from robosystems.operations.providers.payment_provider import get_payment_provider
   from robosystems.security import SecurityAuditLogger, SecurityEventType
@@ -538,6 +539,27 @@ async def delete_graph_op(
     )
 
     if immediate:
+      # Suspend here rather than waiting for expired_graph_subscription_sensor
+      # to notice. The cancel above already wrote everything that sensor keys
+      # off (status=canceled, ends_at=now, cancellation_type=immediate), so the
+      # graph is irreversibly gone the moment it commits — but Graph.status is
+      # a projection of billing state reconciled on a 300s tick, so until then
+      # every read still reports "active" and the graph stays fully usable.
+      # Measured in production: one teardown reported active for 2m50s after
+      # the call returned, another for roughly five minutes — an unpredictable
+      # 0-300s window in which a destroyed graph looks perfectly healthy and
+      # still answers queries. There is no undo past this point, so the status
+      # must not lag the fact.
+      #
+      # The sensor stays as the backstop: it still owns period-end expiry,
+      # payment failures, provider-originated cancels, and any run that dies
+      # between the cancel commit and this write. Its query filters on
+      # status == ACTIVE, so once this lands it simply stops matching. Guarded
+      # on ACTIVE because transition_status rejects suspended -> suspended.
+      graph_row = Graph.get_by_id(graph_id, db)
+      if graph_row and graph_row.status == GraphStatus.ACTIVE.value:
+        graph_row.transition_status(GraphStatus.SUSPENDED, db)
+
       return {
         "graph_id": graph_id,
         "subscription_id": subscription.id,

--- a/tests/routers/graphs/test_delete_graph_op.py
+++ b/tests/routers/graphs/test_delete_graph_op.py
@@ -484,3 +484,151 @@ class TestDeleteGraphRunner:
     assert exc.value.status_code == 502
     sub.cancel.assert_not_called()
     mock_log_event.assert_not_called()
+
+
+class TestDeleteGraphImmediateSuspend:
+  """An immediate teardown must mark the graph suspended before returning.
+
+  `subscription.cancel(immediate=True)` writes everything
+  `expired_graph_subscription_sensor` keys off, so the graph is irreversibly
+  gone the moment it commits. Leaving `Graph.status` for the sensor to
+  reconcile on its 300s tick meant every read reported "active" — and the
+  graph stayed fully usable — for an unpredictable 0-300s afterwards.
+  """
+
+  _setup_admin_membership = TestDeleteGraphRunner._setup_admin_membership
+  # `_patch_org_owner` is a staticmethod on the source class; accessing it
+  # there yields the bare function, so re-wrap it or `self` binds as its
+  # first positional argument.
+  _patch_org_owner = staticmethod(TestDeleteGraphRunner._patch_org_owner)
+
+  @staticmethod
+  def _graph_row(status: str = "active") -> MagicMock:
+    row = MagicMock()
+    row.graph_id = "kg_x"
+    row.status = status
+    return row
+
+  async def _run(self, db: MagicMock, body: DeleteGraphOp):
+    with self._patch_org_owner("OWNER"):
+      return await delete_graph_op(
+        body=body,
+        graph_id="kg_x",
+        user=_user(user_id="usr_admin"),
+        idempotency_key=None,
+        cache=_FakeCache(),
+        db=db,
+      )
+
+  @staticmethod
+  def _sub() -> MagicMock:
+    sub = MagicMock()
+    sub.id = "sub_abc"
+    sub.status = "active"
+    sub.org_id = "org_1"
+    sub.stripe_subscription_id = None
+    return sub
+
+  @pytest.mark.asyncio
+  @patch("robosystems.security.SecurityAuditLogger")
+  @patch("robosystems.models.core.billing.BillingAuditLog.log_event")
+  @patch("robosystems.models.core.graph.Graph.get_by_id")
+  @patch("robosystems.models.core.billing.BillingSubscription.get_by_resource")
+  async def test_immediate_suspends_graph_before_returning(
+    self,
+    mock_get_sub: MagicMock,
+    mock_get_graph: MagicMock,
+    _mock_log_event: MagicMock,
+    _mock_security: MagicMock,
+  ) -> None:
+    from robosystems.models.core.graph import GraphStatus
+
+    db = MagicMock()
+    self._setup_admin_membership(db, role="admin")
+    mock_get_sub.return_value = self._sub()
+    graph_row = self._graph_row(status="active")
+    mock_get_graph.return_value = graph_row
+
+    envelope = await self._run(db, DeleteGraphOp(confirm="kg_x"))
+
+    graph_row.transition_status.assert_called_once_with(GraphStatus.SUSPENDED, db)
+    assert envelope.result["status"] == "deprovisioning_queued"
+
+  @pytest.mark.asyncio
+  @patch("robosystems.security.SecurityAuditLogger")
+  @patch("robosystems.models.core.billing.BillingAuditLog.log_event")
+  @patch("robosystems.models.core.graph.Graph.get_by_id")
+  @patch("robosystems.models.core.billing.BillingSubscription.get_by_resource")
+  async def test_at_period_end_leaves_graph_active(
+    self,
+    mock_get_sub: MagicMock,
+    mock_get_graph: MagicMock,
+    _mock_log_event: MagicMock,
+    _mock_security: MagicMock,
+  ) -> None:
+    """The customer has paid through the period — suspending now would cut off
+    service they are still owed. Only the sensor may suspend this one, once
+    `ends_at` actually passes."""
+    from datetime import UTC, datetime
+
+    db = MagicMock()
+    self._setup_admin_membership(db, role="admin")
+    sub = self._sub()
+    sub.ends_at = datetime(2026, 6, 1, tzinfo=UTC)
+    mock_get_sub.return_value = sub
+    graph_row = self._graph_row(status="active")
+    mock_get_graph.return_value = graph_row
+
+    envelope = await self._run(db, DeleteGraphOp(confirm="kg_x", at_period_end=True))
+
+    graph_row.transition_status.assert_not_called()
+    assert envelope.result["status"] == "scheduled_for_deprovision"
+
+  @pytest.mark.asyncio
+  @patch("robosystems.security.SecurityAuditLogger")
+  @patch("robosystems.models.core.billing.BillingAuditLog.log_event")
+  @patch("robosystems.models.core.graph.Graph.get_by_id")
+  @patch("robosystems.models.core.billing.BillingSubscription.get_by_resource")
+  async def test_non_active_graph_is_not_transitioned(
+    self,
+    mock_get_sub: MagicMock,
+    mock_get_graph: MagicMock,
+    _mock_log_event: MagicMock,
+    _mock_security: MagicMock,
+  ) -> None:
+    """`transition_status` raises on suspended -> suspended, so a graph the
+    sensor already picked up must be left alone rather than 500 the op."""
+    db = MagicMock()
+    self._setup_admin_membership(db, role="admin")
+    mock_get_sub.return_value = self._sub()
+    graph_row = self._graph_row(status="suspended")
+    mock_get_graph.return_value = graph_row
+
+    envelope = await self._run(db, DeleteGraphOp(confirm="kg_x"))
+
+    graph_row.transition_status.assert_not_called()
+    assert envelope.result["status"] == "deprovisioning_queued"
+
+  @pytest.mark.asyncio
+  @patch("robosystems.security.SecurityAuditLogger")
+  @patch("robosystems.models.core.billing.BillingAuditLog.log_event")
+  @patch("robosystems.models.core.graph.Graph.get_by_id")
+  @patch("robosystems.models.core.billing.BillingSubscription.get_by_resource")
+  async def test_missing_graph_row_still_completes(
+    self,
+    mock_get_sub: MagicMock,
+    mock_get_graph: MagicMock,
+    _mock_log_event: MagicMock,
+    _mock_security: MagicMock,
+  ) -> None:
+    """The billing cancel already committed. A missing registry row must not
+    turn a successful teardown into a 500 — the sensor is the backstop."""
+    db = MagicMock()
+    self._setup_admin_membership(db, role="admin")
+    mock_get_sub.return_value = self._sub()
+    mock_get_graph.return_value = None
+
+    envelope = await self._run(db, DeleteGraphOp(confirm="kg_x"))
+
+    assert envelope.status == "completed"
+    assert envelope.result["status"] == "deprovisioning_queued"


### PR DESCRIPTION
## Summary

An immediate `delete-graph` cancels the subscription and returns, but never touches `Graph.status`. That status is a projection of billing state, reconciled by `expired_graph_subscription_sensor` on a 300s tick — so until the next tick, every read reports the graph as `active` and it stays fully usable, despite being irreversibly destroyed the moment the cancel committed.

This sets the status inline on the immediate path, so the API stops advertising a destroyed graph as healthy.

## Changes

- **`robosystems/routers/graphs/operations.py`** — in `delete_graph_op`, the `immediate` branch now transitions the graph to `suspended` before returning.
  - Guarded on `status == ACTIVE`, because `transition_status` rejects `suspended -> suspended` and the sensor may already have won the race.
  - Skipped entirely when `at_period_end=true` — that graph is paid through the period and must stay usable until it closes. Only the sensor may suspend it, once `ends_at` actually passes.
  - A missing registry row is tolerated rather than raised: the billing cancel has already committed, and turning a successful teardown into a 500 would be worse than leaving the sensor to reconcile.

## Why this is safe

`subscription.cancel(immediate=True)` writes exactly what the sensor keys off — `status=canceled`, `ends_at=now`, `cancellation_type=immediate` — so the operation already holds the conclusion the sensor would reach 0-300s later. It is applying a decision, not making a new one.

`suspend_expired_graphs`'s entire body is one `transition_status(SUSPENDED)` call, so the inline write is a complete reproduction of what the job does, not a partial one.

**The sensor is retained and not weakened.** It still uniquely owns:

- period-end cancellations, where `ends_at` is in the future and becomes eligible later;
- `status = "failed"` (payment failure), which never routes through this operation;
- provider-originated cancellations arriving by webhook;
- any run that dies between the cancel commit and this write.

That last case is why ordering matters — provider cancel, then `cancel()`, then the status write — and why the sensor must remain rather than be replaced. Its query filters on `Graph.status == "active"`, so once this write lands the row simply stops matching; there is no double transition.

## Measured behaviour

Two production teardowns, timed against the API:

| | `delete-graph` accepted | reported `suspended` | row gone |
| --- | --- | --- | --- |
| graph A | 05:57:48Z | ~06:02:5xZ (~5.1 min) | 06:05:37Z |
| graph B | 06:05:00.6Z | 06:07:51Z (2m50s) | 06:10:36Z |

The two suspend events are 300s apart and the two deprovision events are 299s apart, confirming a fixed-phase 300s cadence on both sensors. The wait is therefore not a predictable lag but a uniform 0-300s draw depending on where the request lands in the cycle — a caller could equally see 10 seconds or 4m59s with no way to tell which.

Deprovisioning timing is unchanged by this PR and remains sensor-driven, which is fine: by then the graph already reads as `suspended`.

## Breaking Changes

None. No request or response shape changes — `delete-graph` returns the same `deprovisioning_queued` envelope. The only observable difference is that a subsequent `GET /v1/graphs` reports `suspended` immediately instead of after a delay, which is the intended fix. No SDK regeneration required.

## Testing

- `just test` — 14218 passed, 42 skipped.
- `just test-code` — ruff, format, basedpyright and cf-lint all clean.
- Four new tests in `tests/routers/graphs/test_delete_graph_op.py` covering the immediate transition, the `at_period_end` non-transition, the already-suspended guard, and the missing-row path. The first was confirmed to fail against the unmodified handler.

## Related

Frontend companion: RoboFinSystems/robosystems-app#350 renders a `Suspended` badge and disables actions on a non-active graph. That PR made the gap visible; this one closes it.
