### PR TITLE
feat(sec): publish each filing's holon, Tavi and document to the public CDN, with a filer catalog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -274,6 +274,9 @@ SECURITY_AUDIT_ENABLED=false
 # Local control experiments only: keep text-block values in the graph as well as on S3.
 # Never in a real environment — text blocks are most of a filing's bytes.
 # XBRL_KEEP_TEXTBLOCKS_INLINE=false
+# Publish each filing's holon, Tavi model, primary document and manifest to the
+# public data bucket at process time, and the per-filer catalog after staging.
+# SEC_FILING_ARTIFACTS_ENABLED=true
 
 
 

--- a/cloudformation/s3.yaml
+++ b/cloudformation/s3.yaml
@@ -410,6 +410,37 @@ Resources:
         SigningProtocol: sigv4
         Description: "Origin Access Control for Public Data Repository"
 
+  # Filed documents are served but never indexed: sec.gov's copy has ranked
+  # for years, a second copy is duplicate content, and a crawler fetching
+  # ten-megabyte filings is the one real egress risk. The externalized
+  # text-block fragments share the extension and the header. The holon, the
+  # Tavi model and the filer catalog carry no such header and stay indexable.
+  PublicDataNoIndexHeadersPolicy:
+    Type: AWS::CloudFront::ResponseHeadersPolicy
+    Properties:
+      ResponseHeadersPolicyConfig:
+        Name: !Sub ${AWS::StackName}-${Environment}-public-data-noindex
+        Comment: CORS with preflight plus X-Robots-Tag noindex for filed documents
+        CorsConfig:
+          AccessControlAllowCredentials: false
+          AccessControlAllowHeaders:
+            Items:
+              - "*"
+          AccessControlAllowMethods:
+            Items:
+              - GET
+              - HEAD
+              - OPTIONS
+          AccessControlAllowOrigins:
+            Items:
+              - "*"
+          OriginOverride: true
+        CustomHeadersConfig:
+          Items:
+            - Header: X-Robots-Tag
+              Value: noindex
+              Override: true
+
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
     Properties:
@@ -448,6 +479,35 @@ Resources:
           Compress: true
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # Managed-CachingOptimized
           ResponseHeadersPolicyId: 5cc3b908-e619-4b99-88e5-2cf7f45965bd # Managed-CORS-with-preflight
+        CacheBehaviors:
+          - PathPattern: "*.htm"
+            TargetOriginId: S3Origin
+            ViewerProtocolPolicy: redirect-to-https
+            AllowedMethods:
+              - GET
+              - HEAD
+              - OPTIONS
+            CachedMethods:
+              - GET
+              - HEAD
+              - OPTIONS
+            Compress: true
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # Managed-CachingOptimized
+            ResponseHeadersPolicyId: !Ref PublicDataNoIndexHeadersPolicy
+          - PathPattern: "*.html"
+            TargetOriginId: S3Origin
+            ViewerProtocolPolicy: redirect-to-https
+            AllowedMethods:
+              - GET
+              - HEAD
+              - OPTIONS
+            CachedMethods:
+              - GET
+              - HEAD
+              - OPTIONS
+            Compress: true
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # Managed-CachingOptimized
+            ResponseHeadersPolicyId: !Ref PublicDataNoIndexHeadersPolicy
         CustomErrorResponses:
           - ErrorCode: 404
             ResponseCode: 404

--- a/cloudformation/s3.yaml
+++ b/cloudformation/s3.yaml
@@ -413,8 +413,9 @@ Resources:
   # Filed documents are served but never indexed: sec.gov's copy has ranked
   # for years, a second copy is duplicate content, and a crawler fetching
   # ten-megabyte filings is the one real egress risk. The externalized
-  # text-block fragments share the extension and the header. The holon, the
-  # Tavi model and the filer catalog carry no such header and stay indexable.
+  # text-block fragments (.html/.txt) and the narrative extracts (.txt) get the
+  # same header. The holon, the Tavi model and the filer catalog carry no such
+  # header and stay indexable.
   PublicDataNoIndexHeadersPolicy:
     Type: AWS::CloudFront::ResponseHeadersPolicy
     Properties:
@@ -495,6 +496,20 @@ Resources:
             CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # Managed-CachingOptimized
             ResponseHeadersPolicyId: !Ref PublicDataNoIndexHeadersPolicy
           - PathPattern: "*.html"
+            TargetOriginId: S3Origin
+            ViewerProtocolPolicy: redirect-to-https
+            AllowedMethods:
+              - GET
+              - HEAD
+              - OPTIONS
+            CachedMethods:
+              - GET
+              - HEAD
+              - OPTIONS
+            Compress: true
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # Managed-CachingOptimized
+            ResponseHeadersPolicyId: !Ref PublicDataNoIndexHeadersPolicy
+          - PathPattern: "*.txt"
             TargetOriginId: S3Origin
             ViewerProtocolPolicy: redirect-to-https
             AllowedMethods:

--- a/robosystems/adapters/sec/config.py
+++ b/robosystems/adapters/sec/config.py
@@ -77,6 +77,10 @@ XBRL_EXTERNALIZATION_THRESHOLD = 1024
 # see env.XBRL_KEEP_TEXTBLOCKS_INLINE for why it is off everywhere real)
 XBRL_KEEP_TEXTBLOCKS_INLINE = env.XBRL_KEEP_TEXTBLOCKS_INLINE
 
+# Publish the filing's public artifacts (holon, Tavi, primary document, manifest)
+# to the public-data bucket at process time; see processors/artifacts.py
+XBRL_FILING_ARTIFACTS = env.SEC_FILING_ARTIFACTS_ENABLED
+
 # Skip textblock facts entirely (for historical data where text isn't needed)
 XBRL_SKIP_TEXTBLOCK_FACTS = False
 

--- a/robosystems/adapters/sec/pipeline/README.md
+++ b/robosystems/adapters/sec/pipeline/README.md
@@ -120,7 +120,8 @@ per filer and `companies/index.json` for the corpus, on the public CDN.
 Files are regenerated whole — every filer with a filing in the run's
 partitions, all of them on `full_rebuild`, the index always — so overlapping
 runs cannot corrupt one. Also writes `robots.txt` when it is missing.
-Chained off staging by `sec_post_stage_index_sensor`, beside the text index.
+Chained off staging by `sec_post_stage_index_sensor`, beside the text index;
+the job is `sec_catalog` (a job may not share its asset's name).
 
 ```bash
 uv run dagster asset materialize -m robosystems.dagster \

--- a/robosystems/adapters/sec/pipeline/README.md
+++ b/robosystems/adapters/sec/pipeline/README.md
@@ -47,6 +47,15 @@ SIGTERM handler stops the loop and attempts a best-effort flush; if the two-minu
 spot window allows, filings are consolidated and marked success, and if it does
 not, the cache covers them on the next run. Nothing is lost either way.
 
+**Public artifacts.** While the model is in hand, the processor also writes
+the filing's portable representations to the public-data bucket, in the
+folder its externalized text blocks use (`{year}/{cik}/{accession}/`): the
+`holon.jsonld` (text blocks as their CDN URLs), the Project Tavi compiled
+model `tavi.json` with its `tavi.gaps.json` sidecar, the primary document as
+filed, and a `manifest.json` naming what was written. Gated by
+`SEC_FILING_ARTIFACTS_ENABLED`; never fails the filing
+(`processors/artifacts.py`). A backfill of the artifacts is a reprocess.
+
 Output layout:
 
 ```
@@ -102,6 +111,22 @@ indexing into OpenSearch for hybrid BM25 + KNN search.
 `sec_knowledge_artifacts` builds the corpus-level artifacts from the published
 DuckDB file.
 
+### 7. Catalog — `sec_filing_catalog`
+
+The public pages' index, without a database. Folds the processed Report,
+Entity and ENTITY_HAS_REPORT parquet of every partition from `start_year`
+on, joined to each filing's `manifest.json`, into `companies/{ticker}.json`
+per filer and `companies/index.json` for the corpus, on the public CDN.
+Files are regenerated whole — every filer with a filing in the run's
+partitions, all of them on `full_rebuild`, the index always — so overlapping
+runs cannot corrupt one. Also writes `robots.txt` when it is missing.
+Chained off staging by `sec_post_stage_index_sensor`, beside the text index.
+
+```bash
+uv run dagster asset materialize -m robosystems.dagster \
+  --select sec_filing_catalog --partition 2026-Q3
+```
+
 ## Nightly chain
 
 ```
@@ -118,6 +143,7 @@ sec_stage_to_materialize_sensor
 
 sec_post_stage_index_sensor
   → text indexing
+  → filer catalog (companies/*.json + index.json on the public CDN)
 
 sec_post_materialize_publish_sensor
   → lbug S3 publish

--- a/robosystems/adapters/sec/pipeline/__init__.py
+++ b/robosystems/adapters/sec/pipeline/__init__.py
@@ -37,11 +37,17 @@ Pipeline stages (run independently via separate jobs):
 6. ARTIFACTS (graph-based confidence refinement):
    - sec_knowledge_artifacts - Generate element + structure knowledge artifacts
 
+7. CATALOG (the public pages' index, no database):
+   - sec_filing_catalog - Per-filer catalog + corpus index on the public CDN, a fold
+     over the processed Report/Entity tables and each filing's artifact manifest
+     (the artifacts themselves are written by the processor at process time)
+
 Nightly incremental chain (sensor-driven):
   download → process (250 batch loop) → stage (DuckDB INSERT)
   → materialize (full LadybugDB rebuild) → lbug S3 publish
   → duckdb S3 publish → replica refresh
   → text index (parallel with materialize: textblocks + narratives → OpenSearch)
+  → filer catalog (parallel with the text index)
 
 Usage:
     from robosystems.adapters.sec.pipeline import get_dagster_components
@@ -57,6 +63,7 @@ from robosystems.adapters.sec.pipeline.artifact import (
   SECArtifactConfig,
   sec_knowledge_artifacts,
 )
+from robosystems.adapters.sec.pipeline.catalog import sec_filing_catalog
 from robosystems.adapters.sec.pipeline.configs import (
   SEC_FORM_TYPE_BATCHES,
   SEC_HISTORICAL_END_YEAR,
@@ -65,6 +72,7 @@ from robosystems.adapters.sec.pipeline.configs import (
   SEC_QUARTERS,
   SEC_START_YEAR,
   SECDownloadConfig,
+  SECFilingCatalogConfig,
   SECHFPublishConfig,
   SECHistoricalStageConfig,
   SECIncrementalStageConfig,
@@ -83,6 +91,7 @@ from robosystems.adapters.sec.pipeline.jobs import (
   sec_artifact_generation_job,
   sec_download_job,
   sec_duckdb_s3_publish_job,
+  sec_filing_catalog_job,
   sec_historical_duckdb_s3_publish_job,
   sec_historical_lbug_s3_publish_job,
   sec_historical_materialize_job,
@@ -159,6 +168,7 @@ def get_dagster_components():
       sec_knowledge_artifacts,
       sec_narratives_indexed,
       sec_ixbrl_disclosures_indexed,
+      sec_filing_catalog,
     ],
     "jobs": [
       sec_download_job,
@@ -179,6 +189,7 @@ def get_dagster_components():
       sec_historical_lbug_s3_publish_job,
       sec_narratives_index_job,
       sec_ixbrl_index_job,
+      sec_filing_catalog_job,
     ],
     "sensors": [
       sec_processing_sensor,
@@ -205,6 +216,7 @@ __all__ = [
   "SEC_START_YEAR",
   "SECArtifactConfig",
   "SECDownloadConfig",
+  "SECFilingCatalogConfig",
   "SECHFPublishConfig",
   "SECHistoricalStageConfig",
   "SECIncrementalStageConfig",
@@ -218,6 +230,8 @@ __all__ = [
   "sec_duckdb_s3_publish_job",
   "sec_duckdb_s3_published",
   "sec_duckdb_staged",
+  "sec_filing_catalog",
+  "sec_filing_catalog_job",
   "sec_graph_materialized",
   "sec_historical_duckdb_s3_publish_job",
   "sec_historical_duckdb_s3_published",

--- a/robosystems/adapters/sec/pipeline/catalog.py
+++ b/robosystems/adapters/sec/pipeline/catalog.py
@@ -1,0 +1,505 @@
+"""The per-filer catalog on the public CDN — the public pages' index, without a database.
+
+``companies/{ticker}.json`` lists one filer's filings with their public
+representations; ``companies/index.json`` lists every filer with its latest
+filing. Both are a fold over the processed Report and Entity tables — the
+same parquet the graph is built from — joined to each filing's
+``manifest.json``, which the processor wrote beside the artifacts. They are
+regenerated whole: a run rewrites the file of every filer it touched (the
+filers with a filing in its partitions, or all of them on ``full_rebuild``)
+and the index always. Nothing is patched in place, so two overlapping runs
+cannot corrupt a file: the later write is a complete view as of its read,
+stale by at most one cycle.
+
+Reads: the Entity, Report and ENTITY_HAS_REPORT parquet of every partition
+from ``start_year`` on (three small tables), and one manifest per filing of
+a touched filer. Writes: one object per touched filer, the index, and
+``robots.txt`` when it is missing.
+"""
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import quote
+
+import pandas as pd
+from dagster import AssetExecutionContext, BackfillPolicy, MaterializeResult, asset
+
+from robosystems.config import env
+from robosystems.config.storage.shared import (
+  FILING_ARTIFACT_MANIFEST,
+  FILING_CATALOG_INDEX_KEY,
+  FILING_ROBOTS_KEY,
+  DataSourceType,
+  get_filing_artifact_key,
+  get_filing_catalog_key,
+  get_processed_key,
+)
+from robosystems.logger import logger
+from robosystems.operations.aws.s3 import S3Client
+
+from .configs import SEC_QUARTERS, SECFilingCatalogConfig, sec_quarter_partitions
+from .text_index import _get_s3_client
+
+CATALOG_VERSION = 1
+CATALOG_MEDIA_TYPE = "application/json"
+CATALOG_CACHE_CONTROL = "public, max-age=60"
+ROBOTS_CACHE_CONTROL = "public, max-age=3600"
+
+# Filed documents and the text-block fragments are served, never indexed —
+# the CDN adds the X-Robots-Tag on the same extensions (cloudformation/s3.yaml).
+ROBOTS_TXT = "User-agent: *\nDisallow: /*.htm$\nDisallow: /*.html$\n"
+
+REPORT_COLUMNS = [
+  "identifier",
+  "accession_number",
+  "form",
+  "filing_date",
+  "report_date",
+  "fiscal_year_focus",
+  "fiscal_period_focus",
+  "updated_at",
+]
+ENTITY_COLUMNS = [
+  "identifier",
+  "cik",
+  "ticker",
+  "name",
+  "exchange",
+  "sic",
+  "sic_description",
+  "updated_at",
+]
+RELATIONSHIP_COLUMNS = ["from", "to"]
+
+TABLE_PATHS = {
+  "Report": ("nodes", "Report"),
+  "Entity": ("nodes", "Entity"),
+  "ENTITY_HAS_REPORT": ("relationships", "ENTITY_HAS_REPORT"),
+}
+
+
+# ── the fold (pure) ─────────────────────────────────────────────────────────
+
+
+def corpus_partitions(start_year: int) -> list[str]:
+  """The quarter partitions the catalog spans."""
+  return [q for q in SEC_QUARTERS if int(q.split("-")[0]) >= start_year]
+
+
+def _text(value: Any) -> str | None:
+  if value is None or (isinstance(value, float) and pd.isna(value)):
+    return None
+  text = str(value).strip()
+  return text or None
+
+
+def _int(value: Any) -> int | None:
+  text = _text(value)
+  if text is None:
+    return None
+  try:
+    return int(float(text))
+  except ValueError:
+    return None
+
+
+def filers(entities: pd.DataFrame) -> dict[str, dict[str, Any]]:
+  """One row per CIK — the most recently written Entity row, so a ticker or
+  name change on a later filing wins."""
+  out: dict[str, dict[str, Any]] = {}
+  if entities.empty:
+    return out
+  ordered = entities.sort_values("updated_at", na_position="first")
+  for row in ordered.to_dict("records"):
+    cik = _text(row.get("cik"))
+    if not cik:
+      continue
+    out[cik] = {
+      "cik": cik,
+      "ticker": _text(row.get("ticker")),
+      "name": _text(row.get("name")),
+      "exchange": _text(row.get("exchange")),
+      "sic": _text(row.get("sic")),
+      "sic_description": _text(row.get("sic_description")),
+    }
+  return out
+
+
+def filings_by_cik(
+  reports: pd.DataFrame,
+  relationships: pd.DataFrame,
+  entities: pd.DataFrame,
+  form_types: list[str],
+) -> dict[str, list[dict[str, Any]]]:
+  """Each filer's listed filings, newest first, one per accession.
+
+  A filing reprocessed into a later batch appears twice in the parquet; the
+  row written last wins. Forms outside ``form_types`` carry no statements
+  and are dropped.
+  """
+  out: dict[str, list[dict[str, Any]]] = {}
+  if reports.empty or relationships.empty or entities.empty:
+    return out
+  entity_cik = {
+    _text(r["identifier"]): _text(r["cik"])
+    for r in entities[["identifier", "cik"]].to_dict("records")
+  }
+  report_entity = {
+    _text(r["to"]): _text(r["from"])
+    for r in relationships[["from", "to"]].to_dict("records")
+  }
+  wanted = {f.upper() for f in form_types}
+  latest: dict[str, dict[str, Any]] = {}
+  for row in reports.sort_values("updated_at", na_position="first").to_dict("records"):
+    accession = _text(row.get("accession_number"))
+    form = (_text(row.get("form")) or "").upper()
+    if not accession or form not in wanted:
+      continue
+    cik = entity_cik.get(report_entity.get(_text(row.get("identifier"))))
+    if not cik:
+      continue
+    latest[accession] = {
+      "cik": cik,
+      "accession": accession,
+      "form": form,
+      "filing_date": _text(row.get("filing_date")),
+      "report_date": _text(row.get("report_date")),
+      "fiscal_year": _int(row.get("fiscal_year_focus")),
+      "fiscal_period": _text(row.get("fiscal_period_focus")),
+      "report_id": _text(row.get("identifier")),
+    }
+  for filing in latest.values():
+    out.setdefault(filing["cik"], []).append(filing)
+  for filings in out.values():
+    filings.sort(key=lambda f: (f["filing_date"] or "", f["accession"]), reverse=True)
+  return out
+
+
+def filing_folder(filing: dict[str, Any]) -> tuple[str, str, str] | None:
+  """``(year, cik, accession)`` of a filing's artifact folder, or None."""
+  filing_date = filing.get("filing_date")
+  if not filing_date:
+    return None
+  return filing_date[:4], filing["cik"], filing["accession"]
+
+
+def viewer_link(viewer_url: str, url: str) -> str:
+  return f"{viewer_url.rstrip('/')}/?url={quote(url, safe='')}"
+
+
+def build_company(
+  filer: dict[str, Any],
+  filings: list[dict[str, Any]],
+  manifests: dict[str, dict[str, Any] | None],
+  *,
+  viewer_url: str,
+) -> dict[str, Any]:
+  """One filer's catalog file: its filings, each with the representations its
+  manifest lists (none when the filing predates the artifacts), a viewer link
+  per openable representation, and the latest filing per form."""
+  entries = []
+  latest: dict[str, str] = {}
+  for filing in filings:
+    manifest = manifests.get(filing["accession"]) or {}
+    representations = list(manifest.get("representations") or [])
+    viewer = {
+      r["kind"]: viewer_link(viewer_url, r["url"])
+      for r in representations
+      if r.get("kind") in ("holon", "tavi") and r.get("url")
+    }
+    entries.append(
+      {
+        "accession": filing["accession"],
+        "form": filing["form"],
+        "filing_date": filing["filing_date"],
+        "report_date": filing["report_date"],
+        "fiscal_year": filing["fiscal_year"],
+        "fiscal_period": filing["fiscal_period"],
+        "report_id": filing["report_id"],
+        "folder": manifest.get("folder"),
+        "representations": representations,
+        "viewer": viewer,
+      }
+    )
+    if representations:
+      latest.setdefault(filing["form"], filing["accession"])
+  return {
+    "version": CATALOG_VERSION,
+    "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
+    "source": "SEC EDGAR",
+    **filer,
+    "filings": entries,
+    "latest": latest,
+  }
+
+
+def index_row(filer: dict[str, Any], filings: list[dict[str, Any]]) -> dict[str, Any]:
+  newest = filings[0]
+  return {
+    "ticker": filer["ticker"],
+    "cik": filer["cik"],
+    "name": filer["name"],
+    "exchange": filer["exchange"],
+    "sic_description": filer["sic_description"],
+    "filings": len(filings),
+    "latest": {
+      "accession": newest["accession"],
+      "form": newest["form"],
+      "filing_date": newest["filing_date"],
+      "report_date": newest["report_date"],
+      "fiscal_year": newest["fiscal_year"],
+      "fiscal_period": newest["fiscal_period"],
+    },
+  }
+
+
+def build_index(rows: list[dict[str, Any]]) -> dict[str, Any]:
+  companies = sorted(rows, key=lambda r: (r["ticker"] or "", r["cik"]))
+  return {
+    "version": CATALOG_VERSION,
+    "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
+    "source": "SEC EDGAR",
+    "count": len(companies),
+    "companies": companies,
+  }
+
+
+# ── reads ────────────────────────────────────────────────────────────────────
+
+
+def _table_keys(s3: Any, bucket: str, partition: str, table: str) -> list[str]:
+  """Parquet keys of one table in one partition, in either layout the process
+  stage has written (``nodes/Report/part.parquet`` or ``nodes/Report.parquet``)."""
+  kind, name = TABLE_PATHS[table]
+  base = get_processed_key(DataSourceType.SEC, "processed", f"filed={partition}", kind)
+  keys: list[str] = []
+  paginator = s3.get_paginator("list_objects_v2")
+  for page in paginator.paginate(Bucket=bucket, Prefix=f"{base}/{name}"):
+    for obj in page.get("Contents", []):
+      key = obj["Key"]
+      if key.endswith(".parquet") and (
+        f"/{name}/" in key or key.endswith(f"/{name}.parquet")
+      ):
+        keys.append(key)
+  return keys
+
+
+def _read_table(
+  s3: Any, bucket: str, keys: list[str], columns: list[str], partition: str
+) -> pd.DataFrame:
+  import io
+
+  import pyarrow.parquet as pq
+
+  frames = []
+  for key in keys:
+    try:
+      body = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+      table = pq.read_table(io.BytesIO(body))
+      present = [c for c in columns if c in table.column_names]
+      frame = table.select(present).to_pandas()
+      for missing in columns:
+        if missing not in frame.columns:
+          frame[missing] = None
+      frame["partition"] = partition
+      frames.append(frame)
+    except Exception as e:
+      logger.warning(f"Failed to read parquet {key}: {e}")
+  if not frames:
+    return pd.DataFrame(columns=[*columns, "partition"])
+  return pd.concat(frames, ignore_index=True)
+
+
+def read_corpus(
+  s3: Any, bucket: str, partitions: list[str]
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+  """The Report, Entity and ENTITY_HAS_REPORT rows of every partition, each row
+  tagged with its partition."""
+  reports, entities, relationships = [], [], []
+  for partition in partitions:
+    reports.append(
+      _read_table(
+        s3,
+        bucket,
+        _table_keys(s3, bucket, partition, "Report"),
+        REPORT_COLUMNS,
+        partition,
+      )
+    )
+    entities.append(
+      _read_table(
+        s3,
+        bucket,
+        _table_keys(s3, bucket, partition, "Entity"),
+        ENTITY_COLUMNS,
+        partition,
+      )
+    )
+    relationships.append(
+      _read_table(
+        s3,
+        bucket,
+        _table_keys(s3, bucket, partition, "ENTITY_HAS_REPORT"),
+        RELATIONSHIP_COLUMNS,
+        partition,
+      )
+    )
+  return (
+    pd.concat(reports, ignore_index=True),
+    pd.concat(entities, ignore_index=True),
+    pd.concat(relationships, ignore_index=True),
+  )
+
+
+def read_manifests(
+  s3: Any,
+  bucket: str,
+  filings: list[dict[str, Any]],
+  workers: int,
+) -> dict[str, dict[str, Any] | None]:
+  """Each filing's manifest, or None when the filing has none yet."""
+
+  def one(filing: dict[str, Any]) -> tuple[str, dict[str, Any] | None]:
+    folder = filing_folder(filing)
+    if folder is None:
+      return filing["accession"], None
+    key = get_filing_artifact_key(*folder, FILING_ARTIFACT_MANIFEST)
+    try:
+      body = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+      return filing["accession"], json.loads(body)
+    except s3.exceptions.NoSuchKey:
+      return filing["accession"], None
+    except Exception as e:
+      logger.warning(f"Manifest read failed for {key}: {e}")
+      return filing["accession"], None
+
+  with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
+    return dict(pool.map(one, filings))
+
+
+# ── the asset ────────────────────────────────────────────────────────────────
+
+
+def _run_partitions(context: AssetExecutionContext) -> set[str]:
+  try:
+    return set(context.partition_keys)
+  except Exception:
+    return {context.partition_key}
+
+
+def _dump(document: dict[str, Any]) -> str:
+  return json.dumps(document, separators=(",", ":"), ensure_ascii=False)
+
+
+@asset(
+  group_name="sec_pipeline",
+  description="Regenerate the per-filer catalog and corpus index on the public CDN",
+  kinds={"s3"},
+  deps=["sec_processed_filings"],
+  partitions_def=sec_quarter_partitions,
+  backfill_policy=BackfillPolicy.single_run(),
+  metadata={
+    "pipeline": "sec",
+    "stage": "catalog",
+  },
+)
+def sec_filing_catalog(
+  context: AssetExecutionContext,
+  config: SECFilingCatalogConfig,
+) -> MaterializeResult:
+  """Fold the processed Report/Entity tables and the filings' manifests into
+  the filer catalog and corpus index on the public CDN.
+
+  Partitioned by quarter. Rewrites the catalog file of every filer with a
+  filing in the run's partitions (every filer on ``full_rebuild``), and the
+  corpus index always.
+  """
+  public_bucket = env.PUBLIC_DATA_BUCKET
+  if not public_bucket:
+    context.log.warning("No public data bucket configured; catalog skipped")
+    return MaterializeResult(metadata={"status": "skipped", "reason": "no_bucket"})
+
+  s3 = _get_s3_client()
+  writer = S3Client()
+  processed_bucket = env.SHARED_PROCESSED_BUCKET
+  run_partitions = _run_partitions(context)
+  partitions = corpus_partitions(config.start_year)
+  context.log.info(
+    f"Catalog: folding {len(partitions)} partitions from {config.start_year}; "
+    f"run partitions {sorted(run_partitions)}"
+  )
+
+  reports, entities, relationships = read_corpus(s3, processed_bucket, partitions)
+  context.log.info(
+    f"Read {len(reports)} report rows, {len(entities)} entity rows, "
+    f"{len(relationships)} entity-report rows"
+  )
+  by_cik = filings_by_cik(reports, relationships, entities, config.form_types)
+  filer_rows = filers(entities)
+
+  listed: dict[str, tuple[dict[str, Any], list[dict[str, Any]]]] = {}
+  for cik, filer in filer_rows.items():
+    if config.require_ticker and not filer["ticker"]:
+      continue
+    filings = by_cik.get(cik)
+    if filings:
+      listed[cik] = (filer, filings)
+
+  if config.full_rebuild:
+    touched = set(listed)
+  else:
+    in_run = entities[entities["partition"].isin(run_partitions)]
+    touched = {c for c in (_text(v) for v in in_run["cik"]) if c} & set(listed)
+  context.log.info(f"{len(listed)} filers listed; rewriting {len(touched)}")
+
+  written = 0
+  failed = 0
+  for cik in sorted(touched):
+    filer, filings = listed[cik]
+    manifests = read_manifests(s3, public_bucket, filings, config.manifest_workers)
+    document = build_company(filer, filings, manifests, viewer_url=config.viewer_url)
+    ok = writer.upload_string(
+      _dump(document),
+      public_bucket,
+      get_filing_catalog_key(filer["ticker"]),
+      content_type=CATALOG_MEDIA_TYPE,
+      cache_control=CATALOG_CACHE_CONTROL,
+    )
+    written += int(ok)
+    failed += int(not ok)
+
+  index = build_index([index_row(f, fs) for f, fs in listed.values()])
+  index_ok = writer.upload_string(
+    _dump(index),
+    public_bucket,
+    FILING_CATALOG_INDEX_KEY,
+    content_type=CATALOG_MEDIA_TYPE,
+    cache_control=CATALOG_CACHE_CONTROL,
+  )
+
+  if not writer.object_exists(public_bucket, FILING_ROBOTS_KEY):
+    writer.upload_string(
+      ROBOTS_TXT,
+      public_bucket,
+      FILING_ROBOTS_KEY,
+      content_type="text/plain",
+      cache_control=ROBOTS_CACHE_CONTROL,
+    )
+
+  context.log.info(
+    f"Catalog: {written} filer files written, {failed} failed, "
+    f"index of {index['count']} {'written' if index_ok else 'FAILED'}"
+  )
+  return MaterializeResult(
+    metadata={
+      "status": "success" if failed == 0 and index_ok else "partial",
+      "graph_id": config.graph_id,
+      "filers_listed": len(listed),
+      "filers_written": written,
+      "filers_failed": failed,
+      "index_written": index_ok,
+      "partitions": len(partitions),
+    }
+  )

--- a/robosystems/adapters/sec/pipeline/catalog.py
+++ b/robosystems/adapters/sec/pipeline/catalog.py
@@ -47,9 +47,10 @@ CATALOG_MEDIA_TYPE = "application/json"
 CATALOG_CACHE_CONTROL = "public, max-age=60"
 ROBOTS_CACHE_CONTROL = "public, max-age=3600"
 
-# Filed documents and the text-block fragments are served, never indexed —
-# the CDN adds the X-Robots-Tag on the same extensions (cloudformation/s3.yaml).
-ROBOTS_TXT = "User-agent: *\nDisallow: /*.htm$\nDisallow: /*.html$\n"
+# Filed documents, the text-block fragments and the narrative extracts are
+# served, never indexed — the CDN adds the X-Robots-Tag on the same extensions
+# (cloudformation/s3.yaml). The holon, the Tavi and the catalog stay indexable.
+ROBOTS_TXT = "User-agent: *\nDisallow: /*.htm$\nDisallow: /*.html$\nDisallow: /*.txt$\n"
 
 REPORT_COLUMNS = [
   "identifier",
@@ -347,10 +348,19 @@ def read_corpus(
       )
     )
   return (
-    pd.concat(reports, ignore_index=True),
-    pd.concat(entities, ignore_index=True),
-    pd.concat(relationships, ignore_index=True),
+    _concat(reports, REPORT_COLUMNS),
+    _concat(entities, ENTITY_COLUMNS),
+    _concat(relationships, RELATIONSHIP_COLUMNS),
   )
+
+
+def _concat(frames: list[pd.DataFrame], columns: list[str]) -> pd.DataFrame:
+  """Concatenate the non-empty frames (an empty one would only warn), else an
+  empty frame with the expected columns."""
+  present = [f for f in frames if not f.empty]
+  if not present:
+    return pd.DataFrame(columns=[*columns, "partition"])
+  return pd.concat(present, ignore_index=True)
 
 
 def read_manifests(

--- a/robosystems/adapters/sec/pipeline/configs.py
+++ b/robosystems/adapters/sec/pipeline/configs.py
@@ -291,6 +291,40 @@ class SECiXBRLIndexConfig(Config):
   )
 
 
+class SECFilingCatalogConfig(Config):
+  """Configuration for the per-filer catalog on the public CDN.
+
+  Partitioned by quarter. A run rewrites the catalog file of every filer
+  with a filing in its partitions and the corpus index always; the corpus
+  view it folds spans every partition from ``start_year`` on.
+  """
+
+  graph_id: str = "sec"
+  start_year: int = Field(
+    default=SEC_PRIMARY_START_YEAR,
+    description="First filing year in the catalog (the shared sec graph's range)",
+  )
+  form_types: list[str] = Field(
+    default=["10-K", "10-Q", "20-F", "40-F"],
+    description="Forms listed per filer; other forms carry no statements",
+  )
+  require_ticker: bool = Field(
+    default=True,
+    description="List only filers with a ticker (the pages are keyed by ticker)",
+  )
+  full_rebuild: bool = Field(
+    default=False,
+    description="Rewrite every filer's catalog file, not only the partition's",
+  )
+  manifest_workers: int = Field(
+    default=16, description="Concurrent manifest reads from the public bucket"
+  )
+  viewer_url: str = Field(
+    default="https://holon.robosystems.ai",
+    description="The holon viewer the catalog's viewer links open",
+  )
+
+
 class SECHFPublishConfig(Config):
   """Configuration for the manual Hugging Face dataset publish.
 

--- a/robosystems/adapters/sec/pipeline/jobs.py
+++ b/robosystems/adapters/sec/pipeline/jobs.py
@@ -43,6 +43,7 @@ from dagster import (
 )
 
 from .artifact import sec_knowledge_artifacts
+from .catalog import sec_filing_catalog
 from .configs import sec_quarter_partitions
 from .download import sec_raw_filings
 from .duckdb_s3_publish import (
@@ -489,6 +490,34 @@ SEC_INDEX_ECS_TAGS = {
     ],
   },
 }
+
+# The filer catalog: a fold over three small processed tables plus one
+# manifest read per filing of a touched filer. Light, and idempotent on retry
+# (every write is a whole file), so Spot is fine.
+SEC_CATALOG_ECS_TAGS = {
+  "dagster/max_retries": 3,
+  "ecs/cpu": "1024",
+  "ecs/memory": "4096",
+  "ecs/run_task_kwargs": {
+    "capacityProviderStrategy": [
+      {"capacityProvider": "FARGATE_SPOT", "weight": 9, "base": 0},
+      {"capacityProvider": "FARGATE", "weight": 1, "base": 0},
+    ],
+  },
+}
+
+sec_filing_catalog_job = define_asset_job(
+  name="sec_filing_catalog",
+  description="Regenerate the per-filer catalog and corpus index on the public CDN (partitioned by quarter).",
+  selection=AssetSelection.assets(sec_filing_catalog),
+  partitions_def=sec_quarter_partitions,
+  tags={
+    "pipeline": "sec",
+    "phase": "catalog",
+    **SEC_CATALOG_ECS_TAGS,
+  },
+)
+
 
 sec_narratives_index_job = define_asset_job(
   name="sec_narratives_index",

--- a/robosystems/adapters/sec/pipeline/jobs.py
+++ b/robosystems/adapters/sec/pipeline/jobs.py
@@ -506,8 +506,10 @@ SEC_CATALOG_ECS_TAGS = {
   },
 }
 
+# Named apart from its asset: Dagster requires job and op names to be unique
+# within a repository, and an asset's op carries the asset's name.
 sec_filing_catalog_job = define_asset_job(
-  name="sec_filing_catalog",
+  name="sec_catalog",
   description="Regenerate the per-filer catalog and corpus index on the public CDN (partitioned by quarter).",
   selection=AssetSelection.assets(sec_filing_catalog),
   partitions_def=sec_quarter_partitions,

--- a/robosystems/adapters/sec/pipeline/sensors.py
+++ b/robosystems/adapters/sec/pipeline/sensors.py
@@ -50,6 +50,7 @@ from .configs import SEC_HISTORICAL_FORM_TYPES, SEC_PRIMARY_START_YEAR
 from .jobs import (
   sec_download_job,
   sec_duckdb_s3_publish_job,
+  sec_filing_catalog_job,
   sec_incremental_stage_job,
   sec_ixbrl_index_job,
   sec_lbug_s3_publish_job,
@@ -819,10 +820,11 @@ def sec_master_sleep_on_failure_sensor(context: RunStatusSensorContext):
   request_jobs=[
     sec_narratives_index_job,
     sec_ixbrl_index_job,
+    sec_filing_catalog_job,
   ],
   default_status=DefaultSensorStatus.STOPPED,
   minimum_interval_seconds=60,
-  description="Chain: stage → text search indexing (narratives + iXBRL disclosures)",
+  description="Chain: stage → text search indexing (narratives + iXBRL disclosures) + filer catalog",
 )
 def sec_post_stage_index_sensor(context: RunStatusSensorContext):
   """Trigger text search indexing after staging completes.
@@ -859,6 +861,8 @@ def sec_post_stage_index_sensor(context: RunStatusSensorContext):
   index_jobs = {
     "sec_narratives_index": "sec_narratives_indexed",
     "sec_ixbrl_index": "sec_ixbrl_disclosures_indexed",
+    # Not an index, but the same shape: post-stage, per partition, one op config.
+    "sec_filing_catalog": "sec_filing_catalog",
   }
 
   for job_name, asset_name in index_jobs.items():
@@ -910,10 +914,12 @@ _INDEX_RETRY_MAX = 3
   monitored_jobs=[
     sec_narratives_index_job,
     sec_ixbrl_index_job,
+    sec_filing_catalog_job,
   ],
   request_jobs=[
     sec_narratives_index_job,
     sec_ixbrl_index_job,
+    sec_filing_catalog_job,
   ],
   default_status=DefaultSensorStatus.STOPPED,
   minimum_interval_seconds=60,

--- a/robosystems/adapters/sec/pipeline/sensors.py
+++ b/robosystems/adapters/sec/pipeline/sensors.py
@@ -862,7 +862,7 @@ def sec_post_stage_index_sensor(context: RunStatusSensorContext):
     "sec_narratives_index": "sec_narratives_indexed",
     "sec_ixbrl_index": "sec_ixbrl_disclosures_indexed",
     # Not an index, but the same shape: post-stage, per partition, one op config.
-    "sec_filing_catalog": "sec_filing_catalog",
+    "sec_catalog": "sec_filing_catalog",
   }
 
   for job_name, asset_name in index_jobs.items():

--- a/robosystems/adapters/sec/processors/artifacts.py
+++ b/robosystems/adapters/sec/processors/artifacts.py
@@ -1,0 +1,376 @@
+"""Per-filing public artifacts: the holon, the Tavi model, the primary document.
+
+Written by the processor, at process time, from the xbrlkit model it already
+holds — no graph, no second parse. One folder per filing in the public-data
+bucket, the same key family as the externalized text blocks, so a filing's
+portable representations sit beside the note text they reference:
+
+    {year}/{cik}/{accession}/holon.jsonld     the dataset-form JSON-LD holon
+    {year}/{cik}/{accession}/tavi.json        the Project Tavi compiled model
+    {year}/{cik}/{accession}/tavi.gaps.json   what the draft could not hold
+    {year}/{cik}/{accession}/{primary doc}    the filing as filed
+    {year}/{cik}/{accession}/manifest.json    what was written, with sizes
+
+The holon is xbrlkit's projection of the parse with one platform touch: a
+text-block fact the externalizer moved to the CDN carries that URL as its
+value, the way the graph's Fact row does, so the holon stays small and a
+renderer embeds the note from the CDN. The Tavi carries the text blocks
+inline — the draft has no external-value construct — and its gaps sidecar
+records what the filing carries that the draft has nowhere to put.
+
+Every write is a whole object, and the emitters are deterministic, so a
+reprocessed filing rewrites the same bytes unless the emitter moved (a new
+Tavi draft, a holon vocabulary change) — which is exactly when a rewrite is
+wanted. A failure here never fails the filing: the parquet is the product,
+the artifacts are a projection of it, and the catalog lists a filing by its
+manifest, so a filing whose artifacts failed is absent from the pages until
+it is reprocessed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from arelle.UrlUtil import IXDS_DOC_SEPARATOR, IXDS_SURROGATE
+from xbrlkit.model import XbrlModel
+from xbrlkit.serialize import to_holon, to_tavi_report
+from xbrlkit.serialize.lpg import graph_id
+
+from robosystems.config.storage.shared import (
+  FILING_ARTIFACT_HOLON,
+  FILING_ARTIFACT_MANIFEST,
+  FILING_ARTIFACT_TAVI,
+  FILING_ARTIFACT_TAVI_GAPS,
+  get_filing_artifact_key,
+  get_filing_artifact_prefix,
+  get_public_data_url,
+)
+from robosystems.logger import logger
+
+MANIFEST_VERSION = 1
+
+# An artifact changes only when its filing is reprocessed, so a day at the
+# edge is safe. The manifest is what a catalog rebuild reads, so it turns
+# over faster.
+ARTIFACT_CACHE_CONTROL = "public, max-age=86400"
+MANIFEST_CACHE_CONTROL = "public, max-age=300"
+
+HOLON_MEDIA_TYPE = "application/ld+json"
+JSON_MEDIA_TYPE = "application/json"
+DOCUMENT_MEDIA_TYPES = {
+  ".htm": "text/html",
+  ".html": "text/html",
+  ".xml": "application/xml",
+  ".txt": "text/plain",
+  ".pdf": "application/pdf",
+}
+
+
+@dataclass
+class Representation:
+  """One public form of the filing, as the manifest and the catalog list it."""
+
+  kind: str
+  name: str
+  media_type: str
+  bytes: int
+  url: str
+  extra: dict[str, Any] = field(default_factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    return {
+      "kind": self.kind,
+      "name": self.name,
+      "media_type": self.media_type,
+      "bytes": self.bytes,
+      "url": self.url,
+      **self.extra,
+    }
+
+
+@dataclass
+class FilingArtifactResult:
+  prefix: str
+  representations: list[Representation]
+  manifest_key: str | None
+  errors: list[str]
+
+
+def filing_coordinates(model: XbrlModel) -> tuple[str, str, str] | None:
+  """``(year, cik, accession)`` naming the filing's folder, or None when incomplete.
+
+  The year is the filing year, the same the text-block keys use.
+  """
+  filing = model.filing
+  if not filing.accession or not filing.cik or filing.filing_date is None:
+    return None
+  return str(filing.filing_date.year), filing.cik, filing.accession
+
+
+def with_external_values(
+  model: XbrlModel, external_values: dict[str, str]
+) -> XbrlModel:
+  """The model with each externalized fact's value replaced by its CDN URL.
+
+  ``external_values`` is keyed by the graph's Fact identifier — derived from
+  the fact the same way the projection derives it — and holds the URL the
+  externalizer stored on the Fact row. A holon built from the result carries
+  the URL as the fact's string value, which is what the graph carries and
+  what a renderer embeds.
+  """
+  if not external_values:
+    return model
+  report_uri = model.filing.report_uri or model.filing.accession
+  facts = []
+  for fact in model.facts:
+    fact_id = graph_id("fact", f"{report_uri}#fact-{fact.source_hash or fact.id}")
+    url = external_values.get(fact_id)
+    if url is None:
+      facts.append(fact)
+    else:
+      facts.append(fact.model_copy(update={"value_str": url, "raw_value": url}))
+  return model.model_copy(update={"facts": facts})
+
+
+def primary_document_path(
+  instance_path: str | None, primary_document: str | None
+) -> str | None:
+  """The filed primary document on disk, or None when it is not there.
+
+  For an inline filing the instance *is* the primary document. A
+  multi-document inline set arrives as the surrogate path the loader built,
+  and the primary is the member EDGAR names. A non-inline filing's primary
+  document is a separate file the XBRL zip may not carry.
+  """
+  if not instance_path or not primary_document:
+    return None
+  if IXDS_DOC_SEPARATOR in instance_path:
+    members = instance_path.partition(IXDS_SURROGATE)[2].split(IXDS_DOC_SEPARATOR)
+  else:
+    members = [instance_path]
+  for member in members:
+    if os.path.basename(member) == primary_document and os.path.isfile(member):
+      return member
+  sibling = os.path.join(os.path.dirname(members[0]), primary_document)
+  return sibling if os.path.isfile(sibling) else None
+
+
+def _iso(value: Any) -> str | None:
+  return None if value is None else value.isoformat()
+
+
+class FilingArtifactWriter:
+  """Writes one filing's public artifacts and the manifest naming them."""
+
+  def __init__(
+    self,
+    s3_client: Any,
+    bucket: str | None,
+    cdn_url: str | None,
+    enabled: bool = True,
+  ):
+    self.s3_client = s3_client
+    self.bucket = bucket
+    self.cdn_url = cdn_url
+    self._enabled = enabled
+
+  @property
+  def enabled(self) -> bool:
+    return bool(self._enabled and self.s3_client and self.bucket)
+
+  def write(
+    self,
+    model: XbrlModel,
+    *,
+    report_id: str | None,
+    instance_path: str | None,
+    external_values: dict[str, str],
+    processor_version: str,
+  ) -> FilingArtifactResult | None:
+    """Write the artifacts and the manifest; None when disabled or unplaceable."""
+    if not self.enabled:
+      return None
+    coordinates = filing_coordinates(model)
+    if coordinates is None:
+      logger.warning(
+        "Filing artifacts skipped: the filing has no accession, CIK or filing date"
+      )
+      return None
+    year, cik, accession = coordinates
+    prefix = get_filing_artifact_prefix(year, cik, accession)
+    representations: list[Representation] = []
+    errors: list[str] = []
+
+    self._write_tavi(model, coordinates, representations, errors)
+    self._write_holon(model, external_values, coordinates, representations, errors)
+    self._write_document(model, instance_path, coordinates, representations, errors)
+    manifest_key = self._write_manifest(
+      model,
+      coordinates,
+      representations,
+      errors,
+      report_id=report_id,
+      processor_version=processor_version,
+    )
+    return FilingArtifactResult(prefix, representations, manifest_key, errors)
+
+  # ── the artifacts ─────────────────────────────────────────────────────────
+
+  def _write_tavi(
+    self,
+    model: XbrlModel,
+    coordinates: tuple[str, str, str],
+    representations: list[Representation],
+    errors: list[str],
+  ) -> None:
+    try:
+      document, gaps = to_tavi_report(model)
+      text = json.dumps(document, separators=(",", ":"), default=str)
+      key = get_filing_artifact_key(*coordinates, FILING_ARTIFACT_TAVI)
+      size = self._put_text(text, key, JSON_MEDIA_TYPE)
+      if size is None:
+        errors.append("tavi: upload failed")
+        return
+      extra: dict[str, Any] = {
+        "spec": str(document.get("documentInfo", {}).get("documentType", "")),
+      }
+      gaps_key = get_filing_artifact_key(*coordinates, FILING_ARTIFACT_TAVI_GAPS)
+      gaps_text = json.dumps(gaps.to_dict(), indent=2, default=str)
+      if self._put_text(gaps_text, gaps_key, JSON_MEDIA_TYPE) is not None:
+        extra["gaps"] = self._url(gaps_key)
+      else:
+        errors.append("tavi: gaps sidecar upload failed")
+      representations.append(
+        Representation(
+          "tavi", FILING_ARTIFACT_TAVI, JSON_MEDIA_TYPE, size, self._url(key), extra
+        )
+      )
+    except Exception as e:
+      errors.append(f"tavi: {e}")
+      logger.warning(f"Tavi projection failed for {coordinates[2]}: {e}")
+
+  def _write_holon(
+    self,
+    model: XbrlModel,
+    external_values: dict[str, str],
+    coordinates: tuple[str, str, str],
+    representations: list[Representation],
+    errors: list[str],
+  ) -> None:
+    try:
+      text = to_holon(with_external_values(model, external_values))
+      key = get_filing_artifact_key(*coordinates, FILING_ARTIFACT_HOLON)
+      size = self._put_text(text, key, HOLON_MEDIA_TYPE)
+      if size is None:
+        errors.append("holon: upload failed")
+        return
+      representations.append(
+        Representation(
+          "holon", FILING_ARTIFACT_HOLON, HOLON_MEDIA_TYPE, size, self._url(key)
+        )
+      )
+    except Exception as e:
+      errors.append(f"holon: {e}")
+      logger.warning(f"Holon projection failed for {coordinates[2]}: {e}")
+
+  def _write_document(
+    self,
+    model: XbrlModel,
+    instance_path: str | None,
+    coordinates: tuple[str, str, str],
+    representations: list[Representation],
+    errors: list[str],
+  ) -> None:
+    name = model.filing.primary_document
+    path = primary_document_path(instance_path, name)
+    if path is None or name is None:
+      return
+    try:
+      media_type = DOCUMENT_MEDIA_TYPES.get(
+        os.path.splitext(name)[1].lower(), "application/octet-stream"
+      )
+      key = get_filing_artifact_key(*coordinates, name)
+      ok = self.s3_client.upload_file(
+        path,
+        self.bucket,
+        key,
+        content_type=media_type,
+        cache_control=ARTIFACT_CACHE_CONTROL,
+      )
+      if not ok:
+        errors.append("document: upload failed")
+        return
+      representations.append(
+        Representation(
+          "document", name, media_type, os.path.getsize(path), self._url(key)
+        )
+      )
+    except Exception as e:
+      errors.append(f"document: {e}")
+      logger.warning(f"Primary document copy failed for {coordinates[2]}: {e}")
+
+  def _write_manifest(
+    self,
+    model: XbrlModel,
+    coordinates: tuple[str, str, str],
+    representations: list[Representation],
+    errors: list[str],
+    *,
+    report_id: str | None,
+    processor_version: str,
+  ) -> str | None:
+    filing = model.filing
+    year, cik, accession = coordinates
+    manifest = {
+      "version": MANIFEST_VERSION,
+      "accession": accession,
+      "cik": cik,
+      "form": filing.form,
+      "filing_date": _iso(filing.filing_date),
+      "report_date": _iso(filing.report_date),
+      "fiscal_year": filing.fiscal_year_focus,
+      "fiscal_period": filing.fiscal_period_focus,
+      "primary_document": filing.primary_document,
+      "is_inline_xbrl": filing.is_inline_xbrl,
+      "entity": {
+        "cik": model.entity.cik,
+        "name": model.entity.name,
+        "ticker": model.entity.ticker,
+      },
+      "report_id": report_id,
+      "folder": self._url(get_filing_artifact_prefix(year, cik, accession) + "/"),
+      "representations": [r.to_dict() for r in representations],
+      "errors": errors,
+      "processor_version": processor_version,
+      "written_at": datetime.now(UTC).isoformat(timespec="seconds"),
+    }
+    key = get_filing_artifact_key(*coordinates, FILING_ARTIFACT_MANIFEST)
+    text = json.dumps(manifest, indent=2, default=str)
+    if self._put_text(text, key, JSON_MEDIA_TYPE, MANIFEST_CACHE_CONTROL) is None:
+      errors.append("manifest: upload failed")
+      return None
+    return key
+
+  # ── transport ─────────────────────────────────────────────────────────────
+
+  def _put_text(
+    self,
+    text: str,
+    key: str,
+    media_type: str,
+    cache_control: str = ARTIFACT_CACHE_CONTROL,
+  ) -> int | None:
+    """Upload ``text`` and return its byte size, or None when the upload failed."""
+    data = text.encode("utf-8")
+    ok = self.s3_client.upload_bytes(
+      data, self.bucket, key, content_type=media_type, cache_control=cache_control
+    )
+    return len(data) if ok else None
+
+  def _url(self, key: str) -> str:
+    assert self.bucket is not None
+    return get_public_data_url(self.bucket, key, self.cdn_url)

--- a/robosystems/adapters/sec/processors/xbrl_graph.py
+++ b/robosystems/adapters/sec/processors/xbrl_graph.py
@@ -34,12 +34,14 @@ from robosystems.adapters.sec.config import (
   XBRL_COLUMN_STANDARDIZATION,
   XBRL_EXTERNALIZATION_THRESHOLD,
   XBRL_EXTERNALIZE_LARGE_VALUES,
+  XBRL_FILING_ARTIFACTS,
   XBRL_KEEP_TEXTBLOCKS_INLINE,
   XBRL_SEMANTIC_ENRICHMENT,
   XBRL_SKIP_TEXTBLOCK_FACTS,
   XBRL_STANDARDIZED_FILENAMES,
   XBRL_TYPE_PREFIXES,
 )
+from robosystems.adapters.sec.processors.artifacts import FilingArtifactWriter
 from robosystems.adapters.sec.processors.dataframe import DataFrameManager
 from robosystems.adapters.sec.processors.parquet import ParquetWriter
 from robosystems.adapters.sec.processors.schema import (
@@ -93,11 +95,13 @@ class XBRLGraphProcessor:
     self.report_data: dict[str, Any] | None = None
 
     s3_client = None
-    if XBRL_EXTERNALIZE_LARGE_VALUES and env.PUBLIC_DATA_BUCKET:
+    if (
+      XBRL_EXTERNALIZE_LARGE_VALUES or XBRL_FILING_ARTIFACTS
+    ) and env.PUBLIC_DATA_BUCKET:
       try:
         s3_client = S3Client()
       except Exception as e:
-        logger.warning(f"Failed to initialize S3 client for externalization: {e}")
+        logger.warning(f"Failed to initialize S3 client for the public bucket: {e}")
 
     self.textblock_externalizer = TextBlockExternalizer(
       s3_client=s3_client,
@@ -106,6 +110,12 @@ class XBRLGraphProcessor:
       threshold=XBRL_EXTERNALIZATION_THRESHOLD,
       enabled=XBRL_EXTERNALIZE_LARGE_VALUES,
       keep_inline=XBRL_KEEP_TEXTBLOCKS_INLINE,
+    )
+    self.filing_artifacts = FilingArtifactWriter(
+      s3_client=s3_client,
+      bucket=env.PUBLIC_DATA_BUCKET,
+      cdn_url=env.PUBLIC_DATA_CDN_URL,
+      enabled=XBRL_FILING_ARTIFACTS,
     )
 
     self.enable_standardized_filenames = XBRL_STANDARDIZED_FILENAMES
@@ -180,6 +190,9 @@ class XBRLGraphProcessor:
       model = to_xbrl_model(
         model_xbrl, self._filing_meta(), entity=self._entity_identity()
       )
+      # The public artifacts carry the whole filing, text blocks included,
+      # whatever the graph keeps.
+      full_model = model
       if XBRL_SKIP_TEXTBLOCK_FACTS:
         model = _without_textblock_facts(model)
       self.model = model
@@ -188,6 +201,7 @@ class XBRLGraphProcessor:
       self._bind_tables(to_graph_tables(model))
 
       self._externalize_large_values()
+      self._write_filing_artifacts(full_model)
 
       if self.enable_semantic_enrichment:
         logger.info("Computing semantic enrichments")
@@ -732,6 +746,41 @@ class XBRLGraphProcessor:
     if externalized:
       logger.info(f"Externalized {externalized} large fact values")
     externalizer.process_batch_uploads()
+
+  def _write_filing_artifacts(self, model: XbrlModel) -> None:
+    """Publish the filing's portable representations beside its text blocks.
+
+    Runs after externalization so the holon can carry each moved text
+    block's CDN URL the way the Fact row does. Never fails the filing: the
+    parquet is the product and these are a projection of the same parse; a
+    filing whose artifacts failed has no manifest, so the catalog lists it
+    without representations until it is reprocessed.
+    """
+    writer = self.filing_artifacts
+    if not writer.enabled:
+      return
+    try:
+      external: dict[str, str] = {}
+      attr = self.schema_to_dataframe_mapping.get("Fact")
+      facts: pd.DataFrame | None = getattr(self, attr) if attr else None
+      if facts is not None and not facts.empty and "value_type" in facts.columns:
+        moved = facts[facts["value_type"] == "external"]
+        external = dict(zip(moved["identifier"], moved["value"], strict=True))
+      result = writer.write(
+        model,
+        report_id=self.report_data.get("identifier") if self.report_data else None,
+        instance_path=self.instance_path,
+        external_values=external,
+        processor_version=self.version,
+      )
+      if result is not None:
+        logger.info(
+          f"Filing artifacts: {len(result.representations)} representations "
+          f"under {result.prefix}"
+          + (f", {len(result.errors)} errors" if result.errors else "")
+        )
+    except Exception as e:
+      logger.error(f"Filing artifacts failed (non-fatal for the filing): {e}")
 
 
 def _without_textblock_facts(model: XbrlModel) -> XbrlModel:

--- a/robosystems/config/env.py
+++ b/robosystems/config/env.py
@@ -1090,6 +1090,12 @@ class EnvConfig:
   # be able to reach the note text. Filings processed this way carry
   # value_type=inline, so the search index resolves no content_url for them.
   XBRL_KEEP_TEXTBLOCKS_INLINE = get_bool_env("XBRL_KEEP_TEXTBLOCKS_INLINE", False)
+  # Publish each processed filing's portable representations — the holon, the
+  # Tavi compiled model, the primary document and a manifest — to the public
+  # data bucket beside its externalized text blocks, and keep the per-filer
+  # catalog there (adapters/sec/processors/artifacts.py, pipeline/catalog.py).
+  # Off only where there is no public bucket to write to.
+  SEC_FILING_ARTIFACTS_ENABLED = get_bool_env("SEC_FILING_ARTIFACTS_ENABLED", True)
 
   # OpenFIGI (financial identifiers)
   OPENFIGI_API_KEY = get_secret_value("OPENFIGI_API_KEY", "")

--- a/robosystems/config/storage/README.md
+++ b/robosystems/config/storage/README.md
@@ -115,6 +115,40 @@ s3://robosystems-user-{env}/
     {graph_id}/{report_id}/g{generation}.jsonld
 ```
 
+### Public data bucket
+
+CDN-served. One folder per SEC filing holds the externalized text blocks the
+processor writes and, since the filing artifacts landed, the filing's portable
+representations and a manifest naming them; `companies/` beside them is the
+derived filer catalog the public pages and the holon viewer read.
+
+```
+s3://robosystems-public-data-{env}/
+  {year}/{cik}/{accession}/
+    fact_{hash}.html               # externalized text blocks (as today)
+    holon.jsonld                   # the filing as a dataset-form JSON-LD holon
+    tavi.json                      # the Project Tavi compiled model
+    tavi.gaps.json                 # what the Tavi draft could not hold
+    {primary_document}             # the filing as filed (noindex at the CDN)
+    manifest.json                  # what was written, with sizes and URLs
+  companies/
+    index.json                     # every filer with its latest filing
+    {ticker}.json                  # one filer: filings + representations
+  robots.txt                       # filed documents disallowed
+```
+
+```python
+from robosystems.config.storage import shared
+
+shared.get_filing_artifact_key(2025, "0000066740", "0000066740-25-000006", "holon.jsonld")
+# '2025/0000066740/0000066740-25-000006/holon.jsonld'
+shared.get_filing_catalog_key("MMM")
+# 'companies/mmm.json'
+```
+
+The year is the filing year; the CIK is the Entity row's; the accession keeps
+its dashes. `get_public_data_url` turns any of these keys into the CDN URL.
+
 ## Adding a data source
 
 1. Add the member to `DataSourceType` in `shared.py`.

--- a/robosystems/config/storage/shared.py
+++ b/robosystems/config/storage/shared.py
@@ -254,3 +254,56 @@ def get_staging_duckdb_path(graph_id: str = "sec") -> str:
 
   base = env.DUCKDB_STAGING_PATH
   return f"{base}/{graph_id}.duckdb"
+
+
+# =============================================================================
+# Public filing artifacts and the filer catalog (public-data bucket)
+# =============================================================================
+#
+# One folder per SEC filing, the key family the externalized text blocks
+# already use (``{year}/{cik}/{accession}/fact_*``): the filing's portable
+# representations, written by the processor at process time, plus a manifest
+# naming what was written. ``companies/`` beside them is the derived catalog
+# the public pages and the viewer read — a fold over the processed Report and
+# Entity tables, regenerated whole by the catalog asset, never patched.
+
+FILING_ARTIFACT_HOLON = "holon.jsonld"
+FILING_ARTIFACT_TAVI = "tavi.json"
+FILING_ARTIFACT_TAVI_GAPS = "tavi.gaps.json"
+FILING_ARTIFACT_MANIFEST = "manifest.json"
+FILING_CATALOG_PREFIX = "companies/"
+FILING_CATALOG_INDEX_KEY = "companies/index.json"
+FILING_ROBOTS_KEY = "robots.txt"
+
+
+def get_filing_artifact_prefix(year: str | int, cik: str, accession: str) -> str:
+  """A filing's public folder: filing year, the filer's CIK as the Entity row
+  carries it, the dashed accession number.
+
+  Example:
+      >>> get_filing_artifact_prefix(2025, "0000066740", "0000066740-25-000006")
+      '2025/0000066740/0000066740-25-000006'
+  """
+  return f"{year}/{cik}/{accession}"
+
+
+def get_filing_artifact_key(
+  year: str | int, cik: str, accession: str, name: str
+) -> str:
+  """Key of one artifact in a filing's public folder.
+
+  Example:
+      >>> get_filing_artifact_key(2025, "0000066740", "0000066740-25-000006", "holon.jsonld")
+      '2025/0000066740/0000066740-25-000006/holon.jsonld'
+  """
+  return f"{get_filing_artifact_prefix(year, cik, accession)}/{name}"
+
+
+def get_filing_catalog_key(ticker: str) -> str:
+  """Key of one filer's catalog file, by lower-cased ticker.
+
+  Example:
+      >>> get_filing_catalog_key("MMM")
+      'companies/mmm.json'
+  """
+  return f"{FILING_CATALOG_PREFIX}{ticker.strip().lower()}.json"

--- a/robosystems/operations/aws/s3.py
+++ b/robosystems/operations/aws/s3.py
@@ -110,6 +110,7 @@ class S3Client:
     key: str,
     content_type: str | None = None,
     metadata: dict[str, str] | None = None,
+    cache_control: str | None = None,
   ) -> bool:
     """Upload a UTF-8 string as an S3 object. False on any failure.
 
@@ -128,6 +129,9 @@ class S3Client:
 
     if metadata:
       put_args["Metadata"] = metadata
+
+    if cache_control:
+      put_args["CacheControl"] = cache_control
 
     security_errors = {"AccessDenied"}
 
@@ -160,6 +164,7 @@ class S3Client:
     key: str,
     content_type: str | None = None,
     metadata: dict[str, str] | None = None,
+    cache_control: str | None = None,
   ) -> bool:
     """Upload raw bytes as an S3 object. False on any failure.
 
@@ -177,6 +182,9 @@ class S3Client:
 
     if metadata:
       put_args["Metadata"] = metadata
+
+    if cache_control:
+      put_args["CacheControl"] = cache_control
 
     security_errors = {"AccessDenied"}
 
@@ -207,6 +215,7 @@ class S3Client:
     key: str,
     content_type: str | None = None,
     metadata: dict[str, str] | None = None,
+    cache_control: str | None = None,
   ) -> bool:
     """Upload a local file to S3. False on any failure."""
     extra_args = {}
@@ -214,6 +223,8 @@ class S3Client:
       extra_args["ContentType"] = content_type
     if metadata:
       extra_args["Metadata"] = metadata
+    if cache_control:
+      extra_args["CacheControl"] = cache_control
 
     try:
       self.s3_client.upload_file(

--- a/tests/adapters/sec/pipeline/test_catalog.py
+++ b/tests/adapters/sec/pipeline/test_catalog.py
@@ -1,0 +1,339 @@
+"""The filer catalog fold: processed Report/Entity rows plus manifests → JSON."""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from robosystems.adapters.sec.pipeline.catalog import (
+  build_company,
+  build_index,
+  corpus_partitions,
+  filers,
+  filings_by_cik,
+  index_row,
+  read_manifests,
+  viewer_link,
+)
+from robosystems.config.storage.shared import (
+  get_filing_artifact_key,
+  get_filing_catalog_key,
+)
+
+MMM = "0000066740"
+NVDA = "0001045810"
+CDN = "https://data.example.com"
+
+
+def _entities(*rows):
+  return pd.DataFrame(
+    rows,
+    columns=[
+      "identifier",
+      "cik",
+      "ticker",
+      "name",
+      "exchange",
+      "sic",
+      "sic_description",
+      "updated_at",
+      "partition",
+    ],
+  )
+
+
+def _reports(*rows):
+  return pd.DataFrame(
+    rows,
+    columns=[
+      "identifier",
+      "accession_number",
+      "form",
+      "filing_date",
+      "report_date",
+      "fiscal_year_focus",
+      "fiscal_period_focus",
+      "updated_at",
+      "partition",
+    ],
+  )
+
+
+def _links(*rows):
+  return pd.DataFrame(rows, columns=["from", "to", "partition"])
+
+
+@pytest.fixture
+def corpus():
+  entities = _entities(
+    ("e-mmm", MMM, "MMM", "3M CO", "NYSE", "3841", "Surgical", "2025-02-05", "2025-Q1"),
+    (
+      "e-mmm",
+      MMM,
+      "MMM",
+      "3M COMPANY",
+      "NYSE",
+      "3841",
+      "Surgical",
+      "2025-04-30",
+      "2025-Q2",
+    ),
+    (
+      "e-nvda",
+      NVDA,
+      "NVDA",
+      "NVIDIA CORP",
+      "Nasdaq",
+      "3674",
+      "Semis",
+      "2025-02-26",
+      "2025-Q1",
+    ),
+    (
+      "e-priv",
+      "0009999999",
+      None,
+      "PRIVATE CO",
+      None,
+      None,
+      None,
+      "2025-02-01",
+      "2025-Q1",
+    ),
+  )
+  reports = _reports(
+    (
+      "r-mmm-k",
+      "0000066740-25-000006",
+      "10-K",
+      "2025-02-05",
+      "2024-12-31",
+      2024,
+      "FY",
+      "2025-02-05",
+      "2025-Q1",
+    ),
+    # The same 10-K reprocessed into a later batch: the later row wins.
+    (
+      "r-mmm-k",
+      "0000066740-25-000006",
+      "10-K",
+      "2025-02-05",
+      "2024-12-31",
+      2024,
+      "FY",
+      "2025-03-01",
+      "2025-Q1",
+    ),
+    (
+      "r-mmm-q",
+      "0000066740-25-000020",
+      "10-Q",
+      "2025-04-30",
+      "2025-03-31",
+      2025,
+      "Q1",
+      "2025-04-30",
+      "2025-Q2",
+    ),
+    (
+      "r-mmm-8k",
+      "0000066740-25-000021",
+      "8-K",
+      "2025-05-01",
+      None,
+      None,
+      None,
+      "2025-05-01",
+      "2025-Q2",
+    ),
+    (
+      "r-nvda-k",
+      "0001045810-25-000023",
+      "10-K",
+      "2025-02-26",
+      "2025-01-26",
+      2025,
+      "FY",
+      "2025-02-26",
+      "2025-Q1",
+    ),
+    (
+      "r-priv-k",
+      "0009999999-25-000001",
+      "10-K",
+      "2025-02-01",
+      "2024-12-31",
+      2024,
+      "FY",
+      "2025-02-01",
+      "2025-Q1",
+    ),
+  )
+  links = _links(
+    ("e-mmm", "r-mmm-k", "2025-Q1"),
+    ("e-mmm", "r-mmm-q", "2025-Q2"),
+    ("e-mmm", "r-mmm-8k", "2025-Q2"),
+    ("e-nvda", "r-nvda-k", "2025-Q1"),
+    ("e-priv", "r-priv-k", "2025-Q1"),
+  )
+  return entities, reports, links
+
+
+@pytest.mark.unit
+class TestFold:
+  def test_filers_keep_the_latest_entity_row_per_cik(self, corpus):
+    entities, _, _ = corpus
+    rows = filers(entities)
+    assert set(rows) == {MMM, NVDA, "0009999999"}
+    assert rows[MMM]["name"] == "3M COMPANY"
+    assert rows[MMM]["ticker"] == "MMM"
+    assert rows["0009999999"]["ticker"] is None
+
+  def test_filings_by_cik_dedups_filters_forms_and_sorts_newest_first(self, corpus):
+    entities, reports, links = corpus
+    by_cik = filings_by_cik(reports, links, entities, ["10-K", "10-Q"])
+    assert [f["accession"] for f in by_cik[MMM]] == [
+      "0000066740-25-000020",
+      "0000066740-25-000006",
+    ]
+    tenk = by_cik[MMM][1]
+    assert tenk["form"] == "10-K"
+    assert tenk["fiscal_year"] == 2024
+    assert tenk["fiscal_period"] == "FY"
+    assert tenk["report_id"] == "r-mmm-k"
+    assert [f["accession"] for f in by_cik[NVDA]] == ["0001045810-25-000023"]
+    assert "8-K" not in {f["form"] for fs in by_cik.values() for f in fs}
+
+  def test_empty_inputs_fold_to_nothing(self):
+    assert filers(_entities()) == {}
+    assert filings_by_cik(_reports(), _links(), _entities(), ["10-K"]) == {}
+
+
+@pytest.mark.unit
+class TestDocuments:
+  def test_build_company_lists_representations_and_viewer_links(self, corpus):
+    entities, reports, links = corpus
+    filer = filers(entities)[MMM]
+    filings = filings_by_cik(reports, links, entities, ["10-K", "10-Q"])[MMM]
+    holon_url = f"{CDN}/2025/{MMM}/0000066740-25-000006/holon.jsonld"
+    tavi_url = f"{CDN}/2025/{MMM}/0000066740-25-000006/tavi.json"
+    manifests = {
+      "0000066740-25-000006": {
+        "folder": f"{CDN}/2025/{MMM}/0000066740-25-000006/",
+        "representations": [
+          {
+            "kind": "tavi",
+            "name": "tavi.json",
+            "media_type": "application/json",
+            "bytes": 2,
+            "url": tavi_url,
+          },
+          {
+            "kind": "holon",
+            "name": "holon.jsonld",
+            "media_type": "application/ld+json",
+            "bytes": 1,
+            "url": holon_url,
+          },
+          {
+            "kind": "document",
+            "name": "mmm-20241231.htm",
+            "media_type": "text/html",
+            "bytes": 3,
+            "url": f"{CDN}/2025/{MMM}/0000066740-25-000006/mmm-20241231.htm",
+          },
+        ],
+      },
+      # The 10-Q predates the artifacts: listed, nothing to open yet.
+      "0000066740-25-000020": None,
+    }
+
+    doc = build_company(
+      filer, filings, manifests, viewer_url="https://holon.robosystems.ai/"
+    )
+
+    assert doc["ticker"] == "MMM"
+    assert doc["cik"] == MMM
+    assert doc["name"] == "3M COMPANY"
+    assert doc["source"] == "SEC EDGAR"
+    assert [f["accession"] for f in doc["filings"]] == [
+      "0000066740-25-000020",
+      "0000066740-25-000006",
+    ]
+    tenq, tenk = doc["filings"]
+    assert tenq["representations"] == []
+    assert tenq["viewer"] == {}
+    assert tenq["folder"] is None
+    assert len(tenk["representations"]) == 3
+    assert tenk["viewer"] == {
+      "holon": viewer_link("https://holon.robosystems.ai", holon_url),
+      "tavi": viewer_link("https://holon.robosystems.ai", tavi_url),
+    }
+    # The latest openable filing per form: the 10-Q has nothing to open.
+    assert doc["latest"] == {"10-K": "0000066740-25-000006"}
+
+  def test_viewer_link_encodes_the_url_parameter(self):
+    link = viewer_link("https://holon.robosystems.ai", "https://cdn/a/b/holon.jsonld")
+    assert (
+      link
+      == "https://holon.robosystems.ai/?url=https%3A%2F%2Fcdn%2Fa%2Fb%2Fholon.jsonld"
+    )
+
+  def test_build_index_sorts_by_ticker_with_the_newest_filing(self, corpus):
+    entities, reports, links = corpus
+    rows_by_cik = filers(entities)
+    by_cik = filings_by_cik(reports, links, entities, ["10-K", "10-Q"])
+    rows = [index_row(rows_by_cik[cik], by_cik[cik]) for cik in (NVDA, MMM)]
+
+    index = build_index(rows)
+
+    assert index["count"] == 2
+    assert [c["ticker"] for c in index["companies"]] == ["MMM", "NVDA"]
+    mmm = index["companies"][0]
+    assert mmm["filings"] == 2
+    assert mmm["latest"]["accession"] == "0000066740-25-000020"
+    assert mmm["latest"]["form"] == "10-Q"
+
+  def test_catalog_keys(self):
+    assert get_filing_catalog_key("MMM") == "companies/mmm.json"
+    assert get_filing_catalog_key(" brk.b ") == "companies/brk.b.json"
+
+
+@pytest.mark.unit
+class TestReads:
+  def test_corpus_partitions_start_at_the_year(self):
+    partitions = corpus_partitions(2025)
+    assert partitions[0] == "2025-Q1"
+    assert all(int(p[:4]) >= 2025 for p in partitions)
+
+  def test_read_manifests_returns_none_for_a_missing_manifest(self):
+    s3 = MagicMock()
+
+    class NoSuchKey(Exception):
+      pass
+
+    s3.exceptions.NoSuchKey = NoSuchKey
+    present = get_filing_artifact_key(
+      "2025", MMM, "0000066740-25-000006", "manifest.json"
+    )
+
+    def get_object(Bucket, Key):
+      if Key == present:
+        return {"Body": MagicMock(read=lambda: b'{"representations": [1]}')}
+      raise NoSuchKey()
+
+    s3.get_object.side_effect = get_object
+    filings = [
+      {"cik": MMM, "accession": "0000066740-25-000006", "filing_date": "2025-02-05"},
+      {"cik": MMM, "accession": "0000066740-25-000020", "filing_date": "2025-04-30"},
+      {"cik": MMM, "accession": "no-date", "filing_date": None},
+    ]
+
+    manifests = read_manifests(s3, "public", filings, workers=2)
+
+    assert manifests == {
+      "0000066740-25-000006": {"representations": [1]},
+      "0000066740-25-000020": None,
+      "no-date": None,
+    }

--- a/tests/adapters/sec/pipeline/test_init.py
+++ b/tests/adapters/sec/pipeline/test_init.py
@@ -47,13 +47,13 @@ class TestGetDagsterComponents:
     # 1 lbug r2 publish, 1 lbug hf publish, knowledge artifact,
     # 2 text index (narratives + ixbrl disclosures)
     # (shared_master wake/sleep now live in the shared_repositories layer)
-    assert len(components["assets"]) == 16
+    assert len(components["assets"]) == 17
 
   def test_expected_number_of_jobs(self):
     """Test that the expected number of jobs are registered."""
     components = get_dagster_components()
     # (shared_master wake/sleep jobs now live in the shared_repositories layer)
-    assert len(components["jobs"]) == 18
+    assert len(components["jobs"]) == 19
 
   def test_expected_number_of_sensors(self):
     """Test that the expected number of sensors are registered."""

--- a/tests/adapters/sec/pipeline/test_sensors.py
+++ b/tests/adapters/sec/pipeline/test_sensors.py
@@ -766,7 +766,7 @@ class TestSecPostStageIndexSensor:
     assert job_names == {
       "sec_narratives_index",
       "sec_ixbrl_index",
-      "sec_filing_catalog",
+      "sec_catalog",
     }
 
     for r in result:

--- a/tests/adapters/sec/pipeline/test_sensors.py
+++ b/tests/adapters/sec/pipeline/test_sensors.py
@@ -744,7 +744,7 @@ class TestSecPostStageIndexSensor:
 
   @patch("robosystems.adapters.sec.pipeline.sensors.env")
   def test_yields_run_requests_for_all_index_jobs(self, mock_env):
-    """Test sensor yields RunRequests for textblocks, narratives, and iXBRL."""
+    """Test sensor yields RunRequests for narratives, iXBRL, and the filer catalog."""
     mock_env.ENVIRONMENT = "prod"
 
     from dagster import DagsterInstance
@@ -761,11 +761,12 @@ class TestSecPostStageIndexSensor:
 
       result = list(sec_post_stage_index_sensor(context))
 
-    assert len(result) == 2
+    assert len(result) == 3
     job_names = {r.job_name for r in result}
     assert job_names == {
       "sec_narratives_index",
       "sec_ixbrl_index",
+      "sec_filing_catalog",
     }
 
     for r in result:

--- a/tests/adapters/sec/processors/test_filing_artifacts.py
+++ b/tests/adapters/sec/processors/test_filing_artifacts.py
@@ -1,0 +1,318 @@
+"""FilingArtifactWriter: what the processor publishes per filing, and how.
+
+The model is synthetic (Arelle never runs); the S3 client is a mock that
+records every upload, so the tests read the artifacts back from the calls.
+"""
+
+import json
+import os
+from datetime import date
+from unittest.mock import MagicMock
+
+import pytest
+from xbrlkit.model import (
+  Concept,
+  EntityIdentity,
+  FilingMeta,
+  Label,
+  Period,
+  Unit,
+  XbrlFact,
+  XbrlModel,
+)
+from xbrlkit.serialize.lpg import graph_id
+
+from robosystems.adapters.sec.processors.artifacts import (
+  ARTIFACT_CACHE_CONTROL,
+  MANIFEST_CACHE_CONTROL,
+  FilingArtifactWriter,
+  filing_coordinates,
+  primary_document_path,
+  with_external_values,
+)
+
+REPORT_URI = (
+  "https://www.sec.gov/Archives/edgar/data/1045810/000104581024000029/nvda-20240128.htm"
+)
+CIK = "0001045810"
+ACCESSION = "0001045810-24-000029"
+FOLDER = f"2024/{CIK}/{ACCESSION}"
+CDN = "https://data.example.com"
+US_GAAP = "http://fasb.org/us-gaap/2023"
+NVDA = "http://www.nvidia.com/20240128"
+XBRLI = "http://www.xbrl.org/2003/instance"
+STANDARD_LABEL = "http://www.xbrl.org/2003/role/label"
+TEXT_BLOCK_HTML = "<p>" + "Revenue recognition policy. " * 20 + "</p>"
+TEXT_FACT_HASH = "h-text"
+
+
+def _concept(qname, namespace, **kwargs):
+  name = qname.split(":")[1]
+  return Concept(
+    qname=qname,
+    namespace=namespace,
+    name=name,
+    substitution_group="xbrli:item",
+    substitution_group_namespace=XBRLI,
+    labels=[Label(value=name, role=STANDARD_LABEL, language="en-US")],
+    **kwargs,
+  )
+
+
+def _model(filing_date: date | None = date(2024, 2, 21)) -> XbrlModel:
+  filing = FilingMeta(
+    accession=ACCESSION,
+    cik=CIK,
+    form="10-K",
+    filing_date=filing_date,
+    report_date=date(2024, 1, 28),
+    is_inline_xbrl=True,
+    primary_document="nvda-20240128.htm",
+    report_uri=REPORT_URI,
+    extension_namespace=NVDA,
+    fiscal_year_focus="2024",
+    fiscal_period_focus="FY",
+  )
+  entity = EntityIdentity(cik=CIK, name="NVIDIA CORP", ticker="NVDA")
+  concepts = {
+    "us-gaap:Assets": _concept(
+      "us-gaap:Assets",
+      US_GAAP,
+      period_type="instant",
+      balance="debit",
+      is_numeric=True,
+      nice_type="Monetary",
+    ),
+    "nvda:RevenueRecognitionPolicyTextBlock": _concept(
+      "nvda:RevenueRecognitionPolicyTextBlock",
+      NVDA,
+      period_type="duration",
+      is_textblock=True,
+      nice_type="Text Block",
+    ),
+  }
+  periods = [
+    Period(id="i-2024-01-28", period_type="instant", end=date(2024, 1, 28)),
+    Period(
+      id="d-fy2024",
+      period_type="duration",
+      start=date(2023, 1, 30),
+      end=date(2024, 1, 28),
+    ),
+  ]
+  units = [
+    Unit(id="usd", measure="iso4217:USD", uri="http://www.xbrl.org/2003/iso4217#USD")
+  ]
+  context = {
+    "entity_cik": CIK,
+    "entity_scheme": "http://www.sec.gov/CIK",
+    "entity_identifier": CIK,
+  }
+  facts = [
+    XbrlFact(
+      id="f-assets",
+      concept_qname="us-gaap:Assets",
+      period_id="i-2024-01-28",
+      unit_id="usd",
+      value_str="65728000000",
+      raw_value="65728000000",
+      source_hash="h-assets",
+      numeric_value=65728000000.0,
+      decimals="-6",
+      **context,
+    ),
+    XbrlFact(
+      id="f-text",
+      concept_qname="nvda:RevenueRecognitionPolicyTextBlock",
+      period_id="d-fy2024",
+      value_str=TEXT_BLOCK_HTML,
+      raw_value=TEXT_BLOCK_HTML,
+      source_hash=TEXT_FACT_HASH,
+      value_kind="text",
+      **context,
+    ),
+  ]
+  return XbrlModel(
+    filing=filing,
+    entity=entity,
+    concepts=concepts,
+    periods=periods,
+    units=units,
+    facts=facts,
+  )
+
+
+def _text_fact_graph_id() -> str:
+  return graph_id("fact", f"{REPORT_URI}#fact-{TEXT_FACT_HASH}")
+
+
+@pytest.fixture
+def s3():
+  client = MagicMock()
+  client.upload_bytes.return_value = True
+  client.upload_file.return_value = True
+  return client
+
+
+@pytest.fixture
+def writer(s3):
+  return FilingArtifactWriter(s3_client=s3, bucket="public", cdn_url=CDN)
+
+
+def _uploads(s3) -> dict[str, tuple[bytes, str | None, str | None]]:
+  """key → (body, content type, cache control) for every byte upload."""
+  out = {}
+  for call in s3.upload_bytes.call_args_list:
+    data, _bucket, key = call.args
+    out[key] = (data, call.kwargs.get("content_type"), call.kwargs.get("cache_control"))
+  return out
+
+
+def _write(writer, model=None, **kwargs):
+  defaults = {
+    "report_id": "rpt-1",
+    "instance_path": None,
+    "external_values": {},
+    "processor_version": "test",
+  }
+  return writer.write(model or _model(), **{**defaults, **kwargs})
+
+
+@pytest.mark.unit
+class TestFilingArtifactWriter:
+  def test_writes_holon_tavi_and_manifest_under_the_filing_folder(self, writer, s3):
+    result = _write(writer)
+
+    uploads = _uploads(s3)
+    assert set(uploads) == {
+      f"{FOLDER}/holon.jsonld",
+      f"{FOLDER}/tavi.json",
+      f"{FOLDER}/tavi.gaps.json",
+      f"{FOLDER}/manifest.json",
+    }
+    assert uploads[f"{FOLDER}/holon.jsonld"][1] == "application/ld+json"
+    assert uploads[f"{FOLDER}/tavi.json"][1] == "application/json"
+    assert uploads[f"{FOLDER}/holon.jsonld"][2] == ARTIFACT_CACHE_CONTROL
+    assert uploads[f"{FOLDER}/manifest.json"][2] == MANIFEST_CACHE_CONTROL
+
+    assert result is not None
+    assert result.prefix == FOLDER
+    assert result.errors == []
+    assert [r.kind for r in result.representations] == ["tavi", "holon"]
+
+    manifest = json.loads(uploads[f"{FOLDER}/manifest.json"][0])
+    assert manifest["accession"] == ACCESSION
+    assert manifest["cik"] == CIK
+    assert manifest["form"] == "10-K"
+    assert manifest["filing_date"] == "2024-02-21"
+    assert manifest["fiscal_year"] == "2024"
+    assert manifest["entity"] == {"cik": CIK, "name": "NVIDIA CORP", "ticker": "NVDA"}
+    assert manifest["report_id"] == "rpt-1"
+    assert manifest["folder"] == f"{CDN}/{FOLDER}/"
+    kinds = {r["kind"]: r for r in manifest["representations"]}
+    assert kinds["holon"]["url"] == f"{CDN}/{FOLDER}/holon.jsonld"
+    assert kinds["holon"]["bytes"] == len(uploads[f"{FOLDER}/holon.jsonld"][0])
+    assert kinds["tavi"]["spec"].endswith("/compiled")
+    assert kinds["tavi"]["gaps"] == f"{CDN}/{FOLDER}/tavi.gaps.json"
+
+  def test_the_holon_carries_an_externalized_text_block_as_its_cdn_url(
+    self, writer, s3
+  ):
+    url = f"{CDN}/{FOLDER}/fact_abc123.html"
+    _write(writer, external_values={_text_fact_graph_id(): url})
+
+    uploads = _uploads(s3)
+    holon = uploads[f"{FOLDER}/holon.jsonld"][0].decode()
+    tavi = uploads[f"{FOLDER}/tavi.json"][0].decode()
+    assert url in holon
+    assert TEXT_BLOCK_HTML not in holon
+    # The draft has no external-value construct: the Tavi keeps the text inline.
+    assert url not in tavi
+    assert "Revenue recognition policy." in tavi
+
+  def test_the_primary_document_is_copied_when_it_is_the_instance(
+    self, writer, s3, tmp_path
+  ):
+    instance = tmp_path / "nvda-20240128.htm"
+    instance.write_text("<html>filed</html>")
+
+    result = _write(writer, instance_path=str(instance))
+
+    assert result is not None
+    document = [r for r in result.representations if r.kind == "document"]
+    assert len(document) == 1
+    assert document[0].name == "nvda-20240128.htm"
+    assert document[0].media_type == "text/html"
+    assert document[0].bytes == len("<html>filed</html>")
+    args, kwargs = s3.upload_file.call_args
+    assert args == (str(instance), "public", f"{FOLDER}/nvda-20240128.htm")
+    assert kwargs["content_type"] == "text/html"
+    assert kwargs["cache_control"] == ARTIFACT_CACHE_CONTROL
+
+  def test_a_failed_upload_is_recorded_in_the_manifest_not_raised(self, writer, s3):
+    def upload(data, bucket, key, **kwargs):
+      return not key.endswith("tavi.json")
+
+    s3.upload_bytes.side_effect = upload
+
+    result = _write(writer)
+
+    assert result is not None
+    assert [r.kind for r in result.representations] == ["holon"]
+    assert result.errors == ["tavi: upload failed"]
+    manifest = json.loads(_uploads(s3)[f"{FOLDER}/manifest.json"][0])
+    assert manifest["errors"] == ["tavi: upload failed"]
+    assert [r["kind"] for r in manifest["representations"]] == ["holon"]
+
+  def test_disabled_or_unconfigured_writer_writes_nothing(self, s3):
+    off = FilingArtifactWriter(
+      s3_client=s3, bucket="public", cdn_url=CDN, enabled=False
+    )
+    assert _write(off) is None
+    no_bucket = FilingArtifactWriter(s3_client=s3, bucket=None, cdn_url=CDN)
+    assert _write(no_bucket) is None
+    no_client = FilingArtifactWriter(s3_client=None, bucket="public", cdn_url=CDN)
+    assert _write(no_client) is None
+    s3.upload_bytes.assert_not_called()
+
+  def test_a_filing_without_a_filing_date_is_skipped(self, writer, s3):
+    assert _write(writer, model=_model(filing_date=None)) is None
+    s3.upload_bytes.assert_not_called()
+
+
+@pytest.mark.unit
+class TestHelpers:
+  def test_filing_coordinates_use_the_filing_year(self):
+    assert filing_coordinates(_model()) == ("2024", CIK, ACCESSION)
+    assert filing_coordinates(_model(filing_date=None)) is None
+
+  def test_with_external_values_replaces_only_the_matched_fact(self):
+    url = "https://cdn/fact_1.html"
+    swapped = with_external_values(_model(), {_text_fact_graph_id(): url})
+    by_id = {f.id: f for f in swapped.facts}
+    assert by_id["f-text"].value_str == url
+    assert by_id["f-text"].raw_value == url
+    assert by_id["f-assets"].value_str == "65728000000"
+
+  def test_with_external_values_is_identity_when_nothing_moved(self):
+    model = _model()
+    assert with_external_values(model, {}) is model
+
+  def test_primary_document_path_resolves_the_instance_and_ixds_members(self, tmp_path):
+    from arelle.UrlUtil import IXDS_DOC_SEPARATOR, IXDS_SURROGATE
+
+    primary = tmp_path / "nvda-20240128.htm"
+    exhibit = tmp_path / "nvda-ex.htm"
+    primary.write_text("p")
+    exhibit.write_text("e")
+
+    assert primary_document_path(str(primary), "nvda-20240128.htm") == str(primary)
+    surrogate = os.path.join(str(tmp_path), IXDS_SURROGATE) + IXDS_DOC_SEPARATOR.join(
+      [str(exhibit), str(primary)]
+    )
+    assert primary_document_path(surrogate, "nvda-20240128.htm") == str(primary)
+    # A sibling the instance path does not name is still found by name.
+    assert primary_document_path(str(exhibit), "nvda-20240128.htm") == str(primary)
+    assert primary_document_path(str(primary), "missing.htm") is None
+    assert primary_document_path(None, "nvda-20240128.htm") is None
+    assert primary_document_path(str(primary), None) is None


### PR DESCRIPTION
## Summary

Every processed SEC filing now gets a public folder on the data CDN holding its portable representations — the dataset-form JSON-LD holon, the Project Tavi compiled model (PWD-2026-09-01) with its gaps sidecar, the primary document as filed, and a manifest naming what was written — and a new pipeline asset folds those into a per-filer catalog plus a corpus index beside them. This is the first half of `specs/shared-data/filing-artifacts.md`: public, immutable, per-filing artifacts that the app's SEC report view, the holon viewer and the coming company pages can all read without an API call, and a catalog that serves as the pages' index without a database.

## Changes

**Processor — the artifacts (`robosystems/adapters/sec/processors/`)**
- `artifacts.py` (new): `FilingArtifactWriter` writes `holon.jsonld`, `tavi.json`, `tavi.gaps.json`, the primary document and `manifest.json` under `{year}/{cik}/{accession}/`, the key family the externalized text blocks already use. Both projections come from xbrlkit's emitters over the model the processor already holds; there is no graph read and no second parse. The holon carries each externalized text-block fact's CDN URL as its value, the way the graph's Fact row does, so it stays about 8 MB on a large 10-K instead of 12. Every write is a whole object and the emitters are deterministic, so a reprocess rewrites the same bytes unless an emitter moved. A failure records into the manifest and never fails the filing.
- `xbrl_graph.py`: the writer is constructed beside the text-block externalizer (sharing its S3 client), and `process()` calls it after externalization on the full model, before any text-block skip. Reviewers: `_write_filing_artifacts` derives the externalized-fact map from the Fact frame's `value_type == "external"` rows.

**Pipeline — the catalog (`robosystems/adapters/sec/pipeline/`)**
- `catalog.py` (new): `sec_filing_catalog`, quarter-partitioned, folds the Entity, Report and ENTITY_HAS_REPORT parquet of every partition from `start_year` (2024) on, joins each filing's manifest, and regenerates `companies/{ticker}.json` for every filer with a filing in the run's partitions (all filers on `full_rebuild`) and `companies/index.json` always. Files are rewritten whole, never patched, so overlapping runs cannot corrupt one. Filers without a ticker are not listed; a filing that predates the artifacts is listed with no representations. Also writes `robots.txt` when missing. The pure fold functions are separate from the asset so they are unit-testable.
- `configs.py`: `SECFilingCatalogConfig`. `jobs.py`: `sec_filing_catalog_job` on a small Spot task. `sensors.py`: chained off staging by `sec_post_stage_index_sensor` beside the text index, and covered by `sec_index_retry_sensor`. `__init__.py`: registered.

**Configuration and storage**
- `config/env.py`, `adapters/sec/config.py`, `.env.example`: `SEC_FILING_ARTIFACTS_ENABLED` (default on; the writer is also inert without a public bucket).
- `config/storage/shared.py`: the artifact and catalog key helpers and names, documented in the storage README.
- `operations/aws/s3.py`: `upload_string`, `upload_bytes` and `upload_file` accept `cache_control` (artifacts a day, manifests and catalog files short).

**CDN (`cloudformation/s3.yaml`)**
- A `ResponseHeadersPolicy` adding `X-Robots-Tag: noindex`, attached through cache behaviors on `*.htm`, `*.html` and `*.txt`: the filed documents, the text-block fragments and the narrative extracts are served but never indexed (sec.gov's copy already ranks, and crawlers fetching ten-megabyte documents is the one real egress risk). The holon, the Tavi and the catalog carry no such header. Deploys with the next `s3` stack update.

**Docs**: pipeline README (process-time artifacts, the catalog stage, the nightly chain) and storage README (the public bucket layout).

## Breaking Changes

None. No API, GraphQL, operations-envelope or SDK-facing surface changes; the only new public surface is data on the CDN.

## Testing

- New unit tests: `tests/adapters/sec/processors/test_filing_artifacts.py` (the writer against a mock S3: keys, media types, cache headers, the manifest, URL substitution in the holon but not the Tavi, primary-document resolution including multi-document inline sets, failure recording, disabled/unplaceable cases) and `tests/adapters/sec/pipeline/test_catalog.py` (the fold: latest entity row per CIK, accession dedup, form filtering, company and index documents, viewer links, manifest reads). Sensor and component-count tests updated for the third post-stage job.
- `uv run pytest tests/adapters/sec tests/config tests/operations/aws`: 1313 passed. `just typecheck`: clean. `just lint` and `just format`: clean. `cfn-lint cloudformation/s3.yaml`: clean.
- End to end on the local stack (LocalStack): 3M's FY2024 10-K through the processor wrote the holon (8.0 MB, 102 text blocks referenced by URL), the Tavi (6.4 MB), the filed document (4.7 MB) and the manifest with the expected content types and cache headers; the catalog asset over the 26-filing local corpus wrote 24 filer files and the index, and `companies/mmm.json` lists the three representations, the viewer links and the latest 10-K.
- `just test-all` not run in full this session.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
