### PR TITLE
chore(image): drop curl and git from the runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,13 +129,15 @@ ENV PYTHONUNBUFFERED=1 \
 # Install runtime dependencies, apply security patches, and install uv.
 # CACHE_DATE (set per-build in build.yml) busts this layer so the upgrade
 # re-runs despite GHA layer caching — a cached layer keeps stale OS packages.
+# No curl or git here: git is only needed in the builder (EDGAR subtree), and
+# health probes use bin/healthcheck.py — curl would drag libcurl and libssh2
+# into the image, which the container-image scanners then flag.
+# postgresql-client stays: entrypoint.sh waits on the database with psql.
 ARG CACHE_DATE
 RUN echo "os-refresh ${CACHE_DATE}" && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     libpq5 \
     libatomic1 \
     postgresql-client \
-    curl \
-    git \
     zstd \
     && rm -rf /var/lib/apt/lists/*
 

--- a/bin/healthcheck.py
+++ b/bin/healthcheck.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""HTTP health probe for container health checks.
+
+GET the URL and exit 0 on a 2xx response, 1 otherwise. Standard library only,
+so the runtime image needs no curl (and therefore no libcurl or libssh2).
+
+Usage: healthcheck.py URL [TIMEOUT_SECONDS]
+"""
+
+import sys
+import urllib.error
+import urllib.request
+
+
+def main() -> int:
+  if len(sys.argv) < 2:
+    print("usage: healthcheck.py URL [TIMEOUT_SECONDS]", file=sys.stderr)
+    return 2
+  url = sys.argv[1]
+  timeout = float(sys.argv[2]) if len(sys.argv) > 2 else 8.0
+  try:
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+      return 0 if 200 <= response.status < 300 else 1
+  except (urllib.error.URLError, OSError, ValueError) as exc:
+    print(f"healthcheck failed: {exc}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/bin/userdata/common/graph-lifecycle.sh
+++ b/bin/userdata/common/graph-lifecycle.sh
@@ -54,9 +54,12 @@ handle_termination() {
         --expression-attribute-values "{\":status\": {\"S\": \"terminating\"}, \":time\": {\"S\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" \
         --region "$REGION" || log "WARNING: Failed to update instance status"
 
-    # 2. Stop accepting new connections through Graph API
+    # 2. Stop accepting new connections through Graph API.
+    # Called from the host (the container publishes its port and no longer ships
+    # curl). Note: the Graph API does not currently expose /admin/drain or
+    # /admin/connections, so both calls fall through to their fallbacks today.
     log "Draining connections via Graph API..."
-    docker exec ${CONTAINER_NAME} curl -X POST ${DRAIN_ENDPOINT} 2>/dev/null || {
+    curl -s -f -X POST ${DRAIN_ENDPOINT} >/dev/null 2>&1 || {
         log "WARNING: Failed to drain connections via Graph API"
     }
 
@@ -93,7 +96,7 @@ handle_termination() {
     TIMEOUT=300
     ELAPSED=0
     while [ $ELAPSED -lt $TIMEOUT ]; do
-        ACTIVE_CONNECTIONS=$(docker exec ${CONTAINER_NAME} curl -s ${CONNECTIONS_ENDPOINT} 2>/dev/null | jq '.active_connections // 0' || echo "0")
+        ACTIVE_CONNECTIONS=$(curl -s -f ${CONNECTIONS_ENDPOINT} 2>/dev/null | jq '.active_connections // 0' || echo "0")
 
         if [ "$ACTIVE_CONNECTIONS" = "0" ] || [ "$ACTIVE_CONNECTIONS" -eq 0 ]; then
             log "All connections closed"

--- a/bin/userdata/common/run-graph-container.sh
+++ b/bin/userdata/common/run-graph-container.sh
@@ -100,7 +100,7 @@ EXTRA_ENV_VARS="-e LBUG_NODE_TYPE=${NODE_TYPE} \
     -e LBUG_PORT=${CONTAINER_PORT} \
     -e LBUG_ROLE=$(if [ "${NODE_TYPE}" = "shared_replica" ]; then echo "replica"; else echo "master"; fi) \
     -e LBUG_ACCESS_PATTERN=api_writer"
-HEALTH_CMD="timeout 10 curl -s -o /dev/null http://localhost:${CONTAINER_PORT}/health || exit 1"
+HEALTH_CMD="python3 /app/bin/healthcheck.py http://localhost:${CONTAINER_PORT}/health 10"
 
 # Build optional volume mounts
 VOLUME_MOUNTS="-v ${DATA_MOUNT_SOURCE}:${DATA_MOUNT_TARGET} -v ${LOGS_MOUNT_SOURCE}:${LOGS_MOUNT_TARGET}"

--- a/cloudformation/dagster.yaml
+++ b/cloudformation/dagster.yaml
@@ -831,8 +831,10 @@ Resources:
           HealthCheck:
             Command:
               [
-                "CMD-SHELL",
-                "curl -f http://localhost:3000/server_info || exit 1",
+                "CMD",
+                "python3",
+                "/app/bin/healthcheck.py",
+                "http://localhost:3000/server_info",
               ]
             Interval: 30
             Timeout: 10

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,7 +17,7 @@ services:
     volumes:
       - ./robosystems:/app/robosystems
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://robosystems-api:8000/v1/status"]
+      test: ["CMD", "python3", "/app/bin/healthcheck.py", "http://robosystems-api:8000/v1/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -61,7 +61,7 @@ services:
       - ./data/artifacts:/app/data/artifacts
       - ./data/lance:/app/data/lance
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      test: ["CMD", "python3", "/app/bin/healthcheck.py", "http://localhost:8001/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

Remove `curl` and `git` from the API image's runtime stage and move every in-container health probe to a stdlib-only Python script. Neither package is used by the service at runtime, and they pull `libcurl`, `libssh2`, `git` and `liberror-perl` into an image the container scanners keep flagging for advisories no code path here can reach. Removing them clears those findings on rebuild instead of re-explaining them every cycle.

## Changes

- **`Dockerfile`** — runtime stage no longer installs `curl` or `git`. `git` is only needed in the builder (where `arelle_cache_manager.py` fetches the EDGAR subtree) and no dependency in `uv.lock` is git-sourced. `postgresql-client` stays because `entrypoint.sh` waits on the database with `psql`. Comment explains the choice so the packages don't get helpfully restored.
- **`bin/healthcheck.py`** (new) — `GET url [timeout]`, exit 0 on 2xx, 1 otherwise, standard library only. Replaces `curl -f` in every probe.
- **`compose.yaml`** — API and graph-api health checks call the script.
- **`cloudformation/dagster.yaml`** — Dagster webserver ECS container health check calls the script (`CMD` form, no shell).
- **`bin/userdata/common/run-graph-container.sh`** — LadybugDB graph container `--health-cmd` calls the script with the same 10s budget.
- **`bin/userdata/common/graph-lifecycle.sh`** — the ASG drain hook exec'd `curl` inside the graph container; it now calls the published port from the host. Reviewers should note: the Graph API exposes neither `/admin/drain` nor `/admin/connections`, so both calls already fell through to their fallbacks. Behavior is unchanged; the script now says so in a comment. Implementing those endpoints is a separate piece of work.

Not changed: `perl` remains in the image. `postgresql-client` depends on it and `perl-base` is Essential on Debian, so scanner matches against the `perl` source package are a base-image question, not a package-list one.

## Breaking Changes

None. No API surface or SDK-visible shape changes; the SDK tiers are untouched.

## Testing

- `just test-code` — passed (ruff, format, basedpyright, cf-lint incl. the edited `dagster.yaml`).
- `bin/healthcheck.py` exercised inside the running local containers (`robosystems-api`, `robosystems-graph-api`): 2xx → exit 0, 404 → exit 1, connection refused with a 2s timeout → exit 1. `python3` resolves to the venv interpreter for `appuser`, which the `CMD`-form probes rely on.
- Built a trimmed `python:3.13-slim` + runtime package set locally and confirmed with `dpkg-query` that `libssh2-1t64`, `libcurl4t64`, `git` and `liberror-perl` are absent; Trivy on that image reports no libssh2 findings.
- `bash -n` on both edited userdata scripts.
- Full image build and the unit-test half of `just test-all` were not run locally; CI's build + Trivy scan covers the real image.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mdzNFGhSkgCy8eSmsJjJD
