### PR TITLE
fix(ci): wait for the finished review, not the reviewer's placeholder

### DIFF
--- a/.github/actions/classify-change/action.yml
+++ b/.github/actions/classify-change/action.yml
@@ -134,15 +134,13 @@ runs:
         fi
 
         # Normal change: make sure the review has been requested, then wait for it.
-        # The reviewer first posts a placeholder (a spinner image and a
-        # checklist) and edits it in place into the finished review, whose
-        # first line reads "Claude finished …". The finished body keeps the
-        # checklist wording, so the positive signal is the only reliable one:
-        # count a comment when it carries that line, or when it carries no
-        # spinner image at all; never count an error report.
+        # The reviewer first posts a placeholder and edits it in place into the
+        # finished review, whose body begins "**Claude finished"; a failed run
+        # begins "**Claude encountered an error". Anchor on those openings, so
+        # that a review which quotes these very words in its text still counts.
         has_review() {
           gh api "repos/$REPO/issues/$PR/comments" --paginate \
-            --jq "[.[] | select(.user.login == \"$REVIEWER\") | select((.body | test(\"Claude finished\")) or ((.body | test(\"<img \")) | not)) | select(.body | test(\"encountered an error|Claude failed\"; \"i\") | not)] | length"
+            --jq "[.[] | select(.user.login == \"$REVIEWER\") | select(.body | startswith(\"**Claude finished\"))] | length"
         }
         has_request() {
           gh api "repos/$REPO/issues/$PR/comments" --paginate \

--- a/.github/actions/classify-change/action.yml
+++ b/.github/actions/classify-change/action.yml
@@ -134,13 +134,15 @@ runs:
         fi
 
         # Normal change: make sure the review has been requested, then wait for it.
-        # The reviewer first posts a placeholder ("Reviewing PR…", "Review in
-        # progress…", with a spinner image) and edits it in place into the
-        # finished review, which opens with "Claude finished". Count only the
-        # finished form, and never an error report.
+        # The reviewer first posts a placeholder (a spinner image and a
+        # checklist) and edits it in place into the finished review, whose
+        # first line reads "Claude finished …". The finished body keeps the
+        # checklist wording, so the positive signal is the only reliable one:
+        # count a comment when it carries that line, or when it carries no
+        # spinner image at all; never count an error report.
         has_review() {
           gh api "repos/$REPO/issues/$PR/comments" --paginate \
-            --jq "[.[] | select(.user.login == \"$REVIEWER\") | select(((.body | test(\"<img \")) and (.body | test(\"is working|in progress|Reviewing PR\"; \"i\"))) | not) | select(.body | test(\"encountered an error|Claude failed\"; \"i\") | not)] | length"
+            --jq "[.[] | select(.user.login == \"$REVIEWER\") | select((.body | test(\"Claude finished\")) or ((.body | test(\"<img \")) | not)) | select(.body | test(\"encountered an error|Claude failed\"; \"i\") | not)] | length"
         }
         has_request() {
           gh api "repos/$REPO/issues/$PR/comments" --paginate \

--- a/.github/actions/classify-change/action.yml
+++ b/.github/actions/classify-change/action.yml
@@ -29,9 +29,9 @@ inputs:
     required: false
     default: "@claude please review this PR"
   review_timeout_minutes:
-    description: How long to wait for the review to be posted before failing
+    description: How long to wait for the finished review to be posted before failing
     required: false
-    default: "12"
+    default: "15"
   extra_standard_regex:
     description: >-
       Extended regex of additional paths that count as standard for this
@@ -134,9 +134,13 @@ runs:
         fi
 
         # Normal change: make sure the review has been requested, then wait for it.
+        # The reviewer first posts a placeholder ("Reviewing PR…", "Review in
+        # progress…", with a spinner image) and edits it in place into the
+        # finished review, which opens with "Claude finished". Count only the
+        # finished form, and never an error report.
         has_review() {
           gh api "repos/$REPO/issues/$PR/comments" --paginate \
-            --jq "[.[] | select(.user.login == \"$REVIEWER\") | select(.body | test(\"is working\") | not)] | length"
+            --jq "[.[] | select(.user.login == \"$REVIEWER\") | select(((.body | test(\"<img \")) and (.body | test(\"is working|in progress|Reviewing PR\"; \"i\"))) | not) | select(.body | test(\"encountered an error|Claude failed\"; \"i\") | not)] | length"
         }
         has_request() {
           gh api "repos/$REPO/issues/$PR/comments" --paginate \


### PR DESCRIPTION
## Summary

The `change-classification` job passed as soon as the reviewer posted its placeholder comment ("Reviewing PR…" with a spinner), which the reviewer later edits in place into the finished review. The job now waits for the finished form, so a normal change passes only once the review is actually on the pull request.

## Changes

- `.github/actions/classify-change/action.yml`: `has_review` counts a `claude[bot]` comment only when it is not the placeholder (spinner image plus "Reviewing PR", "Review in progress" or "is working") and is not an error report; default wait raised from 12 to 15 minutes to cover the reviewer's typical 3–5 minute run with margin.

## Breaking Changes

None.

## Testing

Not run: composite action shell only; YAML parsed and the script passed `bash -n`. This PR exercises the fix on itself: the job should stay pending until the reviewer's comment reads "Claude finished", then pass. Seen on #1341, robosystems-app #365, roboledger-app #345 and roboinvestor-app #291, all of which passed on the placeholder.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHq6J3q9NKhmMiAsZntBRt
