### PR TITLE
fix(graphs): return the extension display name instead of dropping it

### DIFF
--- a/robosystems/models/api/entity_graph.py
+++ b/robosystems/models/api/entity_graph.py
@@ -121,6 +121,10 @@ class EntityWithGraphResponse(BaseModel):
 
 class AvailableExtension(BaseModel):
   name: str
+  # The name to show a user. `name` is the schema slug the create path takes
+  # ("roboledger"), which is not what a tier or extension picker should be
+  # rendering — clients fall back to the slug only when this is absent.
+  display_name: str | None = None
   description: str
   enabled: bool = False
 

--- a/robosystems/routers/graphs/main.py
+++ b/robosystems/routers/graphs/main.py
@@ -54,8 +54,14 @@ from robosystems.models.core import Graph, GraphUser, OrgLimits, OrgRole, OrgUse
 router = APIRouter(prefix="/v1/graphs", tags=["Graphs"])
 
 # Surfaced to prospects at graph-creation time, so these describe only what is
-# built. Both are read twice below — the schema-loading path and its fallback —
-# and single-sourcing them here is what keeps the two copies from diverging.
+# built. All three are read twice below — the schema-loading path and its
+# fallback — and single-sourcing them here is what keeps the copies from
+# diverging.
+_DISPLAY_NAMES = {
+  "roboledger": "RoboLedger - Accounting & Financial Reporting",
+  "roboinvestor": "RoboInvestor - Investment Management",
+}
+
 _ROBOLEDGER_DESCRIPTION = (
   "Complete accounting system with XBRL reporting and GL transactions. "
   "Context-aware: SEC repositories get reporting-only tables, "
@@ -538,12 +544,6 @@ async def get_available_extensions(
         f"Extension {ext_info['name']}: available={ext_info.get('available', False)}"
       )
       if ext_info["available"]:
-        # Get display names for extensions
-        display_names = {
-          "roboledger": "RoboLedger - Accounting & Financial Reporting",
-          "roboinvestor": "RoboInvestor - Investment Management",
-        }
-
         # Try to get actual node/relationship counts
         try:
           from robosystems.schemas.loader import (
@@ -577,7 +577,7 @@ async def get_available_extensions(
         available_extensions.append(
           {
             "name": ext_info["name"],
-            "display_name": display_names.get(
+            "display_name": _DISPLAY_NAMES.get(
               ext_info["name"], ext_info["name"].title()
             ),
             "description": description,  # Use the correctly set description
@@ -589,7 +589,10 @@ async def get_available_extensions(
     # Convert dictionaries to AvailableExtension objects
     extension_objects = [
       AvailableExtension(
-        name=str(ext["name"]), description=str(ext["description"]), enabled=False
+        name=str(ext["name"]),
+        display_name=str(ext["display_name"]),
+        description=str(ext["description"]),
+        enabled=False,
       )
       for ext in available_extensions
     ]
@@ -605,11 +608,13 @@ async def get_available_extensions(
       extensions=[
         AvailableExtension(
           name="roboledger",
+          display_name=_DISPLAY_NAMES["roboledger"],
           description=_ROBOLEDGER_DESCRIPTION,
           enabled=False,
         ),
         AvailableExtension(
           name="roboinvestor",
+          display_name=_DISPLAY_NAMES["roboinvestor"],
           description=_ROBOINVESTOR_DESCRIPTION,
           enabled=False,
         ),

--- a/tests/routers/graphs/test_schema_integration.py
+++ b/tests/routers/graphs/test_schema_integration.py
@@ -360,6 +360,19 @@ class TestSchemaManagementIntegration:
       extensions = extensions_response.json()
       assert len(extensions["extensions"]) == 2
 
+      # `name` is the slug the create path takes; `display_name` is what a
+      # picker renders. The display name used to be computed and then dropped
+      # when the response model was built, leaving clients with "roboledger".
+      by_name = {ext["name"]: ext for ext in extensions["extensions"]}
+      assert (
+        by_name["roboledger"]["display_name"]
+        == "RoboLedger - Accounting & Financial Reporting"
+      )
+      assert (
+        by_name["roboinvestor"]["display_name"]
+        == "RoboInvestor - Investment Management"
+      )
+
     # Now create a schema that should be compatible with roboledger
     financial_schema = {
       "name": "custom_financial",


### PR DESCRIPTION
`getAvailableExtensions` builds a display-names table, looks each extension up
in it, puts the result in a dict — and then drops it when constructing the
`AvailableExtension` response objects, which carry only `name`, `description`
and `enabled`:

```python
extension_objects = [
  AvailableExtension(
    name=str(ext["name"]), description=str(ext["description"]), enabled=False
  )
  for ext in available_extensions   # ext["display_name"] computed, never read
]
```

So the only human-readable label the endpoint has never leaves it. Clients get
`name`, which is the schema slug the create path takes, and the visible
consequence is the graph creation wizard heading its extension cards
"roboledger" and "roboinvestor" — plus the required-extensions alert listing
slugs.

Found while fixing dark-mode issues in that same wizard
(robosystems-app#351).

## Change

- `display_name` added to `AvailableExtension`, optional so an older client is
  unaffected; clients fall back to the slug when it is absent.
- Populated on both response paths. The fallback branch never had one at all,
  so the table is hoisted to module scope beside the descriptions, where the
  existing comment already explains why those constants are single-sourced.
- Test asserts the display name survives into the response. Verified it fails
  against the old source (`KeyError`), so it is not vacuous.

## Follow-up (not in this PR)

The apps can't use the field until the TypeScript client is regenerated and
released, then adopted. Happy to take that chain next if you want it.

`just test-code` clean; `pytest tests/routers/graphs tests/models` green
(1735 passed, 4 skipped).
