### PR TITLE
fix(justfile): restart-container must name the compose service

### DIFF
--- a/justfile
+++ b/justfile
@@ -57,7 +57,7 @@ restart profile="robosystems":
 
 # Restart specific service(s) without stopping everything
 restart-container container="worker":
-    docker compose -f compose.yaml restart robosystems-{{container}}
+    docker compose -f compose.yaml restart {{container}}
 
 # Restart graph-api if running and wait until it is healthy
 graph-api-restart:


### PR DESCRIPTION
## Summary

`just restart-container <name>` ran `docker compose restart robosystems-<name>`. Compose restart takes service names, so every call failed with `no such service` and, if the output was not read, the old process kept serving. The recipe now passes the service name through. The `logs`, `logs-grep`, and `shell` recipes use `docker logs` / `docker exec`, which take container names, so they keep the prefix.

## Testing

`just restart-container api` now prints `Restarting` / `Started` for the API container and the health endpoint comes back after a few polls. Found while verifying #1348 locally, where the failed restart left the pre-fix process serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGEemTerTkLyDwM544B7JW