### PR TITLE
chore(deps): pin uv, hold two majors, take the focused dbt upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       interval: "monthly"
     labels:
       - "dependencies"
+    ignore:
+      # hold: v9's prune-cache flip bloats the cache; v10's guard covers events we don't use
+      - dependency-name: "astral-sh/setup-uv"
+        update-types: ["version-update:semver-major"]
 
   # Python — uv dependencies in pyproject.toml and uv.lock
   - package-ecosystem: "uv"
@@ -47,3 +51,5 @@ updates:
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "lambda/python"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Must move in lockstep with [tool.uv] required-version in pyproject.toml
+      - dependency-name: "ghcr.io/astral-sh/uv"

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,10 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     curl \
     unzip \
     file \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl -LsSf https://astral.sh/uv/install.sh | sh \
-    && mv /root/.local/bin/uv /usr/local/bin/uv
+    && rm -rf /var/lib/apt/lists/*
+
+# uv pinned to [tool.uv] required-version in pyproject.toml
+COPY --from=ghcr.io/astral-sh/uv:0.12.8 /uv /usr/local/bin/uv
 
 # Copy LadybugDB extensions from official extension repository
 # Extensions pulled from ghcr.io/ladybugdb/extension-repo:latest
@@ -136,9 +137,10 @@ RUN echo "os-refresh ${CACHE_DATE}" && apt-get update && apt-get upgrade -y && a
     curl \
     git \
     zstd \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl -LsSf https://astral.sh/uv/install.sh | sh \
-    && mv /root/.local/bin/uv /usr/local/bin/uv
+    && rm -rf /var/lib/apt/lists/*
+
+# uv pinned to [tool.uv] required-version in pyproject.toml
+COPY --from=ghcr.io/astral-sh/uv:0.12.8 /uv /usr/local/bin/uv
 
 # Copy virtual environment from builder stage
 COPY --from=builder /build/.venv /build/.venv

--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -21,7 +21,7 @@ RUN echo "os-refresh ${CACHE_DATE}" && dnf update -y --releasever=latest && dnf 
 RUN rm -f /usr/local/bin/aws-lambda-rie
 
 # Install uv for dependency export
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.8 /uv /usr/local/bin/uv
 
 # Set working directory to Lambda task root
 WORKDIR ${LAMBDA_TASK_ROOT}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,7 @@ dependencies = [
     "uvloop>=0.21.0,<1.0; sys_platform != 'win32'",
     # Cloud Service (AWS)
     "boto3>=1.42.0,<2.0",
-    # Hugging Face Hub (SEC dataset publish: launches the Hub-side Job, verifies the upload)
     "huggingface-hub>=1.19,<2",
-    "zstandard>=0.23,<1",  # decompress the .lbug.zst dumps on the host (no zstd binary needed)
     # OLAP Staging/Vector/Graph Databases
     "duckdb==1.4.4",
     "lancedb>=0.34.0,<0.35",  # 0.34 made pylance an optional extra (unused here); 0.30<->0.36 format compat verified 2026-08-01
@@ -61,7 +59,7 @@ dependencies = [
     "dagster-postgres>=0.29.15,<1.0",
     "dagster-aws>=0.29.15,<1.0",
     # Data Transformation (dbt)
-    "dbt-core>=1.11.0,<2.0",
+    "dbt-core>=1.11.14,<1.12",  # hold: 1.12 adds a beta parser dep + the metricflow subtree we don't use; 1.11.14 has the sqlparse<0.7.0 lift
     "dbt-duckdb>=1.10.0,<2.0",
     # Data Processing & Analytics
     "arelle-release==2.39.5",
@@ -99,14 +97,15 @@ dependencies = [
     "psutil>=7.2.1,<8.0",
     "pydantic[email]>=2.13.4,<3.0",
     "pyjwt>=2.10.0,<3.0",
+    "pyshacl>=0.26,<0.31",
     "python-multipart>=0.0.27,<1.0",
-    "python-ulid>=3.0.0",
+    "python-ulid>=3.0.0,<4.0",  # hold: 4.0 only reworks generation customization; we use ULID()/from_str/.timestamp/.bytes
     "pyyaml>=6.0.0,<7.0",
     "requests>=2.34.2,<3.0",
     "retrying>=1.4.0,<2.0",
     "uuid6>=2025.0.0",
     "webauthn>=2.7.0,<3.0",
-    "pyshacl>=0.26,<0.31",
+    "zstandard>=0.23,<1"
 ]
 
 [project.optional-dependencies]
@@ -149,12 +148,7 @@ lambda = [
 ]
 
 [tool.uv]
-# sqlparse 0.6.0 (2026-08-13) fixes CVE-2026-59893 / CVE-2026-54284 /
-# CVE-2026-71491 (lexer and grouping DoS). dbt-core pins sqlparse<0.6.0 even
-# at its latest release, and it is the only consumer here (robosystems does not
-# import sqlparse; dbt parses only its own compiled SQL). Override until
-# dbt-core lifts the ceiling, then delete this block.
-override-dependencies = ["sqlparse>=0.6.0"]
+required-version = "==0.12.8"  # setup-uv auto-reads this; Dockerfiles pin the matching tag
 
 [tool.setuptools]
 packages = ["robosystems"]

--- a/uv.lock
+++ b/uv.lock
@@ -6,9 +6,6 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 
-[manifest]
-overrides = [{ name = "sqlparse", specifier = ">=0.6.0" }]
-
 [[package]]
 name = "actionlint-py"
 version = "1.7.12.24"
@@ -922,7 +919,7 @@ wheels = [
 
 [[package]]
 name = "dbt-core"
-version = "1.11.11"
+version = "1.11.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agate" },
@@ -948,14 +945,14 @@ dependencies = [
     { name = "sqlparse" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/62/af8f4ab1e3e979b5677e876444f3a9c1b1021c2d4e77143e80f421bdc1f7/dbt_core-1.11.11.tar.gz", hash = "sha256:e53cfccc8c9c13a082e518bf80cf3bb33c2f1fdc3cab48ec822ef93737eccb81", size = 973079, upload-time = "2026-05-20T11:10:01.8Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5f/65360669232d60c4fa59d6ca0528b77f5f8ed31736b70477575c1e8897cb/dbt_core-1.11.14.tar.gz", hash = "sha256:d7fd94c398b26fbcbb34ee6b9ff136963d3184ca1ed052685c855fcf333561b2", size = 974842, upload-time = "2026-08-20T15:49:54.061Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/d2/9e1eb5d3c8f375d4e5523b9123b2ae25ea21d85abb044db2eff2e3ee9c1d/dbt_core-1.11.11-py3-none-any.whl", hash = "sha256:7f9e11f3f5400e20f40f544440800ace23fa0755086f87b08e9446181f8720e1", size = 1061938, upload-time = "2026-05-20T11:09:59.856Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/98/a8850a5275eeb6929734bcd24fd66f679023b034d0d71ffcaaceb227f8c6/dbt_core-1.11.14-py3-none-any.whl", hash = "sha256:98f7b7b13dada6347439ac44855601e58d482d177be22431fd7f92200d115dcd", size = 1063972, upload-time = "2026-08-20T15:49:52.625Z" },
 ]
 
 [[package]]
 name = "dbt-duckdb"
-version = "1.10.1"
+version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dbt-adapters" },
@@ -963,9 +960,9 @@ dependencies = [
     { name = "dbt-core" },
     { name = "duckdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/d3/0f9f6a4de94e0f95dcfabbba5e8ef7670de695483345edd9e5b36e93d024/dbt_duckdb-1.10.1.tar.gz", hash = "sha256:5d6df1589d4ba21fe20ac08454a32763d3263798c9f5914280eabd1dc285cbc0", size = 145907, upload-time = "2026-02-17T17:29:04.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2e/cd495dbdee474eefb431156055dd7142b893258567e2167e414fceac0641/dbt_duckdb-1.11.0.tar.gz", hash = "sha256:4b087557e8559e2c141a8daae28f4a832a06f425d0b4567eca7c8ffb635cd0fe", size = 170805, upload-time = "2026-08-07T16:08:10.453Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/26/0ce2b1aeecdd1a18a9fac6f02d08f60c95944f036866f3fe37146298d4e4/dbt_duckdb-1.10.1-py3-none-any.whl", hash = "sha256:90658ecb367082786c5ea2ffbf9e35bb4116fa5ad1bc2f287c4dc1f3984bafa1", size = 85089, upload-time = "2026-02-17T17:29:03.117Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/79/52cf57da07b05ff2e6a055c44b249d6fde200af340641995daea22ed6e2c/dbt_duckdb-1.11.0-py3-none-any.whl", hash = "sha256:bac8c77771de890efa1af5b003af7c74de50c5ef67dba5891894e78348f7091b", size = 91227, upload-time = "2026-08-07T16:08:09.004Z" },
 ]
 
 [[package]]
@@ -3769,7 +3766,7 @@ requires-dist = [
     { name = "dagster-aws", specifier = ">=0.29.15,<1.0" },
     { name = "dagster-postgres", specifier = ">=0.29.15,<1.0" },
     { name = "dagster-webserver", specifier = ">=1.13.15,<2.0" },
-    { name = "dbt-core", specifier = ">=1.11.0,<2.0" },
+    { name = "dbt-core", specifier = ">=1.11.14,<1.12" },
     { name = "dbt-duckdb", specifier = ">=1.10.0,<2.0" },
     { name = "duckdb", specifier = "==1.4.4" },
     { name = "email-validator", specifier = ">=2.2.0,<3.0" },
@@ -3811,7 +3808,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6,<4.0" },
     { name = "python-multipart", specifier = ">=0.0.27,<1.0" },
     { name = "python-quickbooks", specifier = ">=0.9.0,<1.0" },
-    { name = "python-ulid", specifier = ">=3.0.0" },
+    { name = "python-ulid", specifier = ">=3.0.0,<4.0" },
     { name = "pyyaml", specifier = ">=6.0.0,<7.0" },
     { name = "rdflib", specifier = ">=7.0.0,<8.0" },
     { name = "redis", specifier = ">=8.0.1,<9.0" },


### PR DESCRIPTION
## Summary

Follow-up to this month's dependabot pass. Three of the ten proposed bumps were majors or carried freight we don't want, so they were closed in favour of deliberate decisions recorded in-tree; while checking them, the uv binary itself turned out to be unpinned in five places. This PR pins uv, records the two holds where dependabot will otherwise re-propose them, and takes the narrow dbt upgrade that delivers what 1.12 was wanted for without its new dependencies.

## Changes

**Pin the uv binary (`pyproject.toml`, `Dockerfile`, `Dockerfile.lambda`)**

uv was unpinned everywhere it is installed — `setup-uv` with no `version:` in `test.yml` and `create-release.yml`, two `curl -LsSf https://astral.sh/uv/install.sh | sh` installs in `Dockerfile`, and `ghcr.io/astral-sh/uv:latest` in `Dockerfile.lambda`. Nothing tracked any of them, so every CI run and image build took whatever uv was newest: the last green Test CI run used 0.12.8, published the day before.

`[tool.uv] required-version = "==0.12.8"` pins it in one place. `setup-uv` reads that key on its own — its `version-file` input defaults to searching `uv.toml` then `pyproject.toml` — so both workflows pin with no workflow change, and uv refuses to run on a mismatch, which makes local/CI skew visible instead of silent. The Dockerfiles now `COPY --from=ghcr.io/astral-sh/uv:0.12.8`, replacing the two curl-pipe-shell installs and the `:latest` tag.

**Hold python-ulid at 3.x (`pyproject.toml`)**

`python-ulid>=3.0.0` was unbounded, so 4.x will be re-proposed indefinitely. 4.0 reworks generation customization only — the new `ULIDGenerator`, monotonicity policies, and the removal of `ValueProvider`/`ULID.provider`. `robosystems/utils/ulid.py` uses `ULID()`, `from_str`, `.timestamp` and `.bytes`, none of which changed, so the major carries risk with no corresponding gain.

**Hold astral-sh/setup-uv at v8 (`.github/dependabot.yml`)**

v9 flipped `prune-cache` to `false`, which grows the Actions cache to the full unpruned uv cache on a dependency set including onnxruntime, arelle, scipy and dagster. v10's cache-poisoning guard applies only to `pull_request_target`, `workflow_run` and `release`; `test.yml` sets `enable-cache: true` explicitly and `create-release.yml` is `workflow_dispatch`, so none of our workflows benefit. Majors are ignored; minors and patches still flow.

The `ghcr.io/astral-sh/uv` image is also ignored for the docker ecosystem, since a Dockerfile-only bump would split the pin from `required-version`.

**Take dbt-core 1.11.14 instead of 1.12.3 (`pyproject.toml`, `uv.lock`)**

Both releases lift dbt's sqlparse ceiling to `<0.7.0`, which is the only thing the 1.12 bump was wanted for. 1.12 additionally adds `dbt-core-experimental-parser` (resolving to a `2.0.0b2` beta) as a hard runtime dependency and swaps `dbt-semantic-interfaces` for `metricflow`, pulling in sqlglot, rapidfuzz, tabulate, referencing and opentelemetry-api for a semantic layer the QuickBooks dbt project doesn't use — all of it into the runtime image, since dbt is a main dependency.

1.11.14 keeps the existing tree and retires the `[tool.uv] override-dependencies = ["sqlparse>=0.6.0"]` block, whose own comment said to delete it once dbt lifted the ceiling. sqlparse stays at 0.6.0 (so the CVE fixes that motivated the override are retained) but now resolves natively rather than being forced past a constraint dbt declared incompatible. `dbt-duckdb` moves to 1.11.0, which requires only `dbt-core>=1.8.0`.

Reviewers may want to confirm the lock: `dbt-core-experimental-parser`, `metricflow`, `sqlglot` and `rapidfuzz` should all be absent, and `sqlparse` should still be 0.6.0.

## Breaking Changes

None. No API surface, GraphQL schema, operations envelope or REST shape is touched, so there is no client SDK impact in either tier.

One local-workflow consequence, by design: `required-version` makes uv exit with an error if the running binary isn't 0.12.8, so contributors on an older uv must upgrade (`brew upgrade uv`) before `uv run` works.

## Testing

`just test-all` passed on this change set (exit 0). Edits after that run were limited to comment wording and dependency-list ordering; the pre-commit gate (ruff, format, basedpyright) passed on the committed tree, and `uv lock --check` confirms the lock matches `pyproject.toml`.

Additionally verified out of band: all 244 locked packages scanned against the OSV advisory database with zero hits, confirming no security driver was deferred by the two holds.

Not exercised locally: the Docker image builds, which are the surface the `COPY --from` change affects. CI build is the check for those.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
