### PR TITLE
CI sweep: fix release-notes generation, share composite actions and the Claude workflow

### DIFF
--- a/.github/actions/select-runner/action.yml
+++ b/.github/actions/select-runner/action.yml
@@ -31,6 +31,10 @@ runs:
     - name: Check if self-hosted runners are available
       id: check-runners
       shell: bash
+      # Pass the token via env rather than inline ${{ }} in the run body, so the
+      # credential is never spliced into the rendered script source.
+      env:
+        GH_API_TOKEN: ${{ inputs.github_token }}
       run: |
         RUNNER_LABELS="${{ inputs.runner_labels }}"
         RUNNER_SCOPE="${{ inputs.runner_scope }}"
@@ -81,7 +85,7 @@ runs:
           local scope_name="$2"
 
           echo "📡 Checking ${scope_name} runners: ${endpoint}"
-          local response=$(curl -s -w "HTTP_CODE:%{http_code}" -H "Authorization: token ${{ inputs.github_token }}" "${endpoint}")
+          local response=$(curl -s -w "HTTP_CODE:%{http_code}" -H "Authorization: token ${GH_API_TOKEN}" "${endpoint}")
 
           local http_code=$(echo "$response" | grep -o "HTTP_CODE:[0-9]*" | cut -d: -f2)
           response=$(echo "$response" | sed 's/HTTP_CODE:[0-9]*$//')

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,99 @@
+name: Claude Code (shared)
+
+# Shared implementation behind each repo's claude.yml. Callers keep only their
+# event triggers and the permissions grant; the author gate, runner selection,
+# and the claude-code-action / checkout pins live here so a version bump is one
+# PR instead of one per repo.
+#
+# Runner selection needs no input: select-runner treats an unset RUNNER_LABELS
+# as "github-hosted" and returns ["ubuntu-latest"] without an API call, so repos
+# with no self-hosted fleet get GitHub-hosted runners for free. vars.* resolve
+# from the CALLER's repository, so each repo keeps its own RUNNER_LABELS.
+
+on:
+  workflow_call:
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        description: 'OAuth token for claude-code-action'
+        required: true
+      ACTIONS_TOKEN:
+        description: 'PAT for org-level runner queries; falls back to github.token'
+        required: false
+
+jobs:
+  check-runner-availability:
+    runs-on: ubuntu-latest
+    outputs:
+      runners_available: ${{ steps.check.outputs.runners_available }}
+      runner_type: ${{ steps.check.outputs.runner_type }}
+      runner_config: ${{ steps.check.outputs.runner_config }}
+    steps:
+      # Referenced by full path, not "./" - inside a called workflow a relative
+      # action path is resolved against the caller's checkout, which does not
+      # have this action.
+      - name: Check runner availability
+        id: check
+        uses: RoboFinSystems/robosystems/.github/actions/select-runner@main
+        with:
+          runner_labels: ${{ vars.RUNNER_LABELS || 'github-hosted' }}
+          runner_scope: ${{ vars.RUNNER_SCOPE || 'both' }}
+          # ACTIONS_TOKEN needed for org runner API access; falls back to github.token
+          # which has limited permissions but action handles this gracefully
+          github_token: ${{ secrets.ACTIONS_TOKEN || github.token }}
+
+  claude:
+    needs: [check-runner-availability]
+    # Defense-in-depth author gate: on top of the action's own permission check,
+    # only run when the triggering actor is a repo OWNER/MEMBER/COLLABORATOR, so a
+    # drive-by comment/issue from an outside account cannot invoke Claude with
+    # repo secrets in scope. These repos are public, so the gate is load-bearing,
+    # not decorative.
+    if: |
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+      )
+    runs-on: ${{ fromJSON(needs.check-runner-availability.outputs.runner_config) }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      actions: read # Required for Claude to read CI results on PRs
+      id-token: write # Required: claude-code-action mints a GitHub OIDC token to
+        # authenticate to GitHub (setupGitHubToken → getOidcToken), independent of
+        # any cloud role. Without it the action fails: "Could not fetch an OIDC
+        # token." (This is GitHub auth, not AWS — do not drop it as "unused".)
+        # The caller must also grant id-token: write on its calling job; a called
+        # workflow cannot exceed the caller's token permissions.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,4 +1,4 @@
-name: Claude Code (shared)
+name: Claude Review (shared)
 
 # Shared implementation behind each repo's claude.yml. Callers keep only their
 # event triggers and the permissions grant; the author gate, runner selection,

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 
 # Triggers only. The implementation - author gate, runner selection, action
-# pins - lives in claude-code.yml, which the other repos in the org call too.
+# pins - lives in claude-review.yml, which the other repos in the org call too.
 
 on:
   issue_comment:
@@ -23,5 +23,5 @@ jobs:
       issues: read
       actions: read
       id-token: write
-    uses: ./.github/workflows/claude-code.yml
+    uses: ./.github/workflows/claude-review.yml
     secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,5 +1,8 @@
 name: Claude Code Review
 
+# Triggers only. The implementation - author gate, runner selection, action
+# pins - lives in claude-code.yml, which the other repos in the org call too.
+
 on:
   issue_comment:
     types: [created]
@@ -11,82 +14,14 @@ on:
     types: [submitted]
 
 jobs:
-  check-runner-availability:
-    runs-on: ubuntu-latest
-    outputs:
-      runners_available: ${{ steps.check.outputs.runners_available }}
-      runner_type: ${{ steps.check.outputs.runner_type }}
-      runner_config: ${{ steps.check.outputs.runner_config }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Check runner availability
-        id: check
-        uses: ./.github/actions/select-runner
-        with:
-          runner_labels: ${{ vars.RUNNER_LABELS || 'github-hosted' }}
-          runner_scope: ${{ vars.RUNNER_SCOPE || 'both' }}
-          # ACTIONS_TOKEN needed for org runner API access; falls back to github.token
-          # which has limited permissions but action handles this gracefully
-          github_token: ${{ secrets.ACTIONS_TOKEN || github.token }}
-
   claude:
-    needs: [check-runner-availability]
-    # Defense-in-depth author gate: on top of the action's own permission check,
-    # only run when the triggering actor is a repo OWNER/MEMBER/COLLABORATOR, so a
-    # drive-by comment/issue from an outside account cannot invoke Claude with
-    # repo secrets in scope (this repo is public).
-    if: |
-      (
-        github.event_name == 'issue_comment' &&
-        contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-      ) ||
-      (
-        github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-      ) ||
-      (
-        github.event_name == 'pull_request_review' &&
-        contains(github.event.review.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
-      ) ||
-      (
-        github.event_name == 'issues' &&
-        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
-      )
-    runs-on: ${{ fromJSON(needs.check-runner-availability.outputs.runner_config) }}
-    timeout-minutes: 15
+    # Granted here as well as in the called workflow: a called workflow's jobs
+    # cannot exceed the permissions of the caller's GITHUB_TOKEN.
     permissions:
       contents: read
       pull-requests: read
       issues: read
-      actions: read # Required for Claude to read CI results on PRs
-      id-token: write # Required: claude-code-action mints a GitHub OIDC token to
-        # authenticate to GitHub (setupGitHubToken → getOidcToken), independent of
-        # any cloud role. Without it the action fails: "Could not fetch an OIDC
-        # token." (This is GitHub auth, not AWS — do not drop it as "unused".)
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+      actions: read
+      id-token: write
+    uses: ./.github/workflows/claude-code.yml
+    secrets: inherit

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -235,7 +235,7 @@ jobs:
             --arg content "$PROMPT" \
             '{
               "model": $model,
-              "max_tokens": 3000,
+              "max_tokens": 8000,
               "messages": [
                 {
                   "role": "user",
@@ -252,7 +252,7 @@ jobs:
             # its own, and curl parses the config at startup so --retry resends the
             # header correctly.
           RESPONSE=$(printf 'header = "x-api-key: %s"\n' "$ANTHROPIC_API_KEY" \
-            | curl -s --config - --max-time 60 --retry 3 --retry-delay 10 -X POST "https://api.anthropic.com/v1/messages" \
+            | curl -s --config - --max-time 180 --retry 3 --retry-delay 10 -X POST "https://api.anthropic.com/v1/messages" \
               -H "Content-Type: application/json" \
               -H "anthropic-version: 2023-06-01" \
               -d "$PAYLOAD")
@@ -261,19 +261,27 @@ jobs:
           if echo "$RESPONSE" | jq -e '.error' > /dev/null; then
             ERROR_MSG=$(echo "$RESPONSE" | jq -r '.error.message // "Unknown error"')
             ERROR_TYPE=$(echo "$RESPONSE" | jq -r '.error.type // "unknown"')
-            echo "❌ Claude API error [$ERROR_TYPE]: $ERROR_MSG"
+            echo "::error::Claude API error [$ERROR_TYPE]: $ERROR_MSG - falling back to commit stats"
             echo "Full response: $RESPONSE" >&2  # Log to stderr for debugging
             echo "Using fallback changelog"
             CHANGELOG="## What's Changed\n\n- ${{ steps.analyze-changes.outputs.commits_count }} commits with ${{ steps.analyze-changes.outputs.files_changed }} files changed\n- ${{ steps.analyze-changes.outputs.additions }} additions and ${{ steps.analyze-changes.outputs.deletions }} deletions\n\nSee commit history for detailed changes."
           else
-            # Extract changelog from Claude's response
-            CHANGELOG=$(echo "$RESPONSE" | jq -r '.content[0].text')
+            # Concatenate every text block. Indexing content[0] assumed the
+            # first block is text, which stopped being true once CLAUDE_MODEL
+            # moved to a model that thinks by default - a leading thinking block
+            # made this return null and silently downgraded every release to
+            # commit stats.
+            CHANGELOG=$(echo "$RESPONSE" | jq -r '[.content[]? | select(.type == "text") | .text] | join("")')
+            STOP_REASON=$(echo "$RESPONSE" | jq -r '.stop_reason // "unknown"')
 
             # Validate that Claude returned meaningful content
             if [ -z "$CHANGELOG" ] || [ "$CHANGELOG" = "null" ]; then
-              echo "❌ Claude returned empty changelog, using fallback"
+              echo "::error::Claude returned no text block (stop_reason=$STOP_REASON, blocks=$(echo "$RESPONSE" | jq -c '[.content[]?.type]')) - falling back to commit stats"
               CHANGELOG="## What's Changed\n\n- ${{ steps.analyze-changes.outputs.commits_count }} commits with ${{ steps.analyze-changes.outputs.files_changed }} files changed\n- ${{ steps.analyze-changes.outputs.additions }} additions and ${{ steps.analyze-changes.outputs.deletions }} deletions\n\nSee commit history for detailed changes."
             else
+              if [ "$STOP_REASON" = "max_tokens" ]; then
+                echo "::warning::Changelog hit max_tokens and may be truncated"
+              fi
               echo "✅ Claude changelog generated successfully"
             fi
           fi


### PR DESCRIPTION
## Why

Release bodies have been bare commit stats since early August. Investigating that surfaced a broader problem: the same workflow code is copy-pasted across the org's repos, so a fix lands in one repo and rots in the others. Three separate defects here had each landed on only one side of a copy.

## What changed

**Release notes were being generated and thrown away.** The response parser read `content[0].text`, assuming the first content block is text. Once `CLAUDE_MODEL` moved to a model that thinks by default, responses lead with a thinking block, so the extraction returned `null` and tripped the empty-content fallback on every release. Verified against the run log for v1.11.12: the failure line is "returned empty", not an API error — the call was succeeding and being discarded.

Text blocks are now selected by type. Also raised `max_tokens` (3000 was shared between thinking and output) and the curl ceiling (60s was tuned for a non-thinking model), and both fallback paths now emit `::error::` with `stop_reason` and the returned block types — this degraded silently for a month, which is the part worth not repeating.

**`select-runner`** — token handling brought in line with the copy the three app repos already use.

**`claude.yml`** — split into triggers (`claude.yml`) and implementation (`claude-review.yml`, a `workflow_call` target). Eleven repos carry this file in two shapes that differ only in runner choice, so every `claude-code-action` pin bump is currently eleven PRs. No input was needed to cover both shapes: `select-runner` treats an unset `RUNNER_LABELS` as `github-hosted` and returns `["ubuntu-latest"]` without an API call.

## Companion PRs

The three app repos switch to the shared composite actions and delete their local copies (~467 lines each). They have no merge-order dependency on this PR — all three actions already resolve on `main`.

Fanning `claude-review.yml` out to the other repos waits until this merges, since it must exist on `main` first.

## Testing

The release-notes fix can only be exercised by a real release — `create-release.yml` has no dry-run path. The jq change was verified locally against both response shapes (thinking-first returns the notes, text-only still works). The next release is the end-to-end test; if it comes back with real notes, it's confirmed.
