### PR TITLE
fix(api): allow MCP-Protocol-Version through CORS preflight

### DIFF
--- a/main.py
+++ b/main.py
@@ -282,6 +282,10 @@ def create_app() -> FastAPI:
       # Auth endpoints read X-App-Source for email branding when Referer-based
       # detection can't identify the originating product app.
       "X-App-Source",
+      # Browser MCP clients (the Holon viewer) echo the negotiated revision on
+      # every request after initialize, per Streamable HTTP — without this the
+      # preflight for POST /v1/graphs/{graph_id}/mcp fails cross-origin.
+      "MCP-Protocol-Version",
     ],
     expose_headers=["X-Request-ID", "X-Rate-Limit-Remaining", "X-Rate-Limit-Reset"],
     max_age=3600,  # Cache preflight requests for 1 hour


### PR DESCRIPTION
## Summary

The Holon viewer is a browser MCP client: it calls `POST /v1/graphs/{graph_id}/mcp` cross-origin from `holon.robosystems.ai` with the user's own API key. Streamable HTTP requires clients to echo the negotiated revision on every request after `initialize` via `MCP-Protocol-Version`, and a browser can only send a non-safelisted header when the CORS preflight allows it. This adds the header to `allow_headers`, so post-handshake requests reach the transport instead of failing at preflight.

Pairs with https://github.com/RoboFinSystems/robosystems-holon-viewer/pull/67, the viewer's move from the removed `GET /mcp/tools` and `POST /mcp/call-tool` REST endpoints to the transport. Deploy this side first; the viewer's production build calls the API directly, while its dev proxy strips `Origin` and never preflights.

## Changes

- `main.py` — add `MCP-Protocol-Version` to the CORS middleware's `allow_headers`. The transport already validates the header's value (`routers/graphs/mcp/remote.py`); this only lets browsers send it. Non-browser MCP clients (Claude connectors, the npx bridge, Cursor) send no `Origin` and were never affected.

## Breaking Changes

None. No public API surface changes. The MCP route is excluded from the OpenAPI schema, so neither SDK is touched.

## Testing

- `just test-code` passes (lint, format, typecheck, cf-lint-all, lint-actions).
- Sent a CORS preflight to `create_app()` for `/v1/graphs/sec/mcp` with `Access-Control-Request-Headers: mcp-protocol-version, x-api-key, content-type` from an allowlisted origin. With this change: 200, and `MCP-Protocol-Version` is listed in `Access-Control-Allow-Headers`. Against the parent commit (same script, previous `main.py`) the same preflight returns 400: Starlette rejects the disallowed header, which is the failure the viewer hits.
- No test added; the repo has no CORS preflight tests today. Happy to add one if wanted.
- `just test` (unit suite) not run for a one-line list entry.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bgvNHMcCiPrEcgkwASRso
