### PR TITLE
fix(demos): abort the scenario load on a failed write, and pull through client 1.13.1

### DIFF
--- a/examples/_scenario/runner.py
+++ b/examples/_scenario/runner.py
@@ -375,7 +375,6 @@ def create_agents(graph_id: str, agents: list[dict]) -> dict[str, str]:
   """
   client = _get_ledger_client()
   lookup: dict[str, str] = {}
-  skipped = 0
 
   for body in agents:
     # No idempotency_key: reset_demo wipes the agents table per-run, but
@@ -386,13 +385,16 @@ def create_agents(graph_id: str, agents: list[dict]) -> dict[str, str]:
     try:
       resp = client.create_agent(graph_id, body)
     except Exception as e:
-      print(f"  WARNING: create-agent failed for {body['name']} — {e}")
-      skipped += 1
-      continue
+      # Same reasoning as the event loop: a dropped agent is invisible
+      # downstream, because `agent_lookup.get(name)` then returns None and
+      # every event for that counterparty posts with no `agent_id` — the
+      # REA linkage the episode exists to demonstrate, silently absent.
+      raise RuntimeError(
+        f"create-agent failed for {body['name']} — {e}\n"
+        f"  Created {len(lookup)} agents before the failure; events posted "
+        f"against the rest would carry no counterparty."
+      ) from e
     lookup[body["name"]] = resp.id
-
-  if skipped:
-    print(f"  WARNING: Skipped {skipped} agents")
 
   return lookup
 
@@ -488,7 +490,7 @@ def create_business_events(
     "journal_entry_recorded": 0,
   }
   line_item_count = 0
-  skipped = 0
+  unmapped = 0
 
   cash_id = element_lookup.get(_CASH_CODE)
   ap_id = element_lookup.get(_AP_CODE)
@@ -496,7 +498,7 @@ def create_business_events(
   for txn_date, txn_type, description, agent_name, lines in txns:
     li_list = _build_line_items(lines, element_lookup)
     if li_list is None or len(li_list) < 2:
-      skipped += 1
+      unmapped += 1
       continue
 
     agent_id = agent_lookup.get(agent_name) if agent_name else None
@@ -616,12 +618,22 @@ def create_business_events(
         line_item_count += len(li_list)
 
     except Exception as e:
-      print(f"  WARNING: create-event-block failed for {txn_date} {txn_type} — {e}")
-      skipped += 1
-      continue
+      # Abort rather than continue. A dropped event does not just cost a
+      # row: `bill_payment` posts two linked events, and a failure between
+      # them strands an AP balance with no discharge, while a dropped
+      # invoice leaves its later payment with no obligation to discharge.
+      # Carrying on would then close periods and materialize the graph on
+      # top of a ledger that is quietly wrong — which is exactly how a run
+      # that lost 25 events to rate limiting still exited green.
+      raise RuntimeError(
+        f"create-event-block failed for {txn_date} {txn_type} — {e}\n"
+        f"  Loaded {sum(counts.values())} events before the failure; the "
+        f"ledger is incomplete, so the run stops here rather than closing "
+        f"periods over it."
+      ) from e
 
-  if skipped:
-    print(f"  WARNING: Skipped {skipped} events (missing elements or errors)")
+  if unmapped:
+    print(f"  WARNING: Skipped {unmapped} transactions (no CoA element)")
 
   return {
     "entries": sum(counts.values()),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # RoboSystems client for demo and testing.
-    "robosystems-client>=1.12.2,<2.0",
+    "robosystems-client>=1.13.1,<2.0",
     # Testing framework
     "pytest>=9.0.0,<10.0",
     "pytest-asyncio>=1.4.0,<2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3822,7 +3822,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.34.2,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=15.0.0,<16.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = ">=1.12.2,<2.0" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = ">=1.13.1,<2.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3848,7 +3848,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "1.12.2"
+version = "1.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3856,9 +3856,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/ff/925f36c63ff05001865dd122a970bc3e8673a0995fafd96a6c7ca536bd3a/robosystems_client-1.12.2.tar.gz", hash = "sha256:7d55fdd2625fabe195cff28372e29ed33174d8473e5a83d700a6393f4e6bc5f0", size = 549582, upload-time = "2026-08-29T05:46:55.251Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/61/c9e9f857d619025fec626b882b3b331bfb0587716b1e1929d153998a2831/robosystems_client-1.13.1.tar.gz", hash = "sha256:8c543bfc3dac2e1944df1920b9de10899e1017945a5febcdf027df432fb359b9", size = 561755, upload-time = "2026-08-31T21:35:36.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/e2/da364a1e41c0356f1646f273c67ece528e1dfb81e637e8c5dc453a8f9d54/robosystems_client-1.12.2-py3-none-any.whl", hash = "sha256:bc03926b0c932c0f817074b8e405c37161080043533c563894d0b06e665a24db", size = 1279738, upload-time = "2026-08-29T05:46:53.041Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d5/1485adbd1b1ec21425c05da92170f9c59ebccaa22f10942600b863ae7b53/robosystems_client-1.13.1-py3-none-any.whl", hash = "sha256:49f0aa4acff9d021170ed06ffa14296a1c82a830c6f2e57b8d037e018d8a6f5e", size = 1286958, upload-time = "2026-08-31T21:35:34.396Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

A showcase demo run lost 25 of 383 business events to `429 Rate limit exceeded for extensions write operations` and **still exited green**, then closed 14 historical months and materialized the graph over the gap. Two independent problems, both fixed here.

The scenario load issues ~500 extensions writes in ~108s against a 300/min budget — 92% of budget with zero headroom, so ordinary jitter converted straight into dropped rows. That half is fixed in the SDK (robosystems-client 1.13.1, pulled through below): a 429 is raised by a request dependency before the endpoint handler runs, so the rejected call had no effect and is safe to replay.

The other half is that the runner treated an API failure as a data skip. Even with retries in place, a load that *does* fail should not go on to close periods over an incomplete ledger.

## Changes

**`examples/_scenario/runner.py`** — the event and agent loops now raise instead of counting failures into `skipped`.

A dropped event is not just a missing row. `bill_payment` posts two linked events, so a failure between them strands an AP balance with no discharge; a dropped invoice leaves its later payment with no obligation to discharge. A dropped agent is quieter still — `agent_lookup.get()` returns `None` and every event for that counterparty posts with no `agent_id`, silently removing the REA linkage the episode exists to demonstrate. Both now abort, naming how far the load got.

The genuine data skip in the event loop — a transaction whose lines have no CoA element — stays non-fatal, but is counted and reported separately. Folding it together with API failures under `"Skipped N events (missing elements or errors)"` is what made this invisible in the first place.

**`pyproject.toml` / `uv.lock`** — dev client floor 1.12.2 → 1.13.1, and locked. This is the half that reaches the demos: the demo workflow clones this repo at `ROBOSYSTEMS_REF` and runs `uv sync` in that checkout, so the episode runner's SDK comes from this lockfile rather than the demo repo's. Floor and lock only.

## Testing

- `just test` — **14,218 passed, 42 skipped** against the new client.
- `just test-code` — ruff, format and basedpyright clean.
- Verified against the published 1.13.1 wheel rather than the source: `LedgerClient._get_client()` returns a `RetryingClient`, the GraphQL client carries the retry budget, and a `Retry-After: 60` yields a 0.57s backoff rather than a 60s sleep (the limiter is a sliding window, so the header reports the whole window).
- The failing episode has not been re-run end-to-end — that needs a demo workflow dispatch against a fresh graph.

## Related

- robosystems-client 1.13.1 — RoboFinSystems/robosystems-python-client#201
- Same lock pull-through: RoboFinSystems/robosystems-integration-template#12, and the demo repo's own `chore/client-1-13-1`.

## Not included

`examples/roboledger_demo/main.py` (the local `just demo-roboledger` path) has the identical swallow in its own event and agent loops. Left out to keep this scoped to the runner the demo workflow actually uses — happy to fold it in if you'd rather fix both at once.
