### PR TITLE
chore(deps): move the uv pin off pyproject so dependabot parses again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,5 +51,6 @@ updates:
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "lambda/python"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # Must move in lockstep with [tool.uv] required-version in pyproject.toml
+      # Pinned in four places that must move together: this tag, the same tag in
+      # Dockerfile.lambda, and setup-uv's `version` in test.yml + create-release.yml.
       - dependency-name: "ghcr.io/astral-sh/uv"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.12.8" # keep in step with the ghcr.io/astral-sh/uv tag in both Dockerfiles
 
       - name: Get current version
         id: current-version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,7 @@ jobs:
         if: runner.os == 'Linux' && !contains(runner.name, 'robosystems')
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
+          version: "0.12.8" # keep in step with the ghcr.io/astral-sh/uv tag in both Dockerfiles
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     file \
     && rm -rf /var/lib/apt/lists/*
 
-# uv pinned to [tool.uv] required-version in pyproject.toml
+# uv pinned here and via setup-uv's `version` input in test.yml + create-release.yml
 COPY --from=ghcr.io/astral-sh/uv:0.12.8 /uv /usr/local/bin/uv
 
 # Copy LadybugDB extensions from official extension repository
@@ -139,7 +139,7 @@ RUN echo "os-refresh ${CACHE_DATE}" && apt-get update && apt-get upgrade -y && a
     zstd \
     && rm -rf /var/lib/apt/lists/*
 
-# uv pinned to [tool.uv] required-version in pyproject.toml
+# uv pinned here and via setup-uv's `version` input in test.yml + create-release.yml
 COPY --from=ghcr.io/astral-sh/uv:0.12.8 /uv /usr/local/bin/uv
 
 # Copy virtual environment from builder stage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,12 @@ lambda = [
 ]
 
 [tool.uv]
-required-version = "==0.12.8"  # setup-uv auto-reads this; Dockerfiles pin the matching tag
+# Deliberately NO required-version here. Dependabot's updater bundles its own uv
+# (0.12.7 as of 2026-09), and an exact required-version makes it refuse to parse this
+# manifest at all — every Python update job dies with tool_version_not_supported and
+# the ecosystem goes silent, security updates included. Pin uv where it actually runs
+# instead: the `version` input on setup-uv in test.yml + create-release.yml, and the
+# ghcr.io/astral-sh/uv tag in Dockerfile + Dockerfile.lambda. Move all four together.
 
 [tool.setuptools]
 packages = ["robosystems"]

--- a/robosystems/adapters/quickbooks/dbt/models/staging/staging.yml
+++ b/robosystems/adapters/quickbooks/dbt/models/staging/staging.yml
@@ -26,14 +26,15 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values:
-                - Asset
-                - Liability
-                - Equity
-                - Revenue
-                - Expense
-                - Other Income
-                - Other Expense
+              arguments:
+                values:
+                  - Asset
+                  - Liability
+                  - Equity
+                  - Revenue
+                  - Expense
+                  - Other Income
+                  - Other Expense
 
   - name: stg_qb_journal_entries
     description: Cleaned QuickBooks journal entries
@@ -62,9 +63,10 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values:
-                - Debit
-                - Credit
+              arguments:
+                values:
+                  - Debit
+                  - Credit
       - name: account_ref_id
         tests:
           - not_null
@@ -79,7 +81,8 @@ models:
       - name: agent_type
         tests:
           - accepted_values:
-              values: [customer]
+              arguments:
+                values: [customer]
 
   - name: stg_qb_vendors
     description: QuickBooks Vendor entities — purchase counterparties
@@ -91,7 +94,8 @@ models:
       - name: agent_type
         tests:
           - accepted_values:
-              values: [vendor]
+              arguments:
+                values: [vendor]
 
   - name: stg_qb_employees
     description: QuickBooks Employee entities
@@ -103,7 +107,8 @@ models:
       - name: agent_type
         tests:
           - accepted_values:
-              values: [employee]
+              arguments:
+                values: [employee]
 
   - name: stg_qb_invoice_headers
     description: QuickBooks Invoice headers (no line items — those still come from JournalReport)


### PR DESCRIPTION
## Summary

Two fixes found while reviewing the dependency blitz ahead of a release.

**The uv pin took Dependabot offline.** `[tool.uv] required-version = "==0.12.8"` (added in f9ff508d) makes Dependabot's updater refuse this manifest outright — it bundles its own uv, 0.12.7, and every Python update job died on parse:

```
tool_version_not_supported {"tool-name": "uv",
  "detected-version": "==0.12.8", "supported-versions": "0.12.7"}
```

It failed for every package, not a subset — `dbt-core`, `boto3`, `uvicorn`, `redis`, `starlette`, `alembic`, `lancedb`, `pyarrow` ([run 33539636377](https://github.com/RoboFinSystems/robosystems/actions/runs/33539636377)). Security updates ride the same updater, so those stopped too. Nothing surfaces this: the symptom is an absence of PRs, which reads as nothing to update, and the `ghcr.io/astral-sh/uv` docker ignore added in the same commit meant uv itself would not be bumped either.

The fix keeps the determinism and moves it off the file Dependabot parses. `setup-uv` takes an explicit `version` input (confirmed present at the pinned v8.3.2 SHA), so `test.yml` and `create-release.yml` carry it directly and both Dockerfiles keep their `ghcr.io/astral-sh/uv` tag. Same 0.12.8 in all four places, each comment naming the others, and `pyproject.toml` keeps a comment where the key sat so it doesn't get helpfully restored.

This also unbreaks local work: the exact pin meant the next `brew upgrade uv` would fail every `uv run` — which CLAUDE.md mandates for everything — until someone hand-edited `pyproject.toml`.

**The dbt deprecation blocking the 1.12 hold.** dbt-core 1.11.14 warns `MissingArgumentsPropertyInGenericTestDeprecation` five times, once per `accepted_values` test in the QuickBooks staging schema, and 1.12 removes the bare form. That's the concrete blocker in front of the deliberate `dbt-core>=1.11.14,<1.12` hold and open Dependabot PR #1003. Wrapping the args in `arguments:` clears it.

## Verification

- `just test-all`: **14218 passed**, 0 failed; ruff + format + basedpyright + cf-lint clean
- `just test-dbt quickbooks`: five-line deprecation summary → **none**, `PASS=71 ERROR=0`, all five `accepted_values` tests still running
- `uv lock --check` clean — `uv.lock` is untouched
- `setup-uv`'s `version` input verified against the pinned SHA, not the action's default branch
- both workflow files and `dependabot.yml` parse

## Note

No application code changes — this release is entirely dependencies and CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKQFGdyYj7C9DwSct4tuna