### PR TITLE
fix(roboledger): derive Entry.provenance, and give non-economic events a class

### DIFF
--- a/migrations/extensions/versions/0035_operational_events_and_entry_provenance.py
+++ b/migrations/extensions/versions/0035_operational_events_and_entry_provenance.py
@@ -1,0 +1,172 @@
+"""operational event class, and repair Entry.provenance
+
+Two related corrections to origin-tracking on the ledger spine, both
+fanned out over every tenant schema.
+
+**1. `event_class = 'operational'`.** The class vocabulary was
+`economic | support`, where economic asserts a resource flow and support
+means *supporting an economic event* (controls, approvals,
+reconciliations, inquiries). A business occurrence that is neither had
+nowhere honest to go: `schedule_created` — setting up a schedule, which
+moves nothing and posts nothing — was filed as `economic/other`, and a
+CRM lead had no legal category under either class. Adds a third class
+with `pipeline | engagement | schedule | other`, and moves the existing
+`schedule_created` rows onto it. The recognition events a schedule later
+emits stay `economic/recognition`; those do drive the GL.
+
+**2. `Entry.provenance` repair.** `create_journal_entry` hardcoded
+`manual_entry` regardless of origin, so every entry that arrived over a
+connection claimed to be hand-entered and `source_sync` — a value the
+CHECK constraint allows — had never been written by anything. The write
+already receives the origin (`body.source`, which the event handler sets
+from `Event.source`); it was simply discarded. The code now derives it,
+and this backfills the rows already written by reading each entry's
+linked event.
+
+The backfill is conservative and idempotent: it only touches entries
+whose provenance is exactly `manual_entry`, only where a linked event
+exists, and it maps a `manual` event straight back to `manual_entry`, so
+genuinely hand-entered rows are unchanged and re-running is a no-op.
+Entries with no linked event are left alone — there is nothing to derive
+from and `manual_entry` remains the honest default.
+
+Revision ID: 0035
+Revises: 0034
+Create Date: 2026-09-05
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+from migrations.extensions.helpers import for_each_tenant_schema
+
+revision = "0035"
+down_revision = "0034"
+branch_labels = None
+depends_on = None
+
+# Migrations carry their own static snapshot of the model's constants and
+# must not import them — see the note on ENTRY_PROVENANCE_VALUES.
+_CLASS_OLD = "event_class IN ('economic', 'support')"
+_CLASS_NEW = "event_class IN ('economic', 'support', 'operational')"
+
+_CATEGORY_OLD = (
+  "(event_class = 'economic' AND event_category IN ("
+  "'sales', 'purchase', 'financing', 'payroll', "
+  "'treasury', 'adjustment', 'recognition', 'other')) "
+  "OR (event_class = 'support' AND event_category IN ("
+  "'control', 'approval', 'reconciliation', 'inquiry'))"
+)
+_CATEGORY_NEW = (
+  _CATEGORY_OLD + " OR (event_class = 'operational' AND event_category IN ("
+  "'pipeline', 'engagement', 'schedule', 'other'))"
+)
+
+# `Event.source` is open on the adapter side: the platform emits manual /
+# system / schedule, and anything else is a registered connection, hence a
+# sync. Mirrors `provenance_for_source` in
+# operations/roboledger/commands/journal_entries.py.
+_PROVENANCE_SQL = """
+  UPDATE "{schema}".entries e
+  SET provenance = CASE ev.source
+        WHEN 'manual'   THEN 'manual_entry'
+        WHEN 'native'   THEN 'manual_entry'
+        WHEN 'system'   THEN 'system_computed'
+        WHEN 'schedule' THEN 'schedule_derived'
+        ELSE 'source_sync'
+      END
+  FROM "{schema}".events ev
+  WHERE ev.id = e.triggered_by_event_id
+    AND e.provenance = 'manual_entry'
+"""
+
+
+def _widen(conn: Connection, schema: str) -> None:
+  conn.execute(
+    text(f'ALTER TABLE "{schema}".events DROP CONSTRAINT IF EXISTS check_event_class')
+  )
+  conn.execute(
+    text(
+      f'ALTER TABLE "{schema}".events ADD CONSTRAINT check_event_class '
+      f"CHECK ({_CLASS_NEW})"
+    )
+  )
+  conn.execute(
+    text(
+      f'ALTER TABLE "{schema}".events DROP CONSTRAINT IF EXISTS check_event_category'
+    )
+  )
+  conn.execute(
+    text(
+      f'ALTER TABLE "{schema}".events ADD CONSTRAINT check_event_category '
+      f"CHECK ({_CATEGORY_NEW})"
+    )
+  )
+  # Re-file the rows that had nowhere to go. Only this event_type — the
+  # recognition events a schedule emits are genuinely economic.
+  conn.execute(
+    text(
+      f"UPDATE \"{schema}\".events SET event_class = 'operational', "
+      "event_category = 'schedule' "
+      "WHERE event_type = 'schedule_created' AND event_class = 'economic'"
+    )
+  )
+
+
+def _repair_provenance(conn: Connection, schema: str) -> None:
+  conn.execute(text(_PROVENANCE_SQL.format(schema=schema)))
+
+
+def _narrow(conn: Connection, schema: str) -> None:
+  # Put the re-filed rows back first, or the narrowed constraint rejects them.
+  conn.execute(
+    text(
+      f"UPDATE \"{schema}\".events SET event_class = 'economic', "
+      "event_category = 'other' "
+      "WHERE event_type = 'schedule_created' AND event_class = 'operational'"
+    )
+  )
+  # Any other operational rows written since would violate the old CHECK.
+  # Fail loudly rather than silently rewriting business data.
+  conn.execute(
+    text(
+      f'ALTER TABLE "{schema}".events DROP CONSTRAINT IF EXISTS check_event_category'
+    )
+  )
+  conn.execute(
+    text(
+      f'ALTER TABLE "{schema}".events ADD CONSTRAINT check_event_category '
+      f"CHECK ({_CATEGORY_OLD})"
+    )
+  )
+  conn.execute(
+    text(f'ALTER TABLE "{schema}".events DROP CONSTRAINT IF EXISTS check_event_class')
+  )
+  conn.execute(
+    text(
+      f'ALTER TABLE "{schema}".events ADD CONSTRAINT check_event_class '
+      f"CHECK ({_CLASS_OLD})"
+    )
+  )
+
+
+def upgrade() -> None:
+  conn = op.get_bind()
+  _widen(conn, "public")
+  for_each_tenant_schema(conn, _widen)
+  _repair_provenance(conn, "public")
+  for_each_tenant_schema(conn, _repair_provenance)
+
+
+def downgrade() -> None:
+  # provenance is deliberately NOT reverted: the repaired values are the
+  # true origins, and restoring the mislabel would be re-introducing the
+  # bug. The constraint change is reversible; the data repair is not worth
+  # undoing.
+  conn = op.get_bind()
+  _narrow(conn, "public")
+  for_each_tenant_schema(conn, _narrow)

--- a/robosystems/models/api/event_block.py
+++ b/robosystems/models/api/event_block.py
@@ -304,9 +304,12 @@ class EventBlockEnvelope(BaseModel):
   event_category: str = Field(
     ...,
     description=(
-      "REA category — economic (`sales`, `purchase`, `financing`, "
-      "`payroll`, `treasury`, `adjustment`, `recognition`, `other`) "
-      "or support (`control`, `approval`, `reconciliation`, `inquiry`)."
+      "REA category, scoped by `event_class` — economic (`sales`, "
+      "`purchase`, `financing`, `payroll`, `treasury`, `adjustment`, "
+      "`recognition`, `other`), support (`control`, `approval`, "
+      "`reconciliation`, `inquiry`), or operational (`pipeline`, "
+      "`engagement`, `schedule`, `other`) for occurrences that drive no "
+      "GL — a lead, a lifecycle change, an outreach, a schedule setup."
     ),
   )
   status: str = Field(

--- a/robosystems/models/extensions/roboledger/event.py
+++ b/robosystems/models/extensions/roboledger/event.py
@@ -132,11 +132,13 @@ class Event(ExtensionsBase):
       "'sales', 'purchase', 'financing', 'payroll', "
       "'treasury', 'adjustment', 'recognition', 'other')) "
       "OR (event_class = 'support' AND event_category IN ("
-      "'control', 'approval', 'reconciliation', 'inquiry'))",
+      "'control', 'approval', 'reconciliation', 'inquiry')) "
+      "OR (event_class = 'operational' AND event_category IN ("
+      "'pipeline', 'engagement', 'schedule', 'other'))",
       name="check_event_category",
     ),
     CheckConstraint(
-      "event_class IN ('economic', 'support')",
+      "event_class IN ('economic', 'support', 'operational')",
       name="check_event_class",
     ),
     CheckConstraint(
@@ -172,6 +174,18 @@ class Event(ExtensionsBase):
   # Event identity
   event_type = Column(String, nullable=False)
   event_category = Column(String, nullable=False)
+  # economic  — a resource flows (REA economic event); drives the GL.
+  # support   — supports an economic event: controls, approvals,
+  #             reconciliations, inquiries. Audit-side, non-posting.
+  # operational — a business occurrence that is neither. It precedes or
+  #             surrounds economic activity without being it: a lead, a
+  #             lifecycle change, an outreach, a schedule being set up.
+  #             Added 2026-09-05 because there was nowhere honest to put
+  #             one — `schedule_created` had been filed as economic/other
+  #             despite producing no GL at all, and a CRM lead had no legal
+  #             category under either existing class. Filing a non-economic
+  #             occurrence as `economic` asserts a resource flow that did
+  #             not happen, which is the thing this column exists to say.
   event_class = Column(String, nullable=False, default="economic")
 
   # Canonical action verb — finer-grained than event_category. See EVENT_ACTIONS.

--- a/robosystems/operations/event_block/python_handlers/asset_disposed.py
+++ b/robosystems/operations/event_block/python_handlers/asset_disposed.py
@@ -182,6 +182,7 @@ def dispatch(
     memo=memo,
     created_by=created_by,
     entry_type="closing",
+    provenance="event_handler",
   )
 
   # 5. Link the entry to the event (audit chain)

--- a/robosystems/operations/roboledger/commands/journal_entries.py
+++ b/robosystems/operations/roboledger/commands/journal_entries.py
@@ -359,6 +359,35 @@ def _raise_if_posting_date_moved(entry: Entry, peeked_date) -> None:
 # ── Create ───────────────────────────────────────────────────────────────
 
 
+# `Event.source` is an open vocabulary: the platform emits `manual`, `system`
+# and `schedule`, and every other value is a connection provider validated at
+# the ops layer against the graph's registered Connections (see the comment on
+# `Event.source` — it deliberately carries no CHECK so registering a connection
+# opens a source name without a schema change). So the mapping is closed on the
+# platform side and open-by-default on the adapter side: anything not emitted
+# by the platform came in over a connection, which is a sync.
+_PLATFORM_SOURCE_PROVENANCE = {
+  "manual": "manual_entry",
+  "native": "manual_entry",
+  "system": "system_computed",
+  "schedule": "schedule_derived",
+}
+
+
+def provenance_for_source(source: str | None) -> str:
+  """Map a Transaction/Event source onto `Entry.provenance`.
+
+  `create_journal_entry` hardcoded `manual_entry` regardless of origin,
+  so every QuickBooks-synced entry claimed to be hand-entered and
+  `source_sync` — a value the constraint allows — was never written by
+  anything. `Entry.provenance` is meant to answer "where did this come
+  from", and the entry write already receives the answer.
+  """
+  if not source:
+    return "manual_entry"
+  return _PLATFORM_SOURCE_PROVENANCE.get(source, "source_sync")
+
+
 def create_journal_entry(
   session: Session,
   body: CreateJournalEntryRequest,
@@ -411,7 +440,7 @@ def create_journal_entry(
     status=status,
     posting_date=body.posting_date,
     memo=body.memo,
-    provenance="manual_entry",
+    provenance=provenance_for_source(body.source),
     posted_at=now,
     created_by=created_by,
   )
@@ -658,6 +687,9 @@ def reverse_journal_entry(
     status="posted",
     posting_date=posting_date,
     memo=memo,
+    # Deliberately not inherited from the original. A reversal is an act by
+    # whoever asked for it, not a re-sync — reversing a QuickBooks-sourced
+    # entry is still a decision someone made here.
     provenance="manual_entry",
     reversal_of=original.id,
     posted_at=now,

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -1351,7 +1351,15 @@ class ScheduleService:
     else:
       regenerated = False
 
-    # Create draft entry
+    # No `transaction_id`, deliberately. A schedule-derived entry has no
+    # source-system record behind it, and the schema supports a standalone
+    # entry on purpose — `Entry.transaction_id` is nullable and
+    # `Entry.triggered_by_event_id` exists precisely so an entry with no
+    # parent can still carry its event chain (see the comment on that
+    # column). `create_journal_entry` mints a Transaction when none is
+    # supplied; that is right for its callers and wrong here. Do not
+    # "fix" this by synthesizing one — it would manufacture rows in the
+    # adapter mirror to satisfy a read, and reads anchor on Entry.
     entry = Entry(
       type=template.get("entry_type", "closing"),
       status="draft",

--- a/robosystems/operations/roboledger/schedules/service.py
+++ b/robosystems/operations/roboledger/schedules/service.py
@@ -760,8 +760,12 @@ class ScheduleService:
       Event(
         id=schedule_created_event_id,
         event_type="schedule_created",
-        event_category="other",
-        event_class="economic",
+        # Setting up a schedule moves no resource — it is the operational
+        # act that arranges future recognition, not the recognition. Filed
+        # as economic/other until 2026-09-05 because no other class would
+        # take it; the recognition events it later emits stay economic.
+        event_category="schedule",
+        event_class="operational",
         occurred_at=now,
         source="schedule",
         status="committed",
@@ -1458,15 +1462,22 @@ class ScheduleService:
     memo: str,
     created_by: str,
     entry_type: str = "closing",
+    provenance: str = "manual_entry",
   ) -> ClosingEntryResult:
     """Create a manual (non-schedule) draft closing entry.
 
     Used for one-off adjustments that aren't derived from a schedule:
     asset disposals, impairments, reclassifications, correcting entries.
 
+    ``provenance`` defaults to ``manual_entry`` — a person made this
+    adjustment — but every caller today is an event handler, which should
+    pass ``event_handler`` so the entry says what actually produced it.
+    "Manual" here means *not schedule-derived*, which is a different
+    question from who wrote it.
+
     The resulting entry has:
     - `source_structure_id = None` (not tied to any schedule)
-    - `provenance = 'manual_entry'`
+    - `provenance` as given (see above)
     - `status = 'draft'` (posted by close-period like any other draft)
 
     Unlike schedule-derived entries which have exactly 2 line items (DR/CR
@@ -1535,7 +1546,7 @@ class ScheduleService:
       posting_date=posting_date,
       memo=memo,
       source_structure_id=None,
-      provenance="manual_entry",
+      provenance=provenance,
       created_by=created_by,
     )
     session.add(entry)

--- a/robosystems/schemas/base.py
+++ b/robosystems/schemas/base.py
@@ -176,7 +176,7 @@ BASE_NODES = [
       Property(
         name="event_category", type="STRING"
       ),  # economic: sales|purchase|... ; support: control|approval|...
-      Property(name="event_class", type="STRING"),  # economic | support
+      Property(name="event_class", type="STRING"),  # economic | support | operational
       Property(
         name="event_action", type="STRING"
       ),  # Canonical 19-verb action vocabulary (see EVENT_ACTIONS in models)

--- a/tests/operations/roboledger/commands/test_journal_entries.py
+++ b/tests/operations/roboledger/commands/test_journal_entries.py
@@ -8,6 +8,7 @@ Tests cover:
 - delete_journal_entry — draft-only gate, hard delete mechanics
 - reverse_journal_entry — posted-only gate, debit↔credit flip, reversal_of FK,
   original marked reversed, closed-period gate on reversal date
+- provenance_for_source — the entry's origin, derived rather than hardcoded
 """
 
 from __future__ import annotations
@@ -33,6 +34,7 @@ from robosystems.operations.roboledger.commands.journal_entries import (
   UnbalancedJournalEntryError,
   create_journal_entry,
   delete_journal_entry,
+  provenance_for_source,
   resolve_flow_element_id,
   reverse_journal_entry,
   update_journal_entry,
@@ -900,3 +902,42 @@ class TestReverseJournalEntry:
     reverse_journal_entry(session, self._body(), "usr_1")
 
     assert original.status == "reversed"
+
+
+class TestProvenanceForSource:
+  """`Entry.provenance` answers "where did this come from".
+
+  It was hardcoded to `manual_entry` for every entry regardless of origin,
+  so entries that arrived over a connection claimed to be hand-entered and
+  `source_sync` was never written by anything — on one live tenant that was
+  1726 QuickBooks-synced entries. The write already receives the origin;
+  these pin the mapping that uses it.
+  """
+
+  @pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+      ("manual", "manual_entry"),
+      ("native", "manual_entry"),
+      ("system", "system_computed"),
+      ("schedule", "schedule_derived"),
+    ],
+  )
+  def test_platform_sources_map_to_their_own_provenance(self, source, expected):
+    assert provenance_for_source(source) == expected
+
+  @pytest.mark.parametrize("source", ["quickbooks", "xero", "plaid", "hubspot"])
+  def test_any_connection_source_is_a_sync(self, source):
+    # `Event.source` is open on the adapter side — registering a connection
+    # opens a source name with no schema change — so the adapter half of
+    # this mapping has to be open by default, not an enumerated list.
+    assert provenance_for_source(source) == "source_sync"
+
+  def test_absent_source_falls_back_to_manual(self):
+    assert provenance_for_source(None) == "manual_entry"
+    assert provenance_for_source("") == "manual_entry"
+
+  def test_a_synced_entry_is_no_longer_labelled_manual(self):
+    # The regression itself: before this, every branch returned
+    # "manual_entry" and "what came from QuickBooks?" was unanswerable.
+    assert provenance_for_source("quickbooks") != "manual_entry"

--- a/tests/operations/roboledger/schedules/test_service.py
+++ b/tests/operations/roboledger/schedules/test_service.py
@@ -928,7 +928,16 @@ class TestCreateScheduleMaterializesObligations:
     assert len(pending) == 3
     assert creators[0].status == "committed"
     assert all(e.status == "pending" for e in pending)
-    assert all(e.event_class == "economic" for e in events)
+
+    # The two event types are classified differently on purpose, and the
+    # previous single `all(... == "economic")` assertion hid that.
+    # Setting a schedule up moves no resource and posts nothing — it is the
+    # operational act that arranges future recognition. The entries it
+    # later emits are the recognition, and those are economic.
+    assert creators[0].event_class == "operational"
+    assert creators[0].event_category == "schedule"
+    assert all(e.event_class == "economic" for e in pending)
+    assert all(e.event_category == "recognition" for e in pending)
 
   def test_pending_events_link_back_to_schedule_created(self):
     session = _mock_session()


### PR DESCRIPTION
Two origin-tracking corrections on the ledger spine, both surfaced by the journal-read work in #1355. Migration **0035**, fanned out over every tenant schema.

## 1. `Entry.provenance` was hardcoded

`create_journal_entry` set `provenance="manual_entry"` for every entry regardless of origin. So every entry that arrived over a connection claimed to be hand-entered, and `source_sync` — a value the CHECK constraint allows — had **never been written by anything**. On the live books that's **1726 QuickBooks-synced entries**.

This directly weakened the filter that just shipped: the Journal's Source filter could answer *"what did the close post?"* but not *"what came from QuickBooks?"*

The column exists to answer "where did this come from", and the write already receives the answer — `body.source`, which the event handler sets from `Event.source`. It was being discarded. Now derived:

| Source | Provenance |
|---|---|
| `manual` / `native` / absent | `manual_entry` |
| `system` | `system_computed` |
| `schedule` | `schedule_derived` |
| **anything else** | `source_sync` |

Closed on the platform side, open by default on the adapter side — because `Event.source` deliberately carries no CHECK (registering a connection opens a source name with no schema change), so the adapter half can't be an enumerated list.

**Backfill** reads each entry's linked event. Conservative and idempotent: only entries whose provenance is exactly `manual_entry`, only where a linked event exists, and a `manual` event maps straight back — so genuinely hand-entered rows are untouched and re-running is a no-op. Entries with no linked event are left alone; there's nothing to derive from.

Two related touches: `create_manual_closing_entry` now takes `provenance` instead of hardcoding it, and the disposal handler passes `event_handler` ("manual" there means *not schedule-derived*, a different question from who wrote it). The reversal path deliberately keeps `manual_entry` — a reversal is an act by whoever asked for it, not a re-sync — with a comment, since it otherwise looks like the bug being fixed.

## 2. `event_class` had no home for a non-economic occurrence

The vocabulary was `economic | support`. Economic asserts a resource flow; support means *supporting* an economic event — controls, approvals, reconciliations, inquiries. Anything that is neither had nowhere honest to go.

That isn't hypothetical. On the live books **`support` has never been used once**, and `schedule_created` — setting a schedule up, which moves nothing and posts nothing — is filed as `economic/other`. The gap was already being papered over.

Adds **`operational`** with `pipeline | engagement | schedule | other`, and re-files the existing `schedule_created` rows. The recognition events a schedule later emits stay `economic/recognition` — those do drive the GL. Filing a non-economic occurrence as economic asserts a resource flow that did not happen, which is exactly what this column is for.

Design context: `specs/ledger/non-financial-events.md` §3 (private vault). This clears the blocker it names; the measurement half is separate and unbuilt.

## Verification

Migration applied locally and checked against Postgres rather than only through mocks:

- constraints land on `public` and fan out per tenant;
- `lead_received` / `operational` / `pipeline` is **accepted** where it was previously impossible;
- `support` / `pipeline` is **still correctly rejected** — the vocabulary kept its shape rather than being opened up;
- backfill maps `quickbooks→source_sync`, `manual→manual_entry`, `system→system_computed`, leaves event-less entries alone, and is a no-op on a second run.

`just test-all` green: 14131 passed, 42 skipped; ruff, format, basedpyright, cf-lint clean.

**Note on the autogenerated migration**: `just migrate-create` missed the CHECK constraint change entirely (as CLAUDE.md warns it does) and emitted 24 spurious FK/type operations that would have been destructive. It was discarded and 0035 written by hand off the `0033` fanout precedent.

**Note on a changed test**: one existing assertion pinned the misclassification — `all(e.event_class == "economic" for e in events)` over both schedule event types at once. It now distinguishes them, which is the thing actually worth asserting.

## Downgrade

The constraint change reverts. The provenance repair deliberately does **not** — the repaired values are the true origins, and restoring the mislabel would be re-introducing the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdMBS1zchAGU4JszgXtMXY