### PR TITLE
fix(sec): index a ticker-less filer under its CIK, not the string "<NA>"

### DIFF
--- a/robosystems/adapters/sec/pipeline/text_index.py
+++ b/robosystems/adapters/sec/pipeline/text_index.py
@@ -31,6 +31,7 @@ import zipfile
 from typing import Any
 
 import boto3
+import pandas as pd
 from dagster import AssetExecutionContext, BackfillPolicy, MaterializeResult, asset
 
 from robosystems.config import env
@@ -111,8 +112,6 @@ def _cell(value: Any) -> str:
   ``str()`` on a pandas missing value is the truthy ``"<NA>"``, which once
   reached the index as the ticker of every filer without one.
   """
-  import pandas as pd
-
   if value is None or pd.isna(value):
     return ""
   return str(value)
@@ -474,7 +473,7 @@ def sec_narratives_indexed(
     fy = report.get("fiscal_year_focus")
     accession_metadata[accession] = {
       "form_type": report.get("form", ""),
-      "filing_date": str(report.get("filing_date", "")),
+      "filing_date": _cell(report.get("filing_date")),
       "fiscal_year": int(fy) if fy is not None and not math.isnan(fy) else None,
       "fiscal_period": report.get("fiscal_period_focus", ""),
       "cik": entity_info.get("cik", ""),
@@ -822,7 +821,7 @@ def sec_ixbrl_disclosures_indexed(
     fy = report.get("fiscal_year_focus")
     accession_metadata[accession] = {
       "form_type": report.get("form", ""),
-      "filing_date": str(report.get("filing_date", "")),
+      "filing_date": _cell(report.get("filing_date")),
       "fiscal_year": int(fy) if fy is not None and not math.isnan(fy) else None,
       "fiscal_period": report.get("fiscal_period_focus", ""),
       "cik": entity_info.get("cik", ""),

--- a/robosystems/adapters/sec/pipeline/text_index.py
+++ b/robosystems/adapters/sec/pipeline/text_index.py
@@ -105,6 +105,19 @@ def _part_document_ids(
   return own, _id(*section_key), next_id
 
 
+def _cell(value: Any) -> str:
+  """A parquet cell as text; a missing value is an empty string.
+
+  ``str()`` on a pandas missing value is the truthy ``"<NA>"``, which once
+  reached the index as the ticker of every filer without one.
+  """
+  import pandas as pd
+
+  if value is None or pd.isna(value):
+    return ""
+  return str(value)
+
+
 def _get_s3_client():
   """Get S3 client (handles LocalStack for dev)."""
   kwargs: dict[str, Any] = {"region_name": env.AWS_REGION}
@@ -441,9 +454,9 @@ def sec_narratives_indexed(
     entities_df = entity_table.to_pandas()
     for _, row in entities_df.iterrows():
       entity_lookup[row.get("identifier")] = {
-        "ticker": str(row.get("ticker", "")),
-        "name": str(row.get("name", "")),
-        "cik": str(row.get("cik", "")),
+        "ticker": _cell(row.get("ticker")),
+        "name": _cell(row.get("name")),
+        "cik": _cell(row.get("cik")),
       }
   if ehr_table is not None:
     ehr_df = ehr_table.to_pandas()
@@ -789,9 +802,9 @@ def sec_ixbrl_disclosures_indexed(
     entities_df = entity_table.to_pandas()
     for _, row in entities_df.iterrows():
       entity_lookup[row.get("identifier")] = {
-        "ticker": str(row.get("ticker", "")),
-        "name": str(row.get("name", "")),
-        "cik": str(row.get("cik", "")),
+        "ticker": _cell(row.get("ticker")),
+        "name": _cell(row.get("name")),
+        "cik": _cell(row.get("cik")),
       }
   if ehr_table is not None:
     ehr_df = ehr_table.to_pandas()

--- a/tests/adapters/sec/pipeline/test_text_index.py
+++ b/tests/adapters/sec/pipeline/test_text_index.py
@@ -185,3 +185,26 @@ class TestPartDocumentIds:
     ixbrl = _part_document_ids("sec", "ixbrl", "acc", _Section("item_7"))[0]
     other = _part_document_ids("sec", "narr", "acc", _Section("item_7a"))[0]
     assert len({narr, ixbrl, other}) == 3
+
+
+@pytest.mark.unit
+class TestCell:
+  """The entity lookup's cells: a missing ticker must fall through to the CIK,
+  not index as the string "<NA>" (U.S. Steel, and every ticker-less filer)."""
+
+  def test_missing_values_are_empty(self):
+    import numpy as np
+    import pandas as pd
+
+    from robosystems.adapters.sec.pipeline.text_index import _cell
+
+    assert _cell(None) == ""
+    assert _cell(pd.NA) == ""
+    assert _cell(np.nan) == ""
+    assert _cell(float("nan")) == ""
+
+  def test_values_are_text(self):
+    from robosystems.adapters.sec.pipeline.text_index import _cell
+
+    assert _cell("MMM") == "MMM"
+    assert _cell(66740) == "66740"


### PR DESCRIPTION
## Summary

A filer without a ticker was indexed with `entity_ticker` set to the string `"<NA>"` instead of its CIK. The two text index assets build their entity lookup with `str()` on each parquet cell, and `str()` of a pandas missing value is `"<NA>"` — truthy, so the `ticker or cik` fallback never fired. Found auditing the local index for the Filing Ladder corpus (U.S. Steel's 119 documents); on prod it is every ticker-less filer.

## Changes

**adapters/sec/pipeline/text_index.py** — `_cell()` turns a parquet cell into text with a missing value (`None`, NaN, pandas NA) as an empty string; both assets' entity lookups (`sec_narratives_indexed`, `sec_ixbrl_disclosures_indexed`) use it for ticker, name and CIK, so a missing ticker falls through to the CIK as intended.

**tests/adapters/sec/pipeline/test_text_index.py** — `TestCell`: missing values of each kind are empty; values are their text.

## Breaking Changes

None. No API surface changes; the indexed `entity_ticker` value for ticker-less filers becomes the CIK, which is what the `entity` search filter and the hit models already expect.

## Testing

- `just test-code` (ruff, format, basedpyright, cf-lint): clean.
- `tests/adapters/sec/pipeline/test_text_index.py`: 13 passed.
- Live, on the local stack: the Filing Ladder corpus (26 filings) force re-indexed with this change: U.S. Steel's 119 documents carry `entity_ticker` `0001163302` (its CIK), 0 of 2,484 documents carry `<NA>`, and the other 25 accessions are unchanged (section sets equal to the parser's output, embeddings on every document). The `entity` search filter finds the filer by name and by CIK as before.

Existing documents on prod keep `"<NA>"` until their filings are re-indexed; the corpus re-index owed after #1352 covers them.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014adkqDsj2Mb2XEri6HDSNa
