### PR TITLE
feat(roboledger): read journal entries on their own terms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # RoboSystems client for demo and testing.
-    "robosystems-client>=1.13.1,<2.0",
+    "robosystems-client>=1.14.0,<2.0",
     # Testing framework
     "pytest>=9.0.0,<10.0",
     "pytest-asyncio>=1.4.0,<2.0",

--- a/robosystems/graphql/resolvers/ledger.py
+++ b/robosystems/graphql/resolvers/ledger.py
@@ -44,6 +44,7 @@ from robosystems.graphql.types.ledger import (
   EventBlock,
   FiscalCalendar,
   LedgerEntity,
+  LedgerJournalEntryList,
   LedgerSummary,
   LedgerTransactionDetail,
   LedgerTransactionList,
@@ -95,6 +96,9 @@ from robosystems.operations.roboledger.reads import (
 )
 from robosystems.operations.roboledger.reads import (
   fiscal_calendar as reads_fiscal_calendar,
+)
+from robosystems.operations.roboledger.reads import (
+  journal_entries as reads_journal_entries,
 )
 from robosystems.operations.roboledger.reads import (
   period_drafts as reads_period_drafts,
@@ -543,6 +547,52 @@ class LedgerQuery:
     if response is None:
       return None
     return LedgerTransactionDetail.from_pydantic(response)
+
+  # ── Journal entries ─────────────────────────────────────────────────────
+
+  @strawberry.field
+  def journal_entries(
+    self,
+    info: Info[GraphQLContext, None],
+    start_date: date | None = None,
+    end_date: date | None = None,
+    status: str | None = None,
+    type: str | None = None,
+    provenance: str | None = None,
+    transaction_id: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+  ) -> LedgerJournalEntryList | None:
+    """Paginated journal — entries with their line items, newest first.
+
+    The entry-centric read. `transactions` lists transactions and hangs
+    entries off them, so it cannot show an entry with no parent; the
+    schedule engine and event handlers create exactly those, which is
+    why everything the close posts is absent from that list. Here an
+    entry stands on its own and `transactionId` is projected, null for a
+    standalone one.
+
+    Filter by `provenance` (`schedule_derived` for what the close
+    posted), `type` (`adjusting` / `closing`), `status`, or a parent
+    `transactionId`.
+    """
+    limit, offset = _resolve_pagination(limit, offset, default_limit=100)
+    try:
+      with _open_session(info, "roboledger") as session:
+        response = reads_journal_entries.list_journal_entries(
+          session,
+          start_date=start_date,
+          end_date=end_date,
+          status=status,
+          type=type,
+          provenance=provenance,
+          transaction_id=transaction_id,
+          limit=limit,
+          offset=offset,
+        )
+    except (ValueError, ProgrammingError):
+      _raise_ledger_not_initialized()
+    return LedgerJournalEntryList.from_pydantic(response)
 
   # ── Taxonomies ──────────────────────────────────────────────────────────
 

--- a/robosystems/graphql/types/ledger.py
+++ b/robosystems/graphql/types/ledger.py
@@ -190,6 +190,12 @@ from robosystems.models.api.extensions.transactions import (
   LedgerEntryResponse as PydanticLedgerEntryResponse,
 )
 from robosystems.models.api.extensions.transactions import (
+  LedgerJournalEntryListResponse as PydanticLedgerJournalEntryListResponse,
+)
+from robosystems.models.api.extensions.transactions import (
+  LedgerJournalEntryResponse as PydanticLedgerJournalEntryResponse,
+)
+from robosystems.models.api.extensions.transactions import (
   LedgerLineItemResponse as PydanticLedgerLineItemResponse,
 )
 from robosystems.models.api.extensions.transactions import (
@@ -508,6 +514,19 @@ class LedgerEntry:
 @pydantic_type(model=PydanticLedgerTransactionDetailResponse, all_fields=True)
 class LedgerTransactionDetail:
   """Transaction with all entries and line items fully expanded."""
+
+
+# ── Journal entries ───────────────────────────────────────────────────────
+
+
+@pydantic_type(model=PydanticLedgerJournalEntryResponse, all_fields=True)
+class LedgerJournalEntry:
+  """A journal entry read on its own terms, parent transaction or not."""
+
+
+@pydantic_type(model=PydanticLedgerJournalEntryListResponse, all_fields=True)
+class LedgerJournalEntryList:
+  """Paginated journal listing."""
 
 
 # ── Taxonomies / elements / structures / mappings ────────────────────────

--- a/robosystems/middleware/mcp/tools/constants.py
+++ b/robosystems/middleware/mcp/tools/constants.py
@@ -53,3 +53,37 @@ What `is_live` means per node (the equivalent `status` filter, if you need finer
 - `Fact` nodes (the XBRL hypercube / published statements) have NO status and are already
   filtered at generation time — always safe to aggregate. This note applies ONLY to the
   ledger spine, not to Fact queries."""
+
+# Ledger traversal anchor — which node a ledger read starts from. Companion to
+# LEDGER_STATUS_GUIDANCE: that one is about which rows are live, this one is
+# about which rows are reachable at all. Transaction is a PARTIAL layer (it
+# exists only where a source system had a record), so anchoring a traversal on
+# it silently drops every parentless Entry — no error, just a short answer.
+# Same failure shape as the status omission, and it reproduces at scale for the
+# same reason: Operators generate Cypher dynamically.
+LEDGER_ANCHOR_GUIDANCE = """**⚠️ LEDGER TRAVERSAL ANCHOR — start at `Entry`, not `Transaction`:**
+`Transaction` is NOT the top of the ledger and NOT a layer every entry passes through.
+It exists only where a source system had a record of the thing (QuickBooks, a bank feed)
+or where a manual journal entry minted one. **`Entry.transaction_id` is nullable by
+design**, and the schedule engine and event handlers create entries with NO parent
+Transaction at all — every depreciation, amortization, accrual and other period-close
+adjusting entry is parentless.
+
+So this pattern silently loses data:
+- ❌ `MATCH (t:Transaction)-[:TRANSACTION_HAS_ENTRY]->(e:Entry)-[:ENTRY_HAS_LINE_ITEM]->(li)`
+- ✅ `MATCH (e:Entry)-[:ENTRY_HAS_LINE_ITEM]->(li:LineItem)`
+
+It returns rows, raises no error, and omits every parentless entry. On a real tenant this
+dropped 30 of 77 entries in a month, and a depreciation-expense question anchored on
+Transaction returned **zero rows** against a real non-zero answer.
+
+**The rule:**
+- Amounts, balances, "what was posted", anything accounting → anchor at `Entry` or
+  `LineItem`. Join UP to `Transaction` with OPTIONAL MATCH only if you need it.
+- Source-system attributes (merchant name, due date, reference number, connection) →
+  `Transaction` is the right node, because those fields live nowhere else.
+- Business occurrences ("how many X happened") → anchor at `Event`. Events are the
+  canonical layer; transactions are derived from a SUBSET of them. Many events
+  legitimately have no Transaction and no Entry.
+
+`Fact` queries are unaffected — the hypercube is generated from posted entries already."""

--- a/robosystems/middleware/mcp/tools/cypher_tool.py
+++ b/robosystems/middleware/mcp/tools/cypher_tool.py
@@ -8,7 +8,7 @@ from robosystems.logger import logger
 
 from ..exceptions import GraphAPIError
 from .base_tool import BaseTool
-from .constants import LEDGER_STATUS_GUIDANCE
+from .constants import LEDGER_ANCHOR_GUIDANCE, LEDGER_STATUS_GUIDANCE
 
 if TYPE_CHECKING:
   from ..client import GraphMCPClient
@@ -87,6 +87,9 @@ RETURN DISTINCT labels(a)[0] AS from_type, type(r) AS rel_type, labels(b)[0] AS 
 `get-example-queries` for patterns that already work against it."""
 
     if self._has_ledger_spine():
+      # Anchor first, then status: a query anchored on the wrong node loses
+      # rows outright, which no amount of correct status filtering recovers.
+      description += "\n\n" + LEDGER_ANCHOR_GUIDANCE
       description += "\n\n" + LEDGER_STATUS_GUIDANCE
 
     return {

--- a/robosystems/middleware/mcp/tools/example_queries_tool.py
+++ b/robosystems/middleware/mcp/tools/example_queries_tool.py
@@ -8,6 +8,7 @@ from robosystems.logger import logger
 
 from .base_tool import BaseTool
 from .constants import (
+  LEDGER_ANCHOR_GUIDANCE,
   LEDGER_STATUS_GUIDANCE,
   PERIOD_TYPE_GUIDANCE,
   QUERY_PATTERN_GUIDANCE,
@@ -214,7 +215,13 @@ LIMIT 10""",
           [
             {
               "category": "ledger",
-              "description": "⚠️ READ FIRST — ledger status filtering",
+              "description": "⚠️ READ FIRST — where a ledger query must start",
+              "info": LEDGER_ANCHOR_GUIDANCE,
+              "explanation": "Transaction is a partial layer; anchoring a traversal on it silently drops every entry that has no parent transaction, which is every period-close adjusting entry.",
+            },
+            {
+              "category": "ledger",
+              "description": "⚠️ READ SECOND — ledger status filtering",
               "info": LEDGER_STATUS_GUIDANCE,
               "explanation": "The graph keeps voided/superseded/draft rows for audit; the examples below show the required live-row filters.",
             },

--- a/robosystems/models/api/extensions/__init__.py
+++ b/robosystems/models/api/extensions/__init__.py
@@ -71,6 +71,8 @@ from .summary import LedgerSummaryResponse
 from .text_blocks import BindTextBlockRequest, BindTextBlockResponse
 from .transactions import (
   LedgerEntryResponse,
+  LedgerJournalEntryListResponse,
+  LedgerJournalEntryResponse,
   LedgerLineItemResponse,
   LedgerTransactionDetailResponse,
   LedgerTransactionListResponse,
@@ -105,6 +107,8 @@ __all__ = [
   "HoldingSecuritySummary",
   "HoldingsListResponse",
   "LedgerEntryResponse",
+  "LedgerJournalEntryListResponse",
+  "LedgerJournalEntryResponse",
   "LedgerLineItemResponse",
   "LedgerSummaryResponse",
   "LedgerTransactionDetailResponse",

--- a/robosystems/models/api/extensions/transactions.py
+++ b/robosystems/models/api/extensions/transactions.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from robosystems.models.api.common import PaginationInfo
 
@@ -102,3 +102,70 @@ class LedgerTransactionDetailResponse(BaseModel):
   status: str
   posted_at: datetime | None = None
   entries: list[LedgerEntryResponse]
+
+
+# ── Journal entries (entry-centric read) ──────────────────────────────────
+
+
+class LedgerJournalEntryResponse(BaseModel):
+  """A posted or draft journal entry, read on its own terms.
+
+  Distinct from `LedgerEntryResponse`, which is an entry *underneath* a
+  transaction in the detail view. An entry does not need a parent:
+  `Entry.transaction_id` is nullable by design (see the model comment on
+  `Entry.triggered_by_event_id`), and the schedule engine and event
+  handlers create entries with no transaction at all. Those entries are
+  invisible to the transaction-centric reads, which is what this shape
+  exists to fix — so `transaction_id` is projected explicitly, and a
+  `None` here means a standalone entry rather than missing data.
+  """
+
+  id: str
+  number: str | None = None
+  transaction_id: str | None = Field(
+    None,
+    description=(
+      "Parent transaction, or null for a standalone entry (schedule-derived "
+      "closing entries and event-handler entries have no parent)"
+    ),
+  )
+  type: str = Field(
+    ..., description="'standard' | 'adjusting' | 'closing' | 'reversing'"
+  )
+  status: str = Field(..., description="'draft' | 'posted' | 'reversed'")
+  posting_date: date
+  memo: str | None = None
+  provenance: str | None = Field(
+    None,
+    description=(
+      "Where the entry came from (ENTRY_PROVENANCE_VALUES): source_sync, "
+      "ai_generated, manual_entry, schedule_derived, system_computed, event_handler"
+    ),
+  )
+  source_structure_id: str | None = Field(
+    None, description="Schedule structure that generated this entry (if any)"
+  )
+  source_structure_name: str | None = Field(
+    None, description="Human-readable name of the source schedule"
+  )
+  triggered_by_event_id: str | None = Field(
+    None, description="Business event that caused this entry (if any)"
+  )
+  reversal_of: str | None = Field(
+    None, description="The entry this one reverses (if any)"
+  )
+  posted_at: datetime | None = None
+  line_items: list[LedgerLineItemResponse]
+  total_debit: float
+  total_credit: float
+  balanced: bool = Field(..., description="True if total_debit == total_credit")
+
+
+class LedgerJournalEntryListResponse(BaseModel):
+  """Paginated journal listing — entries with their line items expanded.
+
+  Pagination counts *entries*, not line-item rows.
+  """
+
+  entries: list[LedgerJournalEntryResponse]
+  pagination: PaginationInfo

--- a/robosystems/operations/operators/implementations/analyst.py
+++ b/robosystems/operations/operators/implementations/analyst.py
@@ -427,6 +427,7 @@ CYPHER RULES:
 {anchor_rule}
 
 LEDGER DATA (only when the schema has Entry / Transaction / LineItem nodes):
+- ANCHOR ON `Entry`, NOT `Transaction`. Transaction is a partial layer — it exists only where a source system had a record, and `Entry.transaction_id` is nullable by design. Every period-close adjusting entry (depreciation, amortization, accruals) has NO parent Transaction, so `MATCH (t:Transaction)-[:TRANSACTION_HAS_ENTRY]->(e:Entry)` silently drops them and returns a short answer with no error. Start at `(e:Entry)-[:ENTRY_HAS_LINE_ITEM]->(li:LineItem)` and OPTIONAL MATCH up to Transaction only if you need source-system fields (merchant, due date, reference). For "how many X happened" questions anchor on `Event` — events are canonical and many have no Transaction and no Entry.
 - The graph keeps cancelled/replaced rows for audit. When counting or summing ledger data, restrict to live rows using the materialized `is_live` boolean — it exists on every spine node (`Entry`, `LineItem`, `Event`, `Transaction`) and is the one rule to remember: `WHERE e.is_live`, `WHERE li.is_live`, `WHERE ev.is_live`, `WHERE t.is_live`. For balances/debit-credit sums, aggregate through live Entry/LineItem (`e.is_live`, ⇔ status = 'posted'), not by summing Transaction.amount. `is_live` keeps open obligations (pending/committed/fulfilled events); for a specific realized set, filter `status` explicitly.
 """
     if curated_tools:

--- a/robosystems/operations/roboledger/reads/journal_entries.py
+++ b/robosystems/operations/roboledger/reads/journal_entries.py
@@ -1,0 +1,286 @@
+"""Journal entry read operations — the entry-centric view of the ledger.
+
+`transactions.py` reads the ledger as transactions with entries hanging
+off them. That shape cannot see an entry with no parent, and parentless
+entries are a supported shape, not an anomaly: `Entry.transaction_id` is
+nullable by design, `create_closing_entry` / `create_manual_closing_entry`
+never set it, and `Entry.triggered_by_event_id` exists precisely to carry
+the event chain for entries that have no transaction to carry it.
+
+The practical consequence, before this module existed: every entry the
+close posted was invisible to every list surface in the product. The
+trial balance saw them (it joins line items directly), the statements
+saw them, and nothing a user could browse did — an entry left the only
+surface that showed it, the close-review outbox, at the moment it was
+posted.
+
+This module owns the entry projection and the row→entry grouping for
+*both* readers. `period_drafts.list_period_drafts` is a caller, so the
+close-review query and the journal query cannot drift apart.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, NamedTuple
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from robosystems.models.api.common import create_pagination_info
+from robosystems.models.api.extensions import cents_to_dollars
+from robosystems.models.api.extensions.transactions import (
+  LedgerJournalEntryListResponse,
+  LedgerJournalEntryResponse,
+  LedgerLineItemResponse,
+)
+
+# One projection, two orderings. The ORDER BY is the only part that varies
+# between the close-review read and the journal read, and it cannot be a
+# bind parameter — so it is interpolated from this fixed, internal map and
+# never from anything a caller supplies.
+_ENTRY_ROWS_TEMPLATE = """
+  WITH matched AS (
+    SELECT e.id
+    FROM entries e
+    LEFT JOIN structures s ON s.id = e.source_structure_id
+    WHERE (:start_date IS NULL OR e.posting_date >= :start_date)
+      AND (:end_date IS NULL OR e.posting_date <= :end_date)
+      AND (:status IS NULL OR e.status = :status)
+      AND (:type IS NULL OR e.type = :type)
+      AND (:provenance IS NULL OR e.provenance = :provenance)
+      AND (:transaction_id IS NULL OR e.transaction_id = :transaction_id)
+    ORDER BY {order_by}
+    LIMIT :limit OFFSET :offset
+  )
+  SELECT
+    e.id                  AS entry_id,
+    e.number              AS number,
+    e.transaction_id      AS transaction_id,
+    e.posting_date        AS posting_date,
+    e.type                AS entry_type,
+    e.status              AS status,
+    e.memo                AS memo,
+    e.provenance          AS provenance,
+    e.source_structure_id AS source_structure_id,
+    e.triggered_by_event_id AS triggered_by_event_id,
+    e.reversal_of         AS reversal_of,
+    e.posted_at           AS posted_at,
+    s.name                AS source_structure_name,
+    li.id                 AS line_item_id,
+    li.element_id         AS element_id,
+    el.code               AS element_code,
+    el.name               AS element_name,
+    li.debit_amount       AS debit_amount,
+    li.credit_amount      AS credit_amount,
+    li.description        AS line_description,
+    li.line_order         AS line_order
+  FROM entries e
+  JOIN matched m ON m.id = e.id
+  LEFT JOIN structures s ON s.id = e.source_structure_id
+  JOIN line_items li ON li.entry_id = e.id
+  JOIN elements el ON el.id = li.element_id
+  ORDER BY {order_by}, li.line_order, li.id
+"""
+
+_COUNT_SQL = text("""
+  SELECT count(*)
+  FROM entries e
+  WHERE (:start_date IS NULL OR e.posting_date >= :start_date)
+    AND (:end_date IS NULL OR e.posting_date <= :end_date)
+    AND (:status IS NULL OR e.status = :status)
+    AND (:type IS NULL OR e.type = :type)
+    AND (:provenance IS NULL OR e.provenance = :provenance)
+    AND (:transaction_id IS NULL OR e.transaction_id = :transaction_id)
+""")
+
+# Close review reads chronologically, grouped by schedule — the order a
+# reviewer walks the outbox in. The journal reads newest first, matching
+# the transaction list it sits beside.
+ORDER_PERIOD_REVIEW = "e.posting_date, s.name NULLS LAST, e.id"
+ORDER_RECENT_FIRST = "e.posting_date DESC, e.id"
+
+_SQL_BY_ORDER = {
+  ORDER_PERIOD_REVIEW: text(_ENTRY_ROWS_TEMPLATE.format(order_by=ORDER_PERIOD_REVIEW)),
+  ORDER_RECENT_FIRST: text(_ENTRY_ROWS_TEMPLATE.format(order_by=ORDER_RECENT_FIRST)),
+}
+
+# A limit is always bound (the CTE needs one), so "no pagination" is a
+# ceiling rather than an absent clause.
+_NO_LIMIT = 1_000_000
+
+
+class EntryRow(NamedTuple):
+  """One entry with its line items, in raw DB units (cents).
+
+  Unit conversion belongs to each caller's response contract — the close
+  outbox reports cents, the journal reports dollars — so the shared
+  fetch stays unit-neutral.
+  """
+
+  entry_id: str
+  number: str | None
+  transaction_id: str | None
+  posting_date: date
+  type: str
+  status: str
+  memo: str | None
+  provenance: str | None
+  source_structure_id: str | None
+  source_structure_name: str | None
+  triggered_by_event_id: str | None
+  reversal_of: str | None
+  posted_at: Any
+  line_items: list[dict[str, Any]]
+
+
+def fetch_entry_rows(
+  session: Session,
+  *,
+  start_date: date | None = None,
+  end_date: date | None = None,
+  status: str | None = None,
+  type: str | None = None,
+  provenance: str | None = None,
+  transaction_id: str | None = None,
+  limit: int | None = None,
+  offset: int = 0,
+  order_by: str = ORDER_RECENT_FIRST,
+) -> list[EntryRow]:
+  """Fetch entries with their line items, grouped, in raw cents.
+
+  Every filter is optional and independent. No filter on
+  `transaction_id` means parentless and parented entries come back
+  together — which is the whole point; a caller that wants only
+  standalone entries has to say so, and today none does.
+  """
+  rows = session.execute(
+    _SQL_BY_ORDER[order_by],
+    {
+      "start_date": start_date,
+      "end_date": end_date,
+      "status": status,
+      "type": type,
+      "provenance": provenance,
+      "transaction_id": transaction_id,
+      "limit": limit if limit is not None else _NO_LIMIT,
+      "offset": offset,
+    },
+  ).fetchall()
+
+  by_entry: dict[str, dict[str, Any]] = {}
+  order: list[str] = []
+  for row in rows:
+    entry_id = row.entry_id
+    if entry_id not in by_entry:
+      order.append(entry_id)
+      by_entry[entry_id] = {
+        "entry_id": entry_id,
+        "number": row.number,
+        "transaction_id": row.transaction_id,
+        "posting_date": row.posting_date,
+        "type": row.entry_type,
+        "status": row.status,
+        "memo": row.memo,
+        "provenance": row.provenance,
+        "source_structure_id": row.source_structure_id,
+        "source_structure_name": row.source_structure_name,
+        "triggered_by_event_id": row.triggered_by_event_id,
+        "reversal_of": row.reversal_of,
+        "posted_at": row.posted_at,
+        "line_items": [],
+      }
+    by_entry[entry_id]["line_items"].append(
+      {
+        "line_item_id": row.line_item_id,
+        "element_id": row.element_id,
+        "element_code": row.element_code,
+        "element_name": row.element_name,
+        "debit_amount": int(row.debit_amount or 0),
+        "credit_amount": int(row.credit_amount or 0),
+        "description": row.line_description,
+        "line_order": row.line_order,
+      }
+    )
+
+  return [EntryRow(**by_entry[entry_id]) for entry_id in order]
+
+
+def list_journal_entries(
+  session: Session,
+  *,
+  start_date: date | None = None,
+  end_date: date | None = None,
+  status: str | None = None,
+  type: str | None = None,
+  provenance: str | None = None,
+  transaction_id: str | None = None,
+  limit: int = 100,
+  offset: int = 0,
+) -> LedgerJournalEntryListResponse:
+  """List journal entries with line items expanded, newest first.
+
+  Entry-centric: an entry is returned on its own terms whether or not it
+  has a parent transaction. Amounts are dollars, matching the
+  transaction reads this sits beside; pagination counts entries.
+  """
+  params = {
+    "start_date": start_date,
+    "end_date": end_date,
+    "status": status,
+    "type": type,
+    "provenance": provenance,
+    "transaction_id": transaction_id,
+  }
+  total = session.execute(_COUNT_SQL, params).scalar() or 0
+
+  entry_rows = fetch_entry_rows(
+    session,
+    limit=limit,
+    offset=offset,
+    order_by=ORDER_RECENT_FIRST,
+    **params,
+  )
+
+  entries: list[LedgerJournalEntryResponse] = []
+  for entry in entry_rows:
+    total_debit = sum(li["debit_amount"] for li in entry.line_items)
+    total_credit = sum(li["credit_amount"] for li in entry.line_items)
+    entries.append(
+      LedgerJournalEntryResponse(
+        id=entry.entry_id,
+        number=entry.number,
+        transaction_id=entry.transaction_id,
+        type=entry.type,
+        status=entry.status,
+        posting_date=entry.posting_date,
+        memo=entry.memo,
+        provenance=entry.provenance,
+        source_structure_id=entry.source_structure_id,
+        source_structure_name=entry.source_structure_name,
+        triggered_by_event_id=entry.triggered_by_event_id,
+        reversal_of=entry.reversal_of,
+        posted_at=entry.posted_at,
+        line_items=[
+          LedgerLineItemResponse(
+            id=li["line_item_id"],
+            account_id=li["element_id"],
+            account_name=li["element_name"],
+            account_code=li["element_code"],
+            debit_amount=cents_to_dollars(li["debit_amount"]),
+            credit_amount=cents_to_dollars(li["credit_amount"]),
+            description=li["description"],
+            line_order=li["line_order"],
+          )
+          for li in entry.line_items
+        ],
+        total_debit=cents_to_dollars(total_debit),
+        total_credit=cents_to_dollars(total_credit),
+        balanced=total_debit == total_credit,
+      )
+    )
+
+  return LedgerJournalEntryListResponse(
+    entries=entries,
+    pagination=create_pagination_info(total, limit, offset),
+  )

--- a/robosystems/operations/roboledger/reads/journal_entries.py
+++ b/robosystems/operations/roboledger/reads/journal_entries.py
@@ -22,6 +22,7 @@ close-review query and the journal query cannot drift apart.
 from __future__ import annotations
 
 from datetime import date
+from enum import StrEnum
 from typing import Any, NamedTuple
 
 from sqlalchemy import text
@@ -75,11 +76,17 @@ _ENTRY_ROWS_TEMPLATE = """
     li.credit_amount      AS credit_amount,
     li.description        AS line_description,
     li.line_order         AS line_order
+  -- LEFT, not INNER, on line_items: `matched` already picked this page of
+  -- entries, so an entry with no line items would be dropped here after
+  -- being counted and after consuming a LIMIT slot — a page silently
+  -- shorter than it claims, and a total that disagrees with the rows.
+  -- Double-entry should make that impossible; if a bug elsewhere ever
+  -- breaks the invariant, the entry shows up empty rather than vanishing.
   FROM entries e
   JOIN matched m ON m.id = e.id
   LEFT JOIN structures s ON s.id = e.source_structure_id
-  JOIN line_items li ON li.entry_id = e.id
-  JOIN elements el ON el.id = li.element_id
+  LEFT JOIN line_items li ON li.entry_id = e.id
+  LEFT JOIN elements el ON el.id = li.element_id
   ORDER BY {order_by}, li.line_order, li.id
 """
 
@@ -94,15 +101,26 @@ _COUNT_SQL = text("""
     AND (:transaction_id IS NULL OR e.transaction_id = :transaction_id)
 """)
 
-# Close review reads chronologically, grouped by schedule — the order a
-# reviewer walks the outbox in. The journal reads newest first, matching
-# the transaction list it sits beside.
-ORDER_PERIOD_REVIEW = "e.posting_date, s.name NULLS LAST, e.id"
-ORDER_RECENT_FIRST = "e.posting_date DESC, e.id"
+
+class EntryOrder(StrEnum):
+  """The orderings this projection supports, and the only values that ever
+  reach the interpolated ORDER BY.
+
+  An enum rather than a bare string so a bad caller is a type error at
+  check time instead of a KeyError at request time — and so nothing can
+  wire a client-supplied ordering through by accident if this ever grows
+  a public ``orderBy`` argument.
+  """
+
+  # Close review reads chronologically, grouped by schedule — the order a
+  # reviewer walks the outbox in.
+  PERIOD_REVIEW = "e.posting_date, s.name NULLS LAST, e.id"
+  # The journal reads newest first, matching the transaction list beside it.
+  RECENT_FIRST = "e.posting_date DESC, e.id"
+
 
 _SQL_BY_ORDER = {
-  ORDER_PERIOD_REVIEW: text(_ENTRY_ROWS_TEMPLATE.format(order_by=ORDER_PERIOD_REVIEW)),
-  ORDER_RECENT_FIRST: text(_ENTRY_ROWS_TEMPLATE.format(order_by=ORDER_RECENT_FIRST)),
+  order: text(_ENTRY_ROWS_TEMPLATE.format(order_by=order.value)) for order in EntryOrder
 }
 
 # A limit is always bound (the CTE needs one), so "no pagination" is a
@@ -145,7 +163,7 @@ def fetch_entry_rows(
   transaction_id: str | None = None,
   limit: int | None = None,
   offset: int = 0,
-  order_by: str = ORDER_RECENT_FIRST,
+  order_by: EntryOrder = EntryOrder.RECENT_FIRST,
 ) -> list[EntryRow]:
   """Fetch entries with their line items, grouped, in raw cents.
 
@@ -190,6 +208,8 @@ def fetch_entry_rows(
         "posted_at": row.posted_at,
         "line_items": [],
       }
+    if row.line_item_id is None:
+      continue
     by_entry[entry_id]["line_items"].append(
       {
         "line_item_id": row.line_item_id,
@@ -238,7 +258,7 @@ def list_journal_entries(
     session,
     limit=limit,
     offset=offset,
-    order_by=ORDER_RECENT_FIRST,
+    order_by=EntryOrder.RECENT_FIRST,
     **params,
   )
 

--- a/robosystems/operations/roboledger/reads/period_drafts.py
+++ b/robosystems/operations/roboledger/reads/period_drafts.py
@@ -26,7 +26,7 @@ from robosystems.operations.roboledger.fiscal_calendar.qb_writeback import (
   writeback_eligible_entry_ids,
 )
 from robosystems.operations.roboledger.reads.journal_entries import (
-  ORDER_PERIOD_REVIEW,
+  EntryOrder,
   fetch_entry_rows,
 )
 
@@ -65,7 +65,7 @@ def list_period_drafts(
     start_date=period_start,
     end_date=period_end,
     status="draft",
-    order_by=ORDER_PERIOD_REVIEW,
+    order_by=EntryOrder.PERIOD_REVIEW,
   )
 
   drafts: list[DraftEntryResponse] = []

--- a/robosystems/operations/roboledger/reads/period_drafts.py
+++ b/robosystems/operations/roboledger/reads/period_drafts.py
@@ -3,13 +3,16 @@
 Returns every draft entry whose `posting_date` falls within a period,
 fully expanded with line items, element names/codes, source schedule
 name, and per-entry balance check. Pure read — no side effects.
+
+The entry projection and row→entry grouping live in `journal_entries`,
+shared with the journal read. This module is the close-review *outbox*
+on top of it: the QB write-back disposition and the period aggregates.
+Amounts stay in cents here — that is this response's contract, and the
+shared fetch is unit-neutral.
 """
 
 from __future__ import annotations
 
-from typing import Any
-
-from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from robosystems.models.api.extensions.fiscal_calendar import (
@@ -22,32 +25,10 @@ from robosystems.operations.roboledger.fiscal_calendar.qb_writeback import (
   WritebackConnection,
   writeback_eligible_entry_ids,
 )
-
-_DRAFT_ENTRIES_SQL = text("""
-  SELECT
-    e.id               AS entry_id,
-    e.posting_date     AS posting_date,
-    e.type             AS entry_type,
-    e.memo             AS memo,
-    e.provenance       AS provenance,
-    e.source_structure_id AS source_structure_id,
-    s.name             AS source_structure_name,
-    li.id              AS line_item_id,
-    li.element_id      AS element_id,
-    el.code            AS element_code,
-    el.name            AS element_name,
-    li.debit_amount    AS debit_amount,
-    li.credit_amount   AS credit_amount,
-    li.description     AS line_description
-  FROM entries e
-  LEFT JOIN structures s ON s.id = e.source_structure_id
-  JOIN line_items li ON li.entry_id = e.id
-  JOIN elements el ON el.id = li.element_id
-  WHERE e.posting_date >= :period_start
-    AND e.posting_date <= :period_end
-    AND e.status = 'draft'
-  ORDER BY e.posting_date, s.name NULLS LAST, e.id, li.line_order, li.id
-""")
+from robosystems.operations.roboledger.reads.journal_entries import (
+  ORDER_PERIOD_REVIEW,
+  fetch_entry_rows,
+)
 
 
 def list_period_drafts(
@@ -79,44 +60,32 @@ def list_period_drafts(
     else set()
   )
 
-  rows = session.execute(
-    _DRAFT_ENTRIES_SQL,
-    {"period_start": period_start, "period_end": period_end},
-  ).fetchall()
-
-  by_entry: dict[str, dict[str, Any]] = {}
-  for row in rows:
-    entry_id = row.entry_id
-    if entry_id not in by_entry:
-      by_entry[entry_id] = {
-        "entry_id": entry_id,
-        "posting_date": row.posting_date,
-        "type": row.entry_type,
-        "memo": row.memo,
-        "provenance": row.provenance,
-        "source_structure_id": row.source_structure_id,
-        "source_structure_name": row.source_structure_name,
-        "line_items": [],
-      }
-    by_entry[entry_id]["line_items"].append(
-      DraftLineItem(
-        line_item_id=row.line_item_id,
-        element_id=row.element_id,
-        element_code=row.element_code,
-        element_name=row.element_name,
-        debit_amount=int(row.debit_amount or 0),
-        credit_amount=int(row.credit_amount or 0),
-        description=row.line_description,
-      )
-    )
+  entry_rows = fetch_entry_rows(
+    session,
+    start_date=period_start,
+    end_date=period_end,
+    status="draft",
+    order_by=ORDER_PERIOD_REVIEW,
+  )
 
   drafts: list[DraftEntryResponse] = []
   total_debit = 0
   total_credit = 0
   all_balanced = True
   qb_publish_count = 0
-  for entry_data in by_entry.values():
-    line_items = entry_data["line_items"]
+  for entry in entry_rows:
+    line_items = [
+      DraftLineItem(
+        line_item_id=li["line_item_id"],
+        element_id=li["element_id"],
+        element_code=li["element_code"],
+        element_name=li["element_name"],
+        debit_amount=li["debit_amount"],
+        credit_amount=li["credit_amount"],
+        description=li["description"],
+      )
+      for li in entry.line_items
+    ]
     entry_debit = sum(li.debit_amount for li in line_items)
     entry_credit = sum(li.credit_amount for li in line_items)
     balanced = entry_debit == entry_credit
@@ -126,18 +95,18 @@ def list_period_drafts(
     total_credit += entry_credit
     # Publishes on close only if both halves of the predicate hold:
     # a write-back connection exists AND this draft is eligible.
-    will_publish = has_writeback and entry_data["entry_id"] in eligible_ids
+    will_publish = has_writeback and entry.entry_id in eligible_ids
     if will_publish:
       qb_publish_count += 1
     drafts.append(
       DraftEntryResponse(
-        entry_id=entry_data["entry_id"],
-        posting_date=entry_data["posting_date"],
-        type=entry_data["type"],
-        memo=entry_data["memo"],
-        provenance=entry_data["provenance"],
-        source_structure_id=entry_data["source_structure_id"],
-        source_structure_name=entry_data["source_structure_name"],
+        entry_id=entry.entry_id,
+        posting_date=entry.posting_date,
+        type=entry.type,
+        memo=entry.memo,
+        provenance=entry.provenance,
+        source_structure_id=entry.source_structure_id,
+        source_structure_name=entry.source_structure_name,
         line_items=line_items,
         total_debit=entry_debit,
         total_credit=entry_credit,

--- a/tests/operations/roboledger/reads/test_journal_entries.py
+++ b/tests/operations/roboledger/reads/test_journal_entries.py
@@ -1,0 +1,255 @@
+"""Unit tests for the entry-centric journal read (list_journal_entries).
+
+The case that matters most is the first one: **a posted entry with no
+parent transaction is returned.** That shape is why this read exists.
+`list_transactions` walks `transactions` and hangs entries off them, so
+an entry whose `transaction_id` is NULL — every entry the schedule
+engine and the event handlers create — appeared on no list surface in
+the product. Nothing exercised a parentless entry, which is how it
+shipped invisible; that gap is closed here.
+
+Mock-based, matching `test_period_drafts`: the read issues a count query
+and a raw-SQL entry query through `session.execute`, so the mock session
+serves both in order.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from robosystems.operations.roboledger.reads.journal_entries import (
+  list_journal_entries,
+)
+
+
+def _line_row(
+  entry_id: str,
+  line_item_id: str,
+  debit: int,
+  credit: int,
+  *,
+  transaction_id: str | None = None,
+  status: str = "posted",
+  entry_type: str = "closing",
+  provenance: str = "schedule_derived",
+  source_structure_id: str | None = None,
+  source_structure_name: str | None = None,
+  line_order: int = 1,
+):
+  """One row in the shape the shared entry projection returns."""
+  return SimpleNamespace(
+    entry_id=entry_id,
+    number=None,
+    transaction_id=transaction_id,
+    posting_date=date(2026, 7, 31),
+    entry_type=entry_type,
+    status=status,
+    memo=f"memo-{entry_id}",
+    provenance=provenance,
+    source_structure_id=source_structure_id,
+    source_structure_name=source_structure_name,
+    triggered_by_event_id=None,
+    reversal_of=None,
+    posted_at=datetime(2026, 8, 1, 12, 0, 0),
+    line_item_id=line_item_id,
+    element_id=f"el-{line_item_id}",
+    element_code="6100",
+    element_name="Depreciation Expense",
+    debit_amount=debit,
+    credit_amount=credit,
+    line_description=None,
+    line_order=line_order,
+  )
+
+
+def _session(rows, total=None):
+  """Mock session serving the count query then the entry query."""
+  session = MagicMock()
+  count_result = MagicMock()
+  count_result.scalar.return_value = (
+    len({r.entry_id for r in rows}) if total is None else total
+  )
+  rows_result = MagicMock()
+  rows_result.fetchall.return_value = rows
+  session.execute.side_effect = [count_result, rows_result]
+  return session
+
+
+def _params(session):
+  """The bind params the entry query was called with."""
+  return session.execute.call_args_list[1].args[1]
+
+
+class TestParentlessEntriesAreVisible:
+  """The defect this read was built to fix."""
+
+  def test_posted_entry_with_no_transaction_is_returned(self):
+    rows = [
+      _line_row("je_dep", "li1", 4241, 0, transaction_id=None),
+      _line_row("je_dep", "li2", 0, 4241, transaction_id=None, line_order=2),
+    ]
+
+    resp = list_journal_entries(_session(rows))
+
+    assert len(resp.entries) == 1
+    entry = resp.entries[0]
+    assert entry.id == "je_dep"
+    assert entry.transaction_id is None
+    assert entry.status == "posted"
+    assert entry.balanced is True
+
+  def test_parentless_and_parented_entries_come_back_together(self):
+    rows = [
+      _line_row("je_standalone", "li1", 1000, 0, transaction_id=None),
+      _line_row("je_standalone", "li2", 0, 1000, transaction_id=None, line_order=2),
+      _line_row("je_parented", "li3", 2000, 0, transaction_id="txn_1"),
+      _line_row("je_parented", "li4", 0, 2000, transaction_id="txn_1", line_order=2),
+    ]
+
+    resp = list_journal_entries(_session(rows))
+
+    by_id = {e.id: e for e in resp.entries}
+    assert set(by_id) == {"je_standalone", "je_parented"}
+    # transaction_id is the only thing distinguishing them, and it is
+    # projected rather than inferred — null means standalone, not missing.
+    assert by_id["je_standalone"].transaction_id is None
+    assert by_id["je_parented"].transaction_id == "txn_1"
+
+
+class TestProjection:
+  def test_line_items_group_under_their_entry(self):
+    rows = [
+      _line_row("je_a", "li1", 1000, 0),
+      _line_row("je_a", "li2", 0, 1000, line_order=2),
+      _line_row("je_b", "li3", 500, 0),
+      _line_row("je_b", "li4", 0, 500, line_order=2),
+    ]
+
+    resp = list_journal_entries(_session(rows))
+
+    assert [len(e.line_items) for e in resp.entries] == [2, 2]
+
+  def test_amounts_are_dollars_not_cents(self):
+    rows = [
+      _line_row("je_a", "li1", 4241, 0),
+      _line_row("je_a", "li2", 0, 4241, line_order=2),
+    ]
+
+    resp = list_journal_entries(_session(rows))
+
+    entry = resp.entries[0]
+    assert entry.total_debit == 42.41
+    assert entry.total_credit == 42.41
+    assert entry.line_items[0].debit_amount == 42.41
+
+  def test_unbalanced_entry_is_flagged(self):
+    rows = [
+      _line_row("je_bad", "li1", 1000, 0),
+      _line_row("je_bad", "li2", 0, 900, line_order=2),
+    ]
+
+    resp = list_journal_entries(_session(rows))
+
+    assert resp.entries[0].balanced is False
+
+  def test_source_schedule_name_is_projected(self):
+    rows = [
+      _line_row(
+        "je_dep",
+        "li1",
+        4241,
+        0,
+        source_structure_id="struct_1",
+        source_structure_name='MacBook Pro 14" (2022) Depreciation',
+      ),
+      _line_row(
+        "je_dep",
+        "li2",
+        0,
+        4241,
+        source_structure_id="struct_1",
+        source_structure_name='MacBook Pro 14" (2022) Depreciation',
+        line_order=2,
+      ),
+    ]
+
+    resp = list_journal_entries(_session(rows))
+
+    assert (
+      resp.entries[0].source_structure_name == 'MacBook Pro 14" (2022) Depreciation'
+    )
+
+
+class TestFilters:
+  def test_filters_are_bound_and_default_to_null(self):
+    session = _session([])
+
+    list_journal_entries(session)
+
+    params = _params(session)
+    for key in (
+      "start_date",
+      "end_date",
+      "status",
+      "type",
+      "provenance",
+      "transaction_id",
+    ):
+      assert params[key] is None, f"{key} should default to no filter"
+
+  def test_provenance_filter_is_bound(self):
+    session = _session([])
+
+    list_journal_entries(session, provenance="schedule_derived")
+
+    assert _params(session)["provenance"] == "schedule_derived"
+
+  def test_date_range_and_status_are_bound(self):
+    session = _session([])
+
+    list_journal_entries(
+      session,
+      start_date=date(2026, 7, 1),
+      end_date=date(2026, 7, 31),
+      status="posted",
+    )
+
+    params = _params(session)
+    assert params["start_date"] == date(2026, 7, 1)
+    assert params["end_date"] == date(2026, 7, 31)
+    assert params["status"] == "posted"
+
+  def test_transaction_id_filter_is_bound(self):
+    session = _session([])
+
+    list_journal_entries(session, transaction_id="txn_1")
+
+    assert _params(session)["transaction_id"] == "txn_1"
+
+
+class TestPagination:
+  def test_pagination_counts_entries_not_line_item_rows(self):
+    # Two entries, four line-item rows. The count query answers in
+    # entries, and the response must not report four.
+    rows = [
+      _line_row("je_a", "li1", 1000, 0),
+      _line_row("je_a", "li2", 0, 1000, line_order=2),
+      _line_row("je_b", "li3", 500, 0),
+      _line_row("je_b", "li4", 0, 500, line_order=2),
+    ]
+
+    resp = list_journal_entries(_session(rows, total=2))
+
+    assert resp.pagination.total == 2
+    assert len(resp.entries) == 2
+
+  def test_limit_and_offset_are_bound(self):
+    session = _session([])
+
+    list_journal_entries(session, limit=25, offset=50)
+
+    params = _params(session)
+    assert params["limit"] == 25
+    assert params["offset"] == 50

--- a/tests/operations/roboledger/reads/test_journal_entries.py
+++ b/tests/operations/roboledger/reads/test_journal_entries.py
@@ -64,6 +64,23 @@ def _line_row(
   )
 
 
+def _empty_line_row(entry_id: str):
+  """The row shape a LEFT JOIN produces when an entry has no line items:
+  the entry columns populated, every line-item column NULL."""
+  row = _line_row(entry_id, "unused", 0, 0)
+  for field in (
+    "line_item_id",
+    "element_id",
+    "element_code",
+    "element_name",
+    "debit_amount",
+    "credit_amount",
+    "line_order",
+  ):
+    setattr(row, field, None)
+  return row
+
+
 def _session(rows, total=None):
   """Mock session serving the count query then the entry query."""
   session = MagicMock()
@@ -180,6 +197,33 @@ class TestProjection:
     assert (
       resp.entries[0].source_structure_name == 'MacBook Pro 14" (2022) Depreciation'
     )
+
+
+class TestLineItemJoin:
+  """The projection LEFT JOINs line_items on purpose."""
+
+  def test_an_entry_with_no_line_items_still_appears(self):
+    # `matched` already picked this entry and it already consumed a LIMIT
+    # slot and a count. An INNER JOIN would drop it here, making the page
+    # silently shorter than it claims and the total disagree with the rows
+    # — the same silent-short-answer failure this whole read exists to fix.
+    # Double-entry should make it impossible; a bug elsewhere should not
+    # turn into a vanishing row.
+    rows = [
+      # What a LEFT JOIN yields for an entry with no line items.
+      _empty_line_row("je_empty"),
+      _line_row("je_ok", "li1", 1000, 0),
+      _line_row("je_ok", "li2", 0, 1000, line_order=2),
+    ]
+
+    resp = list_journal_entries(_session(rows, total=2))
+
+    by_id = {e.id: e for e in resp.entries}
+    assert set(by_id) == {"je_empty", "je_ok"}
+    assert by_id["je_empty"].line_items == []
+    assert by_id["je_empty"].total_debit == 0.0
+    assert by_id["je_empty"].balanced is True
+    assert len(by_id["je_ok"].line_items) == 2
 
 
 class TestFilters:

--- a/tests/operations/roboledger/reads/test_period_drafts.py
+++ b/tests/operations/roboledger/reads/test_period_drafts.py
@@ -6,9 +6,9 @@ under the three cases that matter: a write-back connection with an
 eligible draft, the same drafts with NO write-back connection (all
 local-only), and an ineligible draft (already in QB / synced).
 
-Mock-based: the read does a raw-SQL drafts query (`session.execute`) and
-an ORM eligibility query (`session.query(...)`), so the mock session
-serves both.
+Mock-based: the read does a raw-SQL entry query (`session.execute`, via
+the shared projection in `reads.journal_entries`) and an ORM eligibility
+query (`session.query(...)`), so the mock session serves both.
 """
 
 from __future__ import annotations
@@ -24,15 +24,22 @@ from robosystems.operations.roboledger.reads.period_drafts import list_period_dr
 
 
 def _line_row(entry_id: str, line_item_id: str, debit: int, credit: int):
-  """One draft line-item row in the shape `_DRAFT_ENTRIES_SQL` returns."""
+  """One draft line-item row in the shape the shared entry projection
+  (`journal_entries._ENTRY_ROWS_TEMPLATE`) returns."""
   return SimpleNamespace(
     entry_id=entry_id,
+    number=None,
+    transaction_id=None,
     posting_date=date(2026, 1, 15),
     entry_type="closing",
+    status="draft",
     memo=f"memo-{entry_id}",
     provenance="schedule",
     source_structure_id=None,
     source_structure_name=None,
+    triggered_by_event_id=None,
+    reversal_of=None,
+    posted_at=None,
     line_item_id=line_item_id,
     element_id=f"el-{line_item_id}",
     element_code="1000",
@@ -40,6 +47,7 @@ def _line_row(entry_id: str, line_item_id: str, debit: int, credit: int):
     debit_amount=debit,
     credit_amount=credit,
     line_description=None,
+    line_order=1,
   )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3802,7 +3802,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.34.2,<3.0" },
     { name = "retrying", specifier = ">=1.4.0,<2.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=15.0.0,<16.0" },
-    { name = "robosystems-client", marker = "extra == 'dev'", specifier = ">=1.13.1,<2.0" },
+    { name = "robosystems-client", marker = "extra == 'dev'", specifier = ">=1.14.0,<2.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0" },
     { name = "sse-starlette", specifier = ">=3.3.0,<4.0" },
@@ -3829,7 +3829,7 @@ lambda = [
 
 [[package]]
 name = "robosystems-client"
-version = "1.13.1"
+version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3837,9 +3837,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/61/c9e9f857d619025fec626b882b3b331bfb0587716b1e1929d153998a2831/robosystems_client-1.13.1.tar.gz", hash = "sha256:8c543bfc3dac2e1944df1920b9de10899e1017945a5febcdf027df432fb359b9", size = 561755, upload-time = "2026-08-31T21:35:36.509Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/65/8080cd9a501d9cea3d1865bfc08e4282f36d8c8a439f1f7861f55e53cffc/robosystems_client-1.14.0.tar.gz", hash = "sha256:351dedf514aa83d6ff30137f71dff5e5d89d748c633a042704ca22dabb5565ba", size = 567486, upload-time = "2026-09-05T17:47:56.694Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/d5/1485adbd1b1ec21425c05da92170f9c59ebccaa22f10942600b863ae7b53/robosystems_client-1.13.1-py3-none-any.whl", hash = "sha256:49f0aa4acff9d021170ed06ffa14296a1c82a830c6f2e57b8d037e018d8a6f5e", size = 1286958, upload-time = "2026-08-31T21:35:34.396Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/f60070a5e68f0243689bf8b07eab7108dec8765943faa2f4c26ad63dcb99/robosystems_client-1.14.0-py3-none-any.whl", hash = "sha256:1a34982c5107de4d83a8141cc141c1a588ca740ae7cf51f849551edd3f3f856d", size = 1291214, upload-time = "2026-09-05T17:47:54.987Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The ledger's list surfaces are transaction-centric: `transactions` walks the `transactions` table and hangs entries off each row. An entry with **no parent transaction** therefore appears on no list surface in the product.

Parentless entries are not an anomaly. `Entry.transaction_id` is nullable by design, the schedule engine (`create_closing_entry` / `create_manual_closing_entry`) and the event handlers never set it, and `Entry.triggered_by_event_id` exists precisely to carry the event chain for entries that have no transaction to carry it.

The practical consequence: **everything a period close posts was invisible.** The close-review outbox filters `status = 'draft'`, so posting an entry removed it from the only surface that ever showed it. The trial balance and the statements saw those entries the whole time — so the numbers were right and the audit trail behind them could not be browsed, which is the worst combination for trust.

Found on live books: two closed months, 66 posted schedule-derived entries, none of them reachable from any list view.

## Change

Adds a `journalEntries` GraphQL field — the entry-centric read:

- `transactionId` is **projected**, so null means *standalone*, not *missing*.
- Filters on date range, `status`, `type`, `provenance` and parent `transactionId`. `provenance: "schedule_derived"` answers "what did the close post?" in one query.
- Amounts in dollars, matching the transaction reads it sits beside. Pagination counts **entries**, not line-item rows.

The entry projection and row→entry grouping move into `reads/journal_entries`, shared with `list_period_drafts`, which becomes a caller. The close-review query and the journal query now cannot drift apart. Drafts keep reporting cents — the shared fetch is unit-neutral and that response's contract is unchanged.

## Verification

- Full suite green: 14120 passed, 42 skipped; ruff, format, basedpyright, cf-lint all clean.
- The unit tests are mock-based (matching `test_period_drafts`), which means they never execute SQL — so the statement was **also run against real Postgres**: both orderings, every filter bound simultaneously, and a seeded parentless posted entry returned alongside a parented one, with the drafts outbox still returning only the draft in cents. That check mattered here because the whole point of this read is a row shape no existing query returned.
- New tests cover what nothing exercised before: a posted entry with no parent transaction, and parentless + parented entries returned together. That gap is why this shipped invisible.

## Scope

Backend only. The `LedgerClient` facade method and the transactions-page tab ride the next client cut — generated-tier surface, additive, no deprecation cycle. Design doc is `specs/roboledger/journal-entry-read-surface.md` (private vault).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdMBS1zchAGU4JszgXtMXY