### PR TITLE
refactor(graph): drop the HNSW reader from the vector/search route

### DIFF
--- a/robosystems/graph_api/client/client.py
+++ b/robosystems/graph_api/client/client.py
@@ -910,6 +910,9 @@ class GraphClient(BaseGraphClient):
     Serves from master or replica instances. The index must exist already —
     build it with :meth:`vector_build`. Each result carries the selected
     columns plus a ``distance``; ``select=None`` returns all columns.
+
+    LanceDB only. An HNSW index built by :meth:`build_vector_index` is
+    searched in Cypher with ``CALL QUERY_VECTOR_INDEX(...)``, not here.
     """
     json_data: dict[str, Any] = {"embedding": embedding, "limit": limit}
     if select is not None:

--- a/robosystems/graph_api/routers/databases/vector_search.py
+++ b/robosystems/graph_api/routers/databases/vector_search.py
@@ -5,7 +5,8 @@ Two backends via the `backend` field:
 
   - **hnsw** — the live path. LadybugDB-native HNSW index on a materialized
     table. Built here (the materialize path calls build with backend='hnsw')
-    but *searched in Cypher* via CALL QUERY_VECTOR_INDEX, not the /search route.
+    but *searched in Cypher* via CALL QUERY_VECTOR_INDEX, not the /search
+    route, which rejects backend='hnsw' and says so.
 
   - **lance** — no live consumer today. LanceDB IVF-PQ built from a DuckDB
     staging query, plus a tar.gz export. It is the IVF-PQ foundation for the
@@ -20,7 +21,7 @@ Endpoints:
     Build vector index (lance: from DuckDB query, hnsw: on materialized table)
 
   POST /databases/{graph_id}/tables/{table_name}/vector/search
-    Query by embedding similarity
+    Query by embedding similarity (lance only)
 
   POST /databases/{graph_id}/tables/{table_name}/vector/export
     Package lance index as tar.gz for S3 publish (lance only)
@@ -111,7 +112,8 @@ class VectorSearchRequest(BaseModel):
 
   backend: Literal["lance", "hnsw"] = Field(
     default="lance",
-    description="Vector backend to search.",
+    description="Vector backend to search. Only 'lance' is searchable here; "
+    "'hnsw' is rejected with a pointer to CALL QUERY_VECTOR_INDEX.",
   )
   embedding: list[float] = Field(
     ...,
@@ -127,10 +129,6 @@ class VectorSearchRequest(BaseModel):
   select: list[str] | None = Field(
     default=None,
     description="Columns to include in results. If omitted, returns all non-vector columns.",
-  )
-  column: str = Field(
-    default="embedding",
-    description="Embedding column name (hnsw only).",
   )
 
   class Config:
@@ -274,75 +272,6 @@ def _build_hnsw_index(
     "table_name": table_name,
     "row_count": row_count,
     "duration_ms": duration_ms,
-  }
-
-
-def _search_hnsw_index(
-  graph_id: str,
-  table_name: str,
-  embedding: list[float],
-  limit: int,
-  column: str = "embedding",
-  select_columns: list[str] | None = None,
-) -> dict:
-  """Search HNSW vector index via LadybugDB QUERY_VECTOR_INDEX."""
-  _validate_identifier(table_name, "table_name")
-  if select_columns:
-    for col in select_columns:
-      _validate_identifier(col, "column")
-
-  ladybug_service = _get_ladybug_service()
-  index_name = f"{table_name.lower()}_vec_index"
-  start = time.time()
-
-  vec_str = str(embedding)
-
-  if select_columns:
-    return_parts = [f"node.{col} AS {col}" for col in select_columns]
-  else:
-    return_parts = ["node"]
-  return_parts.append("distance")
-  return_clause = ", ".join(return_parts)
-
-  # Over-fetch then limit (HNSW returns approximate results)
-  fetch_limit = min(limit * 2, 200)
-
-  query = (
-    f"CALL QUERY_VECTOR_INDEX('{table_name}', '{index_name}', {vec_str}, {fetch_limit}) "
-    f"WITH node, distance "
-    f"RETURN {return_clause} "
-    f"ORDER BY distance LIMIT {limit}"
-  )
-
-  with ladybug_service.db_manager.connection_pool.get_connection(graph_id) as conn:
-    try:
-      conn.execute("LOAD EXTENSION vector")
-    except Exception:
-      conn.execute("INSTALL vector")
-      conn.execute("LOAD EXTENSION vector")
-
-    result = conn.execute(query)
-
-    results = []
-    if hasattr(result, "get_as_list"):
-      rows = result.get_as_list()
-      if select_columns:
-        col_names = [*select_columns, "distance"]
-        for row in rows:
-          results.append(dict(zip(col_names, row, strict=False)))
-      else:
-        for row in rows:
-          if isinstance(row[0], dict):
-            entry = {**row[0], "distance": row[1]}
-          else:
-            entry = {"node": row[0], "distance": row[1]}
-          results.append(entry)
-
-  execution_time_ms = (time.time() - start) * 1000
-  return {
-    "results": results,
-    "total": len(results),
-    "execution_time_ms": execution_time_ms,
   }
 
 
@@ -542,45 +471,30 @@ async def vector_build(
 @router.post(
   "/{graph_id}/tables/{table_name}/vector/search",
   response_model=VectorSearchResponse,
-  summary="Search vector index by embedding similarity",
+  summary="Search LanceDB vector index by embedding similarity",
 )
 async def vector_search(
   graph_id: str,
   table_name: str,
   request: VectorSearchRequest,
 ) -> VectorSearchResponse:
-  """Search for similar rows by embedding vector.
+  """Search a LanceDB IVF-PQ index for similar rows (~5ms latency).
 
-  With backend='lance': queries LanceDB IVF-PQ index (~5ms latency).
-  With backend='hnsw': queries LadybugDB HNSW index via QUERY_VECTOR_INDEX.
+  HNSW indexes are not searchable here. They live inside the graph, so they
+  are queried in Cypher — ``CALL QUERY_VECTOR_INDEX(...)`` against the
+  ``/query`` endpoint — which composes with the rest of the traversal
+  instead of returning rows over a second, parallel surface.
   """
   if request.backend == "hnsw":
-    try:
-      result = await asyncio.to_thread(
-        _search_hnsw_index,
-        graph_id=graph_id,
-        table_name=table_name,
-        embedding=request.embedding,
-        limit=request.limit,
-        column=request.column,
-        select_columns=request.select,
-      )
-    except Exception as e:
-      if "doesn't have an index" in str(e) or "not found" in str(e).lower():
-        raise HTTPException(
-          status_code=status.HTTP_404_NOT_FOUND,
-          detail=f"No HNSW index found for {table_name}",
-        ) from e
-      logger.error(f"HNSW vector search failed: {e}", exc_info=True)
-      raise HTTPException(
-        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        detail=f"Vector search failed: {e}",
-      ) from e
-
-    return VectorSearchResponse(
-      results=result["results"],
-      total=result["total"],
-      execution_time_ms=result["execution_time_ms"],
+    index_name = f"{table_name.lower()}_vec_index"
+    raise HTTPException(
+      status_code=status.HTTP_400_BAD_REQUEST,
+      detail=(
+        "HNSW indexes are searched in Cypher, not over this route. Send "
+        f"CALL QUERY_VECTOR_INDEX('{table_name}', '{index_name}', $embedding, $k) "
+        "WITH node, distance RETURN node, distance ORDER BY distance "
+        f"to POST /databases/{graph_id}/query."
+      ),
     )
 
   # Lance backend

--- a/tests/graph_api/routers/databases/test_vector_hnsw.py
+++ b/tests/graph_api/routers/databases/test_vector_hnsw.py
@@ -4,17 +4,21 @@ The LanceDB-backed endpoints are covered in `test_vector_search.py`; this
 file covers the LadybugDB/HNSW path, which interpolates table and column
 names straight into Cypher and therefore leans entirely on
 `_validate_identifier` to stay safe.
+
+Only the build half of that path lives here. HNSW indexes are searched in
+Cypher via CALL QUERY_VECTOR_INDEX, so the search route refuses them.
 """
 
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, status
+from fastapi.testclient import TestClient
 
+from robosystems.graph_api.app import create_app
 from robosystems.graph_api.routers.databases.vector_search import (
   _build_hnsw_index,
   _require_writer,
-  _search_hnsw_index,
   _validate_identifier,
 )
 
@@ -26,13 +30,6 @@ def _service_with(conn):
   service.db_manager.connection_pool.get_connection.return_value.__enter__.return_value = conn
   service.db_manager.rebuild_vector_index.return_value = True
   return service
-
-
-def _vector_query(conn):
-  """The QUERY_VECTOR_INDEX statement the search issued."""
-  return next(
-    c.args[0] for c in conn.execute.call_args_list if "QUERY_VECTOR_INDEX" in c.args[0]
-  )
 
 
 @pytest.mark.unit
@@ -157,115 +154,63 @@ class TestBuildHnswIndex:
 
 
 @pytest.mark.unit
-class TestSearchHnswIndex:
-  def _conn_returning(self, rows):
-    conn = MagicMock()
-    result = MagicMock()
-    result.get_as_list.return_value = rows
-    conn.execute.return_value = result
-    return conn
+class TestSearchRejectsHnsw:
+  """HNSW indexes live inside the graph and are searched in Cypher.
 
-  def test_maps_selected_columns_onto_results(self):
-    conn = self._conn_returning([["f1", "Revenue", 0.12], ["f2", "Cost", 0.30]])
-    service = _service_with(conn)
+  This route used to carry a second, parallel HNSW reader that silently
+  returned zero rows: it read results via ``get_as_list()``, a method the
+  engine does not have, behind a ``hasattr`` guard with no fallback. Nothing
+  called it — the client method never sends ``backend`` — so every search
+  answered 200 with an empty list. The reader is gone; the route now says
+  where to go instead.
+  """
 
-    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
-      out = _search_hnsw_index(
-        "kg1", "Fact", [0.1, 0.2], limit=2, select_columns=["identifier", "label"]
+  @pytest.fixture
+  def client(self, monkeypatch):
+    monkeypatch.setenv("GRAPH_BACKEND_TYPE", "ladybug")
+    return TestClient(create_app())
+
+  def test_rejects_hnsw_backend_with_400(self, client):
+    response = client.post(
+      "/databases/kg1/tables/Fact/vector/search",
+      json={"backend": "hnsw", "embedding": [0.1] * 384, "limit": 10},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+  def test_names_the_cypher_call_that_replaces_it(self, client):
+    """A caller who lands here needs the working query, not just a refusal."""
+    response = client.post(
+      "/databases/kg1/tables/FactSet/vector/search",
+      json={"backend": "hnsw", "embedding": [0.1] * 384},
+    )
+
+    detail = response.json()["detail"]
+    assert "QUERY_VECTOR_INDEX" in detail
+    assert "'FactSet', 'factset_vec_index'" in detail
+    assert "/databases/kg1/query" in detail
+
+  def test_never_silently_returns_an_empty_result_set(self, client):
+    """The regression this replaces: 200 OK with zero rows and no error."""
+    response = client.post(
+      "/databases/kg1/tables/Fact/vector/search",
+      json={"backend": "hnsw", "embedding": [0.1] * 384},
+    )
+
+    assert response.status_code != status.HTTP_200_OK
+    assert "results" not in response.json()
+
+  def test_lance_backend_is_still_served_here(self, client):
+    with patch(f"{MODULE}._get_lance_manager") as mock_manager:
+      mock_manager.return_value.search.return_value = {
+        "results": [{"id": "d1", "distance": 0.1}],
+        "total": 1,
+        "execution_time_ms": 4.5,
+      }
+      response = client.post(
+        "/databases/kg1/tables/Fact/vector/search",
+        json={"backend": "lance", "embedding": [0.1] * 384},
       )
 
-    assert out["total"] == 2
-    assert out["results"][0] == {
-      "identifier": "f1",
-      "label": "Revenue",
-      "distance": 0.12,
-    }
-
-  def test_flattens_node_dicts_when_no_columns_selected(self):
-    conn = self._conn_returning([[{"identifier": "f1", "value": 10}, 0.12]])
-    service = _service_with(conn)
-
-    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
-      out = _search_hnsw_index("kg1", "Fact", [0.1], limit=5)
-
-    assert out["results"][0] == {"identifier": "f1", "value": 10, "distance": 0.12}
-
-  def test_keeps_scalar_nodes_under_a_node_key(self):
-    conn = self._conn_returning([["opaque", 0.5]])
-    service = _service_with(conn)
-
-    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
-      out = _search_hnsw_index("kg1", "Fact", [0.1], limit=5)
-
-    assert out["results"][0] == {"node": "opaque", "distance": 0.5}
-
-  def test_over_fetches_then_applies_the_caller_limit(self):
-    """HNSW is approximate, so the query over-fetches and re-sorts; the
-    over-fetch is capped so a large limit can't blow up the scan."""
-    conn = self._conn_returning([])
-    service = _service_with(conn)
-
-    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
-      _search_hnsw_index("kg1", "Fact", [0.1], limit=10)
-
-    query = _vector_query(conn)
-    assert "20)" in query, "should over-fetch 2x"
-    assert query.rstrip().endswith("LIMIT 10")
-
-  def test_over_fetch_is_capped_at_200(self):
-    conn = self._conn_returning([])
-    service = _service_with(conn)
-
-    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
-      _search_hnsw_index("kg1", "Fact", [0.1], limit=150)
-
-    query = _vector_query(conn)
-    assert "200)" in query
-
-  def test_installs_vector_extension_when_load_fails(self):
-    conn = MagicMock()
-    calls = []
-
-    def execute(sql):
-      calls.append(sql)
-      if sql == "LOAD EXTENSION vector" and calls.count("LOAD EXTENSION vector") == 1:
-        raise RuntimeError("not installed")
-      return MagicMock(get_as_list=MagicMock(return_value=[]))
-
-    conn.execute.side_effect = execute
-    service = _service_with(conn)
-
-    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
-      _search_hnsw_index("kg1", "Fact", [0.1], limit=5)
-
-    assert "INSTALL vector" in calls
-    assert calls.count("LOAD EXTENSION vector") == 2
-
-  def test_derives_index_name_from_table(self):
-    conn = self._conn_returning([])
-    service = _service_with(conn)
-
-    with patch(f"{MODULE}._get_ladybug_service", return_value=service):
-      _search_hnsw_index("kg1", "FactSet", [0.1], limit=5)
-
-    query = _vector_query(conn)
-    assert "'factset_vec_index'" in query
-
-  @pytest.mark.parametrize("bad", ["Fact; DELETE", "1Fact"])
-  def test_rejects_unsafe_table_name(self, bad):
-    with patch(f"{MODULE}._get_ladybug_service") as mock_service:
-      with pytest.raises(ValueError, match="Invalid table_name"):
-        _search_hnsw_index("kg1", bad, [0.1], limit=5)
-
-    mock_service.assert_not_called()
-
-  def test_rejects_unsafe_select_column(self):
-    """select_columns land in the RETURN clause -- a crafted value would let
-    a caller project arbitrary Cypher."""
-    with patch(f"{MODULE}._get_ladybug_service") as mock_service:
-      with pytest.raises(ValueError, match="Invalid column"):
-        _search_hnsw_index(
-          "kg1", "Fact", [0.1], limit=5, select_columns=["identifier", "x) RETURN 1 //"]
-        )
-
-    mock_service.assert_not_called()
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["total"] == 1


### PR DESCRIPTION
## What

Removes the HNSW branch of `POST /databases/{g}/tables/{t}/vector/search`. HNSW indexes are searched in Cypher via `CALL QUERY_VECTOR_INDEX`; that route now returns 400 for `backend="hnsw"` with the query to send instead. The Lance branch is untouched, and so is `/vector/build`, which is the live half of the module.

## Why

The HNSW reader read its rows through `result.get_as_list()` — a method `ladybug` 0.18.1's `QueryResult` does not have (it exposes `get_all`, `rows_as_dict`, `get_next`/`has_next`). The `hasattr` guard around it had no `else`, so the function fell through with an empty list:

```python
result = conn.execute(query)          # ANN runs, rows come back
results = []
if hasattr(result, "get_as_list"):    # False
    ...
return {"results": results, "total": 0}   # 200 OK, zero rows, no error
```

Every HNSW search returned `200 {"results": [], "total": 0}` with a plausible latency and nothing logged. The sibling call sites in the same module (lines 263, 386, 401) and `tables/materialize.py:153` all carry the `else list(result)` fallback — only the reader lacked it.

Nothing consumes it. `GraphClient.vector_search()` is the route's only client and never sends `backend`, so it defaults to `lance` and cannot reach the branch; its sole caller is a unit test. `/vector/build` with `backend="hnsw"` **is** live (`chunked_materialization.py:169`) and is unaffected. The module docstring already said HNSW is *"searched in Cypher via CALL QUERY_VECTOR_INDEX, not the /search route"* — the code contradicted the docs shipping beside it.

Repairing a reader with no consumers would leave two ways to search one index, one of them undocumented. Removing it leaves the way that works, and the 400 hands the caller the working query rather than an empty list.

## Tests

The existing tests could not have caught this — they set `get_as_list` on a `MagicMock`, so `hasattr` was true under test and false against the engine. That's the same shape of blind spot either way, so the replacements are route-level and go through the real request path: the 400, the pointer's contents, an explicit assertion that a 200-with-no-rows can no longer happen, and that `backend="lance"` is still served.

## Verification

Beyond the suite, on the local stack against a subgraph with a `FLOAT[384]` embedding column and 8 nodes of real fastembed vectors:

- `backend="hnsw"` → `400` naming `CALL QUERY_VECTOR_INDEX('Document', 'document_vec_index', ...)` and `POST /databases/{g}/query`
- `column` (removed from the request model) → `422`, per `extra = "forbid"`
- `/vector/build` `backend="hnsw"` → still indexes, `row_count: 8`
- `CALL QUERY_VECTOR_INDEX` through `/v1/graphs/{g}/query/cypher` → correct nearest neighbour on all three probes (goodwill → Goodwill impairment 0.316; coffee roasting → Espresso roasting 0.255; buyback → Share repurchase 0.351)

## Follow-up, not in this PR

The `hasattr(result, "get_as_list")` pattern remains at three sites in this module plus `materialize.py:153`. All are correct today because they have the fallback, but all four are guarding against a method the engine no longer has, so all four silently take the fallback path. Worth collapsing to a single reader helper separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHvoJGP23TsTZZ8njeRTWj