### PR TITLE
Bump xbrlkit to 0.7.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "dagster-postgres>=0.29.15,<1.0",
     "dagster-aws>=0.29.15,<1.0",
     # XBRL Toolkit
-    "xbrlkit>=0.6.0",
+    "xbrlkit>=0.7.2",
     # Tenant-authored notes are markdown; the Tavi projection writes them as
     # HTML text blocks (operations/serialization/model.py).
     "markdown-it-py>=3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3815,7 +3815,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.48.0,<1.0" },
     { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.21.0,<1.0" },
     { name = "webauthn", specifier = ">=2.7.0,<3.0" },
-    { name = "xbrlkit", specifier = ">=0.6.0" },
+    { name = "xbrlkit", specifier = ">=0.7.2" },
     { name = "zstandard", specifier = ">=0.23,<1" },
 ]
 provides-extras = ["dev"]
@@ -4642,7 +4642,7 @@ wheels = [
 
 [[package]]
 name = "xbrlkit"
-version = "0.6.0"
+version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arelle-release" },
@@ -4654,9 +4654,9 @@ dependencies = [
     { name = "regex" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/75/1aa3c71b258f0e5560b7a191fc1c2644139d86217b20fed1aa6459cdf177/xbrlkit-0.6.0.tar.gz", hash = "sha256:995efb741de752d54e0623e645e86bf7abab9271b8a03f5da2080849f226b0e6", size = 1968198, upload-time = "2026-09-08T03:28:41.973Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/16/541516f7954bbc9b27c6f6aed2b9e46f2c6b075c2f9c7a92488e3a79195c/xbrlkit-0.7.2.tar.gz", hash = "sha256:4514903a1d8193eeef8d46b5d49aecb81f1ade72ddc4170b9f1c6e497ce9f7dd", size = 1998149, upload-time = "2026-09-08T05:49:48.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/42/8309bd2c1df6f1ba93992de5b2efbfceaadbe8b7e51ed546b14644484d26/xbrlkit-0.6.0-py3-none-any.whl", hash = "sha256:cbf8253232fa9c9e6a541753a6bc2fd2418c9d8fd25a83e5091988da7844f8f2", size = 1959598, upload-time = "2026-09-08T03:28:39.67Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/31/be3846f21f2b29e6ad15f852cc2a33dfc74f723a1859a105d05a37d26c39/xbrlkit-0.7.2-py3-none-any.whl", hash = "sha256:6c7e8f43f780f1ae3ae9ff188e1095b3d3e0dbb5e45f8203507f0b49ff013df4", size = 1993295, upload-time = "2026-09-08T05:49:46.984Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
0.7.0 added the importers — a Tavi compiled model or a holon read back into `XbrlModel`, with no Arelle — and made the holon lossless against that model. 0.7.1 and 0.7.2 followed with fixes found by running real reports through both directions (including a RoboLedger report whose Tavi and holon disagreed about the same entity).

## What changes here

**`FilingMeta.is_inline_xbrl` is now `bool | None`** — no effect on this pipeline. `xbrl_graph.py:649` always sets it from EDGAR's `isInlineXBRL`, so the Report row and its parquet column are unchanged. It's `None` only for a model that came from an importer, which genuinely cannot know.

**`to_holon(XbrlModel)` writes a different document.** Each report now binds the namespaces its own concepts declare, so:

- a filer's extension concepts compact to `ba:Foo` instead of spelling out `https://robosystems.ai/concept/ba:Foo`
- a us-gaap concept resolves to `http://fasb.org/us-gaap/2024-01-31#Revenues` rather than a year-less IRI FASB never minted
- every label role is present, not just the preferred one
- `dataType`, `baseType`, `nillable`, `language`, `isNil`, `periodEndDate` are new
- the file comes out **~10% larger** — the compaction saves bytes, the full label palette costs more than it saves (Boeing 9,995 → 11,009 KiB, NVIDIA 4,917 → 5,455 KiB, same filing on 0.6.0 vs 0.7.2)

Consumers key on `rs:internalId` — the holon viewer's `describeReport.ts` and `xbrlkit.query` both do — so nothing *reads* differently. But `artifacts.py` publishes `{year}/{cik}/{accession}/holon.jsonld` to the CDN, so those should be regenerated once rather than leaving two shapes in place. Not part of this PR.

**The `StatementBundle` holon path is untouched** — its URI minting kept the old prefix table as the default, so RoboLedger's live-report holons are byte-identical.

## Verification

- 2,513 tests pass across `operations/serialization`, `adapters/sec`, `schemas` and `operations/roboledger` — including `test_xbrlkit_parity.py` (the graph DDL agreement) and the cross-encoder equivalence tests
- `just test-code` clean
- the lock moves xbrlkit alone: `0.6.0 -> 0.7.2`, no other churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EiGTpXmxwZjxzaRoVs4VxB
