### PR TITLE
fix(sec): follow full iXBRL continuation chains and dedup facts by precision

### DIFF
--- a/robosystems/adapters/sec/ixbrl_parser.py
+++ b/robosystems/adapters/sec/ixbrl_parser.py
@@ -9,13 +9,17 @@ ARE the disclosure sections. They wrap the narrative content and contain nested
 `ix:nonFraction` numeric facts. By extracting both the text and the element names,
 we enable bidirectional navigation between graph facts and their filing context.
 
-iXBRL continuation pattern:
+iXBRL continuation pattern (a note that spans pages is a chain, and each
+link's pointer to the next is an attribute on its own tag):
   <ix:nonNumeric name="us-gaap:GoodwillDisclosureTextBlock" continuedAt="f-571-1">
     Goodwill
   </ix:nonNumeric>
-  <ix:continuation id="f-571-1">
+  <ix:continuation id="f-571-1" continuedAt="f-571-2">
     <p>The following table summarizes changes in goodwill...</p>
     <ix:nonFraction name="us-gaap:Goodwill">32,431</ix:nonFraction>
+  </ix:continuation>
+  <ix:continuation id="f-571-2">
+    <p>...and the rest of the note after the page break.</p>
   </ix:continuation>
 """
 
@@ -199,7 +203,7 @@ class iXBRLParser:
     Tag matching goes through `_find_tag_blocks` (string-find, not regex) —
     see that function for why regex is unusable on filings this size.
     """
-    # Build continuation lookup: id → content
+    # Build continuation lookup: id → (attrs, content)
     continuations = self._build_continuation_map(html)
 
     # Find all TextBlock ix:nonNumeric elements using string-find
@@ -267,35 +271,47 @@ class iXBRLParser:
     )
     return sections
 
-  def _build_continuation_map(self, html: str) -> dict[str, str]:
-    """Build a lookup of continuation id → HTML content."""
-    continuations: dict[str, str] = {}
+  def _build_continuation_map(self, html: str) -> dict[str, tuple[str, str]]:
+    """Build a lookup of continuation id → (tag attrs, HTML content).
+
+    The attrs are kept because the chain pointer lives on the tag: an
+    ``ix:continuation`` that continues further carries its own
+    ``continuedAt`` attribute, and only the tag's attributes can say so.
+    """
+    continuations: dict[str, tuple[str, str]] = {}
     for attrs, inner_html in _find_nested_blocks(
       html, "<ix:continuation", "</ix:continuation"
     ):
-      id_match = re.search(r'id="([^"]+)"', attrs)
+      id_match = re.search(r'\bid="([^"]+)"', attrs)
       if id_match:
-        continuations[id_match.group(1)] = inner_html
+        continuations[id_match.group(1)] = (attrs, inner_html)
     return continuations
 
   def _resolve_continuation_chain(
-    self, start_id: str, continuations: dict[str, str]
+    self, start_id: str, continuations: dict[str, tuple[str, str]]
   ) -> str:
-    """Follow a chain of continuedAt references to build full content."""
+    """Follow a chain of continuedAt references to build full content.
+
+    Each hop's pointer is read from the continuation's own tag attributes,
+    never from its content. Until 2026-09-03 the pointer was searched for
+    in the content, where it is absent (so every chain stopped after one
+    hop and every multi-page note lost its tail) or, worse, belongs to an
+    element nested inside the continuation (so the chain spliced in a
+    different note's text).
+    """
     parts: list[str] = []
-    current_id = start_id
+    current_id: str | None = start_id
     visited: set[str] = set()
 
     while current_id and current_id not in visited:
       visited.add(current_id)
-      content = continuations.get(current_id, "")
-      if not content:
+      entry = continuations.get(current_id)
+      if entry is None:
         break
-
-      # Check if this continuation itself continues
-      next_match = re.search(r'continuedAt="([^"]+)"', content)
+      attrs, content = entry
       parts.append(content)
 
+      next_match = re.search(r'continuedAt="([^"]+)"', attrs)
       current_id = next_match.group(1) if next_match else None
 
     return "".join(parts)

--- a/robosystems/operations/roboledger/views/fact_dedup.py
+++ b/robosystems/operations/roboledger/views/fact_dedup.py
@@ -1,0 +1,66 @@
+"""Precision-aware fact deduplication shared by the graph-backed views.
+
+A filer often reports one figure twice in one filing under the same element
+and period: once on the face of a statement at the statement's precision and
+once in the narrative, rounded (3M FY2024 research and development expense is
+``1,085,000,000`` at ``decimals=-6`` on the income statement and
+``1,100,000,000`` at ``decimals=-8`` in the text). Both are consolidated,
+undimensioned facts with identical period identity, so a dedup that keeps
+whichever row the engine returned first hands back the rounded figure about
+half the time. XBRL's own rule for consistent duplicates is that the most
+precise value is the one to use; this module applies it.
+"""
+
+from collections.abc import Callable, Hashable
+from typing import Any
+
+UNKNOWN_PRECISION = float("-inf")
+
+
+def precision_rank(decimals: Any) -> float:
+  """Order a fact's XBRL ``decimals`` so that a larger rank is more precise.
+
+  ``"INF"`` (an exact value) outranks every finite precision; an integer
+  string such as ``"-6"`` ranks as that integer, so ``-6`` (millions) beats
+  ``-8`` (hundred-millions); a missing or unparseable value ranks below any
+  stated precision.
+  """
+  if decimals is None:
+    return UNKNOWN_PRECISION
+  text = str(decimals).strip()
+  if not text:
+    return UNKNOWN_PRECISION
+  if text.upper() == "INF":
+    return float("inf")
+  try:
+    return float(int(text))
+  except ValueError:
+    return UNKNOWN_PRECISION
+
+
+def keep_most_precise(
+  rows: list[dict[str, Any]], key: Callable[[dict[str, Any]], Hashable]
+) -> list[dict[str, Any]]:
+  """Collapse ``rows`` to one per ``key(row)``, keeping the most precise.
+
+  Precision is ``precision_rank(row["decimals"])``. When two rows tie, the
+  first one seen stays: at equal precision two consistent duplicates carry
+  the same value, so the choice cannot change the number. Output keeps the
+  order in which each key was first seen, so a caller's ``ORDER BY`` on
+  the query survives the dedup.
+  """
+  position: dict[Hashable, int] = {}
+  ranks: list[float] = []
+  deduped: list[dict[str, Any]] = []
+  for row in rows:
+    k = key(row)
+    rank = precision_rank(row.get("decimals"))
+    slot = position.get(k)
+    if slot is None:
+      position[k] = len(deduped)
+      ranks.append(rank)
+      deduped.append(row)
+    elif rank > ranks[slot]:
+      ranks[slot] = rank
+      deduped[slot] = row
+  return deduped

--- a/robosystems/operations/roboledger/views/fact_query.py
+++ b/robosystems/operations/roboledger/views/fact_query.py
@@ -30,6 +30,7 @@ from typing import Any
 
 from robosystems.middleware.graph import get_graph_repository
 from robosystems.models.api.views.view_config import DEFAULT_FACT_LIMIT
+from robosystems.operations.roboledger.views.fact_dedup import keep_most_precise
 
 # Pre-compiled patterns for inline Cypher node filter sanitization.
 _SAFE_STR_RE = re.compile(r"[\w:\-]+")
@@ -122,8 +123,8 @@ def _build_entity_match(
 
 
 def _deduplicate_fact_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-  """Dedup on the full period signature, keeping the first occurrence,
-  then sort by ``period_end`` DESC.
+  """Dedup on the full period signature, keeping the most precise
+  occurrence, then sort by ``period_end`` DESC.
 
   DISTINCT + ORDER BY returns empty results in LadybugDB, so the query
   omits both and we handle dedup + sort here.
@@ -136,19 +137,21 @@ def _deduplicate_fact_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
   handing back year-to-date to a caller who asked for a quarter. Entity is
   in the key for the same reason: without it two filers reporting the same
   element for the same period collapse into one row.
+
+  Within one key the most precise fact by ``decimals`` survives (see
+  ``fact_dedup``): a figure reported on the statement face and again,
+  rounded, in the narrative shares every key field, and keeping the first
+  row the engine returned handed back the rounded one about half the time.
   """
-  seen: set[tuple] = set()
-  deduped: list[dict[str, Any]] = []
-  for row in rows:
-    key = (
+  deduped = keep_most_precise(
+    rows,
+    key=lambda row: (
       row.get("element_id", ""),
       row.get("period_start", ""),
       row.get("period_end", ""),
       row.get("entity_ticker") or row.get("entity_name", ""),
-    )
-    if key not in seen:
-      seen.add(key)
-      deduped.append(row)
+    ),
+  )
   deduped.sort(key=lambda r: r.get("period_end", "") or "", reverse=True)
   return deduped
 
@@ -255,6 +258,7 @@ async def query_fact_grid(
     "        p.end_date as period_end,\n"
     "        p.duration_type as duration_type,\n"
     "        f.numeric_value as value,\n"
+    "        f.decimals as decimals,\n"
     "        u.value as unit,\n"
     "        ent.ticker as entity_ticker,\n"
     "        ent.name as entity_name\n      "

--- a/robosystems/operations/roboledger/views/financial_statement_query.py
+++ b/robosystems/operations/roboledger/views/financial_statement_query.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from typing import Any
 
 from robosystems.middleware.graph import get_graph_repository
+from robosystems.operations.roboledger.views.fact_dedup import keep_most_precise
 
 
 async def query_financial_statement(
@@ -123,7 +124,8 @@ async def query_financial_statement(
     "RETURN DISTINCT e.canonical_concept AS canonical_concept, e.qname AS qname, "
     "e.name AS name, f.numeric_value AS value, "
     "p.start_date AS start_date, p.end_date AS end_date, "
-    "p.period_type AS period_type, p.duration_type AS duration_type "
+    "p.period_type AS period_type, p.duration_type AS duration_type, "
+    "f.decimals AS decimals "
     "ORDER BY end_date DESC "
     "LIMIT $limit"
   )
@@ -154,18 +156,21 @@ def deduplicate_facts(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
   rather than the instance; the sibling ``fact_query._deduplicate_fact_rows``
   keys the same way. ``start_date`` is NULL for instants, which is fine —
   an instant's identity is its ``end_date``.
+
+  Within one key the survivor is the most precise fact by ``decimals``
+  (see ``fact_dedup``). Until 2026-09-03 it was the first row the engine
+  returned, and a figure a filer reports both on the statement face and,
+  rounded, in the narrative — the same element, period, and context —
+  came back as the rounded one about half the time (3M FY2024 R&D:
+  1,100 for 1,085). Equal precision keeps the first row seen.
   """
-  seen: set[tuple[str, str, str, str, str]] = set()
-  deduped: list[dict[str, Any]] = []
-  for row in rows:
-    key = (
+  return keep_most_precise(
+    rows,
+    key=lambda row: (
       row.get("qname", "") or "",
       row.get("start_date", "") or "",
       row.get("end_date", "") or "",
       row.get("period_type", "") or "",
       row.get("duration_type", "") or "",
-    )
-    if key not in seen:
-      seen.add(key)
-      deduped.append(row)
-  return deduped
+    ),
+  )

--- a/tests/adapters/sec/test_ixbrl_parser.py
+++ b/tests/adapters/sec/test_ixbrl_parser.py
@@ -308,3 +308,77 @@ class TestiXBRLParser:
     sections = parser.parse(html)
     # Should not hang — visited set breaks the cycle
     assert len(sections) == 1
+
+  def test_resolves_multi_hop_continuation_chain(self):
+    """A note that spans pages is a chain: nonNumeric → continuation →
+    continuation → …, each link pointing to the next via its own
+    ``continuedAt`` attribute. Every link's text and elements must land in
+    the section. Until 2026-09-03 the parser looked for the pointer inside
+    the continuation's content, so every chain stopped after one hop and
+    every multi-page note lost its tail (3M FY2024 Note 6 lost the PFAS
+    exit-actions paragraph; Note 19 kept 570 of 129,803 characters).
+    """
+    html = """
+    <html><body>
+    <ix:nonNumeric contextRef="c-1" name="us-gaap:RestructuringAndRelatedActivitiesDisclosureTextBlock" id="f-1" continuedAt="f-1-a">
+      <p>Restructuring overview with enough words to clear the minimum word count filter for a section.</p>
+    </ix:nonNumeric>
+    <p>Page footer text that is not part of the note.</p>
+    <ix:continuation id="f-1-a" continuedAt="f-1-b">
+      <p>SECOND HOP: charges of
+      <ix:nonFraction name="us-gaap:RestructuringCharges" contextRef="c1">300</ix:nonFraction>
+      million were recorded.</p>
+    </ix:continuation>
+    <ix:continuation id="f-1-b" continuedAt="f-1-c">
+      <p>THIRD HOP: the reserve balance was
+      <ix:nonFraction name="us-gaap:RestructuringReserve" contextRef="c2">120</ix:nonFraction>
+      million.</p>
+    </ix:continuation>
+    <ix:continuation id="f-1-c">
+      <p>FOURTH HOP: PFAS Exit Actions paragraph with
+      <ix:nonFraction name="us-gaap:BusinessExitCosts1" contextRef="c3">45</ix:nonFraction>
+      million.</p>
+    </ix:continuation>
+    </body></html>
+    """
+    sections = iXBRLParser().parse(html)
+
+    assert len(sections) == 1
+    s = sections[0]
+    for marker in ("SECOND HOP", "THIRD HOP", "FOURTH HOP", "PFAS Exit Actions"):
+      assert marker in s.content
+    assert "Page footer" not in s.content
+    assert s.xbrl_elements == [
+      "us-gaap:BusinessExitCosts1",
+      "us-gaap:RestructuringCharges",
+      "us-gaap:RestructuringReserve",
+    ]
+
+  def test_chain_pointer_is_read_from_the_tag_not_the_content(self):
+    """A continuation may wrap an element that itself continues elsewhere.
+    That nested pointer belongs to the nested element's chain, not to the
+    enclosing note: following it would splice another note's text into
+    this one. The chain ends where the continuation's own tag says it ends.
+    """
+    html = """
+    <html><body>
+    <ix:nonNumeric contextRef="c-1" name="us-gaap:DebtDisclosureTextBlock" id="f-1" continuedAt="f-1-a">
+      <p>Debt overview with enough words to clear the minimum word count filter for a section.</p>
+    </ix:nonNumeric>
+    <ix:continuation id="f-1-a">
+      <p>Debt detail, and a nested policy that continues on its own:
+      <ix:nonNumeric name="us-gaap:DebtPolicyTextBlock" contextRef="c-1" id="f-2" continuedAt="f-2-a">policy start</ix:nonNumeric>
+      </p>
+    </ix:continuation>
+    <ix:continuation id="f-2-a">
+      <p>OTHER NOTE TEXT that belongs to the nested policy, not to the debt note.</p>
+    </ix:continuation>
+    </body></html>
+    """
+    sections = iXBRLParser().parse(html)
+
+    debt = next(
+      s for s in sections if s.section_id == "us-gaap:DebtDisclosureTextBlock"
+    )
+    assert "Debt detail" in debt.content
+    assert "OTHER NOTE TEXT" not in debt.content

--- a/tests/operations/roboledger/views/test_fact_dedup.py
+++ b/tests/operations/roboledger/views/test_fact_dedup.py
@@ -1,0 +1,100 @@
+"""Tests for the precision-aware dedup shared by the graph-backed views.
+
+The case that motivated it: 3M FY2024 research and development expense is
+reported twice in the 10-K under the same element and period — 1,085 (in
+millions, ``decimals=-6``) on the income statement and 1,100
+(``decimals=-8``) in the narrative. Both are consolidated facts with the
+same period identity; the statement figure must be the survivor
+regardless of the order the engine returns the rows.
+"""
+
+import pytest
+
+from robosystems.operations.roboledger.views.fact_dedup import (
+  UNKNOWN_PRECISION,
+  keep_most_precise,
+  precision_rank,
+)
+
+MMM_RD_STATEMENT = {
+  "qname": "us-gaap:ResearchAndDevelopmentExpense",
+  "start_date": "2024-01-01",
+  "end_date": "2024-12-31",
+  "value": 1_085_000_000,
+  "decimals": "-6",
+}
+MMM_RD_NARRATIVE = {
+  "qname": "us-gaap:ResearchAndDevelopmentExpense",
+  "start_date": "2024-01-01",
+  "end_date": "2024-12-31",
+  "value": 1_100_000_000,
+  "decimals": "-8",
+}
+
+
+def _period_key(row):
+  return (row["qname"], row["start_date"], row["end_date"])
+
+
+@pytest.mark.unit
+class TestPrecisionRank:
+  def test_millions_beats_hundred_millions(self):
+    assert precision_rank("-6") > precision_rank("-8")
+
+  def test_inf_beats_any_finite_precision(self):
+    assert precision_rank("INF") > precision_rank("6")
+    assert precision_rank("inf") > precision_rank("6")
+
+  def test_integer_input_is_accepted(self):
+    assert precision_rank(-6) == precision_rank("-6")
+
+  @pytest.mark.parametrize("value", [None, "", "   ", "n/a"])
+  def test_missing_or_unparseable_is_least_precise(self, value):
+    assert precision_rank(value) == UNKNOWN_PRECISION
+    assert precision_rank(value) < precision_rank("-8")
+
+
+@pytest.mark.unit
+class TestKeepMostPrecise:
+  def test_statement_figure_survives_when_listed_first(self):
+    rows = [MMM_RD_STATEMENT, MMM_RD_NARRATIVE]
+    assert [r["value"] for r in keep_most_precise(rows, _period_key)] == [1_085_000_000]
+
+  def test_statement_figure_survives_when_listed_second(self):
+    rows = [MMM_RD_NARRATIVE, MMM_RD_STATEMENT]
+    assert [r["value"] for r in keep_most_precise(rows, _period_key)] == [1_085_000_000]
+
+  def test_stated_precision_beats_missing_precision(self):
+    unknown = {**MMM_RD_NARRATIVE, "decimals": None}
+    rows = [unknown, MMM_RD_STATEMENT]
+    assert [r["value"] for r in keep_most_precise(rows, _period_key)] == [1_085_000_000]
+
+  def test_equal_precision_keeps_the_first_row(self):
+    first = {**MMM_RD_STATEMENT, "value": 1}
+    second = {**MMM_RD_STATEMENT, "value": 2}
+    assert [r["value"] for r in keep_most_precise([first, second], _period_key)] == [1]
+
+  def test_no_decimals_column_degrades_to_first_seen(self):
+    """Rows from a query that never projected decimals behave as before."""
+    a = {"qname": "x", "start_date": "", "end_date": "2024-12-31", "value": 1}
+    b = {"qname": "x", "start_date": "", "end_date": "2024-12-31", "value": 2}
+    assert [r["value"] for r in keep_most_precise([a, b], _period_key)] == [1]
+
+  def test_output_keeps_first_seen_key_order(self):
+    """A replaced survivor takes the slot its key was first seen in, so the
+    query's ORDER BY is not disturbed by which duplicate was more precise."""
+    other = {
+      "qname": "us-gaap:Revenues",
+      "start_date": "2024-01-01",
+      "end_date": "2024-12-31",
+      "value": 24_575_000_000,
+      "decimals": "-6",
+    }
+    rows = [MMM_RD_NARRATIVE, other, MMM_RD_STATEMENT]
+    assert [r["value"] for r in keep_most_precise(rows, _period_key)] == [
+      1_085_000_000,
+      24_575_000_000,
+    ]
+
+  def test_empty_input(self):
+    assert keep_most_precise([], _period_key) == []

--- a/tests/operations/roboledger/views/test_fact_query.py
+++ b/tests/operations/roboledger/views/test_fact_query.py
@@ -516,3 +516,36 @@ class TestDeduplicateFactRows:
       "2024-12-31",
       "2023-12-31",
     ]
+
+  @pytest.mark.unit
+  def test_same_period_reported_at_two_precisions_keeps_the_precise_one(self):
+    """3M FY2024 R&D: 1,085 (decimals -6) on the income statement and 1,100
+    (decimals -8) in the narrative share the element, period and entity.
+    The statement figure must win in either row order."""
+    statement = {
+      "element_id": "us-gaap:ResearchAndDevelopmentExpense",
+      "period_start": "2024-01-01",
+      "period_end": "2024-12-31",
+      "duration_type": "annual",
+      "entity_ticker": "MMM",
+      "value": 1_085_000_000,
+      "decimals": "-6",
+    }
+    narrative = {**statement, "value": 1_100_000_000, "decimals": "-8"}
+    assert [r["value"] for r in _deduplicate_fact_rows([statement, narrative])] == [
+      1_085_000_000
+    ]
+    assert [r["value"] for r in _deduplicate_fact_rows([narrative, statement])] == [
+      1_085_000_000
+    ]
+
+
+class TestProjectsDecimals:
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_decimals_is_projected_for_the_dedup(self, mock_repository):
+    """The dedup ranks survivors by decimals, so the query must project it."""
+    with patch(PATCH_REPO, return_value=mock_repository):
+      await query_fact_grid(MOCK_GRAPH_ID, elements=["us-gaap:Assets"])
+    query = mock_repository.execute_query.call_args[0][0]
+    assert "f.decimals as decimals" in query

--- a/tests/operations/roboledger/views/test_financial_statement_query.py
+++ b/tests/operations/roboledger/views/test_financial_statement_query.py
@@ -279,3 +279,42 @@ class TestDeduplicateFacts:
     deduped = deduplicate_facts(rows)
     # Both map to (""", "") — first wins.
     assert len(deduped) == 1
+
+  @pytest.mark.unit
+  def test_same_period_reported_at_two_precisions_keeps_the_precise_one(self):
+    """3M FY2024 R&D: 1,085 (decimals -6) on the income statement and 1,100
+    (decimals -8) in the narrative share the element, period and context.
+    The statement figure must win in either row order; before 2026-09-03
+    the first row the engine returned won, and the tool answered 1,100."""
+    statement = {
+      "qname": "us-gaap:ResearchAndDevelopmentExpense",
+      "start_date": "2024-01-01",
+      "end_date": "2024-12-31",
+      "period_type": "duration",
+      "duration_type": "annual",
+      "value": 1_085_000_000,
+      "decimals": "-6",
+    }
+    narrative = {**statement, "value": 1_100_000_000, "decimals": "-8"}
+    assert [r["value"] for r in deduplicate_facts([statement, narrative])] == [
+      1_085_000_000
+    ]
+    assert [r["value"] for r in deduplicate_facts([narrative, statement])] == [
+      1_085_000_000
+    ]
+
+
+class TestProjectsDecimals:
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_decimals_is_projected_for_the_dedup(self, mock_repository):
+    """The dedup ranks survivors by decimals, so the query must project it."""
+    with patch(
+      "robosystems.operations.roboledger.views.financial_statement_query.get_graph_repository",
+      return_value=mock_repository,
+    ):
+      await query_financial_statement(
+        MOCK_GRAPH, statement_type="income_statement", ticker="MMM"
+      )
+    query, _ = mock_repository.execute_query.call_args[0]
+    assert "f.decimals AS decimals" in query


### PR DESCRIPTION
## Summary

Two data defects on the SEC surface, both found by replaying the Filing Ladder benchmark questions against the live `sec` MCP tools.

- **Text index: multi-page notes were cut after one continuation.** The iXBRL disclosure parser read each continuation's `continuedAt` pointer from its content instead of its tag, so every chain stopped after the first hop. On the 3M FY2024 10-K the whole filing yielded 110K characters of narrative; with the fix it yields 343K, Note 6 recovers the PFAS exit-actions paragraph, and Note 19 goes from 570 to 130,272 characters. Reading the pointer from the tag also stops a nested element's pointer from splicing another note's text into the chain.
- **Views: dedup kept the first duplicate, not the most precise.** `financial-statement-analysis` and `build-fact-grid` collapse facts by period identity and kept whichever row the engine returned first. A figure reported on the statement face and again, rounded, in the narrative shares that identity, and the engine's row order is not stable, so the tools answered the rounded one on a fraction of identical calls (3M FY2024 R&D: 1,100 for 1,085). Both queries now project `decimals` and keep the most precise fact per period; equal precision keeps the first row seen.

## Testing

- New parser tests: a four-link chain, and a nested element's pointer that must not hijack the chain. Both fail on the previous parser.
- New dedup tests for both views, plus the shared helper: the 3M R&D pair in either row order, `INF`, and missing precision.
- `just test-code` clean; 121 targeted and 615 downstream tests pass.
- End to end on a local `just sec-load MMM 2025`, comparing the pre-fix and post-fix API process on the same graph:
  - Pre-fix process: 100 identical `financial-statement-analysis` calls returned 10 distinct fact sets, flipping between 1,085 and 1,100 for FY2024 R&D and between 1,154 and 1,200 for FY2023.
  - Post-fix process: 100 identical REST calls returned one fact set, and 20 MCP tool calls all returned 1,085 / 1,154 / 1,160 for FY2024/23/22. The Filing Ladder R&D question scores correct on the shaped-tools rung, and the PFAS narrative question scores correct now that the index holds the paragraph.
  - The local index holds Note 6 at 5,769 characters with the PFAS paragraph. Note 19 is the one section over the existing 50K section cap and is indexed truncated with the marker; the cap is unchanged here.

## Follow-up

The OpenSearch iXBRL disclosure index carries the truncated sections until it is rebuilt: after deploy, backfill the `sec_ixbrl_index` job with `force_reindex: true` over the populated quarters. Facts, the narratives index, and the CDN section copies (which come from Arelle's resolved value and were always complete) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGEemTerTkLyDwM544B7JW
