### PR TITLE
chore(tunnels): bind offset local ports so a tunnel never collides with the local stack

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -62,7 +62,7 @@ A green workflow means the pipeline finished, not that the app is serving. Confi
 
 ```bash
 curl -sf https://<api-host>/v1/status && echo OK      # public API over HTTPS
-# if the API is in internal mode: tunnel first, then curl http://localhost:8000/v1/status
+# if the API is in internal mode: tunnel first, then curl http://localhost:18000/v1/status
 ```
 
 `/v1/status` is a **liveness** probe — it returns healthy whenever the process is up; it does **not** check the database, cache, or graph. A 200 means "the API is serving HTTP," not "the stack is healthy." Confirm the rest yourself: the app service (running vs desired count), recent errors in its log group, and — if the deploy carried a migration — the orchestrator boot logs (`/migrate`).

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -800,14 +800,14 @@ jobs:
             cat >> $GITHUB_STEP_SUMMARY << EOF
           - **Mode**: Public (HTTPS)
           - **URL**: https://${API_DOMAIN}
-          - **Admin CLI**: \`just admin prod --tunnel <command>\` (requires \`just tunnel prod api-internal\`)
+          - **Admin CLI**: \`just admin prod <command>\` (requires \`just tunnel prod api-internal\`; the CLI targets the tunnel on :18000)
           EOF
           else
             cat >> $GITHUB_STEP_SUMMARY << EOF
           - **Mode**: Internal (SSM tunnel required)
           - **Connect**: \`just tunnel prod all\`
-          - **API**: http://localhost:8000
-          - **Admin CLI**: \`just admin prod --tunnel <command>\`
+          - **API**: http://localhost:18000
+          - **Admin CLI**: \`just admin prod <command>\`
           EOF
           fi
 
@@ -843,10 +843,10 @@ jobs:
 
           | Service | Local Port |
           |---------|------------|
-          | API | http://localhost:8000 |
-          | Dagster UI | http://localhost:8002 |
-          | PostgreSQL | localhost:5432 |
-          | Valkey | localhost:6379 |
+          | API | http://localhost:18000 |
+          | Dagster UI | http://localhost:18002 |
+          | PostgreSQL | localhost:15432 |
+          | Valkey | localhost:16379 |
 
           ### Next Steps
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -810,14 +810,14 @@ jobs:
             cat >> $GITHUB_STEP_SUMMARY << EOF
           - **Mode**: Public (HTTPS)
           - **URL**: https://${API_DOMAIN}
-          - **Admin CLI**: \`just admin staging --tunnel <command>\` (requires \`just tunnel staging api-internal\`)
+          - **Admin CLI**: \`just admin staging <command>\` (requires \`just tunnel staging api-internal\`; the CLI targets the tunnel on :18000)
           EOF
           else
             cat >> $GITHUB_STEP_SUMMARY << EOF
           - **Mode**: Internal (SSM tunnel required)
           - **Connect**: \`just tunnel staging all\`
-          - **API**: http://localhost:8000
-          - **Admin CLI**: \`just admin staging --tunnel <command>\`
+          - **API**: http://localhost:18000
+          - **Admin CLI**: \`just admin staging <command>\`
           EOF
           fi
 
@@ -853,10 +853,10 @@ jobs:
 
           | Service | Local Port |
           |---------|------------|
-          | API | http://localhost:8000 |
-          | Dagster UI | http://localhost:8002 |
-          | PostgreSQL | localhost:5432 |
-          | Valkey | localhost:6379 |
+          | API | http://localhost:18000 |
+          | Dagster UI | http://localhost:18002 |
+          | PostgreSQL | localhost:15432 |
+          | Valkey | localhost:16379 |
 
           ### Next Steps
 

--- a/bin/tools/tunnels.sh
+++ b/bin/tools/tunnels.sh
@@ -11,6 +11,15 @@ set -euo pipefail
 DEFAULT_ENVIRONMENT="prod"
 AWS_REGION="${AWS_REGION:-us-east-1}"
 
+# Local bind ports for the tunnels. Each is the service's real port with a "1"
+# prefixed, so a tunnel never collides with the local dev stack (postgres 5432,
+# valkey 6379, api 8000, dagster 8002) — the stack can stay up while a tunnel is
+# open, and a command left on a default port can't silently hit production.
+LOCAL_PORT_POSTGRES="${LOCAL_PORT_POSTGRES:-15432}"
+LOCAL_PORT_VALKEY="${LOCAL_PORT_VALKEY:-16379}"
+LOCAL_PORT_API="${LOCAL_PORT_API:-18000}"
+LOCAL_PORT_DAGSTER="${LOCAL_PORT_DAGSTER:-18002}"
+
 # Dynamic configuration (populated by discover_infrastructure)
 BASTION_INSTANCE_ID=""
 POSTGRES_ENDPOINT=""
@@ -128,11 +137,11 @@ print_usage() {
     echo -e "${GREEN}======================================================================"
     echo "SSM Tunnels - Access internal services via AWS Systems Manager"
     echo "======================================================================${NC}"
-    echo "  postgres      - PostgreSQL tunnel (localhost:5432)"
-    echo "  valkey        - Valkey ElastiCache tunnel (localhost:6379)"
-    echo "  dagster       - Dagster webserver tunnel (localhost:8002)"
-    echo "  api           - API ALB tunnel (localhost:8000)"
-    echo "  api-internal  - API direct tunnel (localhost:8000, bypasses ALB)"
+    echo "  postgres      - PostgreSQL tunnel (localhost:$LOCAL_PORT_POSTGRES)"
+    echo "  valkey        - Valkey ElastiCache tunnel (localhost:$LOCAL_PORT_VALKEY)"
+    echo "  dagster       - Dagster webserver tunnel (localhost:$LOCAL_PORT_DAGSTER)"
+    echo "  api           - API ALB tunnel (localhost:$LOCAL_PORT_API)"
+    echo "  api-internal  - API direct tunnel (localhost:$LOCAL_PORT_API, bypasses ALB)"
     echo "  all           - All service tunnels (runs in background)"
     echo ""
     echo -e "${GREEN}======================================================================"
@@ -478,12 +487,12 @@ setup_postgres_tunnel() {
 
     echo ""
     echo -e "${YELLOW}Connect to PostgreSQL with:${NC}"
-    echo "psql -h localhost -p 5432 -U postgres -d robosystems"
+    echo "psql -h localhost -p $LOCAL_PORT_POSTGRES -U postgres -d robosystems"
     echo ""
     echo -e "${YELLOW}Press Ctrl+C to stop the tunnel${NC}"
     echo ""
 
-    start_ssm_tunnel "$POSTGRES_ENDPOINT" "5432" "5432" "PostgreSQL"
+    start_ssm_tunnel "$POSTGRES_ENDPOINT" "5432" "$LOCAL_PORT_POSTGRES" "PostgreSQL"
 }
 
 setup_valkey_tunnel() {
@@ -494,12 +503,12 @@ setup_valkey_tunnel() {
 
     echo ""
     echo -e "${YELLOW}Connect to Valkey with:${NC}"
-    echo "redis-cli -h localhost -p 6379"
+    echo "redis-cli -h localhost -p $LOCAL_PORT_VALKEY"
     echo ""
     echo -e "${YELLOW}Press Ctrl+C to stop the tunnel${NC}"
     echo ""
 
-    start_ssm_tunnel "$VALKEY_ENDPOINT" "6379" "6379" "Valkey"
+    start_ssm_tunnel "$VALKEY_ENDPOINT" "6379" "$LOCAL_PORT_VALKEY" "Valkey"
 }
 
 setup_dagster_tunnel() {
@@ -510,12 +519,12 @@ setup_dagster_tunnel() {
 
     echo ""
     echo -e "${YELLOW}Access Dagster UI:${NC}"
-    echo "Open http://127.0.0.1:8002 in your browser"
+    echo "Open http://127.0.0.1:$LOCAL_PORT_DAGSTER in your browser"
     echo ""
     echo -e "${YELLOW}Press Ctrl+C to stop the tunnel${NC}"
     echo ""
 
-    start_ssm_tunnel "$DAGSTER_ENDPOINT" "3000" "8002" "Dagster"
+    start_ssm_tunnel "$DAGSTER_ENDPOINT" "3000" "$LOCAL_PORT_DAGSTER" "Dagster"
 }
 
 setup_api_tunnel() {
@@ -545,13 +554,13 @@ setup_api_tunnel() {
 
     echo ""
     echo -e "${YELLOW}Access API (via ALB):${NC}"
-    echo "curl http://localhost:8000/v1/status"
-    echo "Open http://127.0.0.1:8000/docs in your browser for API docs"
+    echo "curl http://localhost:$LOCAL_PORT_API/v1/status"
+    echo "Open http://127.0.0.1:$LOCAL_PORT_API/docs in your browser for API docs"
     echo ""
     echo -e "${YELLOW}Press Ctrl+C to stop the tunnel${NC}"
     echo ""
 
-    start_ssm_tunnel "$API_ENDPOINT" "80" "8000" "API"
+    start_ssm_tunnel "$API_ENDPOINT" "80" "$LOCAL_PORT_API" "API"
 }
 
 setup_api_internal_tunnel() {
@@ -571,16 +580,16 @@ setup_api_internal_tunnel() {
     echo -e "${YELLOW}Use this for admin operations when ALB IP restrictions apply.${NC}"
     echo ""
     echo -e "${YELLOW}Access API:${NC}"
-    echo "curl http://localhost:8000/v1/status"
+    echo "curl http://localhost:$LOCAL_PORT_API/v1/status"
     echo ""
     echo -e "${YELLOW}Admin API (requires this tunnel):${NC}"
     echo "just admin $environment stats"
-    echo "Open http://127.0.0.1:8000/docs in your browser for API docs"
+    echo "Open http://127.0.0.1:$LOCAL_PORT_API/docs in your browser for API docs"
     echo ""
     echo -e "${YELLOW}Press Ctrl+C to stop the tunnel${NC}"
     echo ""
 
-    start_ssm_tunnel "$API_INTERNAL_ENDPOINT" "8000" "8000" "API-Internal"
+    start_ssm_tunnel "$API_INTERNAL_ENDPOINT" "8000" "$LOCAL_PORT_API" "API-Internal"
 }
 
 setup_all_tunnels() {
@@ -592,26 +601,26 @@ setup_all_tunnels() {
 
     # Start tunnels in background
     if [[ "$POSTGRES_ENDPOINT" != "NOT_FOUND" ]]; then
-        start_ssm_tunnel_background "$POSTGRES_ENDPOINT" "5432" "5432" "PostgreSQL"
+        start_ssm_tunnel_background "$POSTGRES_ENDPOINT" "5432" "$LOCAL_PORT_POSTGRES" "PostgreSQL"
         ((tunnel_count++))
         sleep 1
     fi
 
     if [[ "$VALKEY_ENDPOINT" != "NOT_FOUND" ]]; then
-        start_ssm_tunnel_background "$VALKEY_ENDPOINT" "6379" "6379" "Valkey"
+        start_ssm_tunnel_background "$VALKEY_ENDPOINT" "6379" "$LOCAL_PORT_VALKEY" "Valkey"
         ((tunnel_count++))
         sleep 1
     fi
 
     if [[ -n "$DAGSTER_ENDPOINT" && "$DAGSTER_ENDPOINT" != "NOT_FOUND" ]]; then
-        start_ssm_tunnel_background "$DAGSTER_ENDPOINT" "3000" "8002" "Dagster"
+        start_ssm_tunnel_background "$DAGSTER_ENDPOINT" "3000" "$LOCAL_PORT_DAGSTER" "Dagster"
         ((tunnel_count++))
         sleep 1
     fi
 
     # API tunnel: use ALB for internal mode, Service Discovery for public modes
     if [[ -n "$API_ENDPOINT" && "$API_ENDPOINT" != "NOT_FOUND" && "$API_ACCESS_MODE" == "internal" ]]; then
-        start_ssm_tunnel_background "$API_ENDPOINT" "80" "8000" "API"
+        start_ssm_tunnel_background "$API_ENDPOINT" "80" "$LOCAL_PORT_API" "API"
         ((tunnel_count++))
         sleep 1
     elif [[ "$API_ACCESS_MODE" == "public" ]]; then
@@ -619,7 +628,7 @@ setup_all_tunnels() {
         # This allows admin CLI access since ALB blocks /admin/v1/* in public mode
         if [[ -n "$API_INTERNAL_ENDPOINT" ]]; then
             echo -e "${YELLOW}API is in $API_ACCESS_MODE mode - using api-internal tunnel (bypasses ALB)${NC}"
-            start_ssm_tunnel_background "$API_INTERNAL_ENDPOINT" "8000" "8000" "API-Internal"
+            start_ssm_tunnel_background "$API_INTERNAL_ENDPOINT" "8000" "$LOCAL_PORT_API" "API-Internal"
             ((tunnel_count++))
             sleep 1
         fi
@@ -636,21 +645,21 @@ setup_all_tunnels() {
     echo -e "${YELLOW}Connection commands:${NC}"
 
     if [[ "$POSTGRES_ENDPOINT" != "NOT_FOUND" ]]; then
-        echo "PostgreSQL: psql -h localhost -p 5432 -U postgres -d robosystems"
+        echo "PostgreSQL: psql -h localhost -p $LOCAL_PORT_POSTGRES -U postgres -d robosystems"
     fi
 
     if [[ "$VALKEY_ENDPOINT" != "NOT_FOUND" ]]; then
-        echo "Valkey:     redis-cli -h localhost -p 6379"
+        echo "Valkey:     redis-cli -h localhost -p $LOCAL_PORT_VALKEY"
     fi
 
     if [[ -n "$DAGSTER_ENDPOINT" && "$DAGSTER_ENDPOINT" != "NOT_FOUND" ]]; then
-        echo "Dagster:    Open http://127.0.0.1:8002 in your browser"
+        echo "Dagster:    Open http://127.0.0.1:$LOCAL_PORT_DAGSTER in your browser"
     fi
 
     if [[ "$API_ACCESS_MODE" == "internal" ]]; then
-        echo "API:        curl http://localhost:8000/v1/status"
+        echo "API:        curl http://localhost:$LOCAL_PORT_API/v1/status"
     elif [[ "$API_ACCESS_MODE" == "public" ]]; then
-        echo "API:        curl http://localhost:8000/v1/status (via api-internal)"
+        echo "API:        curl http://localhost:$LOCAL_PORT_API/v1/status (via api-internal)"
         echo "Admin CLI:  just admin $environment stats"
     fi
 

--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -331,9 +331,11 @@ just tunnel prod postgres
 # Raw equivalents
 aws ssm start-session --target i-0123456789abcdef0
 
+# Local ports are the service port with a "1" prefixed (postgres 15432, valkey
+# 16379, api 18000, dagster 18002) so tunnels never collide with the local stack
 aws ssm start-session --target i-0123456789abcdef0 \
   --document-name AWS-StartPortForwardingSessionToRemoteHost \
-  --parameters '{"host":["mydb.xxx.rds.amazonaws.com"],"portNumber":["5432"],"localPortNumber":["5432"]}'
+  --parameters '{"host":["mydb.xxx.rds.amazonaws.com"],"portNumber":["5432"],"localPortNumber":["15432"]}'
 ```
 
 ---

--- a/examples/roboinvestor_demo/main.py
+++ b/examples/roboinvestor_demo/main.py
@@ -887,8 +887,10 @@ def main(argv: list[str] | None = None) -> None:
 
   # Local targets only (F10): the reset issues raw DELETEs against whatever
   # EXTENSIONS_DATABASE_URL points at, which is *not* necessarily the same
-  # system as DEMO_API_URL — with an SSM tunnel open, localhost:5432 can be a
-  # remote RDS. The import lives inside the local-only branch so the route is
+  # system as DEMO_API_URL — an SSM tunnel makes a remote RDS look local
+  # (on an offset port, localhost:15432, so the default port is never prod by
+  # accident, but a URL can still name it). The import lives inside the
+  # local-only branch so the route is
   # unreachable off-local, not merely skipped; and because the API host proves
   # nothing about the database, the reset itself re-checks on the DB side
   # (``examples/_common/local_db.py``: local host + not-RDS) before deleting.

--- a/examples/roboledger_demo/main.py
+++ b/examples/roboledger_demo/main.py
@@ -321,7 +321,8 @@ def reset_demo(graph_id: str) -> None:
   **Local targets only (F10).** ``reset_demo_state`` issues raw DELETEs against
   whatever ``EXTENSIONS_DATABASE_URL`` points at, which is *not* necessarily the
   same system as ``DEMO_API_URL`` — an SSM tunnel makes a remote database look
-  local, so with tunnels open ``localhost:5432`` can be prod RDS. A remote /
+  local (tunnels bind offset ports, ``localhost:15432`` for postgres, so the
+  default port is never prod by accident, but a URL can still name it). A remote /
   integration target has no business reaching Postgres at all, so the reset is
   simply not run off-local — and ``reset_demo_state`` is imported *inside* the
   local-only branch so the route is unreachable there, not merely skipped. The

--- a/robosystems/admin/README.md
+++ b/robosystems/admin/README.md
@@ -24,7 +24,10 @@ just admin dev stats
 
 ### Staging / production
 
-Open a tunnel in one terminal, run commands in another:
+Open a tunnel in one terminal, run commands in another. The tunnel binds
+`localhost:18000` — offset from the local stack's 8000 — so `just start` can stay
+up while you work against staging or prod, and the CLI targets that port
+automatically for those environments:
 
 ```bash
 # Terminal 1

--- a/robosystems/admin/cli.py
+++ b/robosystems/admin/cli.py
@@ -5,9 +5,10 @@ cache, instances, search, and worker operations. Commands are thin wrappers
 over HTTP calls; the API key comes from `ADMIN_API_KEY` in dev, otherwise from
 AWS Secrets Manager.
 
-Requests go to localhost:8000 by default, which serves both local dev and an
-SSM tunnel. Against staging or prod a tunnel is required — the ALB blocks
-`/admin/v1/*` whenever the API is publicly reachable.
+Requests go to localhost:8000 in dev and to the tunnel's port (localhost:18000)
+against staging or prod. A tunnel is required there — the ALB blocks
+`/admin/v1/*` whenever the API is publicly reachable — and the offset port lets
+the local dev stack keep running alongside it.
 
 Examples:
     # Local dev (Docker, no tunnel)
@@ -47,6 +48,11 @@ from .commands.worker import worker
 logger = get_logger(__name__)
 console = Console()
 
+# Local dev serves the API on 8000; the SSM tunnel binds 18000 so both can be up
+# at once (see LOCAL_PORT_API in bin/tools/tunnels.sh).
+LOCAL_API_URL = "http://localhost:8000"
+TUNNEL_API_URL = "http://localhost:18000"
+
 
 class AdminAPIClient:
   """Client for interacting with the RoboSystems admin API."""
@@ -60,9 +66,10 @@ class AdminAPIClient:
   ):
     """Resolve the API base URL and fetch the admin key.
 
-    `api_base_url` defaults to localhost:8000, which reaches the API through
-    an SSM tunnel. `use_direct` swaps in the environment's public URL instead,
-    which the ALB only permits while the API is in 'internal' mode.
+    `api_base_url` defaults to localhost:8000 in dev and to localhost:18000 for
+    staging and prod, where the API is reached through an SSM tunnel (see
+    `bin/tools/tunnels.sh`). `use_direct` swaps in the environment's public URL
+    instead, which the ALB only permits while the API is in 'internal' mode.
     """
     self.environment = environment
     self.aws_profile = aws_profile
@@ -76,9 +83,11 @@ class AdminAPIClient:
       elif environment == "prod":
         self.api_base_url = "https://api.robosystems.ai"
       else:
-        self.api_base_url = "http://localhost:8000"
+        self.api_base_url = LOCAL_API_URL
+    elif environment == "dev":
+      self.api_base_url = LOCAL_API_URL
     else:
-      self.api_base_url = "http://localhost:8000"
+      self.api_base_url = TUNNEL_API_URL
 
     if use_direct and environment != "dev":
       self._check_api_access_mode()
@@ -247,7 +256,7 @@ class AdminAPIClient:
 )
 @click.option(
   "--api-url",
-  help="Override API base URL (default: localhost:8000)",
+  help="Override API base URL (default: localhost:8000 in dev, localhost:18000 via tunnel)",
 )
 @click.option(
   "--aws-profile",
@@ -267,9 +276,9 @@ def cli(ctx, environment, api_url, aws_profile, direct):
   This CLI provides access to subscription management, customer management,
   credit management, graph management, and user management.
 
-  By default, connects to localhost:8000 which works with:
-    - Local dev (Docker): just admin dev stats
-    - SSM tunnel: ./bin/tools/tunnels.sh prod all && just admin prod stats
+  By default, connects to:
+    - Local dev (Docker), localhost:8000: just admin dev stats
+    - SSM tunnel, localhost:18000: ./bin/tools/tunnels.sh prod all && just admin prod stats
 
   Direct mode (--direct / -d):
     Connects to public API URLs. Only works if API is in 'internal' mode.


### PR DESCRIPTION
## Summary
- SSM tunnels now bind the service port with a `1` prefixed locally — postgres `15432`, valkey `16379`, api `18000`, dagster `18002` — overridable through `LOCAL_PORT_*`. The local Docker stack can stay up while a tunnel is open, and a command left on a default port can never silently reach production.
- The admin CLI targets `localhost:8000` in dev and `localhost:18000` for staging and prod automatically; `--api-url` still overrides both and `--direct` is unchanged.
- Deploy summaries (prod + staging), the `/deploy` command, the CloudFormation and admin READMEs, and the two demo scripts' reset-guard comments describe the same ports. The guards themselves are unchanged (they check host + not-RDS on the database side).

## Test plan
- [ ] `just tunnel prod dagster` binds `127.0.0.1:18002` while the local stack still holds `8002`; the prod UI answers there
- [ ] `just tunnel prod api-internal` + `just admin prod stats` reaches the API on `18000` with no flag
- [ ] `just tunnel prod postgres` + `psql -h localhost -p 15432` connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGEemTerTkLyDwM544B7JW