### PR TITLE
fix(serialization): emit the holon from xbrlkit through the bundle bridge

### DIFF
--- a/examples/_common/databook.py
+++ b/examples/_common/databook.py
@@ -37,10 +37,8 @@ from pathlib import Path
 import rdflib
 from rdflib import RDF, Graph, URIRef
 from rdflib.namespace import Namespace
-
-from robosystems.operations.serialization.rdf.holon import (
-  serialize_holon_jsonld_from_graph,
-)
+from xbrlkit.deserialize.holon import from_holon_json
+from xbrlkit.serialize import to_holon
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -559,11 +557,21 @@ def write_holon_jsonld(jsonld_path: Path, out_jsonld: Path) -> Path:
   ``<report>#scene`` / ``#boundary`` / ``#projection`` (``@id`` + nested
   ``@graph``), derived purely from the on-disk flat ``.jsonld``. This is the
   file the holon viewer picks up; JSON is native to the JSON API, so no ``.trig``
-  is required on the critical path. The partition is the shared
-  ``operations/serialization/rdf/holon.py`` logic — one source of truth."""
+  is required on the critical path. The flat bundle is read back into xbrlkit's
+  ``XbrlModel`` and written by the same ``to_holon`` the API's download flavor
+  and the SEC pipeline use — one partition, in one repo. The report id comes
+  from the bundle's ``rs:Report`` node, so the named-graph IRIs match the API's
+  holon for the same report."""
   g = rdflib.Graph().parse(str(jsonld_path), format="json-ld")
-  root = _root(g)
-  out_jsonld.write_text(serialize_holon_jsonld_from_graph(g, root))
+  report_id = str(_root(g)).rsplit("/", 1)[-1]
+  model = from_holon_json(jsonld_path.read_text())
+  # The flat bundle's Report node carries no accession, so the reader leaves
+  # the model's blank; the API's holon names the report by its id there, and
+  # this one should read back the same.
+  model = model.model_copy(
+    update={"filing": model.filing.model_copy(update={"accession": report_id})}
+  )
+  out_jsonld.write_text(to_holon(model, report_id=report_id))
   return out_jsonld
 
 
@@ -600,9 +608,7 @@ def write_databook(
 
   def _ib_sort_key(ib: URIRef) -> tuple[int, float, str, str]:
     struct = g.value(ib, RS.structure)
-    struct_order = (
-      g.value(struct, RS.structureOrder) if struct is not None else None
-    )
+    struct_order = g.value(struct, RS.structureOrder) if struct is not None else None
     return (
       _BLOCK_ORDER.get(str(g.value(ib, RS.blockType)), 99),
       # Disclosure notes tie on block order; rs:structureOrder (published

--- a/examples/saas_startup_demo/sample_output/saas-startup-demo.holon.jsonld
+++ b/examples/saas_startup_demo/sample_output/saas-startup-demo.holon.jsonld
@@ -4,6 +4,9 @@
       "@id": "https://robosystems.ai/vocab/abstract",
       "@type": "xsd:boolean"
     },
+    "accessionNumber": {
+      "@id": "https://robosystems.ai/vocab/accessionNumber"
+    },
     "altLabel": "skos:altLabel",
     "arcrole": {
       "@id": "xlink:arcrole",
@@ -13,16 +16,30 @@
       "@id": "https://robosystems.ai/vocab/associationType"
     },
     "axis": {
-      "@id": "https://robosystems.ai/vocab/axis"
+      "@id": "https://robosystems.ai/vocab/axis",
+      "@type": "@id"
+    },
+    "axisType": {
+      "@id": "https://robosystems.ai/vocab/axisType"
     },
     "balance": {
       "@id": "xbrli:balance"
+    },
+    "baseType": {
+      "@id": "https://robosystems.ai/vocab/baseType"
     },
     "blockType": {
       "@id": "https://robosystems.ai/vocab/blockType"
     },
     "calendarPeriodKey": {
       "@id": "https://robosystems.ai/vocab/calendarPeriodKey"
+    },
+    "calendarQuarter": {
+      "@id": "https://robosystems.ai/vocab/calendarQuarter"
+    },
+    "calendarYear": {
+      "@id": "https://robosystems.ai/vocab/calendarYear",
+      "@type": "xsd:integer"
     },
     "category": {
       "@id": "https://robosystems.ai/vocab/category"
@@ -47,11 +64,11 @@
       "@id": "https://robosystems.ai/vocab/conceptArrangementPatternRequiresConcept",
       "@type": "@id"
     },
-    "contentType": {
-      "@id": "https://robosystems.ai/vocab/contentType"
-    },
     "country": {
       "@id": "https://robosystems.ai/vocab/country"
+    },
+    "dataType": {
+      "@id": "https://robosystems.ai/vocab/dataType"
     },
     "dcterms": "http://purl.org/dc/terms/",
     "decimals": {
@@ -61,6 +78,12 @@
     "deprecated": {
       "@id": "https://robosystems.ai/vocab/deprecated",
       "@type": "xsd:boolean"
+    },
+    "deprecatedDateLabel": {
+      "@id": "https://robosystems.ai/vocab/deprecatedDateLabel"
+    },
+    "deprecatedLabel": {
+      "@id": "https://robosystems.ai/vocab/deprecatedLabel"
     },
     "derivationRole": {
       "@id": "https://robosystems.ai/vocab/derivationRole"
@@ -87,6 +110,9 @@
     },
     "disclosures": "https://robosystems.ai/taxonomy/rs-gaap/disclosures/v1/",
     "documentation": "rdfs:comment",
+    "durationType": {
+      "@id": "https://robosystems.ai/vocab/durationType"
+    },
     "ein": {
       "@id": "https://robosystems.ai/vocab/ein"
     },
@@ -134,6 +160,10 @@
       "@id": "https://robosystems.ai/vocab/filedAt",
       "@type": "xsd:dateTime"
     },
+    "filingDate": {
+      "@id": "https://robosystems.ai/vocab/filingDate",
+      "@type": "xsd:date"
+    },
     "filingStatus": {
       "@id": "https://robosystems.ai/vocab/filingStatus"
     },
@@ -144,6 +174,18 @@
     "financialReportRequiresDisclosure": {
       "@id": "https://robosystems.ai/vocab/financialReportRequiresDisclosure",
       "@type": "@id"
+    },
+    "fiscalPeriodFocus": {
+      "@id": "https://robosystems.ai/vocab/fiscalPeriodFocus"
+    },
+    "fiscalYearEndMonth": {
+      "@id": "https://robosystems.ai/vocab/fiscalYearEndMonth"
+    },
+    "fiscalYearFocus": {
+      "@id": "https://robosystems.ai/vocab/fiscalYearFocus"
+    },
+    "form": {
+      "@id": "https://robosystems.ai/vocab/form"
     },
     "framework": {
       "@id": "https://robosystems.ai/vocab/framework"
@@ -183,6 +225,18 @@
     "internalId": {
       "@id": "https://robosystems.ai/vocab/internalId"
     },
+    "isExplicit": {
+      "@id": "https://robosystems.ai/vocab/isExplicit",
+      "@type": "xsd:boolean"
+    },
+    "isNil": {
+      "@id": "https://robosystems.ai/vocab/isNil",
+      "@type": "xsd:boolean"
+    },
+    "isTyped": {
+      "@id": "https://robosystems.ai/vocab/isTyped",
+      "@type": "xsd:boolean"
+    },
     "iso4217": "http://www.xbrl.org/2003/iso4217#",
     "itemType": {
       "@id": "https://robosystems.ai/vocab/itemType"
@@ -193,6 +247,9 @@
     },
     "labelRole": {
       "@id": "https://robosystems.ai/vocab/labelRole"
+    },
+    "language": {
+      "@id": "https://robosystems.ai/vocab/language"
     },
     "legalName": {
       "@id": "https://robosystems.ai/vocab/legalName"
@@ -207,7 +264,8 @@
       "@type": "@id"
     },
     "member": {
-      "@id": "https://robosystems.ai/vocab/member"
+      "@id": "https://robosystems.ai/vocab/member",
+      "@type": "@id"
     },
     "mode": {
       "@id": "https://robosystems.ai/vocab/mode"
@@ -219,8 +277,66 @@
     "name": {
       "@id": "https://robosystems.ai/vocab/name"
     },
+    "negated": {
+      "@id": "https://robosystems.ai/vocab/negated"
+    },
+    "negatedLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedLabel"
+    },
+    "negatedNetLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedNetLabel"
+    },
+    "negatedPeriodEnd": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodEnd"
+    },
+    "negatedPeriodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodEndLabel"
+    },
+    "negatedPeriodStart": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodStart"
+    },
+    "negatedPeriodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodStartLabel"
+    },
+    "negatedTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedTerseLabel"
+    },
+    "negatedTotal": {
+      "@id": "https://robosystems.ai/vocab/negatedTotal"
+    },
+    "negatedTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedTotalLabel"
+    },
+    "negativeLabel": {
+      "@id": "https://robosystems.ai/vocab/negativeLabel"
+    },
+    "negativePeriodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodEndLabel"
+    },
+    "negativePeriodEndTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodEndTotalLabel"
+    },
+    "negativePeriodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodStartLabel"
+    },
+    "negativePeriodStartTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodStartTotalLabel"
+    },
+    "negativeTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/negativeTerseLabel"
+    },
+    "negativeVerboseLabel": {
+      "@id": "https://robosystems.ai/vocab/negativeVerboseLabel"
+    },
+    "netLabel": {
+      "@id": "https://robosystems.ai/vocab/netLabel"
+    },
     "networkRoleUri": {
       "@id": "https://robosystems.ai/vocab/networkRoleUri"
+    },
+    "nillable": {
+      "@id": "https://robosystems.ai/vocab/nillable",
+      "@type": "xsd:boolean"
     },
     "nonAuthoritative": {
       "@id": "https://robosystems.ai/vocab/nonAuthoritative",
@@ -243,9 +359,19 @@
       "@id": "https://robosystems.ai/vocab/period",
       "@type": "@id"
     },
+    "periodEndDate": {
+      "@id": "https://robosystems.ai/vocab/periodEndDate",
+      "@type": "xsd:date"
+    },
+    "periodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/periodEndLabel"
+    },
     "periodNodes": {
       "@id": "https://robosystems.ai/vocab/periodNodes",
       "@type": "@id"
+    },
+    "periodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/periodStartLabel"
     },
     "periodType": {
       "@id": "xbrli:periodType"
@@ -254,9 +380,33 @@
       "@id": "https://robosystems.ai/vocab/periods",
       "@type": "@id"
     },
+    "positiveLabel": {
+      "@id": "https://robosystems.ai/vocab/positiveLabel"
+    },
+    "positivePeriodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodEndLabel"
+    },
+    "positivePeriodEndTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodEndTotalLabel"
+    },
+    "positivePeriodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodStartLabel"
+    },
+    "positivePeriodStartTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodStartTotalLabel"
+    },
+    "positiveTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/positiveTerseLabel"
+    },
+    "positiveVerboseLabel": {
+      "@id": "https://robosystems.ai/vocab/positiveVerboseLabel"
+    },
     "prefLabel": "skos:prefLabel",
     "preferredLabel": {
       "@id": "https://robosystems.ai/vocab/preferredLabel"
+    },
+    "preferredLabelRole": {
+      "@id": "https://robosystems.ai/vocab/preferredLabelRole"
     },
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
@@ -294,6 +444,9 @@
     "reportingStyleNetworks": {
       "@id": "https://robosystems.ai/vocab/reportingStyleNetworks"
     },
+    "restatedLabel": {
+      "@id": "https://robosystems.ai/vocab/restatedLabel"
+    },
     "retainedEarningsConcept": {
       "@id": "https://robosystems.ai/vocab/retainedEarningsConcept"
     },
@@ -305,9 +458,7 @@
       "@id": "https://robosystems.ai/vocab/roleUri"
     },
     "rs": "https://robosystems.ai/vocab/",
-    "rs-driver": "https://robosystems.ai/taxonomy/rs-gaap/drivers/v1/",
     "rs-gaap": "https://robosystems.ai/taxonomy/rs-gaap/v1/",
-    "rs-metric": "https://robosystems.ai/taxonomy/rs-gaap/metrics/v1/",
     "ruleCategory": {
       "@id": "https://robosystems.ai/vocab/ruleCategory"
     },
@@ -366,6 +517,10 @@
     "sourceReportId": {
       "@id": "https://robosystems.ai/vocab/sourceReportId"
     },
+    "srt": "http://fasb.org/srt/",
+    "standardLabel": {
+      "@id": "https://robosystems.ai/vocab/standardLabel"
+    },
     "start": {
       "@id": "https://robosystems.ai/vocab/start",
       "@type": "xsd:date"
@@ -381,8 +536,7 @@
       "@id": "https://robosystems.ai/vocab/statementType"
     },
     "stringValue": {
-      "@id": "https://robosystems.ai/vocab/stringValue",
-      "@type": "xsd:string"
+      "@id": "https://robosystems.ai/vocab/stringValue"
     },
     "structure": {
       "@id": "https://robosystems.ai/vocab/structure",
@@ -390,6 +544,10 @@
     },
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
+    },
+    "structureOrder": {
+      "@id": "https://robosystems.ai/vocab/structureOrder",
+      "@type": "xsd:integer"
     },
     "structures": {
       "@id": "https://robosystems.ai/vocab/structures",
@@ -415,11 +573,20 @@
     "taxonomyName": {
       "@id": "https://robosystems.ai/vocab/taxonomyName"
     },
+    "terseLabel": {
+      "@id": "https://robosystems.ai/vocab/terseLabel"
+    },
     "to": {
       "@id": "xlink:to",
       "@type": "@id"
     },
+    "totalLabel": {
+      "@id": "https://robosystems.ai/vocab/totalLabel"
+    },
     "trait": "https://robosystems.ai/taxonomy/fac-traits/v1/",
+    "typedValue": {
+      "@id": "https://robosystems.ai/vocab/typedValue"
+    },
     "unit": {
       "@id": "https://robosystems.ai/vocab/unit",
       "@type": "@id"
@@ -439,6 +606,9 @@
     "variableQname": {
       "@id": "https://robosystems.ai/vocab/variableQname"
     },
+    "verboseLabel": {
+      "@id": "https://robosystems.ai/vocab/verboseLabel"
+    },
     "version": {
       "@id": "https://robosystems.ai/vocab/version"
     },
@@ -450,1903 +620,64 @@
     "xbrldt": "http://xbrl.org/2005/xbrldt#",
     "xbrli": "http://www.xbrl.org/2003/instance#",
     "xlink": "http://www.w3.org/1999/xlink#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#"
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "zeroLabel": {
+      "@id": "https://robosystems.ai/vocab/zeroLabel"
+    },
+    "zeroTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/zeroTerseLabel"
+    },
+    "zeroVerboseLabel": {
+      "@id": "https://robosystems.ai/vocab/zeroVerboseLabel"
+    }
   },
   "@graph": [
     {
       "@graph": [
         {
-          "@id": "rs-gaap:LiabilitiesCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "efb036ff-3f30-5deb-bee9-1af4cd4b9800",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Liabilities, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "ff101489-15f4-573d-967b-24f75e0fc0f6",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Payments to Acquire Property, Plant, and Equipment",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS1",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DepreciationDepletionAndAmortization",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS1",
-          "numericValue": "29111.04",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS5",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ResearchAndDevelopmentExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS5",
-          "numericValue": "786000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "@type": "rs:Period",
-          "endDate": "2025-08-31",
-          "periodType": "duration",
-          "startDate": "2024-09-01"
-        },
-        {
-          "@id": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "353f790f-1ed1-5b91-880d-8029b4b687cf",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FRT",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "https://robosystems.ai/concept/cadence:SubscriptionRevenue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKXB",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FRT",
-          "numericValue": "1156399.44",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/struct_01M1ZK19H8V4RE3N1CQ61M2B3H",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTJ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:StockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTJ",
-          "numericValue": "864721.54",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSG",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DeferredRevenueCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSG",
-          "numericValue": "922021.97",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6Q",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Assets",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6Q",
-          "numericValue": "2853155.11",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:NetIncomeLoss",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "27a05717-2370-51c2-a924-db5cbcb48219",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Net Income (Loss) Attributable to Parent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT9",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncomeLossFromContinuingOperations",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT9",
-          "numericValue": "-1066411.6",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:CostOfGoodsAndServicesSold",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "5ca0e51f-dff1-5c2b-94f5-26620852a5f9",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cost of Product and Service Sold",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS2",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:GeneralAndAdministrativeExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS2",
-          "numericValue": "488500.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTM",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Liabilities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTM",
-          "numericValue": "1153999.56",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTB",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTB",
-          "numericValue": "-853622.97",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTD",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AssetsCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTD",
-          "numericValue": "1959498.8",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:AssetsCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "0fc9ab7e-c5ce-5277-9530-344cc127fe26",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Assets, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:DepreciationDepletionAndAmortization",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "189a099a-7512-5144-9215-65d837c2c3b5",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Depreciation, Depletion and Amortization",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:Revenues",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "b26a6cd4-072f-5bf2-b5d3-ebf928150d6c",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Revenues",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6R",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Liabilities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6R",
-          "numericValue": "922021.97",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6W",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:GrossProfit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6W",
-          "numericValue": "153199.8",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6X",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:OperatingIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6X",
-          "numericValue": "-203866.86",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6T",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CostOfRevenue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6T",
-          "numericValue": "39600.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT7",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT7",
-          "numericValue": "-4800.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTS",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:OperatingIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTS",
-          "numericValue": "-1066411.6",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "57ccbf45-c970-5bcd-a381-44d96b6b6d94",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/ib/struct_01M1ZK19H8V4RE3N1CQ61M2B3H",
-          "@type": "rs:InformationBlock",
-          "blockType": "regulatory_disclosure",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKXB",
-          "internalId": "struct_01M1ZK19H8V4RE3N1CQ61M2B3H",
-          "prefLabel": "Disaggregation of Revenue",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/struct_01M1ZK19H8V4RE3N1CQ61M2B3H",
-          "taxonomyId": "tax_01M1ZK19H50G6FGDVYYRAQPC1D",
-          "taxonomyName": "Cadence Reporting Extension"
-        },
-        {
-          "@id": "rs-gaap:AccountsPayableCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "9ddbc9d7-c769-5800-8f65-1089d476e5c9",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Accounts Payable, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTN",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:OperatingExpenses",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTN",
-          "numericValue": "2045211.04",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "811f1cf5-836c-575f-9f3f-cd7fa477e4e5",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:AssetsNoncurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "841cedeb-4cb0-532a-b0bd-c34846a13a8c",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Assets, Noncurrent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "6b0b414f-0c76-54f0-8e51-cf53db59ca24",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:DeferredRevenueCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "f35c2b3a-01eb-50c8-96e3-4c07cc2a0fee",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Deferred Revenue, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:ReceivablesNetCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "44686df3-3871-5c1f-8a08-fc542d69dfa0",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Receivables, Net, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FRX",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FRX",
-          "numericValue": "1913398.8",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTZ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AssetsCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTZ",
-          "numericValue": "2804821.77",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSF",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CostOfGoodsAndServicesSold",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSF",
-          "numericValue": "39600.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:OperatingExpenses",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "71fcdebb-7145-5f76-b5e0-b4ccbf2c29d2",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Operating Expenses",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSM",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PrepaidExpenseCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSM",
-          "numericValue": "33000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FRZ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DeferredRevenueCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FRZ",
-          "numericValue": "1153999.56",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "@type": "rs:Entity",
-          "country": "US",
-          "internalId": "entity_kg1a07f28ad2b28bf365b8",
-          "legalName": "Cadence Labs, Inc.",
-          "prefLabel": "Cadence Labs, Inc."
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS0",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DepreciationDepletionAndAmortization",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS0",
-          "numericValue": "29111.04",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FRY",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CostOfGoodsAndServicesSold",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FRY",
-          "numericValue": "266400.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTA",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Revenues",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTA",
-          "numericValue": "1245199.44",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "69b82be1-1145-5686-8613-31da9eb04a72",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT4",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKXA",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT4",
-          "numericValue": "2835000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS9",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:SellingAndMarketingExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS9",
-          "numericValue": "741600.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSY",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSY",
-          "numericValue": "-203866.86",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "30b2801e-e682-5298-82e6-3670e1d508f1",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Liabilities and Equity",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "93175d59-983c-5012-910f-3dfbf07ce327",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Increase (Decrease) in Accounts Receivable",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:PropertyPlantAndEquipmentNet",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "288099af-5cbb-5f78-8f8a-1a85675fb661",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Property, Plant and Equipment, Net",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSX",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSX",
-          "numericValue": "-1066411.6",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:StockholdersEquity",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "e3796201-9899-5b7b-9477-659550ba8e68",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Stockholders' Equity Attributable to Parent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTT",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncomeLossFromContinuingOperations",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTT",
-          "numericValue": "-203866.86",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/concept/cadence:OperatingExpensePolicyTextBlock",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "elem_01M1ZK1D4NHKY2JQV7B0JFCKJJ",
-          "itemType": "textBlock",
-          "monetary": "false",
-          "periodType": "duration",
-          "source": "native"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FST",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:SellingAndMarketingExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FST",
-          "numericValue": "122400.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "@type": "rs:Period",
-          "endDate": "2026-08-31",
-          "periodType": "duration",
-          "startDate": "2025-09-01"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTC",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTC",
-          "numericValue": "-853622.97",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD",
-          "@type": "rs:Unit",
-          "measure": "iso4217:USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSP",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ResearchAndDevelopmentExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSP",
-          "numericValue": "129000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:CostOfRevenue",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "12ab7417-5324-55d6-946e-2456adba47c5",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cost of Revenue",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTR",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:GrossProfit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTR",
-          "numericValue": "978799.44",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:IncomeLossFromContinuingOperations",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "d60cabda-7060-5aff-ac98-96371606a738",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT5",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT5",
-          "numericValue": "-80000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT8",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT8",
-          "numericValue": "191977.59",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSA",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "https://robosystems.ai/concept/cadence:ProfessionalServicesRevenue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKXB",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSA",
-          "numericValue": "13200.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/struct_01M1ZK19H8V4RE3N1CQ61M2B3H",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "@type": "rs:Period",
-          "instant": "2025-08-31",
-          "periodType": "instant"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZYBG1NFB3B7XXDZM3CK",
-          "@type": "rs:Fact",
-          "contentType": "text/markdown",
-          "element": "https://robosystems.ai/concept/cadence:OperatingExpensePolicyTextBlock",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZYA9Q7JQ3NRQWQQG78W",
-          "factType": "nonnumeric",
-          "internalId": "fact_01M1ZK1ZYBG1NFB3B7XXDZM3CK",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "stringValue": "# Operating Expense & Burn Policy — Cadence Labs, Inc.\n\n## Expense classification (by function)\n| Function | Account | Includes |\n|---|---|---|\n| Cost of Revenue | 5000 | Cloud hosting, customer support |\n| Research & Development | 6000 | Engineering salaries, product development |\n| Sales & Marketing | 6100 | Sales team, commissions, advertising |\n| General & Administrative | 6200 / 6300 / 6400 | Admin, finance, legal, rent, software tools |\n\nR&D is expensed as incurred (no internal-use software capitalization in this policy).\n\n## Depreciation & Prepaids\nStraight-line. Equipment over 36 months; the office build-out over 60 months (DR Depreciation Expense 7000 / CR Accumulated Depreciation 1350). Annual tooling and insurance are capitalized as prepaids and amortized over 12 months.\n\n## Burn & runway\n- **Monthly operating burn** ≈ operating loss + non-cash addbacks (depreciation/amortization), adjusted for working-capital movements.\n- **Runway** = cash ÷ net monthly burn. Report it net of deferred revenue: the prepayment float inflates the cash balance with obligations owed as service.",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/struct_01M1ZK1D4P6AVPB56A512ACZDX"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSH",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DepreciationDepletionAndAmortization",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSH",
-          "numericValue": "6666.66",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "550bb6e5-53d0-5267-adb1-baf78093a0b0",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Increase (Decrease) in Prepaid Expense",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FRV",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AccountsPayableCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FRV",
-          "numericValue": "0.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSW",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKXA",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSW",
-          "numericValue": "-1066411.6",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTV",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Revenues",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTV",
-          "numericValue": "192799.8",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/ib/struct_01M1ZK1D4P6AVPB56A512ACZDX",
-          "@type": "rs:InformationBlock",
-          "blockType": "regulatory_disclosure",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZYA9Q7JQ3NRQWQQG78W",
-          "internalId": "struct_01M1ZK1D4P6AVPB56A512ACZDX",
-          "prefLabel": "Significant Accounting Policies",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/struct_01M1ZK1D4P6AVPB56A512ACZDX",
-          "taxonomyId": "tax_01M1ZK1D4MNABVQYFX38KYK5K0",
-          "taxonomyName": "Cadence Policy Notes"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6H",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6H",
-          "numericValue": "-80000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6V",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6V",
-          "numericValue": "-203866.86",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTF",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTF",
-          "numericValue": "2018721.1",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "20a6586b-880a-5745-94db-e23d397eb5e1",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Cash and Cash Equivalents, at Carrying Value",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSD",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AdditionalPaidInCapital",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSD",
-          "numericValue": "2835000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FRS",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "https://robosystems.ai/concept/cadence:ProfessionalServicesRevenue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKXB",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FRS",
-          "numericValue": "88800.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/struct_01M1ZK19H8V4RE3N1CQ61M2B3H",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSJ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DepreciationDepletionAndAmortization",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSJ",
-          "numericValue": "6666.66",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTE",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AssetsNoncurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTE",
-          "numericValue": "59222.3",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSB",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "https://robosystems.ai/concept/cadence:SubscriptionRevenue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKXB",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSB",
-          "numericValue": "179599.8",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/struct_01M1ZK19H8V4RE3N1CQ61M2B3H",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS4",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ReceivablesNetCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS4",
-          "numericValue": "9600.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTH",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:StockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKXA",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTH",
-          "numericValue": "864721.54",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTG",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTG",
-          "numericValue": "1153999.56",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/concept/cadence:SubscriptionRevenue",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "elem_01M1ZK19H65Z0GF8RCFJFH56J8",
-          "monetary": "true",
-          "periodType": "duration",
-          "source": "native"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSK",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:GeneralAndAdministrativeExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSK",
-          "numericValue": "99000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTQ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTQ",
-          "numericValue": "-1066411.6",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6J",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AssetsNoncurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6J",
-          "numericValue": "48333.34",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSS",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKXB",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSS",
-          "numericValue": "192799.8",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/struct_01M1ZK19H8V4RE3N1CQ61M2B3H",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6P",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:StockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6P",
-          "numericValue": "1931133.14",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/concept/cadence:RevenueRecognitionPolicyTextBlock",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "elem_01M1ZK1D4NHKY2JQV7B0JFCKJH",
-          "itemType": "textBlock",
-          "monetary": "false",
-          "periodType": "duration",
-          "source": "native"
-        },
-        {
-          "@id": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "2eb72b5f-d7e3-5bd5-bf93-be38b6d21820",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Proceeds from Issuance of Common Stock",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/ib/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "@type": "rs:InformationBlock",
-          "blockType": "cash_flow_statement",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX9",
-          "internalId": "5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/ib/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "@type": "rs:InformationBlock",
-          "blockType": "balance_sheet",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "internalId": "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "prefLabel": "rs-gaap — Balance Sheet — Classified",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "37252918-4301-50e2-8d7e-cf2c76986d15",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS6",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS6",
-          "numericValue": "-1970278.46",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:PrepaidExpenseCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "2225e348-90bd-53cb-9784-8b5d54980a69",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Prepaid Expense, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTX",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTX",
-          "numericValue": "2557799.8",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:GrossProfit",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "a92b3181-9fe7-543c-81d9-13ebd12bbefa",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Gross Profit",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSV",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSV",
-          "numericValue": "-1066411.6",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6K",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6K",
-          "numericValue": "2853155.11",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:AdditionalPaidInCapital",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "6146605c-0d63-51e1-a523-3450d6abaca3",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Additional Paid in Capital",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZYBG1NFB3B7XXDZM3CJ",
-          "@type": "rs:Fact",
-          "contentType": "text/markdown",
-          "element": "https://robosystems.ai/concept/cadence:RevenueRecognitionPolicyTextBlock",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZYA9Q7JQ3NRQWQQG78W",
-          "factType": "nonnumeric",
-          "internalId": "fact_01M1ZK1ZYBG1NFB3B7XXDZM3CJ",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "stringValue": "# Revenue Recognition Policy — Cadence Labs, Inc.\n\n## Standard\nRevenue is recognized under ASC 606 as the performance obligation is satisfied.\n\n## Subscriptions (annual, prepaid)\n- Customers sign annual contracts and pay the full year up front.\n- Cash collected is recorded as **Deferred Revenue (2300)**, a current liability.\n- Revenue is recognized **ratably** over the 12-month term: DR Deferred Revenue / CR Subscription Revenue (4000) each month.\n- The deferred-revenue balance equals contracts billed but not yet delivered. It is a source of working-capital \"float\" — cash in hand that finances operations but is owed as future service.\n\n## Professional Services\n- Onboarding/implementation is billed net-30 and recognized as delivered: DR AR (1100) / CR Professional Services (4100).\n\n## Why it matters for runway\nBecause subscriptions are prepaid, cash collected can exceed revenue recognized while the business grows — softening the cash burn. That float is a liability, not equity. When assessing how long the company can operate, subtract deferred revenue from cash before dividing by the burn.",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/struct_01M1ZK1D4P6AVPB56A512ACZDX"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSE",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSE",
-          "numericValue": "2767021.77",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:GeneralAndAdministrativeExpense",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "f92ba8cb-7ae2-5d40-9d15-9a94e9e3aed4",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "General and Administrative Expense",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT3",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT3",
-          "numericValue": "2835000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT0",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT0",
-          "numericValue": "-203866.86",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTK",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Assets",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTK",
-          "numericValue": "2018721.1",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTW",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTW",
-          "numericValue": "-197200.2",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSC",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AccountsPayableCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSC",
-          "numericValue": "0.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6N",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:StockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKXA",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6N",
-          "numericValue": "1931133.14",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:ResearchAndDevelopmentExpense",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "9cb92b07-2629-5534-9959-58c3a963559e",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Research and Development Expense",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "a3227fb2-202b-51db-9574-4e60db03c04f",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:OperatingIncomeLoss",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "16780828-0201-5609-b572-fbe3ebfcb177",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Operating Income (Loss)",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6M",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6M",
-          "numericValue": "922021.97",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FRW",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AdditionalPaidInCapital",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FRW",
-          "numericValue": "2835000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT6",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT6",
-          "numericValue": "-3500.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSR",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSR",
-          "numericValue": "192799.8",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS8",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKXB",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS8",
-          "numericValue": "1245199.44",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/struct_01M1ZK19H8V4RE3N1CQ61M2B3H",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSQ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSQ",
-          "numericValue": "-903866.86",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTP",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CostOfRevenue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTP",
-          "numericValue": "266400.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "@type": "rs:Period",
-          "instant": "2026-08-31",
-          "periodType": "instant"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSN",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ReceivablesNetCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSN",
-          "numericValue": "4800.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6S",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:OperatingExpenses",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6S",
-          "numericValue": "357066.66",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS3",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PrepaidExpenseCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS3",
-          "numericValue": "36500.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "a9c87d60-a1e5-506b-a27e-cbf9e14e5113",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Retained Earnings (Accumulated Deficit)",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/ib/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "@type": "rs:InformationBlock",
-          "blockType": "income_statement",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "internalId": "47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "prefLabel": "rs-gaap — Income Statement — Multi-step",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSZ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKXA",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSZ",
-          "numericValue": "-203866.86",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT1",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PropertyPlantAndEquipmentNet",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT1",
-          "numericValue": "59222.3",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/ib/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "@type": "rs:InformationBlock",
-          "blockType": "equity_statement",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKXA",
-          "internalId": "0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "rs-gaap:SellingAndMarketingExpense",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "4757162f-73d0-5c6e-949e-ed2cafb2a64f",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Selling and Marketing Expense",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTY",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTY",
-          "numericValue": "2835000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS7",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS7",
-          "numericValue": "1245199.44",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/concept/cadence:ProfessionalServicesRevenue",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "elem_01M1ZK19H65Z0GF8RCFJFH56J9",
-          "monetary": "true",
-          "periodType": "duration",
-          "source": "native"
-        },
-        {
-          "@id": "rs-gaap:Assets",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "a1f04756-41d8-5d35-b821-23aa2f3b2fae",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Assets",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT2",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PropertyPlantAndEquipmentNet",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK1ZXTQ9R6N5APZTK6BKX7",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT2",
-          "numericValue": "48333.34",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:Liabilities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "7af273ac-1cba-5fb3-a1c9-5c5d8fdb9bdf",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Liabilities",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        }
-      ],
-      "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH#scene"
-    },
-    {
-      "@graph": [
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/14",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/calculation/0",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:StockholdersEquity",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/12",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperations",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeTaxExpenseBenefit",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/22",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
           "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueCurrent",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/1",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/calculation/1",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:EffectOfExchangeRateOnCash",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/calculation/2",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/calculation/3",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -2360,243 +691,10 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/0",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Assets",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AssetsCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/24",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AdditionalPaidInCapital",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/27",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/0",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseLiabilityCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/14",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NetIncomeLoss",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/13",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:NonoperatingIncomeExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/10",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostOfOperatingRevenue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/33",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/0",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/struct_01M1ZK19H8V4RE3N1CQ61M2B3H/calculation/1",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "order": "1.0",
-          "role": "https://cadencelabs.example.com/roles/disclosures/DisaggregationOfRevenue",
-          "to": "https://robosystems.ai/concept/cadence:SubscriptionRevenue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/11",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ReceivablesNetCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/0"
-          ]
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/15",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DebtCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/8",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ShortTermInvestments",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/17",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingIncomeLoss",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingExpenses",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/2",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/3",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Liabilities",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/struct_01M1ZK19H8V4RE3N1CQ61M2B3H/calculation/2",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "order": "2.0",
-          "role": "https://cadencelabs.example.com/roles/disclosures/DisaggregationOfRevenue",
-          "to": "https://robosystems.ai/concept/cadence:ProfessionalServicesRevenue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/16",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -2607,178 +705,10 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/7",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CommonStockValue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/8",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Revenues",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/15",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InterestExpense",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/6",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/20",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/7",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingIncomeLoss",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GrossProfit",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/9",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/1",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccruedLiabilitiesCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/18",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/19",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:DepreciationDepletionAndAmortization",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/6",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GeneralAndAdministrativeExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/1",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/35",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/23",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -2789,10 +719,10 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/29",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/10",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -2803,193 +733,10 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/20",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherNonoperatingIncomeExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/4",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NetIncomeLoss",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperations",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/18",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/11",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainLossOnDispositionOfAssets",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/23",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "403.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RestructuringCharges",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/28",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/35",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/30",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/29",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/25",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/26",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/34",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/32",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/27",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/31",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/36",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/24",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/37",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/23",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/33"
-          ]
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/16",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ResearchAndDevelopmentExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/31",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseRightOfUseAsset",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/5",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InvestmentIncomeInterest",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/21",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/37",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:TreasuryStockValue",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/4",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Liabilities",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/26",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -3000,52 +747,10 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/3",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:EffectOfExchangeRateOnCash",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/struct_01M1ZK19H8V4RE3N1CQ61M2B3H/calculation/3",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "order": "2.0",
-          "role": "https://cadencelabs.example.com/roles/disclosures/DisaggregationOfRevenue",
-          "to": "https://robosystems.ai/concept/cadence:ProfessionalServicesRevenue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/28",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/12",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/25",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -3056,7 +761,119 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/12",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/13",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/14",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CommonStockValue",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/15",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/16",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Liabilities",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/17",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Liabilities",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/18",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/19",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccountsPayableCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/2",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseRightOfUseAsset",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/20",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -3070,133 +887,7 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/1",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:GrossProfit",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:Revenues",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/struct_01M1ZK19H8V4RE3N1CQ61M2B3H/calculation/0",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "order": "1.0",
-          "role": "https://cadencelabs.example.com/roles/disclosures/DisaggregationOfRevenue",
-          "to": "https://robosystems.ai/concept/cadence:SubscriptionRevenue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/25",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "406.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:AssetImpairmentCharges",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/11",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:GrossProfit",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfRevenue",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/24",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "406.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/21",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostAndExpenseOperating",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/5",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccountsPayableCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/19",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/34",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/17",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/21",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -3210,66 +901,24 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/9",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/22",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:SellingAndMarketingExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/32",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
+          "from": "rs-gaap:StockholdersEquity",
           "order": "500.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesCurrent",
+          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/0",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/23",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfGoodsAndServicesSold",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/30",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/10",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -3280,64 +929,38 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/struct_01M1ZK19H8V4RE3N1CQ61M2B3H",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/struct_01M1ZK19H8V4RE3N1CQ61M2B3H/calculation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/struct_01M1ZK19H8V4RE3N1CQ61M2B3H/calculation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/struct_01M1ZK19H8V4RE3N1CQ61M2B3H/calculation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/struct_01M1ZK19H8V4RE3N1CQ61M2B3H/calculation/3"
-          ]
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/24",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/25",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/23",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/20"
-          ]
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/36",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/24",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "600.0",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "200.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsNoncurrent",
+          "to": "rs-gaap:ReceivablesNetCurrent",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/2",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/25",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:TreasuryStockValue",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/26",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -3348,10 +971,318 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/2",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/27",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AdditionalPaidInCapital",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/28",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/29",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/3",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/30",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/31",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/32",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DebtCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/33",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/34",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:StockholdersEquity",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/35",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/36",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Liabilities",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/37",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/4",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/5",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Assets",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AssetsCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/6",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/7",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseLiabilityCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/8",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ShortTermInvestments",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/9",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccruedLiabilitiesCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/0",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InvestmentIncomeInterest",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/1",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "406.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:AssetImpairmentCharges",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/10",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostOfOperatingRevenue",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/11",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:SellingAndMarketingExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/12",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -3362,7 +1293,49 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/3",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/13",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:GrossProfit",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfRevenue",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/14",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherNonoperatingIncomeExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/15",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "406.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/16",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -3376,24 +1349,178 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/13",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/17",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:Liabilities",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
           "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesNoncurrent",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InterestExpense",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/18",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GeneralAndAdministrativeExpense",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/22",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/19",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostAndExpenseOperating",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/2",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfGoodsAndServicesSold",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/20",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:NonoperatingIncomeExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/21",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NetIncomeLoss",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperations",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/22",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NetIncomeLoss",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/23",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingIncomeLoss",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingExpenses",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/24",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:DepreciationDepletionAndAmortization",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/25",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainLossOnDispositionOfAssets",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/3",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperations",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeTaxExpenseBenefit",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/4",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "403.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RestructuringCharges",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/5",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -3402,6 +1529,210 @@
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
           "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
           "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/6",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Revenues",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/7",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ResearchAndDevelopmentExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/8",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingIncomeLoss",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GrossProfit",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/9",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:GrossProfit",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:Revenues",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/8673d69fbb9ae32e/calculation/0",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "order": "2.0",
+          "role": "https://cadencelabs.example.com/roles/disclosures/DisaggregationOfRevenue",
+          "to": "https://robosystems.ai/concept/cadence:ProfessionalServicesRevenue",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/8673d69fbb9ae32e/calculation/1",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "order": "1.0",
+          "role": "https://cadencelabs.example.com/roles/disclosures/DisaggregationOfRevenue",
+          "to": "https://robosystems.ai/concept/cadence:SubscriptionRevenue",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/8673d69fbb9ae32e/calculation/2",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "order": "1.0",
+          "role": "https://cadencelabs.example.com/roles/disclosures/DisaggregationOfRevenue",
+          "to": "https://robosystems.ai/concept/cadence:SubscriptionRevenue",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/8673d69fbb9ae32e/calculation/3",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "order": "2.0",
+          "role": "https://cadencelabs.example.com/roles/disclosures/DisaggregationOfRevenue",
+          "to": "https://robosystems.ai/concept/cadence:ProfessionalServicesRevenue",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/4d5ede325089bd91",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/calculation/3"
+          ]
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/75bf584b3e4aaaa0",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/23",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/24",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/25",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/26",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/27",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/28",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/29",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/30",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/31",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/32",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/33",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/34",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/35",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/36",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/37",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/calculation/9"
+          ]
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/850c3d8ab3a4a627",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/23",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/24",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/25",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/calculation/9"
+          ]
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/8673d69fbb9ae32e",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/8673d69fbb9ae32e/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/8673d69fbb9ae32e/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/8673d69fbb9ae32e/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/8673d69fbb9ae32e/calculation/3"
+          ]
         }
       ],
       "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH#boundary"
@@ -3409,124 +1740,69 @@
     {
       "@graph": [
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/9",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30190.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable"
+          "@id": "https://robosystems.ai/concept/cadence:OperatingExpensePolicyTextBlock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "dataType": "textBlockItemType",
+          "elementType": "concept",
+          "internalId": "cadence:OperatingExpensePolicyTextBlock",
+          "itemType": "textBlock",
+          "monetary": "false",
+          "periodType": "duration",
+          "source": "cadence"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30130.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccountsReceivable"
+          "@id": "https://robosystems.ai/concept/cadence:ProfessionalServicesRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "cadence:ProfessionalServicesRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "source": "cadence"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/20",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10643.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax"
+          "@id": "https://robosystems.ai/concept/cadence:RevenueRecognitionPolicyTextBlock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "dataType": "textBlockItemType",
+          "elementType": "concept",
+          "internalId": "cadence:RevenueRecognitionPolicyTextBlock",
+          "itemType": "textBlock",
+          "monetary": "false",
+          "periodType": "duration",
+          "source": "cadence"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "@type": [
-            "rs:RollUp",
-            "rs:Structure"
-          ],
-          "blockType": "cash_flow_statement",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/22"
-          ],
-          "internalId": "5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "structureName": "rs-gaap — Cash Flow Statement — Indirect"
+          "@id": "https://robosystems.ai/concept/cadence:SignificantAccountingPoliciesAbstract",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "cadence:SignificantAccountingPoliciesAbstract",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "source": "cadence"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "@type": [
-            "rs:Structure",
-            "rs:Hierarchy"
-          ],
-          "blockType": "equity_statement",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/5"
-          ],
-          "internalId": "0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "structureName": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)"
+          "@id": "https://robosystems.ai/concept/cadence:SubscriptionRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "cadence:SubscriptionRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "source": "cadence"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfRevenue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/11",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30210.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/6",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/3",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/1eae745dbb354952/presentation/0",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -3536,906 +1812,7 @@
           "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/22",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20313.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/20",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30330.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:RepaymentsOfLongTermDebt"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "10230.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostOfOperatingRevenue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/7",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20160.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/struct_01M1ZK19H8V4RE3N1CQ61M2B3H/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "order": "2.0",
-          "role": "https://cadencelabs.example.com/roles/disclosures/DisaggregationOfRevenue",
-          "to": "https://robosystems.ai/concept/cadence:ProfessionalServicesRevenue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/28",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20323.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/14",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/12",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10443.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RestructuringCharges"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20115.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ShortTermInvestments"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInOperatingActivities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/25",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "11100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/12",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30220.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/19",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20311.5",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccruedLiabilitiesCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/21",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20312.5",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/36",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20450.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:Revenues"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/13",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10446.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:AssetImpairmentCharges"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/16",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "20300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Liabilities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30120.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:DepreciationDepletionAndAmortization"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/21",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30340.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/11",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20225.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/14",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30240.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:ShareBasedCompensation"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/15",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsToAcquireIntangibleAssets"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/11",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10440.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostAndExpenseOperating"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/29",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20324.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/10",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInInvestingActivities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/35",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20440.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RetainedEarningsAccumulatedDeficit"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/15",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:NonoperatingIncomeExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:NetIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/26",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20321.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/20",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20312.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DebtCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20110.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/15",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20260.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/18",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10630.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainLossOnDispositionOfAssets"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/6",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30160.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/34",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20430.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AdditionalPaidInCapital"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/26",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "11200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:NetIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/24",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20315.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/23",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10900.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeTaxExpenseBenefit"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Revenues",
-          "order": "10120.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/8",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30180.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccruedLiabilities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/27",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20322.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredIncomeTaxLiabilitiesNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20130.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/12",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20230.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/18",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20311.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccountsPayableCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/7",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10410.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GeneralAndAdministrativeExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/17",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/16",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30260.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromSaleOfIntangibleAssets"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/struct_01M1ZK1D4P6AVPB56A512ACZDX/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "https://robosystems.ai/concept/cadence:SignificantAccountingPoliciesAbstract",
-          "order": "1.0",
-          "role": "https://cadencelabs.example.com/roles/disclosures/AccountingPolicies",
-          "to": "https://robosystems.ai/concept/cadence:RevenueRecognitionPolicyTextBlock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/37",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20460.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:TreasuryStockValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/22",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:EffectOfExchangeRateOnCash"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/struct_01M1ZK1D4P6AVPB56A512ACZDX/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "https://robosystems.ai/concept/cadence:SignificantAccountingPoliciesAbstract",
-          "order": "2.0",
-          "role": "https://cadencelabs.example.com/roles/disclosures/AccountingPolicies",
-          "to": "https://robosystems.ai/concept/cadence:OperatingExpensePolicyTextBlock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/24",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "11000.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperations"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "@type": [
-            "rs:RollUp",
-            "rs:Structure"
-          ],
-          "blockType": "balance_sheet",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/30",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/31",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/35",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/23",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/27",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/25",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/28",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/32",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/29",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/26",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/34",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/24",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/37",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/36",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/33"
-          ],
-          "internalId": "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "prefLabel": "rs-gaap — Balance Sheet — Classified",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "structureName": "rs-gaap — Balance Sheet — Classified"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/23",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20314.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseLiabilityCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/21",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10646.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/7",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30170.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/17",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10620.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InterestExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/31",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "20400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:StockholdersEquity"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Assets",
-          "order": "20100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AssetsCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/10",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10430.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:DepreciationDepletionAndAmortization"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/18",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30310.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/16",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10610.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InvestmentIncomeInterest"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/struct_01M1ZK19H8V4RE3N1CQ61M2B3H",
-          "@type": [
-            "rs:RollUp",
-            "rs:Structure"
-          ],
-          "blockType": "regulatory_disclosure",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/struct_01M1ZK19H8V4RE3N1CQ61M2B3H/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/struct_01M1ZK19H8V4RE3N1CQ61M2B3H/presentation/1"
-          ],
-          "internalId": "struct_01M1ZK19H8V4RE3N1CQ61M2B3H",
-          "prefLabel": "Disaggregation of Revenue",
-          "roleUri": "https://cadencelabs.example.com/roles/disclosures/DisaggregationOfRevenue",
-          "rs:structureOrder": 101,
-          "structureName": "Disaggregation of Revenue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/22",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10800.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/6",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingExpenses"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/32",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20410.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CommonStockValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20140.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PrepaidExpenseCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/13",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20240.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseRightOfUseAsset"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/33",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20420.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PreferredStockValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GrossProfit"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/19",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30320.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/25",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Liabilities",
-          "order": "20320.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/9",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10420.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ResearchAndDevelopmentExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/14",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseRightOfUseAsset"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30110.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/30",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20325.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30140.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInInventories"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/9",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20210.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PropertyPlantAndEquipmentNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/struct_01M1ZK19H8V4RE3N1CQ61M2B3H/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "order": "1.0",
-          "role": "https://cadencelabs.example.com/roles/disclosures/DisaggregationOfRevenue",
-          "to": "https://robosystems.ai/concept/cadence:SubscriptionRevenue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInPrepaidExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/8",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10415.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:SellingAndMarketingExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/5",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/1eae745dbb354952/presentation/1",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -4445,37 +1822,207 @@
           "to": "rs-gaap:PaymentsOfDividends"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/10",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/1eae745dbb354952/presentation/2",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20220.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Goodwill"
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/19",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/1eae745dbb354952/presentation/3",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10640.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherNonoperatingIncomeExpense"
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/3",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/1eae745dbb354952/presentation/4",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20120.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ReceivablesNetCurrent"
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:ShareBasedCompensation"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/13",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/1eae745dbb354952/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:NetIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30330.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:RepaymentsOfLongTermDebt"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30120.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:DepreciationDepletionAndAmortization"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/10",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30210.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/11",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInOperatingActivities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/12",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30220.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/13",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30240.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/14",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsToAcquireIntangibleAssets"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/15",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInInvestingActivities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/16",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30140.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInInventories"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/17",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInPrepaidExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/18",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30190.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/19",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30160.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30320.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/20",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:EffectOfExchangeRateOnCash"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/21",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30170.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/22",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30310.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/3",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -4485,75 +2032,377 @@
           "to": "rs-gaap:PaymentsToAcquireInvestments"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/3",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/4",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "10210.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfGoodsAndServicesSold"
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30130.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccountsReceivable"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/struct_01M1ZK1D4P6AVPB56A512ACZDX",
-          "@type": [
-            "rs:Structure",
-            "rs:Hierarchy"
-          ],
-          "blockType": "regulatory_disclosure",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/struct_01M1ZK1D4P6AVPB56A512ACZDX/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/struct_01M1ZK1D4P6AVPB56A512ACZDX/presentation/0"
-          ],
-          "internalId": "struct_01M1ZK1D4P6AVPB56A512ACZDX",
-          "prefLabel": "Significant Accounting Policies",
-          "roleUri": "https://cadencelabs.example.com/roles/disclosures/AccountingPolicies",
-          "rs:structureOrder": 100,
-          "structureName": "Significant Accounting Policies"
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30340.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "@type": [
-            "rs:Structure",
-            "rs:RollUp"
-          ],
-          "blockType": "income_statement",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/24",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/25",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/23",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/26",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/13"
-          ],
-          "internalId": "47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "prefLabel": "rs-gaap — Income Statement — Multi-step",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "structureName": "rs-gaap — Income Statement — Multi-step"
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/6",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30180.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccruedLiabilities"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/8",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/7",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/8",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30260.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromSaleOfIntangibleAssets"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/9",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30110.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20312.5",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20440.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RetainedEarningsAccumulatedDeficit"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/10",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20313.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/11",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20160.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/12",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20311.5",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccruedLiabilitiesCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/13",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20450.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/14",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20225.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/15",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20324.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/16",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20230.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/17",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Assets",
+          "order": "20100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AssetsCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/18",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20240.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseRightOfUseAsset"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/19",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Liabilities",
+          "order": "20320.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20260.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/20",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20323.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/21",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "20300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Liabilities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/22",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20312.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DebtCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/23",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20322.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredIncomeTaxLiabilitiesNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/24",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20130.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/25",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20140.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PrepaidExpenseCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/26",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20420.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PreferredStockValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/27",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseRightOfUseAsset"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/28",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20220.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Goodwill"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/29",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Liabilities",
+          "order": "20310.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/3",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20430.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AdditionalPaidInCapital"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/30",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/31",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20115.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ShortTermInvestments"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/32",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20321.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/33",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20110.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/34",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20315.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/35",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20325.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/36",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20120.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ReceivablesNetCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/37",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -4563,17 +2412,3875 @@
           "to": "rs-gaap:AssetsNoncurrent"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/17",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/4",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:Liabilities",
-          "order": "20310.0",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20311.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesCurrent"
+          "to": "rs-gaap:AccountsPayableCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20460.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:TreasuryStockValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/6",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20314.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseLiabilityCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/7",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "20400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:StockholdersEquity"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/8",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20410.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CommonStockValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/9",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20210.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PropertyPlantAndEquipmentNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/817b5260ef4b963d/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "https://robosystems.ai/concept/cadence:SignificantAccountingPoliciesAbstract",
+          "order": "1.0",
+          "role": "https://cadencelabs.example.com/roles/disclosures/AccountingPolicies",
+          "to": "https://robosystems.ai/concept/cadence:RevenueRecognitionPolicyTextBlock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/817b5260ef4b963d/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "https://robosystems.ai/concept/cadence:SignificantAccountingPoliciesAbstract",
+          "order": "2.0",
+          "role": "https://cadencelabs.example.com/roles/disclosures/AccountingPolicies",
+          "to": "https://robosystems.ai/concept/cadence:OperatingExpensePolicyTextBlock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "11100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10630.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainLossOnDispositionOfAssets"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/10",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10900.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeTaxExpenseBenefit"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/11",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "11000.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperations"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/12",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10620.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InterestExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/13",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10800.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/14",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/15",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10443.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RestructuringCharges"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/16",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:NonoperatingIncomeExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/17",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "10210.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfGoodsAndServicesSold"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/18",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10643.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/19",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "10230.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostOfOperatingRevenue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10430.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:DepreciationDepletionAndAmortization"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/20",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10446.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:AssetImpairmentCharges"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/21",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10440.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostAndExpenseOperating"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/22",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Revenues",
+          "order": "10120.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/23",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10410.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GeneralAndAdministrativeExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/24",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10646.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/25",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10420.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ResearchAndDevelopmentExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/26",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10640.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherNonoperatingIncomeExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/3",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10610.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InvestmentIncomeInterest"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/4",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingExpenses"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GrossProfit"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/6",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10415.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:SellingAndMarketingExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/7",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfRevenue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/8",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:Revenues"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/9",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "11200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:NetIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/8673d69fbb9ae32e/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "order": "1.0",
+          "role": "https://cadencelabs.example.com/roles/disclosures/DisaggregationOfRevenue",
+          "to": "https://robosystems.ai/concept/cadence:SubscriptionRevenue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/8673d69fbb9ae32e/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "order": "2.0",
+          "role": "https://cadencelabs.example.com/roles/disclosures/DisaggregationOfRevenue",
+          "to": "https://robosystems.ai/concept/cadence:ProfessionalServicesRevenue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/1eae745dbb354952",
+          "@type": [
+            "rs:Hierarchy",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/1eae745dbb354952",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/1eae745dbb354952/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/1eae745dbb354952/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/1eae745dbb354952/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/1eae745dbb354952/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/1eae745dbb354952/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/1eae745dbb354952/presentation/5"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "structureName": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
+          "structureOrder": "1"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/4d5ede325089bd91",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/4d5ede325089bd91/presentation/9"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "structureName": "rs-gaap — Cash Flow Statement — Indirect",
+          "structureOrder": "2"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/75bf584b3e4aaaa0",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/23",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/24",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/25",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/26",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/27",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/28",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/29",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/30",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/31",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/32",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/33",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/34",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/35",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/36",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/37",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/75bf584b3e4aaaa0/presentation/9"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "prefLabel": "rs-gaap — Balance Sheet — Classified",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "structureName": "rs-gaap — Balance Sheet — Classified",
+          "structureOrder": "0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/817b5260ef4b963d",
+          "@type": [
+            "rs:Hierarchy",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/817b5260ef4b963d",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/817b5260ef4b963d/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/817b5260ef4b963d/presentation/1"
+          ],
+          "internalId": "https://cadencelabs.example.com/roles/disclosures/AccountingPolicies",
+          "prefLabel": "Significant Accounting Policies",
+          "roleUri": "https://cadencelabs.example.com/roles/disclosures/AccountingPolicies",
+          "structureName": "Significant Accounting Policies",
+          "structureOrder": "4"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/850c3d8ab3a4a627",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/23",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/24",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/25",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/26",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/850c3d8ab3a4a627/presentation/9"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "prefLabel": "rs-gaap — Income Statement — Multi-step",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "structureName": "rs-gaap — Income Statement — Multi-step",
+          "structureOrder": "3"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/8673d69fbb9ae32e",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/8673d69fbb9ae32e",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/8673d69fbb9ae32e/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/association/8673d69fbb9ae32e/presentation/1"
+          ],
+          "internalId": "https://cadencelabs.example.com/roles/disclosures/DisaggregationOfRevenue",
+          "prefLabel": "Disaggregation of Revenue",
+          "roleUri": "https://cadencelabs.example.com/roles/disclosures/DisaggregationOfRevenue",
+          "structureName": "Disaggregation of Revenue",
+          "structureOrder": "5"
+        },
+        {
+          "@id": "rs-gaap:AccountsPayableCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccountsPayableCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accounts Payable, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Accounts Payable, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AccruedLiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccruedLiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accrued Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Accrued Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accumulated Other Comprehensive Income (Loss), Net of Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Accumulated Other Comprehensive Income (Loss), Net of Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AdditionalPaidInCapital",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AdditionalPaidInCapital",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Additional Paid in Capital",
+          "source": "rs-gaap",
+          "standardLabel": "Additional Paid in Capital",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetImpairmentCharges",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetImpairmentCharges",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Asset Impairment Charges",
+          "source": "rs-gaap",
+          "standardLabel": "Asset Impairment Charges",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Assets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Assets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CommonStockValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CommonStockValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Common Stock, Value, Issued",
+          "source": "rs-gaap",
+          "standardLabel": "Common Stock, Value, Issued",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfGoodsAndServicesSold",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfGoodsAndServicesSold",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Product and Service Sold",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Product and Service Sold",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Revenue",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Revenue",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DebtCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DebtCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Debt, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Debt, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DeferredIncomeTaxLiabilitiesNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DeferredIncomeTaxLiabilitiesNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Deferred Income Tax Liabilities, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Deferred Income Tax Liabilities, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DeferredRevenueCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DeferredRevenueCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Deferred Revenue, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Deferred Revenue, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DeferredRevenueNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DeferredRevenueNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Deferred Revenue, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Deferred Revenue, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DepreciationDepletionAndAmortization",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DepreciationDepletionAndAmortization",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Depreciation, Depletion and Amortization",
+          "source": "rs-gaap",
+          "standardLabel": "Depreciation, Depletion and Amortization",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:EffectOfExchangeRateOnCash",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:EffectOfExchangeRateOnCash",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Effect of Exchange Rate on Cash",
+          "source": "rs-gaap",
+          "standardLabel": "Effect of Exchange Rate on Cash",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:FinanceLeaseLiabilityCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:FinanceLeaseLiabilityCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Finance Lease, Liability, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Finance Lease, Liability, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:FinanceLeaseRightOfUseAsset",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:FinanceLeaseRightOfUseAsset",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Finance Lease, Right-of-Use Asset, after Accumulated Amortization",
+          "source": "rs-gaap",
+          "standardLabel": "Finance Lease, Right-of-Use Asset, after Accumulated Amortization",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gain (Loss), Foreign Currency Transaction, before Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Gain (Loss), Foreign Currency Transaction, before Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GainLossOnDispositionOfAssets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GainLossOnDispositionOfAssets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gain (Loss) on Disposition of Property Plant Equipment, Excluding Oil and Gas Property and Timber Property",
+          "source": "rs-gaap",
+          "standardLabel": "Gain (Loss) on Disposition of Property Plant Equipment, Excluding Oil and Gas Property and Timber Property",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gain (Loss) on Extinguishment of Debt",
+          "source": "rs-gaap",
+          "standardLabel": "Gain (Loss) on Extinguishment of Debt",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GeneralAndAdministrativeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GeneralAndAdministrativeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "General and Administrative Expense",
+          "source": "rs-gaap",
+          "standardLabel": "General and Administrative Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Goodwill",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Goodwill",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Goodwill",
+          "source": "rs-gaap",
+          "standardLabel": "Goodwill",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GrossProfit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GrossProfit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gross Profit",
+          "source": "rs-gaap",
+          "standardLabel": "Gross Profit",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperations",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperations",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Discontinued Operations, Net of Tax, Including Portion Attributable to Noncontrolling Interest",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Discontinued Operations, Net of Tax, Including Portion Attributable to Noncontrolling Interest",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeStatementAbstract",
+          "@type": "rs:Element",
+          "abstract": "true",
+          "balance": "debit",
+          "elementType": "abstract",
+          "internalId": "rs-gaap:IncomeStatementAbstract",
+          "itemType": "string",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income Statement [Abstract]",
+          "source": "rs-gaap",
+          "standardLabel": "Income Statement [Abstract]",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeTaxExpenseBenefit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeTaxExpenseBenefit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income Tax Expense (Benefit)",
+          "source": "rs-gaap",
+          "standardLabel": "Income Tax Expense (Benefit)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accounts Payable and Accrued Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accounts Payable and Accrued Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accounts Receivable",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accounts Receivable",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Income Taxes Payable",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Income Taxes Payable",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accrued Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accrued Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInInventories",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInInventories",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Inventories",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Inventories",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Prepaid Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Prepaid Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Intangible Assets, Net (Excluding Goodwill)",
+          "source": "rs-gaap",
+          "standardLabel": "Intangible Assets, Net (Excluding Goodwill)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:InterestExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:InterestExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Interest Expense, Operating and Nonoperating",
+          "source": "rs-gaap",
+          "standardLabel": "Interest Expense, Operating and Nonoperating",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
+          "source": "rs-gaap",
+          "standardLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:InvestmentIncomeInterest",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:InvestmentIncomeInterest",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Investment Income, Interest",
+          "source": "rs-gaap",
+          "standardLabel": "Investment Income, Interest",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Liabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Liabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities and Equity",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities and Equity",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Debt and Lease Obligation",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Debt and Lease Obligation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermDebtCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermDebtCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Debt, Current Maturities",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Debt, Current Maturities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Investments and Receivables, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Investments and Receivables, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Net Income (Loss) Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Net Income (Loss) Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NonoperatingIncomeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NonoperatingIncomeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Nonoperating Income (Expense)",
+          "source": "rs-gaap",
+          "standardLabel": "Nonoperating Income (Expense)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingExpenses",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingExpenses",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Expenses",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Expenses",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Income (Loss)",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Income (Loss)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Operating Lease, Liability, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Lease, Liability, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingLeaseRightOfUseAsset",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingLeaseRightOfUseAsset",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Operating Lease, Right-of-Use Asset",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Lease, Right-of-Use Asset",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherAssetsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherAssetsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Assets, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Other Assets, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherAssetsNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherAssetsNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Assets, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Other Assets, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Comprehensive Income (Loss), Net of Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Other Comprehensive Income (Loss), Net of Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherCostAndExpenseOperating",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherCostAndExpenseOperating",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Cost and Expense, Operating",
+          "source": "rs-gaap",
+          "standardLabel": "Other Cost and Expense, Operating",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherCostOfOperatingRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherCostOfOperatingRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Cost of Operating Revenue",
+          "source": "rs-gaap",
+          "standardLabel": "Other Cost of Operating Revenue",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherLiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherLiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Other Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherLiabilitiesNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherLiabilitiesNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Liabilities, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Other Liabilities, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherNonoperatingIncomeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherNonoperatingIncomeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Nonoperating Income (Expense)",
+          "source": "rs-gaap",
+          "standardLabel": "Other Nonoperating Income (Expense)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsForRepurchaseOfCommonStock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsForRepurchaseOfCommonStock",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments for Repurchase of Common Stock",
+          "source": "rs-gaap",
+          "standardLabel": "Payments for Repurchase of Common Stock",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsOfDividends",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsOfDividends",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments of Dividends",
+          "source": "rs-gaap",
+          "standardLabel": "Payments of Dividends",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquireIntangibleAssets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquireIntangibleAssets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Intangible Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Intangible Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquireInvestments",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquireInvestments",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Investments",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Investments",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PreferredStockValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PreferredStockValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Preferred Stock, Value, Issued",
+          "source": "rs-gaap",
+          "standardLabel": "Preferred Stock, Value, Issued",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PrepaidExpenseCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PrepaidExpenseCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Prepaid Expense, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Prepaid Expense, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Issuance of Common Stock",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Issuance of Common Stock",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Issuance of Long-Term Debt",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Issuance of Long-Term Debt",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Sale, Maturity and Collection of Investments",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Sale, Maturity and Collection of Investments",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromSaleOfIntangibleAssets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromSaleOfIntangibleAssets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Sale of Intangible Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Sale of Intangible Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Sale of Property, Plant, and Equipment",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Sale of Property, Plant, and Equipment",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Property, Plant and Equipment, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Property, Plant and Equipment, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ReceivablesNetCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ReceivablesNetCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Receivables, Net, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Receivables, Net, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RepaymentsOfLongTermDebt",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RepaymentsOfLongTermDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Repayments of Long-Term Debt",
+          "source": "rs-gaap",
+          "standardLabel": "Repayments of Long-Term Debt",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ResearchAndDevelopmentExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ResearchAndDevelopmentExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Research and Development Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Research and Development Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Restricted Cash and Investments, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Restricted Cash and Investments, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RestructuringCharges",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RestructuringCharges",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Restructuring Charges",
+          "source": "rs-gaap",
+          "standardLabel": "Restructuring Charges",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Retained Earnings (Accumulated Deficit)",
+          "source": "rs-gaap",
+          "standardLabel": "Retained Earnings (Accumulated Deficit)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Revenues",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Revenues",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenues",
+          "source": "rs-gaap",
+          "standardLabel": "Revenues",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:SellingAndMarketingExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:SellingAndMarketingExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Selling and Marketing Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Selling and Marketing Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ShareBasedCompensation",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ShareBasedCompensation",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Share-Based Payment Arrangement, Noncash Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Share-Based Payment Arrangement, Noncash Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ShortTermInvestments",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ShortTermInvestments",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Short-Term Investments",
+          "source": "rs-gaap",
+          "standardLabel": "Short-Term Investments",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:StockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:StockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Stockholders' Equity Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Stockholders' Equity Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:TreasuryStockValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:TreasuryStockValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Treasury Stock, Value",
+          "source": "rs-gaap",
+          "standardLabel": "Treasury Stock, Value",
+          "substitutionGroup": "xbrli:item"
         }
       ],
       "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH#projection"
+    },
+    {
+      "@graph": [
+        {
+          "@id": "https://robosystems.ai/concept/cadence:OperatingExpensePolicyTextBlock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "dataType": "textBlockItemType",
+          "elementType": "concept",
+          "internalId": "cadence:OperatingExpensePolicyTextBlock",
+          "itemType": "textBlock",
+          "monetary": "false",
+          "periodType": "duration",
+          "source": "cadence"
+        },
+        {
+          "@id": "https://robosystems.ai/concept/cadence:ProfessionalServicesRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "cadence:ProfessionalServicesRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "source": "cadence"
+        },
+        {
+          "@id": "https://robosystems.ai/concept/cadence:RevenueRecognitionPolicyTextBlock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "dataType": "textBlockItemType",
+          "elementType": "concept",
+          "internalId": "cadence:RevenueRecognitionPolicyTextBlock",
+          "itemType": "textBlock",
+          "monetary": "false",
+          "periodType": "duration",
+          "source": "cadence"
+        },
+        {
+          "@id": "https://robosystems.ai/concept/cadence:SubscriptionRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "cadence:SubscriptionRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "source": "cadence"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH",
+          "@type": "rs:Report",
+          "accessionNumber": "rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "mode": "report",
+          "reportingStyle": "sec-as-filed",
+          "serializationVersion": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "@type": "rs:Entity",
+          "internalId": "entity_kg1a07f28ad2b28bf365b8",
+          "legalName": "Cadence Labs, Inc.",
+          "prefLabel": "Cadence Labs, Inc.",
+          "scheme": "http://robosystems.ai/entity"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FRS",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "https://robosystems.ai/concept/cadence:ProfessionalServicesRevenue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/8673d69fbb9ae32e",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FRS",
+          "numericValue": "88800.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FRT",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "https://robosystems.ai/concept/cadence:SubscriptionRevenue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/8673d69fbb9ae32e",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FRT",
+          "numericValue": "1156399.44",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FRV",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AccountsPayableCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FRV",
+          "numericValue": "0.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FRW",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AdditionalPaidInCapital",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FRW",
+          "numericValue": "2835000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FRX",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FRX",
+          "numericValue": "1913398.8",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FRY",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CostOfGoodsAndServicesSold",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FRY",
+          "numericValue": "266400.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FRZ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DeferredRevenueCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FRZ",
+          "numericValue": "1153999.56",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS0",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DepreciationDepletionAndAmortization",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS0",
+          "numericValue": "29111.04",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS1",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DepreciationDepletionAndAmortization",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS1",
+          "numericValue": "29111.04",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS2",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:GeneralAndAdministrativeExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS2",
+          "numericValue": "488500.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS3",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PrepaidExpenseCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS3",
+          "numericValue": "36500.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS4",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ReceivablesNetCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS4",
+          "numericValue": "9600.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS5",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ResearchAndDevelopmentExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS5",
+          "numericValue": "786000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS6",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS6",
+          "numericValue": "-1970278.46",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS7",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/850c3d8ab3a4a627",
+            "https://robosystems.ai/factset/8673d69fbb9ae32e"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS7",
+          "numericValue": "1245199.44",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS8",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/850c3d8ab3a4a627",
+            "https://robosystems.ai/factset/8673d69fbb9ae32e"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS8",
+          "numericValue": "1245199.44",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FS9",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:SellingAndMarketingExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FS9",
+          "numericValue": "741600.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSA",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "https://robosystems.ai/concept/cadence:ProfessionalServicesRevenue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/8673d69fbb9ae32e",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSA",
+          "numericValue": "13200.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSB",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "https://robosystems.ai/concept/cadence:SubscriptionRevenue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/8673d69fbb9ae32e",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSB",
+          "numericValue": "179599.8",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSC",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AccountsPayableCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSC",
+          "numericValue": "0.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSD",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AdditionalPaidInCapital",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSD",
+          "numericValue": "2835000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSE",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSE",
+          "numericValue": "2767021.77",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSF",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CostOfGoodsAndServicesSold",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSF",
+          "numericValue": "39600.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSG",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DeferredRevenueCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSG",
+          "numericValue": "922021.97",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSH",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DepreciationDepletionAndAmortization",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSH",
+          "numericValue": "6666.66",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSJ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DepreciationDepletionAndAmortization",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSJ",
+          "numericValue": "6666.66",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSK",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:GeneralAndAdministrativeExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSK",
+          "numericValue": "99000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSM",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PrepaidExpenseCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSM",
+          "numericValue": "33000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSN",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ReceivablesNetCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSN",
+          "numericValue": "4800.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSP",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ResearchAndDevelopmentExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSP",
+          "numericValue": "129000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSQ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSQ",
+          "numericValue": "-903866.86",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSR",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/850c3d8ab3a4a627",
+            "https://robosystems.ai/factset/8673d69fbb9ae32e"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSR",
+          "numericValue": "192799.8",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSS",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/850c3d8ab3a4a627",
+            "https://robosystems.ai/factset/8673d69fbb9ae32e"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSS",
+          "numericValue": "192799.8",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FST",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:SellingAndMarketingExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FST",
+          "numericValue": "122400.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSV",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSV",
+          "numericValue": "-1066411.6",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSW",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSW",
+          "numericValue": "-1066411.6",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSX",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSX",
+          "numericValue": "-1066411.6",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSY",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSY",
+          "numericValue": "-203866.86",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FSZ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FSZ",
+          "numericValue": "-203866.86",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT0",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT0",
+          "numericValue": "-203866.86",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT1",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT1",
+          "numericValue": "59222.3",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT2",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT2",
+          "numericValue": "48333.34",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT3",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT3",
+          "numericValue": "2835000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT4",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT4",
+          "numericValue": "2835000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT5",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT5",
+          "numericValue": "-80000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT6",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT6",
+          "numericValue": "-3500.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT7",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT7",
+          "numericValue": "-4800.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT8",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT8",
+          "numericValue": "191977.59",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FT9",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncomeLossFromContinuingOperations",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FT9",
+          "numericValue": "-1066411.6",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTA",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Revenues",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTA",
+          "numericValue": "1245199.44",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTB",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTB",
+          "numericValue": "-853622.97",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTC",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTC",
+          "numericValue": "-853622.97",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTD",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AssetsCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTD",
+          "numericValue": "1959498.8",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTE",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AssetsNoncurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTE",
+          "numericValue": "59222.3",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTF",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTF",
+          "numericValue": "2018721.1",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTG",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTG",
+          "numericValue": "1153999.56",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTH",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:StockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTH",
+          "numericValue": "864721.54",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTJ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:StockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTJ",
+          "numericValue": "864721.54",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTK",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Assets",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTK",
+          "numericValue": "2018721.1",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTM",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Liabilities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTM",
+          "numericValue": "1153999.56",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTN",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:OperatingExpenses",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTN",
+          "numericValue": "2045211.04",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTP",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CostOfRevenue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTP",
+          "numericValue": "266400.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTQ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTQ",
+          "numericValue": "-1066411.6",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTR",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:GrossProfit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTR",
+          "numericValue": "978799.44",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTS",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:OperatingIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTS",
+          "numericValue": "-1066411.6",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTT",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncomeLossFromContinuingOperations",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTT",
+          "numericValue": "-203866.86",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTV",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Revenues",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTV",
+          "numericValue": "192799.8",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTW",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTW",
+          "numericValue": "-197200.2",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTX",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTX",
+          "numericValue": "2557799.8",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTY",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTY",
+          "numericValue": "2835000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY0JTBQFNSE1XRT0FTZ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AssetsCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY0JTBQFNSE1XRT0FTZ",
+          "numericValue": "2804821.77",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6H",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6H",
+          "numericValue": "-80000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6J",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AssetsNoncurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6J",
+          "numericValue": "48333.34",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6K",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6K",
+          "numericValue": "2853155.11",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6M",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6M",
+          "numericValue": "922021.97",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6N",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:StockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6N",
+          "numericValue": "1931133.14",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6P",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:StockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6P",
+          "numericValue": "1931133.14",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6Q",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Assets",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6Q",
+          "numericValue": "2853155.11",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6R",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Liabilities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6R",
+          "numericValue": "922021.97",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6S",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:OperatingExpenses",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6S",
+          "numericValue": "357066.66",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6T",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CostOfRevenue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6T",
+          "numericValue": "39600.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6V",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6V",
+          "numericValue": "-203866.86",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6W",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:GrossProfit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6W",
+          "numericValue": "153199.8",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZY1Z2CB34JBGTX8NF6X",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:OperatingIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK1ZY1Z2CB34JBGTX8NF6X",
+          "numericValue": "-203866.86",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZYBG1NFB3B7XXDZM3CJ",
+          "@type": "rs:Fact",
+          "element": "https://robosystems.ai/concept/cadence:RevenueRecognitionPolicyTextBlock",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/817b5260ef4b963d",
+          "factType": "nonnumeric",
+          "internalId": "fact_01M1ZK1ZYBG1NFB3B7XXDZM3CJ",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "stringValue": "# Revenue Recognition Policy — Cadence Labs, Inc.\n\n## Standard\nRevenue is recognized under ASC 606 as the performance obligation is satisfied.\n\n## Subscriptions (annual, prepaid)\n- Customers sign annual contracts and pay the full year up front.\n- Cash collected is recorded as **Deferred Revenue (2300)**, a current liability.\n- Revenue is recognized **ratably** over the 12-month term: DR Deferred Revenue / CR Subscription Revenue (4000) each month.\n- The deferred-revenue balance equals contracts billed but not yet delivered. It is a source of working-capital \"float\" — cash in hand that finances operations but is owed as future service.\n\n## Professional Services\n- Onboarding/implementation is billed net-30 and recognized as delivered: DR AR (1100) / CR Professional Services (4100).\n\n## Why it matters for runway\nBecause subscriptions are prepaid, cash collected can exceed revenue recognized while the business grows — softening the cash burn. That float is a liability, not equity. When assessing how long the company can operate, subtract deferred revenue from cash before dividing by the burn."
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/fact/fact_01M1ZK1ZYBG1NFB3B7XXDZM3CK",
+          "@type": "rs:Fact",
+          "element": "https://robosystems.ai/concept/cadence:OperatingExpensePolicyTextBlock",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/entity/entity_kg1a07f28ad2b28bf365b8",
+          "factSet": "https://robosystems.ai/factset/817b5260ef4b963d",
+          "factType": "nonnumeric",
+          "internalId": "fact_01M1ZK1ZYBG1NFB3B7XXDZM3CK",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "stringValue": "# Operating Expense & Burn Policy — Cadence Labs, Inc.\n\n## Expense classification (by function)\n| Function | Account | Includes |\n|---|---|---|\n| Cost of Revenue | 5000 | Cloud hosting, customer support |\n| Research & Development | 6000 | Engineering salaries, product development |\n| Sales & Marketing | 6100 | Sales team, commissions, advertising |\n| General & Administrative | 6200 / 6300 / 6400 | Admin, finance, legal, rent, software tools |\n\nR&D is expensed as incurred (no internal-use software capitalization in this policy).\n\n## Depreciation & Prepaids\nStraight-line. Equipment over 36 months; the office build-out over 60 months (DR Depreciation Expense 7000 / CR Accumulated Depreciation 1350). Annual tooling and insurance are capitalized as prepaids and amortized over 12 months.\n\n## Burn & runway\n- **Monthly operating burn** ≈ operating loss + non-cash addbacks (depreciation/amortization), adjusted for working-capital movements.\n- **Runway** = cash ÷ net monthly burn. Report it net of deferred revenue: the prepayment float inflates the cash balance with obligations owed as service."
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/ib/1eae745dbb354952",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/1eae745dbb354952",
+          "internalId": "1eae745dbb354952",
+          "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/1eae745dbb354952"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/ib/4d5ede325089bd91",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "internalId": "4d5ede325089bd91",
+          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/4d5ede325089bd91"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/ib/75bf584b3e4aaaa0",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "internalId": "75bf584b3e4aaaa0",
+          "prefLabel": "rs-gaap — Balance Sheet — Classified",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/75bf584b3e4aaaa0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/ib/817b5260ef4b963d",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/817b5260ef4b963d",
+          "internalId": "817b5260ef4b963d",
+          "prefLabel": "Significant Accounting Policies",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/817b5260ef4b963d"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/ib/850c3d8ab3a4a627",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "internalId": "850c3d8ab3a4a627",
+          "prefLabel": "rs-gaap — Income Statement — Multi-step",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/850c3d8ab3a4a627"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/ib/8673d69fbb9ae32e",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/8673d69fbb9ae32e",
+          "internalId": "8673d69fbb9ae32e",
+          "prefLabel": "Disaggregation of Revenue",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/structure/8673d69fbb9ae32e"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2025",
+          "calendarQuarter": "FY",
+          "calendarYear": "2025",
+          "durationType": "annual",
+          "endDate": "2025-08-31",
+          "periodType": "duration",
+          "startDate": "2024-09-01"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2026",
+          "calendarQuarter": "FY",
+          "calendarYear": "2026",
+          "durationType": "annual",
+          "endDate": "2026-08-31",
+          "periodType": "duration",
+          "startDate": "2025-09-01"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2026-08-31",
+          "calendarQuarter": "Q3",
+          "calendarYear": "2026",
+          "instant": "2026-08-31",
+          "periodType": "instant"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2025-08-31",
+          "calendarQuarter": "Q3",
+          "calendarYear": "2025",
+          "instant": "2025-08-31",
+          "periodType": "instant"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785",
+          "@type": "rs:Unit",
+          "measure": "iso4217:USD"
+        },
+        {
+          "@id": "rs-gaap:AccountsPayableCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccountsPayableCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accounts Payable, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Accounts Payable, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AdditionalPaidInCapital",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AdditionalPaidInCapital",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Additional Paid in Capital",
+          "source": "rs-gaap",
+          "standardLabel": "Additional Paid in Capital",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Assets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Assets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfGoodsAndServicesSold",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfGoodsAndServicesSold",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Product and Service Sold",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Product and Service Sold",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Revenue",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Revenue",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DeferredRevenueCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DeferredRevenueCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Deferred Revenue, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Deferred Revenue, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DepreciationDepletionAndAmortization",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DepreciationDepletionAndAmortization",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Depreciation, Depletion and Amortization",
+          "source": "rs-gaap",
+          "standardLabel": "Depreciation, Depletion and Amortization",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GeneralAndAdministrativeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GeneralAndAdministrativeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "General and Administrative Expense",
+          "source": "rs-gaap",
+          "standardLabel": "General and Administrative Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GrossProfit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GrossProfit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gross Profit",
+          "source": "rs-gaap",
+          "standardLabel": "Gross Profit",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperations",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperations",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accounts Receivable",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accounts Receivable",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Prepaid Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Prepaid Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Liabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Liabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities and Equity",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities and Equity",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Net Income (Loss) Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Net Income (Loss) Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingExpenses",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingExpenses",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Expenses",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Expenses",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Income (Loss)",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Income (Loss)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PrepaidExpenseCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PrepaidExpenseCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Prepaid Expense, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Prepaid Expense, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Issuance of Common Stock",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Issuance of Common Stock",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Property, Plant and Equipment, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Property, Plant and Equipment, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ReceivablesNetCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ReceivablesNetCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Receivables, Net, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Receivables, Net, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ResearchAndDevelopmentExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ResearchAndDevelopmentExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Research and Development Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Research and Development Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Retained Earnings (Accumulated Deficit)",
+          "source": "rs-gaap",
+          "standardLabel": "Retained Earnings (Accumulated Deficit)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Revenues",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Revenues",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenues",
+          "source": "rs-gaap",
+          "standardLabel": "Revenues",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:SellingAndMarketingExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:SellingAndMarketingExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Selling and Marketing Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Selling and Marketing Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:StockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:StockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Stockholders' Equity Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Stockholders' Equity Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        }
+      ],
+      "@id": "https://robosystems.ai/report/rpt_01M1ZK1ZWEZ2Z01E1GX55PXWKH#scene"
     }
   ]
 }

--- a/robosystems/operations/serialization/rdf/holon.py
+++ b/robosystems/operations/serialization/rdf/holon.py
@@ -9,7 +9,8 @@ one report IRI —
 * ``<report>#boundary`` — the calculation network: the roll-up rules the facts
   must obey.
 * ``<report>#projection`` — the presentation network: order, indentation,
-  subtotals (structures + presentation arcs).
+  subtotals (structures + presentation arcs), with the elements those arcs
+  reach so every row carries its label whether or not it reports a value.
 
 The fourth graph, ``#lineage`` (the ledger behind the facts), is intentionally
 *absent* from the published holon — a report is an aggregation of the books, not
@@ -17,143 +18,39 @@ the books. The access boundary holds by graph omission, no filter code.
 
 The holon is a **shape, not a file format**. JSON-LD's data model *is* an RDF
 dataset, so dataset-form JSON-LD carries these named graphs natively — the
-single canonical, API-native holon. (rdflib can serialize the same
-:class:`~rdflib.Dataset` to TriG / N-Quads, but the platform does not emit
-them: JSON-LD is the one holon format.)
+single canonical, API-native holon.
 
-This module is the **single source of truth** for the partition. Two entry
-paths converge on :func:`build_holon_dataset`:
-
-* production — :func:`serialize_to_holon_jsonld` builds the flat
-  :class:`~rdflib.Graph` from a ``StatementBundle`` (via ``build_graph``), then
-  partitions it;
-* demo / offline — ``examples/_common/databook.py`` parses a downloaded flat
-  ``.jsonld`` into a graph and partitions *that*.
-
-Both call :func:`build_holon_dataset`, so the holon is derived one way.
+The partition lives in xbrlkit (``xbrlkit.serialize.holon.to_holon``), the
+writer behind the SEC pipeline's per-filing holons. This module is the
+platform's flavor entry: it re-expresses the ``StatementBundle`` as an
+``XbrlModel`` through the bridge in ``model.py`` — the waist the Tavi flavor
+already reads through — and hands it to that writer. A platform-side copy of
+the partition used to live here; it fell behind the kernel it was forked from
+and seeded the scene from facts alone, so every element reached only by an arc
+(an empty statement line, an abstract header) left the holon without its
+declaration and rendered unlabelled. One partition, one repo: the demo
+DataBook converter (``examples/_common/databook.py``) reads the flat JSON-LD
+back through xbrlkit's reader and calls the same writer.
 """
 
 from __future__ import annotations
 
-from rdflib import RDF, Dataset, Graph, URIRef
+from xbrlkit.serialize import to_holon
 
 from robosystems.operations.serialization.bundle import StatementBundle
-from robosystems.operations.serialization.rdf.jsonld import (
-  RS,
-  _build_context,
-  _root_uri,
-  build_graph,
+from robosystems.operations.serialization.model import (
+  bundle_to_xbrl_model,
+  report_identifier,
 )
-
-# The named-graph suffixes on the report IRI — the scene / boundary / projection
-# partition, keyed under the report IRI.
-HOLON_GRAPHS: tuple[str, str, str] = ("scene", "boundary", "projection")
-
-
-# ── Partition ──────────────────────────────────────────────────────────────
-
-
-def partition_report_graph(g: Graph) -> dict[str, Graph]:
-  """Split a flat report graph into the three *published* holon graphs.
-
-  ``scene`` (facts + the InformationBlock that groups them + the
-  element/period/unit/entity/factSet they reference), ``boundary``
-  (calculation arcs) and ``projection`` (presentation arcs + structures).
-  The ``lineage`` / event graph is intentionally absent: a report is an
-  aggregation of the books, not the books. Everything here already lives in
-  the report graph, so this is a pure repartition — no ledger access.
-
-  The bulky ``rs:envelopeJson`` literal is dropped from the published graphs;
-  it lives in the flat JSON-LD bundle for callers that need the opaque IB
-  mechanics.
-  """
-  scene, boundary, projection = Graph(), Graph(), Graph()
-
-  scene_subjects: set[URIRef] = set()
-  for fact in g.subjects(RDF.type, RS.Fact):
-    scene_subjects.add(fact)  # type: ignore[arg-type]
-    for ref in (RS.element, RS.period, RS.unit, RS.entity, RS.factSet):
-      v = g.value(fact, ref)
-      if isinstance(v, URIRef):
-        scene_subjects.add(v)
-  # The InformationBlock molecule groups its facts via the shared factSet
-  # (Fact --factSet--> FactSet <--factSet-- InformationBlock); include it so its
-  # blockType / prefLabel and that grouping link land in scene.
-  for ib in g.subjects(RDF.type, RS.InformationBlock):
-    scene_subjects.add(ib)  # type: ignore[arg-type]
-  for s in scene_subjects:
-    for p, o in g.predicate_objects(s):
-      if p == RS.envelopeJson:
-        continue
-      scene.add((s, p, o))
-
-  for assoc in g.subjects(RDF.type, RS.Association):
-    at = str(g.value(assoc, RS.associationType) or "")
-    target = (
-      boundary if at == "calculation" else projection if at == "presentation" else None
-    )
-    if target is None:
-      continue
-    for p, o in g.predicate_objects(assoc):
-      target.add((assoc, p, o))
-
-  for struct in g.subjects(RDF.type, RS.Structure):
-    for p, o in g.predicate_objects(struct):
-      if p == RS.envelopeJson:
-        continue
-      if p == RS.hasAssociation:
-        at = str(g.value(o, RS.associationType) or "")
-        (boundary if at == "calculation" else projection).add((struct, p, o))
-      else:
-        projection.add((struct, p, o))
-
-  return {"scene": scene, "boundary": boundary, "projection": projection}
-
-
-def build_holon_dataset(g: Graph, root: URIRef) -> Dataset:
-  """Assemble the holon :class:`~rdflib.Dataset` from a flat report graph.
-
-  Each partition lands in a named graph keyed by the report IRI —
-  ``<root>#scene`` / ``#boundary`` / ``#projection``. These IRIs are the ones
-  the DataBook's ``graph:`` map declares and the holon viewer reads, so they
-  must stay stable.
-  """
-  ds = Dataset()
-  for name, sub in partition_report_graph(g).items():
-    ctx = ds.graph(URIRef(f"{root}#{name}"))
-    for triple in sub:
-      ctx.add(triple)
-  return ds
-
-
-# ── Serializers ────────────────────────────────────────────────────────────
-
-
-def serialize_holon_jsonld_from_graph(g: Graph, root: URIRef) -> str:
-  """Serialize a flat report graph to the canonical **dataset-form JSON-LD**
-  holon — ``{"@context", "@graph": [ {@id: …#scene, @graph: […]}, … ]}``.
-
-  Passing the canonical ``@context`` compacts qnames and keeps the emitted
-  vocabulary identical to the flat JSON-LD bundle; without it rdflib dumps its
-  entire built-in prefix registry into ``@context``.
-  """
-  ds = build_holon_dataset(g, root)
-  return ds.serialize(
-    format="json-ld",
-    auto_compact=True,
-    context=_build_context(),
-    indent=2,
-    sort_keys=True,
-  )
 
 
 def serialize_to_holon_jsonld(bundle: StatementBundle) -> str:
   """Serialize a ``StatementBundle`` to the canonical dataset-form JSON-LD holon.
 
-  Builds the flat report graph from the bundle (the same ``build_graph`` the
-  flat JSON-LD serializer uses), then partitions it into the scene/boundary/
-  projection named graphs and emits dataset-form JSON-LD.
+  The report IRI the named graphs hang off is
+  ``https://robosystems.ai/report/{report_id}`` — the root the flat JSON-LD
+  stamps for the same report — so a DataBook's ``graph:`` map and the holon
+  viewer address ``#scene`` / ``#boundary`` / ``#projection`` identically
+  whichever path produced the file.
   """
-  g = build_graph(bundle)
-  root = _root_uri(bundle)
-  return serialize_holon_jsonld_from_graph(g, root)
+  return to_holon(bundle_to_xbrl_model(bundle), report_id=report_identifier(bundle))

--- a/tests/operations/serialization/test_jsonld_encoder.py
+++ b/tests/operations/serialization/test_jsonld_encoder.py
@@ -29,10 +29,7 @@ from robosystems.operations.serialization.bundle import (
   ReportMeta,
   StatementBundle,
 )
-from robosystems.operations.serialization.rdf.holon import (
-  partition_report_graph,
-  serialize_to_holon_jsonld,
-)
+from robosystems.operations.serialization.rdf.holon import serialize_to_holon_jsonld
 from robosystems.operations.serialization.rdf.jsonld import (
   SERIALIZATION_VERSION,
   BundleValidationError,
@@ -388,14 +385,23 @@ class TestHolon:
         out[str(node["@id"]).rsplit("#", 1)[-1]] = node["@graph"]
     return out
 
-  def test_partition_places_facts_and_calc_arcs(self) -> None:
-    parts = partition_report_graph(build_graph(_bundle(with_arc=True)))
-    assert set(parts) == {"scene", "boundary", "projection"}
-    # The fact lands in scene; the calculation arc in boundary.
-    assert list(parts["scene"].subjects(RDF.type, RS.Fact))
-    assert list(parts["boundary"].subjects(RDF.type, RS.Association))
+  def _local_types(self, node: dict) -> set[str]:
+    types = node.get("@type", [])
+    if isinstance(types, str):
+      types = [types]
+    return {t.rsplit(":", 1)[-1] for t in types}
+
+  def test_facts_land_in_scene_and_calc_arcs_in_boundary(self) -> None:
+    named = self._named_graphs(serialize_to_holon_jsonld(_bundle(with_arc=True)))
+    assert set(named) == {"scene", "boundary", "projection"}
+    assert any("Fact" in self._local_types(n) for n in named["scene"])
+    assert any(
+      "Association" in self._local_types(n)
+      and n.get("associationType") == "calculation"
+      for n in named["boundary"]
+    )
     # Lineage is never emitted — a report is an aggregation of the books.
-    assert "lineage" not in parts
+    assert "lineage" not in named
 
   def test_serializes_dataset_form_with_three_named_graphs(self) -> None:
     holon = serialize_to_holon_jsonld(_bundle(with_arc=True))
@@ -403,19 +409,46 @@ class TestHolon:
     assert set(named) == {"scene", "boundary", "projection"}
     assert named["scene"], "scene graph is non-empty"
 
-  def test_holon_round_trips_losslessly(self) -> None:
-    from rdflib import Dataset
+  def test_named_graphs_hang_off_the_report_iri(self) -> None:
+    """The root is the flat bundle's report IRI — what a DataBook's ``graph:``
+    map and the holon viewer address — not xbrlkit's default (the accession)."""
+    import json
 
-    holon = serialize_to_holon_jsonld(_bundle(with_arc=True))
-    src = partition_report_graph(build_graph(_bundle(with_arc=True)))
-    ds = Dataset()
-    ds.parse(data=holon, format="json-ld")
-    rt = {
-      str(c.identifier).rsplit("#", 1)[-1]: len(list(c))
-      for c in ds.graphs()
-      if str(c.identifier) != "urn:x-rdflib:default" and len(list(c))
+    doc = json.loads(serialize_to_holon_jsonld(_bundle(with_arc=True)))
+    graph_ids = {
+      n["@id"] for n in doc["@graph"] if isinstance(n, dict) and "@graph" in n
     }
-    assert rt == {k: len(v) for k, v in src.items()}
+    assert graph_ids == {
+      f"https://robosystems.ai/report/rpt_test#{name}"
+      for name in ("scene", "boundary", "projection")
+    }
+
+  def test_every_arc_endpoint_is_declared(self) -> None:
+    """The regression: an element reached only by an arc used to be dropped.
+
+    The platform's own partition seeded the scene from facts alone, so a
+    presentation row with no fact behind it — an empty line, an abstract
+    header — had no ``rs:Element`` anywhere in the holon and rendered without
+    a label: 56 of 98 elements on the SaaS demo. ``AssetsCurrent`` here is
+    that case (an arc names it, no fact does).
+    """
+    named = self._named_graphs(serialize_to_holon_jsonld(_bundle(with_arc=True)))
+    nodes = [n for graph in named.values() for n in graph]
+    declared = {n["@id"] for n in nodes if "Element" in self._local_types(n)}
+    referenced = {n[k] for n in nodes for k in ("from", "to") if k in n}
+    assert referenced, "the fixture carries an arc"
+    assert referenced <= declared, sorted(referenced - declared)
+
+  def test_xbrlkit_reads_back_every_concept(self) -> None:
+    from xbrlkit.deserialize.holon import from_holon_json
+
+    bundle = _bundle(with_arc=True)
+    model = from_holon_json(serialize_to_holon_jsonld(bundle))
+    assert set(model.concepts) == {c.qname for c in bundle.schema_concepts}
+    assert [label.value for label in model.concepts["rs-gaap:Assets"].labels] == [
+      "Assets"
+    ]
+    assert len(model.facts) == 1
 
 
 # ── Non-numeric (text-block) fact arm ────────────────────────────────────


### PR DESCRIPTION
## Summary

The platform's `rdf/holon.py` carried its own copy of the scene/boundary/projection partition, forked from the kernel xbrlkit now owns. It seeded the scene from facts alone, so every element reached only by an arc — an empty statement line, an abstract header — left the holon without its `rs:Element` and rendered without a label: **56 of the SaaS demo's 98 elements**. xbrlkit's kernel had since fixed this (arc endpoints carried into `#projection`, dimensions, the `rs:Report` node); the fork never inherited it.

- `serialize_to_holon_jsonld` is now `to_holon(bundle_to_xbrl_model(bundle))` — the waist the Tavi flavor already reads through. The platform partition is deleted.
- The DataBook converter (`examples/_common/databook.py`) reads the flat JSON-LD back through xbrlkit's reader and calls the same writer, and stamps the report id as the accession so the derived holon reads back like the API's.
- The flat JSON-LD encoder — the synchronous publish path — is untouched.
- The tracked demo sample `saas-startup-demo.holon.jsonld` is regenerated through the new path.

## Verification

| | before | after |
|---|---|---|
| `rs:Element` declared | 42 | 98 |
| arc endpoints referenced but undeclared | 56 | 0 |
| xbrlkit load — concepts / labelled | 42 / 38 | 98 / 93 |
| `rs:Report` node in `#scene` | no | yes |
| root IRI | `https://robosystems.ai/report/{id}` | unchanged |

Facts are identical before and after (86, 84 numeric, no value differences). New tests pin the regression — every arc endpoint declared, xbrlkit reads back every bundle concept, the named graphs hang off the report IRI. `tests/operations/serialization` plus the download and publication-artifact tests: 230 passed.

This is the holon half of `serialization-waist` phase 3, pulled early by the defect; the JSON-LD half stays parked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQNt2hdNJqbJwfoSRshaXo
