### PR TITLE
chore(deps): xbrlkit 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "dagster-postgres>=0.29.15,<1.0",
     "dagster-aws>=0.29.15,<1.0",
     # XBRL Toolkit
-    "xbrlkit>=0.4.2",
+    "xbrlkit>=0.6.0",
     # Tenant-authored notes are markdown; the Tavi projection writes them as
     # HTML text blocks (operations/serialization/model.py).
     "markdown-it-py>=3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3815,7 +3815,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.48.0,<1.0" },
     { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.21.0,<1.0" },
     { name = "webauthn", specifier = ">=2.7.0,<3.0" },
-    { name = "xbrlkit", specifier = ">=0.4.2" },
+    { name = "xbrlkit", specifier = ">=0.6.0" },
     { name = "zstandard", specifier = ">=0.23,<1" },
 ]
 provides-extras = ["dev"]
@@ -4642,7 +4642,7 @@ wheels = [
 
 [[package]]
 name = "xbrlkit"
-version = "0.4.2"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arelle-release" },
@@ -4654,9 +4654,9 @@ dependencies = [
     { name = "regex" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/b8/0b8f9a92ca3e62961631c527855cec412dec19ea27002cba33e722abf106/xbrlkit-0.4.2.tar.gz", hash = "sha256:916ff6ab5224343af6aa58b552d3d4581808bd2982b25826f02328b8fca1eb29", size = 1897632, upload-time = "2026-09-06T19:55:07.431Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/75/1aa3c71b258f0e5560b7a191fc1c2644139d86217b20fed1aa6459cdf177/xbrlkit-0.6.0.tar.gz", hash = "sha256:995efb741de752d54e0623e645e86bf7abab9271b8a03f5da2080849f226b0e6", size = 1968198, upload-time = "2026-09-08T03:28:41.973Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/63/8f6eecf5bb4ac60efe960c4ee81ab59f1f9178cc093415821bf8b6cd5ba2/xbrlkit-0.4.2-py3-none-any.whl", hash = "sha256:40244ff9294eedbf7e44576d84eebd3ce0ce115937192a1313185ad0a2a49f7c", size = 1902516, upload-time = "2026-09-06T19:55:05.535Z" },
+    { url = "https://files.pythonhosted.org/packages/31/42/8309bd2c1df6f1ba93992de5b2efbfceaadbe8b7e51ed546b14644484d26/xbrlkit-0.6.0-py3-none-any.whl", hash = "sha256:cbf8253232fa9c9e6a541753a6bc2fd2418c9d8fd25a83e5091988da7844f8f2", size = 1959598, upload-time = "2026-09-08T03:28:39.67Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bumps the xbrlkit floor from `>=0.4.2` to `>=0.6.0` and refreshes the lock. Two files, no source changes.

0.5.0 and 0.6.0 add the `serve` MCP server, a `filings_org` LEI-based loader for ESEF and the national regimes, and EDGAR's pre-2001 unsplit filings. Nothing in this repo calls any of it yet — the bump keeps the floor at the current release rather than adopting new surface.

## Why it's safe

This repo uses xbrlkit deep in the SEC pipeline, not just for Tavi — `xbrlkit.schema` supplies the graph DDL and `serialize.lpg` the processor version — so the bump was checked against exactly those modules:

| Module | v0.4.2 → v0.6.0 |
| --- | --- |
| `serialize/` (tavi, holon, lpg) | **0 diff lines** |
| `schema.py` (graph DDL) | **0 diff lines** |
| `namespaces.py` | **0 diff lines** |
| `XBRL_GRAPH_PROCESSOR_VERSION` | unchanged at `1.0.0` |
| `model.py` | +5 lines — one optional `document_name` field |
| `edgar/__init__.py` | `__all__` reshuffled and grown to 16; `EdgarClient` / `EftsClient` / `EftsHit` all retained |

The release is 4341 insertions against 7 deletions, and all 7 deletions are docstrings and that `__all__` reshuffle. Because the DDL and processor version are unchanged, **no SEC reprocessing or re-materialization is implied**.

The lock diff touches xbrlkit alone — no transitive churn, since the `serve` dependencies sit behind the optional `[mcp]` extra.

## Verification

- Full unit suite on 0.6.0: **14,208 passed, 42 skipped**.
- Rebuilt the local stack on a 0.6.0 image and re-ran the roboledger demo. Its emitted Tavi has **identical fact content and an identical model body** to the sample regenerated on 0.4.2 in #1363. The committed `sample_output/` sets stand as-is and need no regeneration.

## One thing noticed, not fixed here

Comparing the two runs surfaced a pre-existing nondeterminism: the Tavi `facts` array comes out in a different order run-to-run, and `name` is positional (`rpt:f-0`, `rpt:f-1`, …), so the same data lands under different fact names each time. Content compares equal once ordering is normalized.

This is not caused by the bump — `serialize/` is byte-identical across it, so the ordering originates upstream of the emitter. The practical cost is that every sample regeneration churns the whole facts array in the diff even when nothing has changed. Worth a look if `rpt:f-N` is ever treated as a stable identifier by a consumer; filed here rather than fixed since it is out of scope for a dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gBgndhHN1pg24apjVraGH