### PR TITLE
Bump xbrlkit to 0.7.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "dagster-postgres>=0.29.15,<1.0",
     "dagster-aws>=0.29.15,<1.0",
     # XBRL Toolkit
-    "xbrlkit>=0.7.2",
+    "xbrlkit>=0.7.3",
     # Tenant-authored notes are markdown; the Tavi projection writes them as
     # HTML text blocks (operations/serialization/model.py).
     "markdown-it-py>=3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3815,7 +3815,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.48.0,<1.0" },
     { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.21.0,<1.0" },
     { name = "webauthn", specifier = ">=2.7.0,<3.0" },
-    { name = "xbrlkit", specifier = ">=0.7.2" },
+    { name = "xbrlkit", specifier = ">=0.7.3" },
     { name = "zstandard", specifier = ">=0.23,<1" },
 ]
 provides-extras = ["dev"]
@@ -4642,7 +4642,7 @@ wheels = [
 
 [[package]]
 name = "xbrlkit"
-version = "0.7.2"
+version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arelle-release" },
@@ -4654,9 +4654,9 @@ dependencies = [
     { name = "regex" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/16/541516f7954bbc9b27c6f6aed2b9e46f2c6b075c2f9c7a92488e3a79195c/xbrlkit-0.7.2.tar.gz", hash = "sha256:4514903a1d8193eeef8d46b5d49aecb81f1ade72ddc4170b9f1c6e497ce9f7dd", size = 1998149, upload-time = "2026-09-08T05:49:48.773Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/80/361415e701ffad337e800b071cb2da4a78f1d24f6152362025031d263a50/xbrlkit-0.7.3.tar.gz", hash = "sha256:a146aa0115833931cf8233a88f394cdd3ead3acf71480f2e681f0f73851a7fb6", size = 1999229, upload-time = "2026-09-08T06:31:20.759Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/31/be3846f21f2b29e6ad15f852cc2a33dfc74f723a1859a105d05a37d26c39/xbrlkit-0.7.2-py3-none-any.whl", hash = "sha256:6c7e8f43f780f1ae3ae9ff188e1095b3d3e0dbb5e45f8203507f0b49ff013df4", size = 1993295, upload-time = "2026-09-08T05:49:46.984Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/08/370439a6b6193b9e05bde0cbb02430d5a2b90dec18487dee8d62df8a75c1/xbrlkit-0.7.3-py3-none-any.whl", hash = "sha256:7cf2bc505998ac4bfd57e3ea3ae0b949cda4c676cb887a588ab943835697715f", size = 1993582, upload-time = "2026-09-08T06:31:19.031Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
0.7.3 fixes a term collision in the holon's canonical context. 0.7.0 added a second `"label"` key, which silently shadowed the `"label": "rdfs:label"` already there — so every holon xbrlkit wrote in 0.7.0–0.7.2 bound `label` to `rs:label` instead. This platform's own holon context binds it to `rdfs:label`, so the two disagreed about one term across two documents that both call themselves holons.

## Why the floor moves, not just the lock

`>=0.7.2` would still resolve a version that writes the wrong binding, and the SEC artifact path (`adapters/sec/processors/artifacts.py`) goes through xbrlkit's holon writer. **0.7.3 is the minimum that produces correct output**, not merely the newest — so it belongs in `pyproject.toml`, not only in the lock.

## Nothing changes today

- RoboLedger's holon comes from the platform's **own** encoder (`operations/serialization/rdf/`), untouched by any xbrlkit version
- its Tavi comes from an emitter byte-identical since 0.6.0
- the SEC download schedule is `DefaultScheduleStatus.STOPPED`, so no artifact is being written on either version

This is the prerequisite for regenerating the SEC holons on the CDN, which waits on the serialization waist's phase 3 so the vocabulary is published once rather than twice.

## Verification

- 2,513 tests pass across `operations/serialization`, `adapters/sec`, `schemas` and `operations/roboledger`, including `test_xbrlkit_parity.py`
- `just test-code` clean
- the lock moves xbrlkit alone: `0.7.2 -> 0.7.3`, no other churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EiGTpXmxwZjxzaRoVs4VxB