### PR TITLE
fix(oidc): trust GitHub's immutable subject beside the classic one

### DIFF
--- a/cloudformation/bootstrap-oidc.yaml
+++ b/cloudformation/bootstrap-oidc.yaml
@@ -120,11 +120,22 @@ Resources:
               StringEquals:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
               StringLike:
-                # Allow main, release branches, and version tags for backend repo only
+                # Allow main, release branches, and version tags for backend repo only.
+                # Each ref appears twice: GitHub's classic subject
+                # (repo:ORG/REPO:ref:…) and its immutable one
+                # (repo:ORG@ID/REPO@ID:ref:…), which GitHub issues for a
+                # repository after it is renamed and for repositories created
+                # after July 2026. Only GitHub can mint the ID-qualified form
+                # for this org and repo name, so accepting both narrows nothing
+                # — and a rename no longer locks the deploy out (2026-09-09,
+                # the viewer's rename did exactly that).
                 token.actions.githubusercontent.com:sub:
                   - !Sub repo:${GitHubOrg}/${GitHubRepoName}:ref:refs/heads/main
                   - !Sub repo:${GitHubOrg}/${GitHubRepoName}:ref:refs/heads/release/*
                   - !Sub repo:${GitHubOrg}/${GitHubRepoName}:ref:refs/tags/v*
+                  - !Sub repo:${GitHubOrg}@*/${GitHubRepoName}@*:ref:refs/heads/main
+                  - !Sub repo:${GitHubOrg}@*/${GitHubRepoName}@*:ref:refs/heads/release/*
+                  - !Sub repo:${GitHubOrg}@*/${GitHubRepoName}@*:ref:refs/tags/v*
       Policies:
         - PolicyName: !Sub ${ServiceTag}DeploymentPolicy
           PolicyDocument:
@@ -594,24 +605,39 @@ Resources:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
               StringLike:
                 # Explicitly allow only these frontend repos
-                # If a repo isn't used, it simply won't assume this role
+                # If a repo isn't used, it simply won't assume this role.
+                # Classic and immutable subject forms for each ref — see the
+                # backend role above for why both.
                 token.actions.githubusercontent.com:sub:
                   # Primary dashboard frontend
                   - !Sub repo:${GitHubOrg}/${GitHubAppRepoName}:ref:refs/heads/main
                   - !Sub repo:${GitHubOrg}/${GitHubAppRepoName}:ref:refs/heads/release/*
                   - !Sub repo:${GitHubOrg}/${GitHubAppRepoName}:ref:refs/tags/v*
+                  - !Sub repo:${GitHubOrg}@*/${GitHubAppRepoName}@*:ref:refs/heads/main
+                  - !Sub repo:${GitHubOrg}@*/${GitHubAppRepoName}@*:ref:refs/heads/release/*
+                  - !Sub repo:${GitHubOrg}@*/${GitHubAppRepoName}@*:ref:refs/tags/v*
                   # RoboLedger frontend
                   - !Sub repo:${GitHubOrg}/${GitHubLedgerAppRepoName}:ref:refs/heads/main
                   - !Sub repo:${GitHubOrg}/${GitHubLedgerAppRepoName}:ref:refs/heads/release/*
                   - !Sub repo:${GitHubOrg}/${GitHubLedgerAppRepoName}:ref:refs/tags/v*
+                  - !Sub repo:${GitHubOrg}@*/${GitHubLedgerAppRepoName}@*:ref:refs/heads/main
+                  - !Sub repo:${GitHubOrg}@*/${GitHubLedgerAppRepoName}@*:ref:refs/heads/release/*
+                  - !Sub repo:${GitHubOrg}@*/${GitHubLedgerAppRepoName}@*:ref:refs/tags/v*
                   # RoboInvestor frontend
                   - !Sub repo:${GitHubOrg}/${GitHubInvestorAppRepoName}:ref:refs/heads/main
                   - !Sub repo:${GitHubOrg}/${GitHubInvestorAppRepoName}:ref:refs/heads/release/*
                   - !Sub repo:${GitHubOrg}/${GitHubInvestorAppRepoName}:ref:refs/tags/v*
-                  # xbrlkit viewer (static SPA → S3 + CloudFront)
+                  - !Sub repo:${GitHubOrg}@*/${GitHubInvestorAppRepoName}@*:ref:refs/heads/main
+                  - !Sub repo:${GitHubOrg}@*/${GitHubInvestorAppRepoName}@*:ref:refs/heads/release/*
+                  - !Sub repo:${GitHubOrg}@*/${GitHubInvestorAppRepoName}@*:ref:refs/tags/v*
+                  # xbrlkit viewer (static SPA → S3 + CloudFront) — renamed
+                  # 2026-09-09, so GitHub issues its immutable subject
                   - !Sub repo:${GitHubOrg}/${GitHubViewerRepoName}:ref:refs/heads/main
                   - !Sub repo:${GitHubOrg}/${GitHubViewerRepoName}:ref:refs/heads/release/*
                   - !Sub repo:${GitHubOrg}/${GitHubViewerRepoName}:ref:refs/tags/v*
+                  - !Sub repo:${GitHubOrg}@*/${GitHubViewerRepoName}@*:ref:refs/heads/main
+                  - !Sub repo:${GitHubOrg}@*/${GitHubViewerRepoName}@*:ref:refs/heads/release/*
+                  - !Sub repo:${GitHubOrg}@*/${GitHubViewerRepoName}@*:ref:refs/tags/v*
       Policies:
         - PolicyName: !Sub ${ServiceTag}FrontendDeploymentPolicy
           PolicyDocument:


### PR DESCRIPTION
## Summary

The renamed viewer repository could not assume the frontend deploy role (`Not authorized to perform sts:AssumeRoleWithWebIdentity`, run 34376676371). GitHub moves a repository to its **immutable OIDC subject** after a rename or transfer made after 2026-07-15, and for every repository created after that date: the subject reads `repo:ORG@ORG-ID/REPO@REPO-ID:ref:…` instead of `repo:ORG/REPO:ref:…`. The deploy roles trusted only the classic form. This PR trusts both forms for every ref on both roles.

## Changes

- `cloudformation/bootstrap-oidc.yaml` — each trusted ref on the backend role and the frontend role appears twice: `repo:${GitHubOrg}/${Repo}:ref:…` and `repo:${GitHubOrg}@*/${Repo}@*:ref:…`. The `@` character cannot appear in a GitHub owner or repository name, so the second pattern can only be satisfied by a subject GitHub mints for these exact names; it widens trust to nothing else. The comment on the backend role records the mechanism and the date it bit. No policy statements change; only the trust conditions.

Applying it: `just bootstrap-oidc` after merge, then re-dispatch the viewer deploy.

## Breaking Changes

None.

## Testing

- `just cf-lint bootstrap-oidc` clean.
- The subject format is taken from GitHub's OIDC reference (immutable subject claims) and from the repository's own customization endpoint, which reports the prefix `repo:RoboFinSystems@213902224/xbrlkit-viewer@1280910947` where never-renamed siblings still report the classic prefix. Verified end to end by the next viewer deploy after the stack update.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.
