### PR TITLE
chore(bootstrap): set the frontend repos' OIDC variables from the backend

### DIFF
--- a/bin/setup/bootstrap.sh
+++ b/bin/setup/bootstrap.sh
@@ -15,14 +15,17 @@
 #   1. Configures AWS CLI SSO profile (if not exists)
 #   2. Deploys the GitHub OIDC CloudFormation stack (the deploy roles)
 #   3. Sets GitHub variables (role ARN, etc.)
-#   4. First run only: ECR repository, SES identity, application secrets
+#   4. Sets the same identity variables on the frontend app repos, which own
+#      no AWS access of their own — the repos come from the stack parameters
+#   5. First run only: ECR repository, SES identity, application secrets
 #
 # MODES:
 #   full (default)  Everything above. On a re-run the application-config
 #                   step (Secrets Manager, GitHub variables) is skipped unless
 #                   --with-app-config is given — those are the two steps that
 #                   can rewrite a live account, so they never run by accident.
-#   --oidc          Only the OIDC stack + the three identity variables. Use this
+#   --oidc          Only the OIDC stack + the identity variables, here and on
+#                   the frontend app repos. Use this
 #                   after editing cloudformation/bootstrap-oidc.yaml. The stack
 #                   update is previewed as a change set: you see exactly which
 #                   resources change before anything is applied, and a stack
@@ -601,15 +604,28 @@ deploy_oidc_update() {
 # GITHUB CONFIGURATION
 # =============================================================================
 
+# The optional third argument targets another repository (owner/name); with it
+# omitted the variable is set on the current one. Written without arrays so the
+# script still runs on a stock macOS bash 3.2.
 set_variable_if_changed() {
-    local name="$1" value="$2" current
-    current=$(gh variable get "$name" 2>/dev/null || echo "")
+    local name="$1" value="$2" repo="${3:-}" current
+    if [ -n "$repo" ]; then
+        current=$(gh variable get "$name" --repo "$repo" 2>/dev/null || echo "")
+    else
+        current=$(gh variable get "$name" 2>/dev/null || echo "")
+    fi
+
     if [ "$current" = "$value" ]; then
         print_success "${name} already set"
+        return 0
+    fi
+
+    if [ -n "$repo" ]; then
+        gh variable set "$name" --body "$value" --repo "$repo"
     else
         gh variable set "$name" --body "$value"
-        print_success "Set ${name}"
     fi
+    print_success "Set ${name}"
 }
 
 configure_github() {
@@ -633,6 +649,85 @@ configure_github() {
     echo ""
     print_step "Note: No AWS secrets needed with OIDC!"
     print_info "Workflows will use role assumption instead of access keys"
+}
+
+# =============================================================================
+# FRONTEND REPOSITORY CONFIGURATION
+# =============================================================================
+
+# The frontend apps deploy through the stack this script owns, assuming the
+# separate frontend role. Nothing they need is per-repo — one role ARN, one
+# account, one region, all three known here the moment the stack is up. So the
+# identity variables are pushed from this side, and the app repos need no AWS
+# access, no aws CLI and no SSO profile of their own.
+configure_frontend_repos() {
+    print_header "Configuring Frontend Repositories"
+
+    local frontend_role_arn
+    frontend_role_arn=$(aws cloudformation describe-stacks \
+        --stack-name "${OIDC_STACK_NAME}" \
+        --profile "${SSO_PROFILE}" \
+        --region "${AWS_REGION}" \
+        --query 'Stacks[0].Outputs[?OutputKey==`GitHubActionsFrontendRoleArn`].OutputValue' \
+        --output text 2>/dev/null) || frontend_role_arn=""
+
+    if [ -z "$frontend_role_arn" ] || [ "$frontend_role_arn" = "None" ]; then
+        print_warning "Stack exposes no GitHubActionsFrontendRoleArn — skipping frontends"
+        print_info "Run 'just bootstrap-oidc' to update the stack from the current template"
+        return 0
+    fi
+
+    # Repo names are stack parameters, so a fork that renamed its apps stays
+    # consistent: take the trusted names from the stack rather than a list
+    # hardcoded here that would silently drift from the trust policy.
+    local params
+    params=$(aws cloudformation describe-stacks \
+        --stack-name "${OIDC_STACK_NAME}" \
+        --profile "${SSO_PROFILE}" \
+        --region "${AWS_REGION}" \
+        --query 'Stacks[0].Parameters' \
+        --output json 2>/dev/null) || params="[]"
+
+    local repo_names="" key name
+    for key in GitHubAppRepoName GitHubLedgerAppRepoName \
+        GitHubInvestorAppRepoName GitHubHolonViewerRepoName; do
+        name=$(echo "$params" | jq -r --arg k "$key" \
+            '.[] | select(.ParameterKey == $k) | .ParameterValue')
+        if [ -n "$name" ] && [ "$name" != "null" ]; then
+            repo_names="${repo_names}${name}
+"
+        fi
+    done
+
+    if [ -z "$repo_names" ]; then
+        print_warning "Stack carries no frontend repository parameters — skipping frontends"
+        return 0
+    fi
+
+    print_info "Frontend role: ${frontend_role_arn}"
+
+    local repo_name target
+    while IFS= read -r repo_name; do
+        [ -z "$repo_name" ] && continue
+        target="${GITHUB_ORG}/${repo_name}"
+
+        echo ""
+        print_step "${target}"
+
+        if ! gh repo view "$target" &>/dev/null; then
+            print_warning "Not accessible to this gh account — skipping"
+            continue
+        fi
+
+        set_variable_if_changed AWS_ROLE_ARN "$frontend_role_arn" "$target"
+        set_variable_if_changed AWS_ACCOUNT_ID "$AWS_ACCOUNT_ID" "$target"
+        set_variable_if_changed AWS_REGION "$AWS_REGION" "$target"
+    done <<EOF
+${repo_names}
+EOF
+
+    echo ""
+    print_info "Each app's remaining setup is GitHub-only: bin/gha-setup.sh"
 }
 
 # =============================================================================
@@ -1358,6 +1453,9 @@ main() {
 
     # Configure GitHub
     configure_github
+
+    # Push the identity variables to the frontend app repos
+    configure_frontend_repos
 
     if [ "$BOOTSTRAP_MODE" = "oidc" ]; then
         show_summary

--- a/bin/setup/bootstrap.sh
+++ b/bin/setup/bootstrap.sh
@@ -688,6 +688,15 @@ configure_frontend_repos() {
         --query 'Stacks[0].Parameters' \
         --output json 2>/dev/null) || params="[]"
 
+    # A stack with no Parameters block answers this query with a literal null,
+    # which the || above does not catch: the call succeeded. Iterating null in
+    # jq exits 5, and under set -e that kills the whole bootstrap run instead
+    # of reaching the skip below. Written as an if, never `[ ... ] && ...`,
+    # which would itself trip errexit on the far more common non-null case.
+    if [ "$params" = "null" ]; then
+        params="[]"
+    fi
+
     local repo_names="" key name
     for key in GitHubAppRepoName GitHubLedgerAppRepoName \
         GitHubInvestorAppRepoName GitHubHolonViewerRepoName; do


### PR DESCRIPTION
## Summary

The frontend apps deploy through the OIDC stack this repo owns, assuming the separate `RoboSystemsGitHubActionsFrontendRole`. Nothing they need from AWS is per-repo — one role ARN, one account, one region — yet each app repo carried a 486-line `bin/bootstrap.sh` to re-derive values this side already holds, and needed its own AWS session to do it. That script could never *create* anything either: it hard-failed when the stack was missing and told you to come back here and run `just bootstrap`.

This adds `configure_frontend_repos()`, which reads `GitHubActionsFrontendRoleArn` from the stack and fans `AWS_ROLE_ARN` / `AWS_ACCOUNT_ID` / `AWS_REGION` out to each frontend repo with `gh variable set --repo`.

## Details

- **Repo names come from the stack's own parameters** (`GitHubAppRepoName`, `GitHubLedgerAppRepoName`, `GitHubInvestorAppRepoName`, `GitHubHolonViewerRepoName`), not a list hardcoded in the script. A fork that renamed its apps stays consistent with the trust policy instead of drifting from it silently.
- Runs in **both** the full and `--oidc` paths — `just bootstrap-oidc` is now the re-run path for frontend identity variables too.
- Skips a repo the `gh` account cannot see, and skips the whole step against a stack that predates the frontend role output, pointing at `just bootstrap-oidc` to update it.
- `set_variable_if_changed` grows an optional target-repo argument and keeps its read-only-when-unchanged behavior, so a re-run against a correct account still writes nothing.
- Written without bash arrays, matching the rest of the script — it stays runnable on a stock macOS bash 3.2.

## Companion PRs

The app repos delete their bootstrap machinery and end up with **no AWS surface at all** — nothing in their `bin/` touches the aws CLI, and their VS Code task lists lose the duplicated SSO logins:

- RoboFinSystems/robosystems-app#373
- RoboFinSystems/roboledger-app#352
- RoboFinSystems/roboinvestor-app#300

Merge this one first: it takes over setting the variables those repos stop setting for themselves.

## Testing

- `bash -n` clean; `shellcheck -S warning` reports only the four pre-existing SC2155 warnings elsewhere in the file.
- Repo-name parsing and the skip paths exercised offline against stubbed `describe-stacks` output, including a stack with no holon-viewer parameter and one with no parameters at all.
- Not yet run against the live stack — the SSO session here has expired. Worth a `just bootstrap-oidc` before merging the app PRs.

## Docs

`Bootstrap-Guide.md` in the wiki needs the matching edit (the "Multi-Repository Setup" and frontend "Bootstrap" sections still say `npm run setup:bootstrap`). Prepared locally, not pushed — the wiki has no PR flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U23eqA9V5R7VYSorFs23Rm
