### PR TITLE
fix(graph): exempt deleted rows from the orphan-registration sweep

### DIFF
--- a/robosystems/operations/graph/infrastructure.py
+++ b/robosystems/operations/graph/infrastructure.py
@@ -407,10 +407,13 @@ class InstanceMonitor:
     when the instance reappears. Reconciling from on-disk truth is the
     follow-up, not this sweep.
 
-    Shared repositories are exempt from the orphan check — their rows are
-    bookkeeping, not routing, and their master is deliberately parked to zero
-    between ingestion runs. An exempt row that still carries a stamp from
-    before this rule is cleared on the next sweep.
+    Shared repositories and rows already marked ``deleted`` are exempt from
+    the orphan check — neither is routing. A shared repository's master is
+    deliberately parked to zero between ingestion runs; a deleted graph's
+    instance is recycled long before the row ages out, so counting it means
+    every fleet replacement pages for ``STALE_GRAPH_DAYS`` and then heals
+    itself. An exempt row that still carries a stamp from before these rules
+    is cleared on the next sweep.
     """
     logger.info("Starting graph registry cleanup")
 
@@ -481,9 +484,16 @@ class InstanceMonitor:
         # legitimately absent most of the day; counting that as drift pages
         # every night for a healthy fleet. Same predicate the router uses, so
         # the two can never disagree about which graphs this applies to.
+        # A row already marked deleted is not routing either: it is waiting
+        # out ``STALE_GRAPH_DAYS`` above, and the instance it names was
+        # released with the graph and recycled by the ASG well inside that
+        # window. Counting it turns every fleet replacement into a page that
+        # clears itself a week later, on an alarm whose whole meaning is
+        # "a live graph's routing is stale".
         instance_missing = (
           bool(instance_id)
           and instance_id not in valid_instances
+          and status != "deleted"
           and not is_shared_repository_or_subgraph(graph_id)
         )
         already_marked = item.get("instance_missing_since") is not None

--- a/tests/operations/graph/test_infrastructure.py
+++ b/tests/operations/graph/test_infrastructure.py
@@ -554,6 +554,95 @@ class TestCleanupStaleGraphs:
     assert metric["MetricData"][0]["Value"] == 1
 
   @pytest.mark.unit
+  def test_recently_deleted_graph_is_not_orphaned(self, monitor):
+    """A deleted row inside the retention window is not routing: its instance
+    was released with the graph and recycled by the ASG. Counting it made
+    every fleet replacement page for a week and then heal itself."""
+    graph_table = _make_dynamo_table(
+      items=[
+        {
+          "graph_id": "kg_deleted",
+          "status": "deleted",
+          "deleted_at": (datetime.now(UTC) - timedelta(days=2)).isoformat(),
+          "instance_id": "i-recycled000000001",
+        },
+      ]
+    )
+    instance_table = _make_dynamo_table(items=[])
+    monitor._dynamodb.Table.side_effect = lambda name: (
+      graph_table if name == "test-graph" else instance_table
+    )
+
+    result = monitor.cleanup_stale_graphs()
+
+    assert result.orphaned_count == 0
+    assert result.removed_count == 0
+    graph_table.update_item.assert_not_called()
+    graph_table.delete_item.assert_not_called()
+    metric = monitor._cloudwatch.put_metric_data.call_args.kwargs
+    assert metric["MetricData"][0]["Value"] == 0
+
+  @pytest.mark.unit
+  def test_deleted_graph_marker_from_before_the_exemption_is_cleared(self, monitor):
+    """A row stamped while it was still live, then deleted, drops the marker
+    rather than carrying it until the row ages out."""
+    graph_table = _make_dynamo_table(
+      items=[
+        {
+          "graph_id": "kg_deleted",
+          "status": "deleted",
+          "deleted_at": (datetime.now(UTC) - timedelta(days=2)).isoformat(),
+          "instance_id": "i-recycled000000001",
+          "instance_missing_since": "2026-09-02T03:01:26+00:00",
+        },
+      ]
+    )
+    instance_table = _make_dynamo_table(items=[])
+    monitor._dynamodb.Table.side_effect = lambda name: (
+      graph_table if name == "test-graph" else instance_table
+    )
+
+    result = monitor.cleanup_stale_graphs()
+
+    assert result.orphaned_count == 0
+    assert result.updated_count == 1
+    update = graph_table.update_item.call_args.kwargs
+    assert update["Key"] == {"graph_id": "kg_deleted"}
+    assert update["UpdateExpression"] == "REMOVE instance_missing_since"
+
+  @pytest.mark.unit
+  def test_live_graph_is_still_orphaned_alongside_a_deleted_row(self, monitor):
+    """The exemption is scoped to deleted rows — a live graph swept at the
+    same time is still marked and counted."""
+    graph_table = _make_dynamo_table(
+      items=[
+        {
+          "graph_id": "kg_deleted",
+          "status": "deleted",
+          "deleted_at": (datetime.now(UTC) - timedelta(days=2)).isoformat(),
+          "instance_id": "i-recycled000000001",
+        },
+        {
+          "graph_id": "kg_orphan",
+          "status": "active",
+          "instance_id": "i-doesnotexist00001",
+        },
+      ]
+    )
+    instance_table = _make_dynamo_table(items=[])
+    monitor._dynamodb.Table.side_effect = lambda name: (
+      graph_table if name == "test-graph" else instance_table
+    )
+
+    result = monitor.cleanup_stale_graphs()
+
+    assert result.orphaned_count == 1
+    update = graph_table.update_item.call_args.kwargs
+    assert update["Key"] == {"graph_id": "kg_orphan"}
+    metric = monitor._cloudwatch.put_metric_data.call_args.kwargs
+    assert metric["MetricData"][0]["Value"] == 1
+
+  @pytest.mark.unit
   def test_exception_sets_error_message(self, monitor):
     """Top-level exception is captured in error_message."""
     monitor._dynamodb.Table.side_effect = Exception("scan failed")


### PR DESCRIPTION
## Summary

The `OrphanedGraphRegistrations` alarm has been firing on graph-registry rows for graphs that no longer exist. `cleanup_stale_graphs` removes a deleted row only once it is older than `STALE_GRAPH_DAYS`; a deleted row still inside that window fell through to the orphan check, which had no `status` predicate, and was stamped and counted as soon as the instance it named left the instance registry.

That instance is always about to leave — a deleted graph's writer is released with the graph and recycled by the ASG well inside seven days — so every rolling fleet replacement that followed a deletion raised the alarm for a week and then healed itself. This scopes the orphan check to rows that are actually routing.

## Changes

**`robosystems/operations/graph/infrastructure.py`**

- `cleanup_stale_graphs`: add `status != "deleted"` to the `instance_missing` predicate, alongside the existing shared-repository exemption. Both exemptions say the same thing — the row is not a routing pointer — so they sit together and are documented together.
- Docstring and inline comment updated to record why, including the failure mode the predicate prevents (a page that clears itself after `STALE_GRAPH_DAYS`).
- The clear path needed no change and now covers the other half for free: a row stamped while it was live and subsequently deleted drops its `instance_missing_since` marker on the next sweep, rather than carrying it until the row ages out.

**`tests/operations/graph/test_infrastructure.py`** — three cases in `TestCleanupStaleGraphs`, mirroring the shared-repository exemption trio that already exists:

- `test_recently_deleted_graph_is_not_orphaned` — a deleted row whose instance is absent is neither counted nor stamped, and the published metric is 0.
- `test_deleted_graph_marker_from_before_the_exemption_is_cleared` — a marker left from a sweep that predates this rule is removed.
- `test_live_graph_is_still_orphaned_alongside_a_deleted_row` — the exemption is scoped; an active graph swept at the same time is still marked and counted.

Worth a close look: the first test is a negative control. Verified that it fails without the predicate, and that when it fails it emits the same warning line the production sweep did — so it reproduces the defect rather than asserting around it.

No behaviour change to routing, allocation, or any request path. `cleanup_stale_graphs` runs only from the daily `instance_registry_cleanup_job` and the weekly `full_instance_maintenance_job`; what changes is which rows those sweeps count and stamp.

## Breaking Changes

None. No API surface is touched — no GraphQL schema, operations envelope, or REST shape changes — so there is no client-SDK impact in either tier and no regen is required.

## Testing

- `just test-code` — clean (ruff, format, basedpyright, cf-lint).
- `uv run pytest tests/operations/graph/test_infrastructure.py` — 33 passed.
- `uv run pytest tests/operations/graph tests/dagster` — 992 passed.
- Negative control: reverted the predicate, confirmed `test_recently_deleted_graph_is_not_orphaned` fails and emits the production warning line, restored.

Full `just test-all` was not run; the unit suite above covers the changed module and its callers, and CI runs the full gate.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBkpeEv3gBUzL812xqfXnS
