### PR TITLE
build(deps): xbrlkit>=0.4.1 for the complete text-block sections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "dagster-postgres>=0.29.15,<1.0",
     "dagster-aws>=0.29.15,<1.0",
     # XBRL Toolkit
-    "xbrlkit>=0.4",
+    "xbrlkit>=0.4.1",
     # Data Transformation (dbt)
     "dbt-core>=1.11.14,<1.12",  # hold: 1.12 adds a beta parser dep + the metricflow subtree we don't use; 1.11.14 has the sqlparse<0.7.0 lift
     "dbt-duckdb>=1.10.0,<2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3813,7 +3813,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.48.0,<1.0" },
     { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.21.0,<1.0" },
     { name = "webauthn", specifier = ">=2.7.0,<3.0" },
-    { name = "xbrlkit", specifier = ">=0.4" },
+    { name = "xbrlkit", specifier = ">=0.4.1" },
     { name = "zstandard", specifier = ">=0.23,<1" },
 ]
 provides-extras = ["dev"]
@@ -4640,7 +4640,7 @@ wheels = [
 
 [[package]]
 name = "xbrlkit"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arelle-release" },
@@ -4652,9 +4652,9 @@ dependencies = [
     { name = "regex" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/02/abe080b2faab627dde49bf54b987317dae41862f491440fb0984deb7a577/xbrlkit-0.4.0.tar.gz", hash = "sha256:e014cb0e9443bc7b5856cefdc8a67f63f0f1f7f2a9102db074ed7814d35793cb", size = 1892679, upload-time = "2026-09-05T06:45:48.132Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/5d/1ce60a6b800df384752e0e1e2e85b1c1a5d31a3ed7711dfae4f457591473/xbrlkit-0.4.1.tar.gz", hash = "sha256:591717494d3a12566c1d50179fa6fb0510c840a0286f77d461df3f76a380de4c", size = 1894176, upload-time = "2026-09-05T20:59:02.891Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/a7/d49857bb5974992dbcf3ff473db7801148aac9699aa9d6844df3111beee8/xbrlkit-0.4.0-py3-none-any.whl", hash = "sha256:73c2db6abeed09eb64eb65d3bdb06dd804f96ece2ebc41193fd6ca711b54e2c4", size = 1899888, upload-time = "2026-09-05T06:45:46.445Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/04/abc177b583699360b30eea870f8e5eb26feb7209cf3c61eb8d012da4127f/xbrlkit-0.4.1-py3-none-any.whl", hash = "sha256:4fcb002520d99f73097a56aef8bace033a42a1fd5efab8fc9619cd470daf1c60", size = 1900452, upload-time = "2026-09-05T20:59:01.046Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Takes xbrlkit 0.4.1 (RoboFinSystems/xbrlkit#24), which carries the two parser fixes the 2026-09-05 corpus verification found: a text block tagged more than once is one section holding every occurrence (Microsoft's second acquisitions table and loanDepot's second servicing roll-forward were absent from the index), and `ix:exclude` page headers are dropped from a section (23 Oracle and Microsoft sections carried them). No code change here; the index assets import the parsers from `xbrlkit.text`.

## Changes

- `pyproject.toml` — `xbrlkit>=0.4.1`.
- `uv.lock` — xbrlkit 0.4.0 → 0.4.1, nothing else.

## Breaking Changes

None. Existing index documents are unchanged until their filings are re-indexed; the corpus re-index owed after #1352 (both source types from 2024-Q1) picks the fixes up.

## Testing

- `just test-code` (ruff, format, basedpyright, cf-lint): clean on the released 0.4.1.
- `tests/adapters/sec` and `tests/operations/search` on 0.4.1: 1,060 passed, 9 skipped.
- The fixes themselves were verified before release on the local stack by force re-indexing the Filing Ladder's 26 filings with the patched parser: `just sec-corpus-check audit --check` 26 filings, 0 problems; probes 52 of 52 (#1358).

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014adkqDsj2Mb2XEri6HDSNa
