### PR TITLE
fix(demos): abort the roboledger load when an event or agent write fails

### DIFF
--- a/examples/roboledger_demo/main.py
+++ b/examples/roboledger_demo/main.py
@@ -418,7 +418,6 @@ def create_agents(graph_id: str) -> dict[str, str]:
 
   client = _get_ledger_client()
   lookup: dict[str, str] = {}
-  skipped = 0
 
   for body in AGENTS:
     # No idempotency_key: reset_demo wipes the agents table per-run, but
@@ -429,13 +428,16 @@ def create_agents(graph_id: str) -> dict[str, str]:
     try:
       resp = client.create_agent(graph_id, body)
     except Exception as e:
-      print(f"  WARNING: create-agent failed for {body['name']} — {e}")
-      skipped += 1
-      continue
+      # A dropped agent is invisible downstream: `agent_lookup.get(name)`
+      # then returns None and every event for that counterparty posts with
+      # no `agent_id` — the REA linkage the demo exists to show, silently
+      # absent. Matches `_scenario/runner.py`.
+      raise RuntimeError(
+        f"create-agent failed for {body['name']} — {e}\n"
+        f"  Created {len(lookup)} agents before the failure; events posted "
+        f"against the rest would carry no counterparty."
+      ) from e
     lookup[body["name"]] = resp.id
-
-  if skipped:
-    print(f"  WARNING: Skipped {skipped} agents")
 
   return lookup
 
@@ -529,7 +531,7 @@ def create_business_events(
     "journal_entry_recorded": 0,
   }
   line_item_count = 0
-  skipped = 0
+  unmapped = 0
 
   cash_id = element_lookup.get(_CASH_CODE)
   ap_id = element_lookup.get(_AP_CODE)
@@ -537,7 +539,7 @@ def create_business_events(
   for txn_date, txn_type, description, agent_name, lines in txns:
     li_list = _build_line_items(lines, element_lookup)
     if li_list is None or len(li_list) < 2:
-      skipped += 1
+      unmapped += 1
       continue
 
     agent_id = agent_lookup.get(agent_name) if agent_name else None
@@ -656,12 +658,20 @@ def create_business_events(
         line_item_count += len(li_list)
 
     except Exception as e:
-      print(f"  WARNING: create-event-block failed for {txn_date} {txn_type} — {e}")
-      skipped += 1
-      continue
+      # Abort rather than continue. `bill_payment` posts two linked events,
+      # so a failure between them strands an AP balance with no discharge,
+      # and a dropped invoice leaves its later payment with no obligation
+      # to discharge. Carrying on would then close periods and materialize
+      # over a ledger that is quietly wrong. Matches `_scenario/runner.py`.
+      raise RuntimeError(
+        f"create-event-block failed for {txn_date} {txn_type} — {e}\n"
+        f"  Loaded {sum(counts.values())} events before the failure; the "
+        f"ledger is incomplete, so the run stops here rather than closing "
+        f"periods over it."
+      ) from e
 
-  if skipped:
-    print(f"  WARNING: Skipped {skipped} events (missing elements or errors)")
+  if unmapped:
+    print(f"  WARNING: Skipped {unmapped} transactions (no CoA element)")
 
   return {
     "entries": sum(counts.values()),


### PR DESCRIPTION
## Summary

The second copy of the defect #1318 fixed in the scenario runner. `just demo-roboledger` loads Cascade Advisory through `examples/roboledger_demo/main.py`, which carries its own duplicate of the event and agent loops — and both swallowed a failed write into a counter and carried on.

The consequences are the ones #1318 spelled out, and the CI run that started all this demonstrated them: `bill_payment` posts two linked events, so a failure between them strands an AP balance with no discharge (`bill_received: 95` against `bill_paid: 94` in that log); a dropped invoice leaves its later payment with no obligation to discharge; and a dropped agent is quieter still, because `agent_lookup.get()` then returns `None` and every event for that counterparty posts with no `agent_id` — the REA linkage the demo exists to show, silently absent. The run would then close periods and materialize over the gap and still exit 0.

Locally this can never fire: `RATE_LIMIT_ENABLED=false`, so nothing is rejected. But this demo also runs against a deployed API via `DEMO_API_URL`, which is exactly the configuration where the showcase episode lost 25 of 383 events while reporting success.

## Changes

`examples/roboledger_demo/main.py` only.

- **`create_agents`** — raises instead of counting, naming how many agents were created first.
- **`create_business_events`** — raises instead of counting, naming how many events were loaded first.
- The genuine data skip (a transaction whose lines resolve to no CoA element) stays non-fatal and is now counted as `unmapped`, reported separately. Folding it together with API failures under `"Skipped N events (missing elements or errors)"` is what made the original invisible.

Both comments point at `_scenario/runner.py` so the two copies stay legible as the pair they are.

## Testing

- `just test-code` — ruff, format, basedpyright clean.
- **`just demo-roboledger` run end-to-end against the local stack**: exit 0, no warnings, 17 agents, 317 events / 683 line items, with `bill_received` 85 = `bill_paid` 85 and `invoice_issued` 47 = `payment_received` 47 — the balanced pairs that were asymmetric in the failing CI log.
- The abort path itself is not exercised: nothing is rejected locally with rate limiting off. It is the same code shape already reviewed in #1318.
