### PR TITLE
chore(examples): share one operation-status reader across the demos

### DIFF
--- a/examples/_common/sdk.py
+++ b/examples/_common/sdk.py
@@ -12,6 +12,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from robosystems_client.api.operations.get_operation_status import (
+  sync_detailed as api_get_operation_status,
+)
+from robosystems_client.client import AuthenticatedClient
 from robosystems_client.clients import LedgerClient
 
 from examples._common.config import require_api_key
@@ -52,3 +56,24 @@ def latest_report_id(client: LedgerClient, graph_id: str) -> str:
     raise SystemExit(f"No Report found for graph {graph_id}.")
   reports.sort(key=lambda r: r.created_at or "", reverse=True)
   return reports[0].id
+
+
+def operation_status(client: AuthenticatedClient, operation_id: str) -> dict[str, Any]:
+  """Current status of an async operation, as a plain dict.
+
+  Returns ``{}`` when the response carried no body — a transient blip
+  mid-poll, which callers should treat as "ask again", not as failure.
+
+  The operations endpoints are declared as free-form objects, so the
+  generated model carries only ``additional_properties`` and attribute
+  access on it raises. ``to_dict()`` is the accessor that works. Each
+  demo used to inline a three-branch dance around that, whose ``getattr``
+  fallback could never fire.
+  """
+  response = api_get_operation_status(operation_id=operation_id, client=client)
+  parsed = response.parsed
+  if parsed is None:
+    return {}
+  if isinstance(parsed, dict):
+    return parsed
+  return parsed.to_dict() if hasattr(parsed, "to_dict") else {}

--- a/examples/_scenario/runner.py
+++ b/examples/_scenario/runner.py
@@ -183,11 +183,10 @@ def create_demo_graph(scenario: Scenario, entity_type: str) -> str:
   from robosystems_client.api.graphs.create_graph import (
     sync_detailed as api_create_graph,
   )
-  from robosystems_client.api.operations.get_operation_status import (
-    sync_detailed as api_get_operation_status,
-  )
   from robosystems_client.client import AuthenticatedClient
   from robosystems_client.models import CreateGraphRequest, GraphMetadata
+
+  from examples._common.sdk import operation_status
 
   client = AuthenticatedClient(
     base_url=BASE_URL,
@@ -233,20 +232,11 @@ def create_demo_graph(scenario: Scenario, entity_type: str) -> str:
     print(f"  Queued (operation: {operation_id}), waiting...")
     for _ in range(30):
       time.sleep(2)
-      status_resp = api_get_operation_status(operation_id=operation_id, client=client)
-      if not status_resp.parsed:
+      status_data = operation_status(client, operation_id)
+      if not status_data:
         continue
-      status_data = status_resp.parsed
-      if isinstance(status_data, dict):
-        status = status_data.get("status")
-        result = status_data.get("result", {})
-      elif hasattr(status_data, "additional_properties"):
-        props = status_data.additional_properties
-        status = props.get("status")
-        result = props.get("result", {})
-      else:
-        status = getattr(status_data, "status", None)
-        result = getattr(status_data, "result", {})
+      status = status_data.get("status")
+      result = status_data.get("result", {})
 
       if status == "completed":
         graph_id = result.get("graph_id") if isinstance(result, dict) else None

--- a/examples/custom_graph_demo/create_graph.py
+++ b/examples/custom_graph_demo/create_graph.py
@@ -29,9 +29,6 @@ from robosystems_client.clients import (
 from robosystems_client.clients.graph_client import GraphClient
 from robosystems_client.client import AuthenticatedClient
 from robosystems_client.api.graphs.create_graph import sync_detailed as api_create_graph
-from robosystems_client.api.operations.get_operation_status import (
-  sync_detailed as api_get_operation_status,
-)
 from robosystems_client.models import (
   CreateGraphRequest,
   GraphMetadata as APIGraphMetadata,
@@ -43,6 +40,7 @@ if str(PROJECT_ROOT) not in sys.path:
   sys.path.insert(0, str(PROJECT_ROOT))
 
 from examples._common.config import get_graph_id, save_graph_id
+from examples._common.sdk import operation_status
 
 DEFAULT_CREDENTIALS_FILE = Path(__file__).resolve().parents[2] / ".local" / "config.json"
 DEMO_NAME = "custom_graph_demo"
@@ -128,24 +126,13 @@ def create_graph_with_custom_schema(
   for _ in range(max_attempts):
     time.sleep(poll_interval)
 
-    status_response = api_get_operation_status(operation_id=operation_id, client=client)
-    if not status_response.parsed:
+    status_data = operation_status(client, operation_id)
+    if not status_data:
       continue
 
-    status_data = status_response.parsed
-    if isinstance(status_data, dict):
-      status = status_data.get("status")
-      result = status_data.get("result")
-      error = status_data.get("error") or status_data.get("message")
-    elif hasattr(status_data, "additional_properties"):
-      props = status_data.additional_properties
-      status = props.get("status")
-      result = props.get("result")
-      error = props.get("error") or props.get("message")
-    else:
-      status = getattr(status_data, "status", None)
-      result = getattr(status_data, "result", None)
-      error = getattr(status_data, "message", None)
+    status = status_data.get("status")
+    result = status_data.get("result")
+    error = status_data.get("error") or status_data.get("message")
 
     if status == "completed":
       graph_id = None

--- a/examples/roboinvestor_demo/main.py
+++ b/examples/roboinvestor_demo/main.py
@@ -277,11 +277,10 @@ def create_investor_graph() -> str:
   from robosystems_client.api.graphs.create_graph import (
     sync_detailed as api_create_graph,
   )
-  from robosystems_client.api.operations.get_operation_status import (
-    sync_detailed as api_get_operation_status,
-  )
   from robosystems_client.client import AuthenticatedClient
   from robosystems_client.models import CreateGraphRequest, GraphMetadata
+
+  from examples._common.sdk import operation_status
 
   client = AuthenticatedClient(
     base_url=BASE_URL, token=api_key, prefix="", auth_header_name="X-API-Key"
@@ -323,20 +322,11 @@ def create_investor_graph() -> str:
     print(f"  Queued (operation: {operation_id}), waiting...")
     for _ in range(30):
       time.sleep(2)
-      status_resp = api_get_operation_status(operation_id=operation_id, client=client)
-      if not status_resp.parsed:
+      status_data = operation_status(client, operation_id)
+      if not status_data:
         continue
-      status_data = status_resp.parsed
-      if isinstance(status_data, dict):
-        status = status_data.get("status")
-        result = status_data.get("result", {})
-      elif hasattr(status_data, "additional_properties"):
-        props = status_data.additional_properties
-        status = props.get("status")
-        result = props.get("result", {})
-      else:
-        status = getattr(status_data, "status", None)
-        result = getattr(status_data, "result", {})
+      status = status_data.get("status")
+      result = status_data.get("result", {})
 
       if status == "completed":
         graph_id = result.get("graph_id") if isinstance(result, dict) else None

--- a/examples/roboledger_demo/main.py
+++ b/examples/roboledger_demo/main.py
@@ -204,11 +204,10 @@ def create_demo_graph(skeleton: bool = False, entity_type: str = "corporation") 
   from robosystems_client.api.graphs.create_graph import (
     sync_detailed as api_create_graph,
   )
-  from robosystems_client.api.operations.get_operation_status import (
-    sync_detailed as api_get_operation_status,
-  )
   from robosystems_client.client import AuthenticatedClient
   from robosystems_client.models import CreateGraphRequest, GraphMetadata
+
+  from examples._common.sdk import operation_status
 
   client = AuthenticatedClient(
     base_url=BASE_URL,
@@ -280,20 +279,11 @@ def create_demo_graph(skeleton: bool = False, entity_type: str = "corporation") 
     print(f"  Queued (operation: {operation_id}), waiting...")
     for _ in range(30):
       time.sleep(2)
-      status_resp = api_get_operation_status(operation_id=operation_id, client=client)
-      if not status_resp.parsed:
+      status_data = operation_status(client, operation_id)
+      if not status_data:
         continue
-      status_data = status_resp.parsed
-      if isinstance(status_data, dict):
-        status = status_data.get("status")
-        result = status_data.get("result", {})
-      elif hasattr(status_data, "additional_properties"):
-        props = status_data.additional_properties
-        status = props.get("status")
-        result = props.get("result", {})
-      else:
-        status = getattr(status_data, "status", None)
-        result = getattr(status_data, "result", {})
+      status = status_data.get("status")
+      result = status_data.get("result", {})
 
       if status == "completed":
         graph_id = result.get("graph_id") if isinstance(result, dict) else None

--- a/examples/seattle_method_demo/main.py
+++ b/examples/seattle_method_demo/main.py
@@ -165,11 +165,10 @@ def step_provision_graph() -> str:
   from robosystems_client.api.graphs.create_graph import (
     sync_detailed as api_create_graph,
   )
-  from robosystems_client.api.operations.get_operation_status import (
-    sync_detailed as api_get_operation_status,
-  )
   from robosystems_client.client import AuthenticatedClient
   from robosystems_client.models import CreateGraphRequest, GraphMetadata
+
+  from examples._common.sdk import operation_status
 
   client = AuthenticatedClient(
     base_url=BASE_URL,
@@ -218,20 +217,11 @@ def step_provision_graph() -> str:
     print(f"  Queued (operation: {operation_id}), waiting...")
     for _ in range(30):
       time.sleep(2)
-      status_resp = api_get_operation_status(operation_id=operation_id, client=client)
-      if not status_resp.parsed:
+      status_data = operation_status(client, operation_id)
+      if not status_data:
         continue
-      status_data = status_resp.parsed
-      if isinstance(status_data, dict):
-        status = status_data.get("status")
-        result = status_data.get("result", {})
-      elif hasattr(status_data, "additional_properties"):
-        props = status_data.additional_properties
-        status = props.get("status")
-        result = props.get("result", {})
-      else:
-        status = getattr(status_data, "status", None)
-        result = getattr(status_data, "result", {})
+      status = status_data.get("status")
+      result = status_data.get("result", {})
 
       if status == "completed":
         graph_id = result.get("graph_id") if isinstance(result, dict) else None

--- a/examples/seattle_method_world_online/main.py
+++ b/examples/seattle_method_world_online/main.py
@@ -146,11 +146,10 @@ def step_provision_graph() -> str:
   from robosystems_client.api.graphs.create_graph import (
     sync_detailed as api_create_graph,
   )
-  from robosystems_client.api.operations.get_operation_status import (
-    sync_detailed as api_get_operation_status,
-  )
   from robosystems_client.client import AuthenticatedClient
   from robosystems_client.models import CreateGraphRequest, GraphMetadata
+
+  from examples._common.sdk import operation_status
 
   client = AuthenticatedClient(
     base_url=BASE_URL, token=api_key, prefix="", auth_header_name="X-API-Key"
@@ -196,20 +195,11 @@ def step_provision_graph() -> str:
     print(f"  Queued (operation: {operation_id}), waiting…")
     for _ in range(30):
       time.sleep(2)
-      status_resp = api_get_operation_status(operation_id=operation_id, client=client)
-      if not status_resp.parsed:
+      status_data = operation_status(client, operation_id)
+      if not status_data:
         continue
-      status_data = status_resp.parsed
-      if isinstance(status_data, dict):
-        status = status_data.get("status")
-        result = status_data.get("result", {})
-      elif hasattr(status_data, "additional_properties"):
-        props = status_data.additional_properties
-        status = props.get("status")
-        result = props.get("result", {})
-      else:
-        status = getattr(status_data, "status", None)
-        result = getattr(status_data, "result", {})
+      status = status_data.get("status")
+      result = status_data.get("result", {})
       if status == "completed":
         graph_id = result.get("graph_id") if isinstance(result, dict) else None
         break


### PR DESCRIPTION
## Summary

Six demos polled async operations through the same twelve-line dance, branching on the response body's shape to extract `status` and `result`:

```python
status_data = status_resp.parsed
if isinstance(status_data, dict):
    status = status_data.get("status")
elif hasattr(status_data, "additional_properties"):
    props = status_data.additional_properties
    status = props.get("status")
else:
    status = getattr(status_data, "status", None)   # could never fire
```

The operations endpoints are declared as free-form objects, so the generated model carries only `additional_properties` and attribute access on it raises — that middle branch is the workaround, and the `getattr` fallback beneath it was unreachable. This is the consumer-side echo of the client defect fixed in RoboFinSystems/robosystems-python-client#202: everyone hit the wall and hand-rolled the same escape.

## Changes

- **`examples/_common/sdk.py`** — `operation_status(client, operation_id)` reads the body through `to_dict()` and returns a plain dict, or `{}` when the response carried no body.
- **Six polling loops** — `_scenario/runner.py`, `custom_graph_demo/create_graph.py`, `roboinvestor_demo/main.py`, `roboledger_demo/main.py`, `seattle_method_demo/main.py`, `seattle_method_world_online/main.py` — each drops the dance for the helper and swaps the generated import for it. Net −99/+61 across seven files.

**Behaviour is unchanged at every site.** `{}` is falsy, so the existing `continue` still fires on an empty body; an error response or a body without a `status` key yields `status is None`, so the loop keeps polling rather than mistaking it for a terminal state — same as before.

## Not touched

Three other `additional_properties` reads under `examples/` — `custom_graph_demo/memory_subgraph.py`, `custom_graph_demo/upload_documents.py`, `roboledger_demo/validate.py` — read *different* response models (period-close overflow, an investor payload). The operations accessor does not apply, so they stay as they are.

This does **not** bump the client pin. The helper only needs `to_dict()`, which has always been generated, so it works against the currently-locked 1.13.1. Moving to 1.13.2 (for the query/operator/operations retry parity in #202) is worth doing on its own merits and belongs in its own change.

## Testing

- `just test-code` — ruff, format and basedpyright clean. Note `examples` is in ruff's `exclude` list in `pyproject.toml`, so the tree is deliberately unlinted; these edits match the surrounding style by hand rather than by running a formatter over an excluded path.
- All seven touched modules import clean.
- `operation_status` exercised against a live stub for four cases: a completed operation (`result.graph_id` read back), a failed one, a 500 error body, and a 200 whose body omits `status` — the last two yielding `status is None` so a poll continues.
- The demos themselves need a live stack; not run end-to-end here.
