### PR TITLE
feat(sec): keep text blocks in the graph behind a local-only flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -271,6 +271,9 @@ SECURITY_AUDIT_ENABLED=false
 
 ## Adapter Pipelines
 # SEC_PIPELINE_ENABLED=true
+# Local control experiments only: keep text-block values in the graph as well as on S3.
+# Never in a real environment — text blocks are most of a filing's bytes.
+# XBRL_KEEP_TEXTBLOCKS_INLINE=false
 
 
 

--- a/robosystems/adapters/sec/config.py
+++ b/robosystems/adapters/sec/config.py
@@ -65,6 +65,10 @@ XBRL_EXTERNALIZE_LARGE_VALUES = True
 # Character threshold for externalizing values
 XBRL_EXTERNALIZATION_THRESHOLD = 1024
 
+# Keep the externalized value in the graph too (local control experiments only;
+# see env.XBRL_KEEP_TEXTBLOCKS_INLINE for why it is off everywhere real)
+XBRL_KEEP_TEXTBLOCKS_INLINE = env.XBRL_KEEP_TEXTBLOCKS_INLINE
+
 # Skip textblock facts entirely (for historical data where text isn't needed)
 XBRL_SKIP_TEXTBLOCK_FACTS = False
 

--- a/robosystems/adapters/sec/processors/textblock.py
+++ b/robosystems/adapters/sec/processors/textblock.py
@@ -20,12 +20,16 @@ class TextBlockExternalizer:
     cdn_url: str | None,
     threshold: int,
     enabled: bool = True,
+    keep_inline: bool = False,
   ):
     self.s3_client = s3_client
     self.bucket = bucket
     self.cdn_url = cdn_url
     self.threshold = threshold
     self.enabled = enabled
+    # Store the value in the graph as well as uploading it. A local control
+    # experiment's switch (env.XBRL_KEEP_TEXTBLOCKS_INLINE); never on for real.
+    self.keep_inline = keep_inline
 
     self.upload_queue: list[tuple[str, str, str]] = []
     self.upload_map: dict[str, dict[str, Any]] = {}
@@ -85,11 +89,7 @@ class TextBlockExternalizer:
         )
         external_url = get_public_data_url(self.bucket, s3_key, self.cdn_url)
 
-        result = {
-          "url": external_url,
-          "value_type": "external",
-          "content_type": content_type,
-        }
+        result = self._result(external_url, value_str, content_type)
 
         self.content_cache[content_hash] = result
         return result
@@ -104,11 +104,7 @@ class TextBlockExternalizer:
         "content_type": content_type,
       }
 
-      result = {
-        "url": external_url,
-        "value_type": "external",
-        "content_type": content_type,
-      }
+      result = self._result(external_url, value_str, content_type)
 
       self.content_cache[content_hash] = result
 
@@ -117,6 +113,18 @@ class TextBlockExternalizer:
     except Exception as e:
       logger.error(f"Error queueing value for S3: {e}")
       return None
+
+  def _result(
+    self, external_url: str, value_str: str, content_type: str
+  ) -> dict[str, Any]:
+    """What the processor stores for the fact: the URL, or the text itself when the
+    value is kept inline. ``url`` is the CDN copy either way."""
+    return {
+      "url": external_url,
+      "stored_value": value_str if self.keep_inline else external_url,
+      "value_type": "inline" if self.keep_inline else "external",
+      "content_type": content_type,
+    }
 
   def process_batch_uploads(self) -> None:
     if not self.upload_queue:

--- a/robosystems/adapters/sec/processors/xbrl_graph.py
+++ b/robosystems/adapters/sec/processors/xbrl_graph.py
@@ -14,6 +14,7 @@ from robosystems.adapters.sec.config import (
   XBRL_COLUMN_STANDARDIZATION,
   XBRL_EXTERNALIZATION_THRESHOLD,
   XBRL_EXTERNALIZE_LARGE_VALUES,
+  XBRL_KEEP_TEXTBLOCKS_INLINE,
   XBRL_SEMANTIC_ENRICHMENT,
   XBRL_SKIP_TEXTBLOCK_FACTS,
   XBRL_STANDARDIZED_FILENAMES,
@@ -93,6 +94,7 @@ class XBRLGraphProcessor:
       cdn_url=env.PUBLIC_DATA_CDN_URL,
       threshold=XBRL_EXTERNALIZATION_THRESHOLD,
       enabled=XBRL_EXTERNALIZE_LARGE_VALUES,
+      keep_inline=XBRL_KEEP_TEXTBLOCKS_INLINE,
     )
 
     # Feature flags for upstream simplification
@@ -1050,11 +1052,12 @@ class XBRLGraphProcessor:
       )
 
       if external_result:
-        # Use the expected URL (will be uploaded in batch)
-        fact_value = external_result["url"]
+        # The URL (uploaded in batch) — or the text itself, when a local control
+        # experiment keeps text blocks in the graph as well.
+        fact_value = external_result["stored_value"]
         value_type = external_result["value_type"]
         content_type = external_result["content_type"]
-        logger.debug(f"Queued for externalization: {fact_value}")
+        logger.debug(f"Queued for externalization: {external_result['url']}")
       else:
         logger.warning("Failed to queue large value, storing inline")
 

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -1083,6 +1083,13 @@ class EnvConfig:
   SEC_GOV_USER_AGENT = get_secret_value(
     "SEC_GOV_USER_AGENT", "YourCompany your-email@example.com"
   )
+  # Keep externalized text-block values in the graph as well as on S3/CDN. Off in
+  # every real environment: text blocks are most of a filing's bytes, and moving
+  # them out of the graph into the document index is what keeps the shared SEC
+  # graph its size. On only for a local control experiment where raw Cypher must
+  # be able to reach the note text. Filings processed this way carry
+  # value_type=inline, so the search index resolves no content_url for them.
+  XBRL_KEEP_TEXTBLOCKS_INLINE = get_bool_env("XBRL_KEEP_TEXTBLOCKS_INLINE", False)
 
   # OpenFIGI (financial identifiers)
   OPENFIGI_API_KEY = get_secret_value("OPENFIGI_API_KEY", "")

--- a/tests/adapters/sec/processors/test_graph_core.py
+++ b/tests/adapters/sec/processors/test_graph_core.py
@@ -279,6 +279,7 @@ class TestMakeFact:
       processor.textblock_externalizer.queue_value_for_s3 = MagicMock(
         return_value={
           "url": "https://cdn.example.com/fact.html",
+          "stored_value": "https://cdn.example.com/fact.html",
           "value_type": "external",
           "content_type": "text/html",
         }

--- a/tests/adapters/sec/processors/test_textblock_externalizer.py
+++ b/tests/adapters/sec/processors/test_textblock_externalizer.py
@@ -427,3 +427,56 @@ class TestProcessBatchUploads:
     externalizer.process_batch_uploads()
 
     assert len(externalizer.upload_queue) == 1
+
+
+class TestKeepInline:
+  """XBRL_KEEP_TEXTBLOCKS_INLINE: the value stays in the graph AND is uploaded.
+
+  The local control for the Filing Ladder's rung 7b — raw Cypher on a graph that still
+  holds the note text. Off everywhere real, so the default path must be unchanged.
+  """
+
+  def _externalizer(self, mock_s3_client, keep_inline):
+    return TextBlockExternalizer(
+      s3_client=mock_s3_client,
+      bucket="test-bucket",
+      cdn_url="https://cdn.example.com",
+      threshold=100,
+      enabled=True,
+      keep_inline=keep_inline,
+    )
+
+  def test_default_stores_the_url_as_external(
+    self, mock_s3_client, entity_data, report_data
+  ):
+    ext = self._externalizer(mock_s3_client, keep_inline=False)
+    text = "<div>" + "narrative " * 40 + "</div>"
+    result = ext.queue_value_for_s3(text, "fact-1", entity_data, report_data)
+    assert result is not None
+    assert result["value_type"] == "external"
+    assert result["stored_value"] == result["url"]
+    assert result["url"].startswith("https://cdn.example.com/")
+    assert len(ext.upload_queue) == 1
+
+  def test_keep_inline_stores_the_text_and_still_uploads(
+    self, mock_s3_client, entity_data, report_data
+  ):
+    ext = self._externalizer(mock_s3_client, keep_inline=True)
+    text = "<div>" + "narrative " * 40 + "</div>"
+    result = ext.queue_value_for_s3(text, "fact-1", entity_data, report_data)
+    assert result is not None
+    assert result["value_type"] == "inline"
+    assert result["stored_value"] == text
+    assert result["url"].startswith("https://cdn.example.com/")
+    assert len(ext.upload_queue) == 1  # the CDN copy is still made
+
+  def test_keep_inline_survives_the_content_cache(
+    self, mock_s3_client, entity_data, report_data
+  ):
+    ext = self._externalizer(mock_s3_client, keep_inline=True)
+    text = "<p>" + "same note " * 30 + "</p>"
+    first = ext.queue_value_for_s3(text, "fact-1", entity_data, report_data)
+    second = ext.queue_value_for_s3(text, "fact-2", entity_data, report_data)
+    assert first is not None and second is not None
+    assert second["stored_value"] == text and second["value_type"] == "inline"
+    assert len(ext.upload_queue) == 1  # identical content is uploaded once


### PR DESCRIPTION
## Summary

Adds `XBRL_KEEP_TEXTBLOCKS_INLINE`, default `false`, which makes the SEC graph processor store an externalized text-block value in the Fact as the text itself (`value_type=inline`) while still uploading the CDN copy. It exists for one purpose: a local control experiment for the Filing Ladder's raw-Cypher rung (7b), which on the shipped graph cannot reach note narrative because text blocks live in the document index by design.

It must never be set in a real environment. Text blocks are most of a filing's bytes, and moving them out of the graph into OpenSearch is what keeps the shared `sec` graph its size — that decision is the reason the document index exists. The flag is documented as such in `env.py` and `.env.example`.

## Changes

- `config/env.py`: `XBRL_KEEP_TEXTBLOCKS_INLINE = get_bool_env(..., False)` with the rationale.
- `adapters/sec/config.py`: exposes it beside the other XBRL constants.
- `adapters/sec/processors/textblock.py`: `TextBlockExternalizer(keep_inline=...)`; every result now carries `stored_value` (the URL, or the text when kept inline) and the matching `value_type`, built in one `_result` helper so the three return paths agree.
- `adapters/sec/processors/xbrl_graph.py`: stores `stored_value` instead of `url`.
- `.env.example`: the flag, commented out, with the warning.

Known consequence, by design: the iXBRL index's `content_url` resolution keys on `value_type=external`, so a filing processed with the flag on gets no CDN link in search results. Nothing else reads `value_type` for SEC facts.

## Breaking Changes

None. The default path stores exactly what it stored before.

## Testing

`uv run pytest tests/adapters/sec/processors`: 64 passed, including three new tests (default path unchanged; keep-inline stores the text, uploads once, and survives the content cache). `just test-code`: ruff, format, basedpyright and cfn-lint clean. The flag verified to read `true` from the shell through `UV_ENV_FILE=.env.local` and `false` without it.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pEqR1iCHTmMfJJX9bLTE5
