### PR TITLE
fix(reports): persist report facts at cents precision

### DIFF
--- a/robosystems/operations/roboledger/reports/statement_sets.py
+++ b/robosystems/operations/roboledger/reports/statement_sets.py
@@ -370,6 +370,11 @@ def _pre_create_report_fact_sets(
   session.flush()
 
 
+def to_cents_precision(value: float) -> float:
+  """A dollar amount rounded to cents — the ledger's own precision."""
+  return round(value, 2)
+
+
 def _stamp_facts_into_sets(
   session: Session,
   facts,
@@ -391,6 +396,15 @@ def _stamp_facts_into_sets(
   Fact row per owning structure, each pinned to that structure's
   FactSet. This is what lets the CF block's calc walker resolve
   NetIncome locally without cross-structure fact lookup.
+
+  Every value through here is dollars (the row is stamped ``unit="USD"``)
+  derived from the ledger's integer cents, so it is rounded to cents
+  before it is written. The pivot and the subtotal derivations add in
+  float, and a sum such as ``52585 + 5400.02`` lands on
+  ``57985.020000000004``; ``facts.value`` is ``double precision`` and
+  would keep that tail, and every published flavor prints the stored
+  double faithfully. Rounding here removes float noise, never real
+  precision — the ledger has none below a cent.
   """
   for fact in facts.facts:
     for structure_id in element_to_structures.get(fact.element_id, ()):
@@ -399,7 +413,7 @@ def _stamp_facts_into_sets(
         continue
       rf = Fact(
         element_id=fact.element_id,
-        value=fact.value,
+        value=to_cents_precision(fact.value),
         period_start=fact.period_start,
         period_end=fact.period_end,
         period_type=fact.period_type,

--- a/tests/operations/roboledger/reports/test_statement_sets.py
+++ b/tests/operations/roboledger/reports/test_statement_sets.py
@@ -19,8 +19,10 @@ from robosystems.models.extensions import Fact
 from robosystems.models.extensions.roboledger.fact_set import FactSet
 from robosystems.operations.roboledger.reports.statement_sets import (
   StatementStampError,
+  _stamp_facts_into_sets,
   retract_canonical_statement_sets,
   stamp_canonical_statement_sets,
+  to_cents_precision,
 )
 
 GRAPH_ID = "kg01234567890abcdef"
@@ -346,3 +348,42 @@ class TestRetractCanonicalSets:
     assert "factset_type = 'report'" in sql
     assert "report_id IS NULL" in sql
     assert "scenario_id IS NULL" in sql
+
+
+class TestStampRoundsToCents:
+  """Every value stamped through ``_stamp_facts_into_sets`` is dollars derived
+  from integer cents, so it persists at cents precision — the float tail a
+  subtotal picks up in the pivot (``52585 + 5400.02`` → ``57985.020000000004``)
+  never reaches ``facts.value`` and so never reaches a published file."""
+
+  def _stamp_one(self, value: float) -> float:
+    session = MagicMock()
+    fact = SimpleNamespace(
+      element_id="el_assets",
+      value=value,
+      period_start=date(2025, 12, 31),
+      period_end=date(2025, 12, 31),
+      period_type="instant",
+    )
+    _stamp_facts_into_sets(
+      session,
+      SimpleNamespace(facts=[fact]),
+      "ent_1",
+      {"el_assets": ["struct_bs"]},
+      {"struct_bs": "fs_bs"},
+    )
+    (row,) = [call.args[0] for call in session.add.call_args_list]
+    assert row.unit == "USD"
+    return row.value
+
+  def test_a_float_summed_subtotal_persists_as_cents(self):
+    assert self._stamp_one(52585 + 5400.02) == 57985.02
+    assert self._stamp_one(0.1 + 0.2) == 0.3
+
+  def test_negative_and_whole_amounts_are_untouched(self):
+    assert self._stamp_one(-7385.02) == -7385.02
+    assert self._stamp_one(148_000_000.0) == 148_000_000.0
+
+  def test_helper_is_the_ledgers_precision(self):
+    assert to_cents_precision(6085.000000000004) == 6085.0
+    assert to_cents_precision(1.005) in (1.0, 1.01)  # binary rounding, never a tail


### PR DESCRIPTION
## Summary

Report facts now persist at cents precision. The ledger stores integer cents; the report engine converts them to dollars and adds subtotals in float, and `facts.value` is `double precision`, so a subtotal such as `52585 + 5400.02` was stored as `57985.020000000004` and every published flavor — JSON-LD, holon, Tavi, XBRL 2.1 — printed it faithfully. In the demo tenant 12 of 335 numeric facts carried a tail, all subtotals (Assets, Net Income, Stockholders' Equity, operating cash flow); the leaves were clean. Found in the first Tavi off a ledger report (#1361); traced to the database rather than the serialization layer, which was printing what it was given.

## Changes

- `operations/roboledger/reports/statement_sets.py` — `to_cents_precision(value)` and its use in `_stamp_facts_into_sets`, the one choke point both report publication and canonical stamping write rows through. Every value there is dollars (the row is stamped `unit="USD"`), so rounding to cents removes float noise and no real precision: the ledger has none below a cent. The published files keep claiming `decimals="INF"` (the bundle producer hardcodes it), while the row's `decimals` stays NULL and the graph coalesces that to `-2` — a pre-existing three-way disagreement about precision metadata, filed separately; this PR is about `value`.
- `tests/operations/roboledger/reports/test_statement_sets.py` — a float-summed subtotal persists as `57985.02` (and `0.1 + 0.2` as `0.3`); negative and whole amounts are untouched; the helper's contract.

No column change, no migration, no encoder change. Existing reports keep their tails until regenerated.

## Breaking Changes

None.

## Testing

`tests/operations/roboledger` green (1046 passed); ruff, format and basedpyright clean on the changed files. Then on the restarted local stack, `just demo-roboledger` regenerated the demo's FY2025 report and re-downloaded all four flavors: the new report's 41 numeric facts have zero tails in the database, the JSON-LD, holon and Tavi contain no float noise, the totals read `57985.02` / `7385.02` / `57185.02`, SHACL conforms and Arelle validates. Full `just test` runs in CI.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBKj1VsfBpKsFY7PPcrCFu
