### PR TITLE
chore(examples): regenerate the demo holon samples through xbrlkit

### DIFF
--- a/examples/coffee_roaster_demo/sample_output/coffee-roaster-demo.holon.jsonld
+++ b/examples/coffee_roaster_demo/sample_output/coffee-roaster-demo.holon.jsonld
@@ -4,6 +4,9 @@
       "@id": "https://robosystems.ai/vocab/abstract",
       "@type": "xsd:boolean"
     },
+    "accessionNumber": {
+      "@id": "https://robosystems.ai/vocab/accessionNumber"
+    },
     "altLabel": "skos:altLabel",
     "arcrole": {
       "@id": "xlink:arcrole",
@@ -13,16 +16,30 @@
       "@id": "https://robosystems.ai/vocab/associationType"
     },
     "axis": {
-      "@id": "https://robosystems.ai/vocab/axis"
+      "@id": "https://robosystems.ai/vocab/axis",
+      "@type": "@id"
+    },
+    "axisType": {
+      "@id": "https://robosystems.ai/vocab/axisType"
     },
     "balance": {
       "@id": "xbrli:balance"
+    },
+    "baseType": {
+      "@id": "https://robosystems.ai/vocab/baseType"
     },
     "blockType": {
       "@id": "https://robosystems.ai/vocab/blockType"
     },
     "calendarPeriodKey": {
       "@id": "https://robosystems.ai/vocab/calendarPeriodKey"
+    },
+    "calendarQuarter": {
+      "@id": "https://robosystems.ai/vocab/calendarQuarter"
+    },
+    "calendarYear": {
+      "@id": "https://robosystems.ai/vocab/calendarYear",
+      "@type": "xsd:integer"
     },
     "category": {
       "@id": "https://robosystems.ai/vocab/category"
@@ -47,11 +64,11 @@
       "@id": "https://robosystems.ai/vocab/conceptArrangementPatternRequiresConcept",
       "@type": "@id"
     },
-    "contentType": {
-      "@id": "https://robosystems.ai/vocab/contentType"
-    },
     "country": {
       "@id": "https://robosystems.ai/vocab/country"
+    },
+    "dataType": {
+      "@id": "https://robosystems.ai/vocab/dataType"
     },
     "dcterms": "http://purl.org/dc/terms/",
     "decimals": {
@@ -61,6 +78,12 @@
     "deprecated": {
       "@id": "https://robosystems.ai/vocab/deprecated",
       "@type": "xsd:boolean"
+    },
+    "deprecatedDateLabel": {
+      "@id": "https://robosystems.ai/vocab/deprecatedDateLabel"
+    },
+    "deprecatedLabel": {
+      "@id": "https://robosystems.ai/vocab/deprecatedLabel"
     },
     "derivationRole": {
       "@id": "https://robosystems.ai/vocab/derivationRole"
@@ -87,6 +110,9 @@
     },
     "disclosures": "https://robosystems.ai/taxonomy/rs-gaap/disclosures/v1/",
     "documentation": "rdfs:comment",
+    "durationType": {
+      "@id": "https://robosystems.ai/vocab/durationType"
+    },
     "ein": {
       "@id": "https://robosystems.ai/vocab/ein"
     },
@@ -134,6 +160,10 @@
       "@id": "https://robosystems.ai/vocab/filedAt",
       "@type": "xsd:dateTime"
     },
+    "filingDate": {
+      "@id": "https://robosystems.ai/vocab/filingDate",
+      "@type": "xsd:date"
+    },
     "filingStatus": {
       "@id": "https://robosystems.ai/vocab/filingStatus"
     },
@@ -144,6 +174,18 @@
     "financialReportRequiresDisclosure": {
       "@id": "https://robosystems.ai/vocab/financialReportRequiresDisclosure",
       "@type": "@id"
+    },
+    "fiscalPeriodFocus": {
+      "@id": "https://robosystems.ai/vocab/fiscalPeriodFocus"
+    },
+    "fiscalYearEndMonth": {
+      "@id": "https://robosystems.ai/vocab/fiscalYearEndMonth"
+    },
+    "fiscalYearFocus": {
+      "@id": "https://robosystems.ai/vocab/fiscalYearFocus"
+    },
+    "form": {
+      "@id": "https://robosystems.ai/vocab/form"
     },
     "framework": {
       "@id": "https://robosystems.ai/vocab/framework"
@@ -183,6 +225,18 @@
     "internalId": {
       "@id": "https://robosystems.ai/vocab/internalId"
     },
+    "isExplicit": {
+      "@id": "https://robosystems.ai/vocab/isExplicit",
+      "@type": "xsd:boolean"
+    },
+    "isNil": {
+      "@id": "https://robosystems.ai/vocab/isNil",
+      "@type": "xsd:boolean"
+    },
+    "isTyped": {
+      "@id": "https://robosystems.ai/vocab/isTyped",
+      "@type": "xsd:boolean"
+    },
     "iso4217": "http://www.xbrl.org/2003/iso4217#",
     "itemType": {
       "@id": "https://robosystems.ai/vocab/itemType"
@@ -193,6 +247,9 @@
     },
     "labelRole": {
       "@id": "https://robosystems.ai/vocab/labelRole"
+    },
+    "language": {
+      "@id": "https://robosystems.ai/vocab/language"
     },
     "legalName": {
       "@id": "https://robosystems.ai/vocab/legalName"
@@ -207,7 +264,8 @@
       "@type": "@id"
     },
     "member": {
-      "@id": "https://robosystems.ai/vocab/member"
+      "@id": "https://robosystems.ai/vocab/member",
+      "@type": "@id"
     },
     "mode": {
       "@id": "https://robosystems.ai/vocab/mode"
@@ -219,8 +277,66 @@
     "name": {
       "@id": "https://robosystems.ai/vocab/name"
     },
+    "negated": {
+      "@id": "https://robosystems.ai/vocab/negated"
+    },
+    "negatedLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedLabel"
+    },
+    "negatedNetLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedNetLabel"
+    },
+    "negatedPeriodEnd": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodEnd"
+    },
+    "negatedPeriodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodEndLabel"
+    },
+    "negatedPeriodStart": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodStart"
+    },
+    "negatedPeriodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodStartLabel"
+    },
+    "negatedTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedTerseLabel"
+    },
+    "negatedTotal": {
+      "@id": "https://robosystems.ai/vocab/negatedTotal"
+    },
+    "negatedTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedTotalLabel"
+    },
+    "negativeLabel": {
+      "@id": "https://robosystems.ai/vocab/negativeLabel"
+    },
+    "negativePeriodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodEndLabel"
+    },
+    "negativePeriodEndTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodEndTotalLabel"
+    },
+    "negativePeriodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodStartLabel"
+    },
+    "negativePeriodStartTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodStartTotalLabel"
+    },
+    "negativeTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/negativeTerseLabel"
+    },
+    "negativeVerboseLabel": {
+      "@id": "https://robosystems.ai/vocab/negativeVerboseLabel"
+    },
+    "netLabel": {
+      "@id": "https://robosystems.ai/vocab/netLabel"
+    },
     "networkRoleUri": {
       "@id": "https://robosystems.ai/vocab/networkRoleUri"
+    },
+    "nillable": {
+      "@id": "https://robosystems.ai/vocab/nillable",
+      "@type": "xsd:boolean"
     },
     "nonAuthoritative": {
       "@id": "https://robosystems.ai/vocab/nonAuthoritative",
@@ -243,9 +359,19 @@
       "@id": "https://robosystems.ai/vocab/period",
       "@type": "@id"
     },
+    "periodEndDate": {
+      "@id": "https://robosystems.ai/vocab/periodEndDate",
+      "@type": "xsd:date"
+    },
+    "periodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/periodEndLabel"
+    },
     "periodNodes": {
       "@id": "https://robosystems.ai/vocab/periodNodes",
       "@type": "@id"
+    },
+    "periodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/periodStartLabel"
     },
     "periodType": {
       "@id": "xbrli:periodType"
@@ -254,9 +380,33 @@
       "@id": "https://robosystems.ai/vocab/periods",
       "@type": "@id"
     },
+    "positiveLabel": {
+      "@id": "https://robosystems.ai/vocab/positiveLabel"
+    },
+    "positivePeriodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodEndLabel"
+    },
+    "positivePeriodEndTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodEndTotalLabel"
+    },
+    "positivePeriodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodStartLabel"
+    },
+    "positivePeriodStartTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodStartTotalLabel"
+    },
+    "positiveTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/positiveTerseLabel"
+    },
+    "positiveVerboseLabel": {
+      "@id": "https://robosystems.ai/vocab/positiveVerboseLabel"
+    },
     "prefLabel": "skos:prefLabel",
     "preferredLabel": {
       "@id": "https://robosystems.ai/vocab/preferredLabel"
+    },
+    "preferredLabelRole": {
+      "@id": "https://robosystems.ai/vocab/preferredLabelRole"
     },
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
@@ -294,6 +444,9 @@
     "reportingStyleNetworks": {
       "@id": "https://robosystems.ai/vocab/reportingStyleNetworks"
     },
+    "restatedLabel": {
+      "@id": "https://robosystems.ai/vocab/restatedLabel"
+    },
     "retainedEarningsConcept": {
       "@id": "https://robosystems.ai/vocab/retainedEarningsConcept"
     },
@@ -305,9 +458,7 @@
       "@id": "https://robosystems.ai/vocab/roleUri"
     },
     "rs": "https://robosystems.ai/vocab/",
-    "rs-driver": "https://robosystems.ai/taxonomy/rs-gaap/drivers/v1/",
     "rs-gaap": "https://robosystems.ai/taxonomy/rs-gaap/v1/",
-    "rs-metric": "https://robosystems.ai/taxonomy/rs-gaap/metrics/v1/",
     "ruleCategory": {
       "@id": "https://robosystems.ai/vocab/ruleCategory"
     },
@@ -366,6 +517,10 @@
     "sourceReportId": {
       "@id": "https://robosystems.ai/vocab/sourceReportId"
     },
+    "srt": "http://fasb.org/srt/",
+    "standardLabel": {
+      "@id": "https://robosystems.ai/vocab/standardLabel"
+    },
     "start": {
       "@id": "https://robosystems.ai/vocab/start",
       "@type": "xsd:date"
@@ -381,8 +536,7 @@
       "@id": "https://robosystems.ai/vocab/statementType"
     },
     "stringValue": {
-      "@id": "https://robosystems.ai/vocab/stringValue",
-      "@type": "xsd:string"
+      "@id": "https://robosystems.ai/vocab/stringValue"
     },
     "structure": {
       "@id": "https://robosystems.ai/vocab/structure",
@@ -390,6 +544,10 @@
     },
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
+    },
+    "structureOrder": {
+      "@id": "https://robosystems.ai/vocab/structureOrder",
+      "@type": "xsd:integer"
     },
     "structures": {
       "@id": "https://robosystems.ai/vocab/structures",
@@ -415,11 +573,20 @@
     "taxonomyName": {
       "@id": "https://robosystems.ai/vocab/taxonomyName"
     },
+    "terseLabel": {
+      "@id": "https://robosystems.ai/vocab/terseLabel"
+    },
     "to": {
       "@id": "xlink:to",
       "@type": "@id"
     },
+    "totalLabel": {
+      "@id": "https://robosystems.ai/vocab/totalLabel"
+    },
     "trait": "https://robosystems.ai/taxonomy/fac-traits/v1/",
+    "typedValue": {
+      "@id": "https://robosystems.ai/vocab/typedValue"
+    },
     "unit": {
       "@id": "https://robosystems.ai/vocab/unit",
       "@type": "@id"
@@ -439,6 +606,9 @@
     "variableQname": {
       "@id": "https://robosystems.ai/vocab/variableQname"
     },
+    "verboseLabel": {
+      "@id": "https://robosystems.ai/vocab/verboseLabel"
+    },
     "version": {
       "@id": "https://robosystems.ai/vocab/version"
     },
@@ -450,1564 +620,50 @@
     "xbrldt": "http://xbrl.org/2005/xbrldt#",
     "xbrli": "http://www.xbrl.org/2003/instance#",
     "xlink": "http://www.w3.org/1999/xlink#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#"
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "zeroLabel": {
+      "@id": "https://robosystems.ai/vocab/zeroLabel"
+    },
+    "zeroTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/zeroTerseLabel"
+    },
+    "zeroVerboseLabel": {
+      "@id": "https://robosystems.ai/vocab/zeroVerboseLabel"
+    }
   },
   "@graph": [
     {
       "@graph": [
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK06K9AMDD3MH09QJ9M59C/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "https://robosystems.ai/concept/driftline:SignificantAccountingPoliciesAbstract",
-          "order": "2.0",
-          "role": "https://driftlinecoffee.example.com/roles/disclosures/AccountingPolicies",
-          "to": "https://robosystems.ai/concept/driftline:RevenueRecognitionPolicyTextBlock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/10",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/calculation/0",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
           "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30200.0",
+          "order": "100.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInInvestingActivities"
+          "to": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/calculation/1",
           "@type": [
-            "rs:RollUp",
-            "rs:Structure"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
-          "blockType": "balance_sheet",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/23",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/30",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/31",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/32",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/35",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/34",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/28",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/36",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/37",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/26",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/24",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/33",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/27",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/25",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/29",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/22"
-          ],
-          "internalId": "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "prefLabel": "rs-gaap — Balance Sheet — Classified",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "structureName": "rs-gaap — Balance Sheet — Classified"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/20",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10643.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/17",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Liabilities",
-          "order": "20310.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/24",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20315.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/8",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10415.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:SellingAndMarketingExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/28",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20323.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "@type": [
-            "rs:RollUp",
-            "rs:Structure"
-          ],
-          "blockType": "cash_flow_statement",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/18"
-          ],
-          "internalId": "5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "structureName": "rs-gaap — Cash Flow Statement — Indirect"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GrossProfit"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/17",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10620.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InterestExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/13",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10446.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:AssetImpairmentCharges"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "@type": [
-            "rs:RollUp",
-            "rs:Structure"
-          ],
-          "blockType": "income_statement",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/25",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/23",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/24",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/26",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/4"
-          ],
-          "internalId": "47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "prefLabel": "rs-gaap — Income Statement — Multi-step",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "structureName": "rs-gaap — Income Statement — Multi-step"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:ShareBasedCompensation"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/14",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30240.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/34",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20430.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AdditionalPaidInCapital"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/7",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10410.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GeneralAndAdministrativeExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/22",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
           "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:EffectOfExchangeRateOnCash"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:Revenues"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/11",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30210.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/33",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20420.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PreferredStockValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/12",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10443.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RestructuringCharges"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/22",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20313.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/37",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20460.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:TreasuryStockValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30120.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:DepreciationDepletionAndAmortization"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "order": "3.0",
-          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
-          "to": "https://robosystems.ai/concept/driftline:InventoryFinishedGoods"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30140.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInInventories"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:NetIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK06K9AMDD3MH09QJ9M59C/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "https://robosystems.ai/concept/driftline:SignificantAccountingPoliciesAbstract",
-          "order": "3.0",
-          "role": "https://driftlinecoffee.example.com/roles/disclosures/AccountingPolicies",
-          "to": "https://robosystems.ai/concept/driftline:DepreciationPolicyTextBlock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/26",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "11200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:NetIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/29",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20324.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/20",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30330.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:RepaymentsOfLongTermDebt"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/18",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10630.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainLossOnDispositionOfAssets"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/15",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:NonoperatingIncomeExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/17",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/10",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20220.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Goodwill"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/6",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInPrepaidExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/18",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30310.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "@type": [
-            "rs:Hierarchy",
-            "rs:Structure"
-          ],
-          "blockType": "equity_statement",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/3"
-          ],
-          "internalId": "0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "structureName": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/20",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20312.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DebtCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/8",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Assets",
-          "order": "20200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AssetsNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/7",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30170.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/struct_01M1ZK06K9AMDD3MH09QJ9M59C",
-          "@type": [
-            "rs:Hierarchy",
-            "rs:Structure"
-          ],
-          "blockType": "regulatory_disclosure",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK06K9AMDD3MH09QJ9M59C/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK06K9AMDD3MH09QJ9M59C/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK06K9AMDD3MH09QJ9M59C/presentation/1"
-          ],
-          "internalId": "struct_01M1ZK06K9AMDD3MH09QJ9M59C",
-          "prefLabel": "Significant Accounting Policies",
-          "roleUri": "https://driftlinecoffee.example.com/roles/disclosures/AccountingPolicies",
-          "rs:structureOrder": 100,
-          "structureName": "Significant Accounting Policies"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/18",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20311.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccountsPayableCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/24",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "11000.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperations"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "10210.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfGoodsAndServicesSold"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/9",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10420.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ResearchAndDevelopmentExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/32",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20410.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CommonStockValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/16",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30260.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromSaleOfIntangibleAssets"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/21",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30340.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/31",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "20400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:StockholdersEquity"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/9",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20210.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PropertyPlantAndEquipmentNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/26",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20321.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20140.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PrepaidExpenseCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/36",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20450.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Assets",
-          "order": "20100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AssetsCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/11",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10440.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostAndExpenseOperating"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/11",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20225.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20115.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ShortTermInvestments"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/10",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10430.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:DepreciationDepletionAndAmortization"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30110.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/19",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20311.5",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccruedLiabilitiesCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/25",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "11100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/19",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10640.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherNonoperatingIncomeExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20110.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/21",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20312.5",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/27",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20322.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredIncomeTaxLiabilitiesNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/12",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30220.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/6",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30160.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/13",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30230.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsToAcquireInvestments"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "order": "4.0",
-          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
-          "to": "https://robosystems.ai/concept/driftline:InventoryPackagingSupplies"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/15",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsToAcquireIntangibleAssets"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30130.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccountsReceivable"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/12",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20230.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/23",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20314.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseLiabilityCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Revenues",
-          "order": "10120.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInOperatingActivities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/9",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30190.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/14",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseRightOfUseAsset"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/35",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20440.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RetainedEarningsAccumulatedDeficit"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/25",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Liabilities",
-          "order": "20320.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20120.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ReceivablesNetCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/15",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20260.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfRevenue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/16",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "20300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Liabilities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "10230.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostOfOperatingRevenue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/19",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30320.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "order": "1.0",
-          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
-          "to": "https://robosystems.ai/concept/driftline:InventoryRawMaterials"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/13",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20240.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseRightOfUseAsset"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "order": "2.0",
-          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
-          "to": "https://robosystems.ai/concept/driftline:InventoryWorkInProcess"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/struct_01M1ZK01V0RM8658J9EE0ZA2PT",
-          "@type": [
-            "rs:RollUp",
-            "rs:Structure"
-          ],
-          "blockType": "regulatory_disclosure",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/presentation/2"
-          ],
-          "internalId": "struct_01M1ZK01V0RM8658J9EE0ZA2PT",
-          "prefLabel": "Inventory Components",
-          "roleUri": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
-          "rs:structureOrder": 101,
-          "structureName": "Inventory Components"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/21",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10646.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/30",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20325.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/22",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10800.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/7",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20160.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK06K9AMDD3MH09QJ9M59C/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "https://robosystems.ai/concept/driftline:SignificantAccountingPoliciesAbstract",
-          "order": "1.0",
-          "role": "https://driftlinecoffee.example.com/roles/disclosures/AccountingPolicies",
-          "to": "https://robosystems.ai/concept/driftline:InventoryPolicyTextBlock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/23",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10900.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeTaxExpenseBenefit"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:PaymentsOfDividends"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/8",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30180.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccruedLiabilities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20130.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/16",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10610.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InvestmentIncomeInterest"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/14",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/6",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingExpenses"
-        }
-      ],
-      "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8#projection"
-    },
-    {
-      "@graph": [
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/10",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CostOfRevenue",
           "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostOfOperatingRevenue",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/9",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccruedLiabilitiesCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/calculation/0",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "order": "1.0",
-          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
-          "to": "https://robosystems.ai/concept/driftline:InventoryRawMaterials",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/35",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/26",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/27",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/34",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/29",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/32",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/31",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/28",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/33",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/24",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/23",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/37",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/36",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/25",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/30",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/2"
-          ]
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/23",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/35",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/3"
-          ]
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/24",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/23",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/25",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/15"
-          ]
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/11",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ReceivablesNetCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/4",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NetIncomeLoss",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperations",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/5",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccountsPayableCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/10",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Assets",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AssetsNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/15",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DebtCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/calculation/6",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "order": "4.0",
-          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
-          "to": "https://robosystems.ai/concept/driftline:InventoryPackagingSupplies",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/2",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PropertyPlantAndEquipmentNet",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/19",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/23",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "403.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RestructuringCharges",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/5",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InvestmentIncomeInterest",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/0",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Assets",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AssetsCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/19",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:DepreciationDepletionAndAmortization",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/16",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredIncomeTaxLiabilitiesNet",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/20",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherNonoperatingIncomeExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/2",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/calculation/2",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -2021,500 +677,10 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/7",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/calculation/3",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingIncomeLoss",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GrossProfit",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/calculation/4",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "order": "3.0",
-          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
-          "to": "https://robosystems.ai/concept/driftline:InventoryFinishedGoods",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/14",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NetIncomeLoss",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/26",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseRightOfUseAsset",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/calculation/3",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "order": "2.0",
-          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
-          "to": "https://robosystems.ai/concept/driftline:InventoryWorkInProcess",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/37",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:TreasuryStockValue",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/13",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Liabilities",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/24",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "406.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/6",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/calculation/5",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "order": "3.0",
-          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
-          "to": "https://robosystems.ai/concept/driftline:InventoryFinishedGoods",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/calculation/2",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "order": "2.0",
-          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
-          "to": "https://robosystems.ai/concept/driftline:InventoryWorkInProcess",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/27",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseLiabilityCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/9",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:SellingAndMarketingExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/1",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/2",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperations",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/1",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:GrossProfit",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:Revenues",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/36",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/12",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperations",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeTaxExpenseBenefit",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/22",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/18",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/8",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Revenues",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/16",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ResearchAndDevelopmentExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/25",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PrepaidExpenseCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/0",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfGoodsAndServicesSold",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/3",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingIncomeLoss",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/30",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/15",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InterestExpense",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/17",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingIncomeLoss",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingExpenses",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/34",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/13",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:NonoperatingIncomeExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/17",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PreferredStockValue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/22",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "403.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/14",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:StockholdersEquity",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/29",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/4",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Liabilities",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/3",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -2525,202 +691,35 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/24",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AdditionalPaidInCapital",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/12",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Goodwill",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/28",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/8",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/0",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "150.0",
+          "from": "rs-gaap:Assets",
+          "order": "200.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ShortTermInvestments",
+          "to": "rs-gaap:AssetsNoncurrent",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/31",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/1",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseRightOfUseAsset",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/32",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
           "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/0",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/18",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainLossOnDispositionOfAssets",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/1",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
           "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/11",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:GrossProfit",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfRevenue",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/struct_01M1ZK01V0RM8658J9EE0ZA2PT",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/calculation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/calculation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/calculation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/calculation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/calculation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/calculation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/calculation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/calculation/1"
-          ]
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/6",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GeneralAndAdministrativeExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/3",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Liabilities",
-          "order": "100.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesCurrent",
+          "to": "rs-gaap:DebtCurrent",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/21",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/33",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/10",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -2734,63 +733,119 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/calculation/7",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/11",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "order": "4.0",
-          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
-          "to": "https://robosystems.ai/concept/driftline:InventoryPackagingSupplies",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ReceivablesNetCurrent",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/21",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/12",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccountsPayableCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/13",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
           "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostAndExpenseOperating",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseRightOfUseAsset",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/struct_01M1ZK01V0RM8658J9EE0ZA2PT/calculation/1",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/14",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "order": "1.0",
-          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
-          "to": "https://robosystems.ai/concept/driftline:InventoryRawMaterials",
-          "weight": "1.0"
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:TreasuryStockValue",
+          "weight": "-1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/25",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/15",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "406.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:AssetImpairmentCharges",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/20",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/16",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AdditionalPaidInCapital",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/17",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseRightOfUseAsset",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/18",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/19",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -2804,10 +859,276 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/7",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/2",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/20",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccruedLiabilitiesCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/21",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/22",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/23",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/24",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/25",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/26",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PrepaidExpenseCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/27",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/28",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/29",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Liabilities",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/3",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Assets",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AssetsCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/30",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/31",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/32",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredIncomeTaxLiabilitiesNet",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/33",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Liabilities",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/34",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseLiabilityCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/35",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/36",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ShortTermInvestments",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/37",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -2816,6 +1137,662 @@
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
           "to": "rs-gaap:CommonStockValue",
           "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/4",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/5",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PreferredStockValue",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/6",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:StockholdersEquity",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/7",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Liabilities",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/8",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Goodwill",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/9",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/0",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "403.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RestructuringCharges",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/1",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherNonoperatingIncomeExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/10",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:DepreciationDepletionAndAmortization",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/11",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingIncomeLoss",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GrossProfit",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/12",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperations",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeTaxExpenseBenefit",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/13",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfGoodsAndServicesSold",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/14",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingIncomeLoss",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/15",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingIncomeLoss",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingExpenses",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/16",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:NonoperatingIncomeExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/17",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GeneralAndAdministrativeExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/18",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostAndExpenseOperating",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/19",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "406.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:AssetImpairmentCharges",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/2",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperations",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/20",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostOfOperatingRevenue",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/21",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NetIncomeLoss",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/22",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "406.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/23",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:SellingAndMarketingExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/24",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:GrossProfit",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:Revenues",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/25",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InterestExpense",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/3",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Revenues",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/4",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NetIncomeLoss",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperations",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/5",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InvestmentIncomeInterest",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/6",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ResearchAndDevelopmentExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/7",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "403.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/8",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainLossOnDispositionOfAssets",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/9",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:GrossProfit",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfRevenue",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/calculation/0",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "order": "3.0",
+          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
+          "to": "https://robosystems.ai/concept/driftline:InventoryFinishedGoods",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/calculation/1",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "order": "4.0",
+          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
+          "to": "https://robosystems.ai/concept/driftline:InventoryPackagingSupplies",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/calculation/2",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "order": "1.0",
+          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
+          "to": "https://robosystems.ai/concept/driftline:InventoryRawMaterials",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/calculation/3",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "order": "1.0",
+          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
+          "to": "https://robosystems.ai/concept/driftline:InventoryRawMaterials",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/calculation/4",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "order": "2.0",
+          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
+          "to": "https://robosystems.ai/concept/driftline:InventoryWorkInProcess",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/calculation/5",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "order": "3.0",
+          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
+          "to": "https://robosystems.ai/concept/driftline:InventoryFinishedGoods",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/calculation/6",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "order": "2.0",
+          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
+          "to": "https://robosystems.ai/concept/driftline:InventoryWorkInProcess",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/calculation/7",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "order": "4.0",
+          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
+          "to": "https://robosystems.ai/concept/driftline:InventoryPackagingSupplies",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/4d5ede325089bd91",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/calculation/3"
+          ]
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/75bf584b3e4aaaa0",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/23",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/24",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/25",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/26",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/27",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/28",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/29",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/30",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/31",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/32",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/33",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/34",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/35",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/36",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/37",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/calculation/9"
+          ]
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/850c3d8ab3a4a627",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/23",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/24",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/25",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/calculation/9"
+          ]
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/d86840caccad8af9",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/calculation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/calculation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/calculation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/calculation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/calculation/7"
+          ]
         }
       ],
       "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8#boundary"
@@ -2823,431 +1800,1304 @@
     {
       "@graph": [
         {
-          "@id": "rs-gaap:LiabilitiesCurrent",
+          "@id": "https://robosystems.ai/concept/driftline:DepreciationPolicyTextBlock",
           "@type": "rs:Element",
           "abstract": "false",
-          "balance": "credit",
+          "balance": "debit",
+          "dataType": "textBlockItemType",
           "elementType": "concept",
-          "internalId": "efb036ff-3f30-5deb-bee9-1af4cd4b9800",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Liabilities, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW3",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DepreciationDepletionAndAmortization",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW3",
-          "numericValue": "13785.62",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "ff101489-15f4-573d-967b-24f75e0fc0f6",
-          "monetary": "true",
+          "internalId": "driftline:DepreciationPolicyTextBlock",
+          "itemType": "textBlock",
+          "monetary": "false",
           "periodType": "duration",
-          "prefLabel": "Payments to Acquire Property, Plant, and Equipment",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
+          "source": "driftline"
         },
         {
-          "@id": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "@id": "https://robosystems.ai/concept/driftline:InventoryFinishedGoods",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "353f790f-1ed1-5b91-880d-8029b4b687cf",
-          "monetary": "true",
+          "internalId": "driftline:InventoryFinishedGoods",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "source": "driftline"
+        },
+        {
+          "@id": "https://robosystems.ai/concept/driftline:InventoryPackagingSupplies",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "driftline:InventoryPackagingSupplies",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "source": "driftline"
+        },
+        {
+          "@id": "https://robosystems.ai/concept/driftline:InventoryPolicyTextBlock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "dataType": "textBlockItemType",
+          "elementType": "concept",
+          "internalId": "driftline:InventoryPolicyTextBlock",
+          "itemType": "textBlock",
+          "monetary": "false",
           "periodType": "duration",
-          "prefLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
+          "source": "driftline"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXT",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:OperatingExpenses",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXT",
-          "numericValue": "556685.62",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
+          "@id": "https://robosystems.ai/concept/driftline:InventoryRawMaterials",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "driftline:InventoryRawMaterials",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "source": "driftline"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX8",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0C",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX8",
-          "numericValue": "100000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
+          "@id": "https://robosystems.ai/concept/driftline:InventoryWorkInProcess",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "driftline:InventoryWorkInProcess",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "source": "driftline"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY7",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY7",
-          "numericValue": "183563.47",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
+          "@id": "https://robosystems.ai/concept/driftline:RevenueRecognitionPolicyTextBlock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "dataType": "textBlockItemType",
+          "elementType": "concept",
+          "internalId": "driftline:RevenueRecognitionPolicyTextBlock",
+          "itemType": "textBlock",
+          "monetary": "false",
+          "periodType": "duration",
+          "source": "driftline"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXZ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncomeLossFromContinuingOperations",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXZ",
-          "numericValue": "8785.7",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
+          "@id": "https://robosystems.ai/concept/driftline:SignificantAccountingPoliciesAbstract",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "driftline:SignificantAccountingPoliciesAbstract",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "source": "driftline"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/ib/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "@type": "rs:InformationBlock",
-          "blockType": "equity_statement",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0C",
-          "internalId": "0b179e5c-5f02-506d-b8d5-860cb10c7694",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/1eae745dbb354952/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:ShareBasedCompensation"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/1eae745dbb354952/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:NetIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/1eae745dbb354952/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/1eae745dbb354952/presentation/3",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:PaymentsOfDividends"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/1eae745dbb354952/presentation/4",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/1eae745dbb354952/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/2922f6eb4bc9c274/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "https://robosystems.ai/concept/driftline:SignificantAccountingPoliciesAbstract",
+          "order": "1.0",
+          "role": "https://driftlinecoffee.example.com/roles/disclosures/AccountingPolicies",
+          "to": "https://robosystems.ai/concept/driftline:InventoryPolicyTextBlock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/2922f6eb4bc9c274/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "https://robosystems.ai/concept/driftline:SignificantAccountingPoliciesAbstract",
+          "order": "2.0",
+          "role": "https://driftlinecoffee.example.com/roles/disclosures/AccountingPolicies",
+          "to": "https://robosystems.ai/concept/driftline:RevenueRecognitionPolicyTextBlock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/2922f6eb4bc9c274/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "https://robosystems.ai/concept/driftline:SignificantAccountingPoliciesAbstract",
+          "order": "3.0",
+          "role": "https://driftlinecoffee.example.com/roles/disclosures/AccountingPolicies",
+          "to": "https://robosystems.ai/concept/driftline:DepreciationPolicyTextBlock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30330.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:RepaymentsOfLongTermDebt"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInPrepaidExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/10",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30180.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccruedLiabilities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/11",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInInvestingActivities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/12",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30240.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/13",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:EffectOfExchangeRateOnCash"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/14",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30120.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:DepreciationDepletionAndAmortization"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/15",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30140.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInInventories"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/16",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30310.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/17",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30220.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/18",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30210.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/19",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30170.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/20",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30260.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromSaleOfIntangibleAssets"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/21",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30160.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/22",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInOperatingActivities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/3",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30340.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/4",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30230.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsToAcquireInvestments"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30110.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/6",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsToAcquireIntangibleAssets"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/7",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30130.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccountsReceivable"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/8",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30190.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/9",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30320.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20315.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20313.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/10",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20460.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:TreasuryStockValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/11",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Assets",
+          "order": "20200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AssetsNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/12",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20311.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccountsPayableCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/13",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20410.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CommonStockValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/14",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20140.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PrepaidExpenseCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/15",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Assets",
+          "order": "20100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AssetsCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/16",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20225.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/17",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20230.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/18",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseRightOfUseAsset"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/19",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20440.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RetainedEarningsAccumulatedDeficit"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/20",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Liabilities",
+          "order": "20320.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/21",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20260.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/22",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20210.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PropertyPlantAndEquipmentNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/23",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20420.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PreferredStockValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/24",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20312.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DebtCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/25",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20321.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/26",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20450.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/27",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20115.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ShortTermInvestments"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/28",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20312.5",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/29",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20322.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredIncomeTaxLiabilitiesNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/3",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "20400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:StockholdersEquity"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/30",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20430.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AdditionalPaidInCapital"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/31",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20324.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/32",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20220.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Goodwill"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/33",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20110.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/34",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20120.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ReceivablesNetCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/35",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20240.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseRightOfUseAsset"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/36",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20325.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/37",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20130.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/4",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20311.5",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccruedLiabilitiesCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20314.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseLiabilityCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/6",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "20300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Liabilities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/7",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20160.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/8",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Liabilities",
+          "order": "20310.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/9",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20323.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10643.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10415.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:SellingAndMarketingExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/10",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfRevenue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/11",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10646.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/12",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GrossProfit"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/13",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10446.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:AssetImpairmentCharges"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/14",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "11200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:NetIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/15",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10430.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:DepreciationDepletionAndAmortization"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/16",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "10230.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostOfOperatingRevenue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/17",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10900.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeTaxExpenseBenefit"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/18",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/19",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10620.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InterestExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10410.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GeneralAndAdministrativeExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/20",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10630.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainLossOnDispositionOfAssets"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/21",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:NonoperatingIncomeExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/22",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10420.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ResearchAndDevelopmentExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/23",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10640.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherNonoperatingIncomeExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/24",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Revenues",
+          "order": "10120.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/25",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10800.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/26",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingExpenses"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/3",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "11100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/4",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10610.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InvestmentIncomeInterest"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:Revenues"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/6",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10443.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RestructuringCharges"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/7",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "11000.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperations"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/8",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "10210.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfGoodsAndServicesSold"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/9",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10440.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostAndExpenseOperating"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "order": "4.0",
+          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
+          "to": "https://robosystems.ai/concept/driftline:InventoryPackagingSupplies"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "order": "1.0",
+          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
+          "to": "https://robosystems.ai/concept/driftline:InventoryRawMaterials"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "order": "2.0",
+          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
+          "to": "https://robosystems.ai/concept/driftline:InventoryWorkInProcess"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/presentation/3",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "order": "3.0",
+          "role": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
+          "to": "https://robosystems.ai/concept/driftline:InventoryFinishedGoods"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/1eae745dbb354952",
+          "@type": [
+            "rs:Hierarchy",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/1eae745dbb354952",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/1eae745dbb354952/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/1eae745dbb354952/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/1eae745dbb354952/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/1eae745dbb354952/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/1eae745dbb354952/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/1eae745dbb354952/presentation/5"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
           "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "structureName": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
+          "structureOrder": "2"
         },
         {
-          "@id": "rs-gaap:NetIncomeLoss",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "27a05717-2370-51c2-a924-db5cbcb48219",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Net Income (Loss) Attributable to Parent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/2922f6eb4bc9c274",
+          "@type": [
+            "rs:Hierarchy",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/2922f6eb4bc9c274",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/2922f6eb4bc9c274/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/2922f6eb4bc9c274/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/2922f6eb4bc9c274/presentation/2"
+          ],
+          "internalId": "https://driftlinecoffee.example.com/roles/disclosures/AccountingPolicies",
+          "prefLabel": "Significant Accounting Policies",
+          "roleUri": "https://driftlinecoffee.example.com/roles/disclosures/AccountingPolicies",
+          "structureName": "Significant Accounting Policies",
+          "structureOrder": "5"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX3",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0C",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX3",
-          "numericValue": "8785.7",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/4d5ede325089bd91",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/4d5ede325089bd91/presentation/9"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "structureName": "rs-gaap — Cash Flow Statement — Indirect",
+          "structureOrder": "3"
         },
         {
-          "@id": "rs-gaap:CostOfGoodsAndServicesSold",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "5ca0e51f-dff1-5c2b-94f5-26620852a5f9",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cost of Product and Service Sold",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/75bf584b3e4aaaa0",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/23",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/24",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/25",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/26",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/27",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/28",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/29",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/30",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/31",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/32",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/33",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/34",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/35",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/36",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/37",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/75bf584b3e4aaaa0/presentation/9"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "prefLabel": "rs-gaap — Balance Sheet — Classified",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "structureName": "rs-gaap — Balance Sheet — Classified",
+          "structureOrder": "1"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXF",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Revenues",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXF",
-          "numericValue": "1226399.87",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/850c3d8ab3a4a627",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/23",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/24",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/25",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/26",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/850c3d8ab3a4a627/presentation/9"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "prefLabel": "rs-gaap — Income Statement — Multi-step",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "structureName": "rs-gaap — Income Statement — Multi-step",
+          "structureOrder": "0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW5",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:GeneralAndAdministrativeExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW5",
-          "numericValue": "368500.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWY",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:SellingAndMarketingExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWY",
-          "numericValue": "20600.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW0",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW0",
-          "numericValue": "31166.49",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCVW",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "https://robosystems.ai/concept/driftline:InventoryRawMaterials",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0D",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCVW",
-          "numericValue": "88000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/struct_01M1ZK01V0RM8658J9EE0ZA2PT",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY4",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AssetsCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY4",
-          "numericValue": "126777.73",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWB",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWB",
-          "numericValue": "1226399.87",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:AssetsCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "0fc9ab7e-c5ce-5277-9530-344cc127fe26",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Assets, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW8",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PrepaidExpenseCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW8",
-          "numericValue": "11000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCYG",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:GrossProfit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCYG",
-          "numericValue": "105599.96",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:DepreciationDepletionAndAmortization",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "189a099a-7512-5144-9215-65d837c2c3b5",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Depreciation, Depletion and Amortization",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX1",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX1",
-          "numericValue": "161714.25",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWK",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CostOfGoodsAndServicesSold",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWK",
-          "numericValue": "84000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXS",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Liabilities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXS",
-          "numericValue": "51999.99",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXH",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXH",
-          "numericValue": "-40777.91",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:Revenues",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "b26a6cd4-072f-5bf2-b5d3-ebf928150d6c",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Revenues",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXE",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncomeLossFromContinuingOperations",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXE",
-          "numericValue": "161714.25",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX9",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX9",
-          "numericValue": "-90000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "@type": "rs:Period",
-          "instant": "2025-08-31",
-          "periodType": "instant"
-        },
-        {
-          "@id": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "57ccbf45-c970-5bcd-a381-44d96b6b6d94",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/d86840caccad8af9",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/d86840caccad8af9",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/association/d86840caccad8af9/presentation/3"
+          ],
+          "internalId": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
+          "prefLabel": "Inventory Components",
+          "roleUri": "https://driftlinecoffee.example.com/roles/disclosures/InventoryComponents",
+          "structureName": "Inventory Components",
+          "structureOrder": "4"
         },
         {
           "@id": "rs-gaap:AccountsPayableCurrent",
@@ -3255,80 +3105,103 @@
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "9ddbc9d7-c769-5800-8f65-1089d476e5c9",
-          "monetary": "true",
+          "internalId": "rs-gaap:AccountsPayableCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "instant",
           "prefLabel": "Accounts Payable, Current",
           "source": "rs-gaap",
+          "standardLabel": "Accounts Payable, Current",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWH",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AdditionalPaidInCapital",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWH",
-          "numericValue": "100000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
+          "@id": "rs-gaap:AccruedLiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccruedLiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accrued Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Accrued Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCVX",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "https://robosystems.ai/concept/driftline:InventoryWorkInProcess",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0D",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCVX",
-          "numericValue": "3000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/struct_01M1ZK01V0RM8658J9EE0ZA2PT",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
+          "@id": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accumulated Other Comprehensive Income (Loss), Net of Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Accumulated Other Comprehensive Income (Loss), Net of Tax",
+          "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXW",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXW",
-          "numericValue": "161714.25",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
+          "@id": "rs-gaap:AdditionalPaidInCapital",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AdditionalPaidInCapital",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Additional Paid in Capital",
+          "source": "rs-gaap",
+          "standardLabel": "Additional Paid in Capital",
+          "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY6",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AssetsNoncurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY6",
-          "numericValue": "56785.74",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "@id": "rs-gaap:AssetImpairmentCharges",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "811f1cf5-836c-575f-9f3f-cd7fa477e4e5",
-          "monetary": "true",
+          "internalId": "rs-gaap:AssetImpairmentCharges",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "duration",
-          "prefLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "prefLabel": "Asset Impairment Charges",
           "source": "rs-gaap",
+          "standardLabel": "Asset Impairment Charges",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Assets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Assets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Current",
           "substitutionGroup": "xbrli:item"
         },
         {
@@ -3337,24 +3210,118 @@
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "841cedeb-4cb0-532a-b0bd-c34846a13a8c",
-          "monetary": "true",
+          "internalId": "rs-gaap:AssetsNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "instant",
           "prefLabel": "Assets, Noncurrent",
           "source": "rs-gaap",
+          "standardLabel": "Assets, Noncurrent",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "@id": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CommonStockValue",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "6b0b414f-0c76-54f0-8e51-cf53db59ca24",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "internalId": "rs-gaap:CommonStockValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Common Stock, Value, Issued",
           "source": "rs-gaap",
+          "standardLabel": "Common Stock, Value, Issued",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfGoodsAndServicesSold",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfGoodsAndServicesSold",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Product and Service Sold",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Product and Service Sold",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Revenue",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Revenue",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DebtCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DebtCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Debt, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Debt, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DeferredIncomeTaxLiabilitiesNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DeferredIncomeTaxLiabilitiesNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Deferred Income Tax Liabilities, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Deferred Income Tax Liabilities, Net",
           "substitutionGroup": "xbrli:item"
         },
         {
@@ -3363,1041 +3330,134 @@
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "f35c2b3a-01eb-50c8-96e3-4c07cc2a0fee",
-          "monetary": "true",
+          "internalId": "rs-gaap:DeferredRevenueCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "instant",
           "prefLabel": "Deferred Revenue, Current",
           "source": "rs-gaap",
+          "standardLabel": "Deferred Revenue, Current",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXN",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXN",
-          "numericValue": "51999.99",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX2",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX2",
-          "numericValue": "8785.7",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:ReceivablesNetCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "44686df3-3871-5c1f-8a08-fc542d69dfa0",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Receivables, Net, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0ST59VCSR3R3M7C0SJWY",
-          "@type": "rs:Fact",
-          "contentType": "text/markdown",
-          "element": "https://robosystems.ai/concept/driftline:RevenueRecognitionPolicyTextBlock",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0ST1XEXD086KDBYFYE9G",
-          "factType": "nonnumeric",
-          "internalId": "fact_01M1ZK0ST59VCSR3R3M7C0SJWY",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "stringValue": "# Revenue Recognition Policy — Driftline Coffee Roasters\n\n## Standard\nRevenue is recognized under ASC 606 as control of the coffee transfers to the customer.\n\n## Channels\n\n| Channel | Account | Recognition Timing | Cash Timing |\n|---|---|---|---|\n| DTC Subscriptions | Subscription Revenue — DTC (4000) | Ratably as each month's coffee ships | **Prepaid** — billed a quarter ahead into Deferred Subscription Revenue (2300) |\n| DTC Single Orders | Single-Order Revenue — DTC (4200) | On shipment | Immediate (card at checkout) |\n| Wholesale | Wholesale Revenue (4100) | On delivery to the grocer/café | **Net 30** — builds Accounts Receivable (1100) |\n\n## Deferred Subscription Revenue\nSubscriber prepayments are a liability until the coffee ships. Each month:\n- DR Deferred Subscription Revenue (2300) / CR Subscription Revenue — DTC (4000) for the month earned.\n- The deferred balance is cash already collected for future shipments — a source of working capital.\n\n## Wholesale Accounts Receivable\nWholesale sells on net-30 terms. Receivables that age past 60 days, or that concentrate in a single large account, are a working-capital and credit risk — review the AR aging by customer every close.",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/struct_01M1ZK06K9AMDD3MH09QJ9M59C"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWR",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0D",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWR",
-          "numericValue": "22000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/struct_01M1ZK01V0RM8658J9EE0ZA2PT",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWV",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ReceivablesNetCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWV",
-          "numericValue": "17333.33",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWA",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWA",
-          "numericValue": "206499.95",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW6",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0D",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW6",
-          "numericValue": "96000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/struct_01M1ZK01V0RM8658J9EE0ZA2PT",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:OperatingExpenses",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "71fcdebb-7145-5f76-b5e0-b4ccbf2c29d2",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Operating Expenses",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCYC",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Liabilities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCYC",
-          "numericValue": "38777.77",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY9",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:StockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0C",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY9",
-          "numericValue": "144785.7",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/concept/driftline:InventoryRawMaterials",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "elem_01M1ZK01TXJ8TDV06QCNBDJ5T2",
-          "monetary": "true",
-          "periodType": "instant",
-          "source": "native"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCYH",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:OperatingIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCYH",
-          "numericValue": "8785.7",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWE",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "https://robosystems.ai/concept/driftline:InventoryRawMaterials",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0D",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWE",
-          "numericValue": "14000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/struct_01M1ZK01V0RM8658J9EE0ZA2PT",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWD",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "https://robosystems.ai/concept/driftline:InventoryFinishedGoods",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0D",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWD",
-          "numericValue": "5000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/struct_01M1ZK01V0RM8658J9EE0ZA2PT",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/ib/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "@type": "rs:InformationBlock",
-          "blockType": "cash_flow_statement",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "internalId": "5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "@type": "rs:Period",
-          "instant": "2026-08-31",
-          "periodType": "instant"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX4",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX4",
-          "numericValue": "8785.7",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "69b82be1-1145-5686-8613-31da9eb04a72",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXA",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXA",
-          "numericValue": "4500.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXV",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CostOfRevenue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXV",
-          "numericValue": "508000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "@id": "rs-gaap:DeferredRevenueNoncurrent",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "30b2801e-e682-5298-82e6-3670e1d508f1",
-          "monetary": "true",
+          "internalId": "rs-gaap:DeferredRevenueNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "instant",
-          "prefLabel": "Liabilities and Equity",
+          "prefLabel": "Deferred Revenue, Noncurrent",
           "source": "rs-gaap",
+          "standardLabel": "Deferred Revenue, Noncurrent",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/concept/driftline:InventoryFinishedGoods",
+          "@id": "rs-gaap:DepreciationDepletionAndAmortization",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "elem_01M1ZK01TXJ8TDV06QCNBDJ5T4",
-          "monetary": "true",
-          "periodType": "instant",
-          "source": "native"
-        },
-        {
-          "@id": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "93175d59-983c-5012-910f-3dfbf07ce327",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Increase (Decrease) in Accounts Receivable",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY1",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY1",
-          "numericValue": "11999.96",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:PropertyPlantAndEquipmentNet",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "288099af-5cbb-5f78-8f8a-1a85675fb661",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Property, Plant and Equipment, Net",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:StockholdersEquity",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "e3796201-9899-5b7b-9477-659550ba8e68",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Stockholders' Equity Attributable to Parent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/concept/driftline:DepreciationPolicyTextBlock",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "elem_01M1ZK06K73TWDCDHVXFTH98MF",
-          "itemType": "textBlock",
+          "internalId": "rs-gaap:DepreciationDepletionAndAmortization",
+          "itemType": "decimal",
           "monetary": "false",
           "periodType": "duration",
-          "source": "native"
+          "prefLabel": "Depreciation, Depletion and Amortization",
+          "source": "rs-gaap",
+          "standardLabel": "Depreciation, Depletion and Amortization",
+          "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCVY",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AccountsPayableCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCVY",
-          "numericValue": "0.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0ST59VCSR3R3M7C0SJWX",
-          "@type": "rs:Fact",
-          "contentType": "text/markdown",
-          "element": "https://robosystems.ai/concept/driftline:DepreciationPolicyTextBlock",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0ST1XEXD086KDBYFYE9G",
-          "factType": "nonnumeric",
-          "internalId": "fact_01M1ZK0ST59VCSR3R3M7C0SJWX",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "stringValue": "# Depreciation & Prepaid Policy — Driftline Coffee Roasters\n\n## Depreciation\nStraight-line, no salvage value unless specified. Entry: DR Depreciation Expense (7000) / CR Accumulated Depreciation (1550).\n\n| Asset | Cost | Useful Life | Monthly |\n|---|---|---|---|\n| Roasting & Packaging Equipment | $90,000.00 | 84 months | $1,071.43 |\n| Automated Packaging Line | $24,000.00 | 60 months | $400.00 |\n\n## Prepaid Expense Amortization\nPurchases with a term greater than one month are capitalized and amortized straight-line. Entry: DR expense / CR prepaid account.\n\n| Item | Cost | Term | Monthly | Debit | Credit |\n|---|---|---|---|---|---|\n| Business Insurance | $12,000.00 | 12 months | $1,000.00 | Insurance (6500) | Prepaid Insurance (1200) |\n| Annual Platform Prepay | $6,000.00 | 12 months | $500.00 | Software & Subscriptions (6400) | Prepaid Software (1210) |\n\nDuring each close, review prepaid and fixed-asset accounts for new purchases that lack a schedule, and create one.",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/struct_01M1ZK06K9AMDD3MH09QJ9M59C"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW4",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DepreciationDepletionAndAmortization",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW4",
-          "numericValue": "13785.62",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXQ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:StockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXQ",
-          "numericValue": "306499.95",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWX",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWX",
-          "numericValue": "189599.96",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW2",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DeferredRevenueCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW2",
-          "numericValue": "51999.99",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXJ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AssetsCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXJ",
-          "numericValue": "291499.82",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCYA",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:StockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCYA",
-          "numericValue": "144785.7",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCYD",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:OperatingExpenses",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCYD",
-          "numericValue": "96814.26",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:CostOfRevenue",
+          "@id": "rs-gaap:EffectOfExchangeRateOnCash",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "12ab7417-5324-55d6-946e-2456adba47c5",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cost of Revenue",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWC",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:SellingAndMarketingExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWC",
-          "numericValue": "174400.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWM",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DeferredRevenueCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWM",
-          "numericValue": "38777.77",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:IncomeLossFromContinuingOperations",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "d60cabda-7060-5aff-ac98-96371606a738",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCYE",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CostOfRevenue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCYE",
-          "numericValue": "84000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWS",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWS",
-          "numericValue": "22000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY5",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY5",
-          "numericValue": "-90000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "550bb6e5-53d0-5267-adb1-baf78093a0b0",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Increase (Decrease) in Prepaid Expense",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY8",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY8",
-          "numericValue": "38777.77",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX7",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX7",
-          "numericValue": "100000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0ST59VCSR3R3M7C0SJWW",
-          "@type": "rs:Fact",
-          "contentType": "text/markdown",
-          "element": "https://robosystems.ai/concept/driftline:InventoryPolicyTextBlock",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0ST1XEXD086KDBYFYE9G",
-          "factType": "nonnumeric",
-          "internalId": "fact_01M1ZK0ST59VCSR3R3M7C0SJWW",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "stringValue": "# Inventory & Cost of Goods Sold Policy — Driftline Coffee Roasters\n\n## Method\nInventory is carried at cost (FIFO). Green coffee is purchased in bulk from the importer ahead of demand, roasted, and sold through DTC and wholesale channels.\n\n## Lifecycle\n1. **Purchase** — green coffee received from the importer: DR Inventory — Green Coffee (1400) / CR Cash or Accounts Payable (2000). Cash leaves the business when the coffee is bought, not when it is sold.\n2. **Sale / consumption** — when finished coffee is sold, recognize cost of goods sold: DR Cost of Goods Sold (5000) / CR Inventory — Green Coffee (1400).\n\n## Watch-out: the cash trap\nBuying green coffee ahead of a wholesale launch or the holiday season builds the Inventory asset and drains cash *before* the corresponding revenue and COGS are recognized. A month can show strong gross profit while operating cash falls — the difference is sitting in inventory. During close, compare the change in inventory to the change in cash.\n\n## Gross Margin\nTarget blended gross margin ≈ 55%. Investigate months where COGS as a share of revenue moves materially off trend.",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/struct_01M1ZK06K9AMDD3MH09QJ9M59C"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX0",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0C",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX0",
-          "numericValue": "161714.25",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "20a6586b-880a-5745-94db-e23d397eb5e1",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Cash and Cash Equivalents, at Carrying Value",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW9",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ReceivablesNetCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW9",
-          "numericValue": "153333.33",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCVZ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AdditionalPaidInCapital",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCVZ",
-          "numericValue": "100000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWJ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWJ",
-          "numericValue": "71944.4",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW7",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW7",
-          "numericValue": "96000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXC",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInInventories",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXC",
-          "numericValue": "-74000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW1",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CostOfGoodsAndServicesSold",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW1",
-          "numericValue": "508000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/concept/driftline:RevenueRecognitionPolicyTextBlock",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "elem_01M1ZK06K73TWDCDHVXFTH98ME",
-          "itemType": "textBlock",
+          "internalId": "rs-gaap:EffectOfExchangeRateOnCash",
+          "itemType": "decimal",
           "monetary": "false",
           "periodType": "duration",
-          "source": "native"
+          "prefLabel": "Effect of Exchange Rate on Cash",
+          "source": "rs-gaap",
+          "standardLabel": "Effect of Exchange Rate on Cash",
+          "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/ib/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "@type": "rs:InformationBlock",
-          "blockType": "income_statement",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "internalId": "47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "prefLabel": "rs-gaap — Income Statement — Multi-step",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCYF",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCYF",
-          "numericValue": "8785.7",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWF",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "https://robosystems.ai/concept/driftline:InventoryWorkInProcess",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0D",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWF",
-          "numericValue": "3000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/struct_01M1ZK01V0RM8658J9EE0ZA2PT",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWP",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DepreciationDepletionAndAmortization",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWP",
-          "numericValue": "3214.26",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "@id": "rs-gaap:FinanceLeaseLiabilityCurrent",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "37252918-4301-50e2-8d7e-cf2c76986d15",
-          "monetary": "true",
+          "internalId": "rs-gaap:FinanceLeaseLiabilityCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Finance Lease, Liability, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Finance Lease, Liability, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:FinanceLeaseRightOfUseAsset",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:FinanceLeaseRightOfUseAsset",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Finance Lease, Right-of-Use Asset, after Accumulated Amortization",
+          "source": "rs-gaap",
+          "standardLabel": "Finance Lease, Right-of-Use Asset, after Accumulated Amortization",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "duration",
-          "prefLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "prefLabel": "Gain (Loss), Foreign Currency Transaction, before Tax",
           "source": "rs-gaap",
+          "standardLabel": "Gain (Loss), Foreign Currency Transaction, before Tax",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXM",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXM",
-          "numericValue": "358499.94",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "4afa5950-85ac-5a85-a9cb-01c387c6ab08",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXG",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXG",
-          "numericValue": "-40777.91",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:PrepaidExpenseCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "2225e348-90bd-53cb-9784-8b5d54980a69",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Prepaid Expense, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/ib/struct_01M1ZK06K9AMDD3MH09QJ9M59C",
-          "@type": "rs:InformationBlock",
-          "blockType": "regulatory_disclosure",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0ST1XEXD086KDBYFYE9G",
-          "internalId": "struct_01M1ZK06K9AMDD3MH09QJ9M59C",
-          "prefLabel": "Significant Accounting Policies",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/struct_01M1ZK06K9AMDD3MH09QJ9M59C",
-          "taxonomyId": "tax_01M1ZK06K68AE9X0PRE67JGV0A",
-          "taxonomyName": "Driftline Policy Notes"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXY",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:OperatingIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXY",
-          "numericValue": "161714.25",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY0",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Revenues",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY0",
-          "numericValue": "189599.96",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:GrossProfit",
+          "@id": "rs-gaap:GainLossOnDispositionOfAssets",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "a92b3181-9fe7-543c-81d9-13ebd12bbefa",
-          "monetary": "true",
+          "internalId": "rs-gaap:GainLossOnDispositionOfAssets",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "duration",
-          "prefLabel": "Gross Profit",
+          "prefLabel": "Gain (Loss) on Disposition of Property Plant Equipment, Excluding Oil and Gas Property and Timber Property",
           "source": "rs-gaap",
+          "standardLabel": "Gain (Loss) on Disposition of Property Plant Equipment, Excluding Oil and Gas Property and Timber Property",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD",
-          "@type": "rs:Unit",
-          "measure": "iso4217:USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXD",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXD",
-          "numericValue": "-10777.78",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:AdditionalPaidInCapital",
+          "@id": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "6146605c-0d63-51e1-a523-3450d6abaca3",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Additional Paid in Capital",
+          "internalId": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gain (Loss) on Extinguishment of Debt",
           "source": "rs-gaap",
+          "standardLabel": "Gain (Loss) on Extinguishment of Debt",
           "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/concept/driftline:InventoryWorkInProcess",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "elem_01M1ZK01TXJ8TDV06QCNBDJ5T3",
-          "monetary": "true",
-          "periodType": "instant",
-          "source": "native"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWN",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DepreciationDepletionAndAmortization",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWN",
-          "numericValue": "3214.26",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY2",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY2",
-          "numericValue": "21999.96",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/ib/struct_01M1ZK01V0RM8658J9EE0ZA2PT",
-          "@type": "rs:InformationBlock",
-          "blockType": "regulatory_disclosure",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0D",
-          "internalId": "struct_01M1ZK01V0RM8658J9EE0ZA2PT",
-          "prefLabel": "Inventory Components",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/struct_01M1ZK01V0RM8658J9EE0ZA2PT",
-          "taxonomyId": "tax_01M1ZK01TXJ8TDV06QCNBDJ5T1",
-          "taxonomyName": "Driftline Reporting Extension"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX5",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PropertyPlantAndEquipmentNet",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX5",
-          "numericValue": "67000.12",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
         },
         {
           "@id": "rs-gaap:GeneralAndAdministrativeExpense",
@@ -4405,201 +3465,179 @@
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "f92ba8cb-7ae2-5d40-9d15-9a94e9e3aed4",
-          "monetary": "true",
+          "internalId": "rs-gaap:GeneralAndAdministrativeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "duration",
           "prefLabel": "General and Administrative Expense",
           "source": "rs-gaap",
+          "standardLabel": "General and Administrative Expense",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWT",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PrepaidExpenseCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWT",
-          "numericValue": "15500.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "@type": "rs:Period",
-          "endDate": "2025-08-31",
-          "periodType": "duration",
-          "startDate": "2024-09-01"
-        },
-        {
-          "@id": "https://robosystems.ai/concept/driftline:InventoryPolicyTextBlock",
+          "@id": "rs-gaap:Goodwill",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "elem_01M1ZK06K73TWDCDHVXFTH98MD",
-          "itemType": "textBlock",
+          "internalId": "rs-gaap:Goodwill",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Goodwill",
+          "source": "rs-gaap",
+          "standardLabel": "Goodwill",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GrossProfit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GrossProfit",
+          "itemType": "decimal",
           "monetary": "false",
           "periodType": "duration",
-          "source": "native"
+          "prefLabel": "Gross Profit",
+          "source": "rs-gaap",
+          "standardLabel": "Gross Profit",
+          "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "@id": "rs-gaap:IncomeLossFromContinuingOperations",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "a3227fb2-202b-51db-9574-4e60db03c04f",
-          "monetary": "true",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperations",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "duration",
-          "prefLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "prefLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
           "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "rs-gaap:OperatingIncomeLoss",
+          "@id": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "16780828-0201-5609-b572-fbe3ebfcb177",
-          "monetary": "true",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "duration",
-          "prefLabel": "Operating Income (Loss)",
+          "prefLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
           "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWG",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AccountsPayableCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWG",
-          "numericValue": "0.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
+          "@id": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Discontinued Operations, Net of Tax, Including Portion Attributable to Noncontrolling Interest",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Discontinued Operations, Net of Tax, Including Portion Attributable to Noncontrolling Interest",
+          "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXX",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:GrossProfit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXX",
-          "numericValue": "718399.87",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
+          "@id": "rs-gaap:IncomeStatementAbstract",
+          "@type": "rs:Element",
+          "abstract": "true",
+          "balance": "debit",
+          "elementType": "abstract",
+          "internalId": "rs-gaap:IncomeStatementAbstract",
+          "itemType": "string",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income Statement [Abstract]",
+          "source": "rs-gaap",
+          "standardLabel": "Income Statement [Abstract]",
+          "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWZ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWZ",
-          "numericValue": "161714.25",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
+          "@id": "rs-gaap:IncomeTaxExpenseBenefit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeTaxExpenseBenefit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income Tax Expense (Benefit)",
+          "source": "rs-gaap",
+          "standardLabel": "Income Tax Expense (Benefit)",
+          "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXR",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Assets",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXR",
-          "numericValue": "358499.94",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
+          "@id": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accounts Payable and Accrued Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accounts Payable and Accrued Liabilities",
+          "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXP",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:StockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0C",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXP",
-          "numericValue": "306499.95",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
+          "@id": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accounts Receivable",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accounts Receivable",
+          "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCYB",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Assets",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCYB",
-          "numericValue": "183563.47",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
+          "@id": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Income Taxes Payable",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Income Taxes Payable",
+          "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/ib/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "@type": "rs:InformationBlock",
-          "blockType": "balance_sheet",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "internalId": "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "prefLabel": "rs-gaap — Balance Sheet — Classified",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX6",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PropertyPlantAndEquipmentNet",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX6",
-          "numericValue": "56785.74",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY3",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY3",
-          "numericValue": "100000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "@type": "rs:Entity",
-          "country": "US",
-          "internalId": "entity_kg1a07f25fc1f9f8def4c4",
-          "legalName": "Driftline Coffee Roasters",
-          "prefLabel": "Driftline Coffee Roasters"
+          "@id": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accrued Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accrued Liabilities",
+          "substitutionGroup": "xbrli:item"
         },
         {
           "@id": "rs-gaap:IncreaseDecreaseInInventories",
@@ -4607,140 +3645,103 @@
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "c8b0722b-7993-592f-8ef1-5b0964ac8a10",
-          "monetary": "true",
+          "internalId": "rs-gaap:IncreaseDecreaseInInventories",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "duration",
           "prefLabel": "Increase (Decrease) in Inventories",
           "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Inventories",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "@id": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "a9c87d60-a1e5-506b-a27e-cbf9e14e5113",
-          "monetary": "true",
+          "internalId": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Prepaid Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Prepaid Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "instant",
-          "prefLabel": "Retained Earnings (Accumulated Deficit)",
+          "prefLabel": "Intangible Assets, Net (Excluding Goodwill)",
           "source": "rs-gaap",
+          "standardLabel": "Intangible Assets, Net (Excluding Goodwill)",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWQ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:GeneralAndAdministrativeExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0A",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWQ",
-          "numericValue": "73000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_4",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXB",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0B",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXB",
-          "numericValue": "-136000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWW",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWW",
-          "numericValue": "44785.7",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:SellingAndMarketingExpense",
+          "@id": "rs-gaap:InterestExpense",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "4757162f-73d0-5c6e-949e-ed2cafb2a64f",
-          "monetary": "true",
+          "internalId": "rs-gaap:InterestExpense",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "duration",
-          "prefLabel": "Selling and Marketing Expense",
+          "prefLabel": "Interest Expense, Operating and Nonoperating",
           "source": "rs-gaap",
+          "standardLabel": "Interest Expense, Operating and Nonoperating",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXK",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AssetsNoncurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG09",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXK",
-          "numericValue": "67000.12",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:Assets",
+          "@id": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "a1f04756-41d8-5d35-b821-23aa2f3b2fae",
-          "monetary": "true",
+          "internalId": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "instant",
-          "prefLabel": "Assets",
+          "prefLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
           "source": "rs-gaap",
+          "standardLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "@type": "rs:Period",
-          "endDate": "2026-08-31",
-          "periodType": "duration",
-          "startDate": "2025-09-01"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCVV",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "https://robosystems.ai/concept/driftline:InventoryFinishedGoods",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK0SSH5JQYNZFMQGX1CG0D",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCVV",
-          "numericValue": "5000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/struct_01M1ZK01V0RM8658J9EE0ZA2PT",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "@id": "rs-gaap:InvestmentIncomeInterest",
           "@type": "rs:Element",
           "abstract": "false",
-          "balance": "debit",
+          "balance": "credit",
           "elementType": "concept",
-          "internalId": "2eb72b5f-d7e3-5bd5-bf93-be38b6d21820",
-          "monetary": "true",
+          "internalId": "rs-gaap:InvestmentIncomeInterest",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "duration",
-          "prefLabel": "Proceeds from Issuance of Common Stock",
+          "prefLabel": "Investment Income, Interest",
           "source": "rs-gaap",
+          "standardLabel": "Investment Income, Interest",
           "substitutionGroup": "xbrli:item"
         },
         {
@@ -4749,11 +3750,2753 @@
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "7af273ac-1cba-5fb3-a1c9-5c5d8fdb9bdf",
-          "monetary": "true",
+          "internalId": "rs-gaap:Liabilities",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "instant",
           "prefLabel": "Liabilities",
           "source": "rs-gaap",
+          "standardLabel": "Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities and Equity",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities and Equity",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Debt and Lease Obligation",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Debt and Lease Obligation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermDebtCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermDebtCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Debt, Current Maturities",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Debt, Current Maturities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Investments and Receivables, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Investments and Receivables, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Net Income (Loss) Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Net Income (Loss) Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NonoperatingIncomeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NonoperatingIncomeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Nonoperating Income (Expense)",
+          "source": "rs-gaap",
+          "standardLabel": "Nonoperating Income (Expense)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingExpenses",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingExpenses",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Expenses",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Expenses",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Income (Loss)",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Income (Loss)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Operating Lease, Liability, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Lease, Liability, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingLeaseRightOfUseAsset",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingLeaseRightOfUseAsset",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Operating Lease, Right-of-Use Asset",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Lease, Right-of-Use Asset",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherAssetsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherAssetsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Assets, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Other Assets, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherAssetsNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherAssetsNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Assets, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Other Assets, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Comprehensive Income (Loss), Net of Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Other Comprehensive Income (Loss), Net of Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherCostAndExpenseOperating",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherCostAndExpenseOperating",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Cost and Expense, Operating",
+          "source": "rs-gaap",
+          "standardLabel": "Other Cost and Expense, Operating",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherCostOfOperatingRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherCostOfOperatingRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Cost of Operating Revenue",
+          "source": "rs-gaap",
+          "standardLabel": "Other Cost of Operating Revenue",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherLiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherLiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Other Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherLiabilitiesNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherLiabilitiesNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Liabilities, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Other Liabilities, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherNonoperatingIncomeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherNonoperatingIncomeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Nonoperating Income (Expense)",
+          "source": "rs-gaap",
+          "standardLabel": "Other Nonoperating Income (Expense)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsForRepurchaseOfCommonStock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsForRepurchaseOfCommonStock",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments for Repurchase of Common Stock",
+          "source": "rs-gaap",
+          "standardLabel": "Payments for Repurchase of Common Stock",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsOfDividends",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsOfDividends",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments of Dividends",
+          "source": "rs-gaap",
+          "standardLabel": "Payments of Dividends",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquireIntangibleAssets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquireIntangibleAssets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Intangible Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Intangible Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquireInvestments",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquireInvestments",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Investments",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Investments",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PreferredStockValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PreferredStockValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Preferred Stock, Value, Issued",
+          "source": "rs-gaap",
+          "standardLabel": "Preferred Stock, Value, Issued",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PrepaidExpenseCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PrepaidExpenseCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Prepaid Expense, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Prepaid Expense, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Issuance of Common Stock",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Issuance of Common Stock",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Issuance of Long-Term Debt",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Issuance of Long-Term Debt",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Sale, Maturity and Collection of Investments",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Sale, Maturity and Collection of Investments",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromSaleOfIntangibleAssets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromSaleOfIntangibleAssets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Sale of Intangible Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Sale of Intangible Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Sale of Property, Plant, and Equipment",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Sale of Property, Plant, and Equipment",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Property, Plant and Equipment, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Property, Plant and Equipment, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ReceivablesNetCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ReceivablesNetCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Receivables, Net, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Receivables, Net, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RepaymentsOfLongTermDebt",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RepaymentsOfLongTermDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Repayments of Long-Term Debt",
+          "source": "rs-gaap",
+          "standardLabel": "Repayments of Long-Term Debt",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ResearchAndDevelopmentExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ResearchAndDevelopmentExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Research and Development Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Research and Development Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Restricted Cash and Investments, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Restricted Cash and Investments, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RestructuringCharges",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RestructuringCharges",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Restructuring Charges",
+          "source": "rs-gaap",
+          "standardLabel": "Restructuring Charges",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Retained Earnings (Accumulated Deficit)",
+          "source": "rs-gaap",
+          "standardLabel": "Retained Earnings (Accumulated Deficit)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Revenues",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Revenues",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenues",
+          "source": "rs-gaap",
+          "standardLabel": "Revenues",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:SellingAndMarketingExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:SellingAndMarketingExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Selling and Marketing Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Selling and Marketing Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ShareBasedCompensation",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ShareBasedCompensation",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Share-Based Payment Arrangement, Noncash Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Share-Based Payment Arrangement, Noncash Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ShortTermInvestments",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ShortTermInvestments",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Short-Term Investments",
+          "source": "rs-gaap",
+          "standardLabel": "Short-Term Investments",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:StockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:StockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Stockholders' Equity Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Stockholders' Equity Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:TreasuryStockValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:TreasuryStockValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Treasury Stock, Value",
+          "source": "rs-gaap",
+          "standardLabel": "Treasury Stock, Value",
+          "substitutionGroup": "xbrli:item"
+        }
+      ],
+      "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8#projection"
+    },
+    {
+      "@graph": [
+        {
+          "@id": "https://robosystems.ai/concept/driftline:DepreciationPolicyTextBlock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "dataType": "textBlockItemType",
+          "elementType": "concept",
+          "internalId": "driftline:DepreciationPolicyTextBlock",
+          "itemType": "textBlock",
+          "monetary": "false",
+          "periodType": "duration",
+          "source": "driftline"
+        },
+        {
+          "@id": "https://robosystems.ai/concept/driftline:InventoryFinishedGoods",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "driftline:InventoryFinishedGoods",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "source": "driftline"
+        },
+        {
+          "@id": "https://robosystems.ai/concept/driftline:InventoryPolicyTextBlock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "dataType": "textBlockItemType",
+          "elementType": "concept",
+          "internalId": "driftline:InventoryPolicyTextBlock",
+          "itemType": "textBlock",
+          "monetary": "false",
+          "periodType": "duration",
+          "source": "driftline"
+        },
+        {
+          "@id": "https://robosystems.ai/concept/driftline:InventoryRawMaterials",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "driftline:InventoryRawMaterials",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "source": "driftline"
+        },
+        {
+          "@id": "https://robosystems.ai/concept/driftline:InventoryWorkInProcess",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "driftline:InventoryWorkInProcess",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "source": "driftline"
+        },
+        {
+          "@id": "https://robosystems.ai/concept/driftline:RevenueRecognitionPolicyTextBlock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "dataType": "textBlockItemType",
+          "elementType": "concept",
+          "internalId": "driftline:RevenueRecognitionPolicyTextBlock",
+          "itemType": "textBlock",
+          "monetary": "false",
+          "periodType": "duration",
+          "source": "driftline"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8",
+          "@type": "rs:Report",
+          "accessionNumber": "rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "mode": "report",
+          "reportingStyle": "sec-as-filed",
+          "serializationVersion": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "@type": "rs:Entity",
+          "internalId": "entity_kg1a07f25fc1f9f8def4c4",
+          "legalName": "Driftline Coffee Roasters",
+          "prefLabel": "Driftline Coffee Roasters",
+          "scheme": "http://robosystems.ai/entity"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCVV",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "https://robosystems.ai/concept/driftline:InventoryFinishedGoods",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/d86840caccad8af9",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCVV",
+          "numericValue": "5000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCVW",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "https://robosystems.ai/concept/driftline:InventoryRawMaterials",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/d86840caccad8af9",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCVW",
+          "numericValue": "88000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCVX",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "https://robosystems.ai/concept/driftline:InventoryWorkInProcess",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/d86840caccad8af9",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCVX",
+          "numericValue": "3000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCVY",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AccountsPayableCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCVY",
+          "numericValue": "0.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCVZ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AdditionalPaidInCapital",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCVZ",
+          "numericValue": "100000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW0",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW0",
+          "numericValue": "31166.49",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW1",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CostOfGoodsAndServicesSold",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW1",
+          "numericValue": "508000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW2",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DeferredRevenueCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW2",
+          "numericValue": "51999.99",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW3",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DepreciationDepletionAndAmortization",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW3",
+          "numericValue": "13785.62",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW4",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DepreciationDepletionAndAmortization",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW4",
+          "numericValue": "13785.62",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW5",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:GeneralAndAdministrativeExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW5",
+          "numericValue": "368500.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW6",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+            "https://robosystems.ai/factset/d86840caccad8af9"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW6",
+          "numericValue": "96000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW7",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+            "https://robosystems.ai/factset/d86840caccad8af9"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW7",
+          "numericValue": "96000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW8",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PrepaidExpenseCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW8",
+          "numericValue": "11000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCW9",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ReceivablesNetCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCW9",
+          "numericValue": "153333.33",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWA",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWA",
+          "numericValue": "206499.95",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWB",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWB",
+          "numericValue": "1226399.87",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWC",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:SellingAndMarketingExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWC",
+          "numericValue": "174400.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWD",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "https://robosystems.ai/concept/driftline:InventoryFinishedGoods",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/d86840caccad8af9",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWD",
+          "numericValue": "5000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWE",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "https://robosystems.ai/concept/driftline:InventoryRawMaterials",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/d86840caccad8af9",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWE",
+          "numericValue": "14000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWF",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "https://robosystems.ai/concept/driftline:InventoryWorkInProcess",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/d86840caccad8af9",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWF",
+          "numericValue": "3000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWG",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AccountsPayableCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWG",
+          "numericValue": "0.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWH",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AdditionalPaidInCapital",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWH",
+          "numericValue": "100000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWJ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWJ",
+          "numericValue": "71944.4",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWK",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CostOfGoodsAndServicesSold",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWK",
+          "numericValue": "84000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWM",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DeferredRevenueCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWM",
+          "numericValue": "38777.77",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWN",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DepreciationDepletionAndAmortization",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWN",
+          "numericValue": "3214.26",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWP",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DepreciationDepletionAndAmortization",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWP",
+          "numericValue": "3214.26",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWQ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:GeneralAndAdministrativeExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWQ",
+          "numericValue": "73000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWR",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+            "https://robosystems.ai/factset/d86840caccad8af9"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWR",
+          "numericValue": "22000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWS",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+            "https://robosystems.ai/factset/d86840caccad8af9"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWS",
+          "numericValue": "22000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWT",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PrepaidExpenseCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWT",
+          "numericValue": "15500.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWV",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ReceivablesNetCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWV",
+          "numericValue": "17333.33",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWW",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWW",
+          "numericValue": "44785.7",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWX",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWX",
+          "numericValue": "189599.96",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWY",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:SellingAndMarketingExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWY",
+          "numericValue": "20600.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCWZ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCWZ",
+          "numericValue": "161714.25",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX0",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX0",
+          "numericValue": "161714.25",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX1",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX1",
+          "numericValue": "161714.25",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX2",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX2",
+          "numericValue": "8785.7",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX3",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX3",
+          "numericValue": "8785.7",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX4",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX4",
+          "numericValue": "8785.7",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX5",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX5",
+          "numericValue": "67000.12",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX6",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX6",
+          "numericValue": "56785.74",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX7",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX7",
+          "numericValue": "100000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX8",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX8",
+          "numericValue": "100000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCX9",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCX9",
+          "numericValue": "-90000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXA",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXA",
+          "numericValue": "4500.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXB",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXB",
+          "numericValue": "-136000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXC",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInInventories",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXC",
+          "numericValue": "-74000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXD",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXD",
+          "numericValue": "-10777.78",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXE",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncomeLossFromContinuingOperations",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXE",
+          "numericValue": "161714.25",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXF",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Revenues",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXF",
+          "numericValue": "1226399.87",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXG",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXG",
+          "numericValue": "-40777.91",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXH",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXH",
+          "numericValue": "-40777.91",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXJ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AssetsCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXJ",
+          "numericValue": "291499.82",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXK",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AssetsNoncurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXK",
+          "numericValue": "67000.12",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXM",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXM",
+          "numericValue": "358499.94",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXN",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXN",
+          "numericValue": "51999.99",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXP",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:StockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXP",
+          "numericValue": "306499.95",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXQ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:StockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXQ",
+          "numericValue": "306499.95",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXR",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Assets",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXR",
+          "numericValue": "358499.94",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXS",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Liabilities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXS",
+          "numericValue": "51999.99",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXT",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:OperatingExpenses",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXT",
+          "numericValue": "556685.62",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXV",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CostOfRevenue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXV",
+          "numericValue": "508000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXW",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXW",
+          "numericValue": "161714.25",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXX",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:GrossProfit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXX",
+          "numericValue": "718399.87",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXY",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:OperatingIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXY",
+          "numericValue": "161714.25",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCXZ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncomeLossFromContinuingOperations",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCXZ",
+          "numericValue": "8785.7",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY0",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Revenues",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY0",
+          "numericValue": "189599.96",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY1",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY1",
+          "numericValue": "11999.96",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY2",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY2",
+          "numericValue": "21999.96",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY3",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY3",
+          "numericValue": "100000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY4",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AssetsCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY4",
+          "numericValue": "126777.73",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY5",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY5",
+          "numericValue": "-90000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY6",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AssetsNoncurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY6",
+          "numericValue": "56785.74",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY7",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY7",
+          "numericValue": "183563.47",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY8",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY8",
+          "numericValue": "38777.77",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCY9",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:StockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCY9",
+          "numericValue": "144785.7",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCYA",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:StockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCYA",
+          "numericValue": "144785.7",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCYB",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Assets",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCYB",
+          "numericValue": "183563.47",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCYC",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Liabilities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCYC",
+          "numericValue": "38777.77",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCYD",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:OperatingExpenses",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCYD",
+          "numericValue": "96814.26",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCYE",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CostOfRevenue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCYE",
+          "numericValue": "84000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCYF",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCYF",
+          "numericValue": "8785.7",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCYG",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:GrossProfit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCYG",
+          "numericValue": "105599.96",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0SSTRHA2ZPTZ9AERQCYH",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:OperatingIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK0SSTRHA2ZPTZ9AERQCYH",
+          "numericValue": "8785.7",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0ST59VCSR3R3M7C0SJWW",
+          "@type": "rs:Fact",
+          "element": "https://robosystems.ai/concept/driftline:InventoryPolicyTextBlock",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/2922f6eb4bc9c274",
+          "factType": "nonnumeric",
+          "internalId": "fact_01M1ZK0ST59VCSR3R3M7C0SJWW",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "stringValue": "# Inventory & Cost of Goods Sold Policy — Driftline Coffee Roasters\n\n## Method\nInventory is carried at cost (FIFO). Green coffee is purchased in bulk from the importer ahead of demand, roasted, and sold through DTC and wholesale channels.\n\n## Lifecycle\n1. **Purchase** — green coffee received from the importer: DR Inventory — Green Coffee (1400) / CR Cash or Accounts Payable (2000). Cash leaves the business when the coffee is bought, not when it is sold.\n2. **Sale / consumption** — when finished coffee is sold, recognize cost of goods sold: DR Cost of Goods Sold (5000) / CR Inventory — Green Coffee (1400).\n\n## Watch-out: the cash trap\nBuying green coffee ahead of a wholesale launch or the holiday season builds the Inventory asset and drains cash *before* the corresponding revenue and COGS are recognized. A month can show strong gross profit while operating cash falls — the difference is sitting in inventory. During close, compare the change in inventory to the change in cash.\n\n## Gross Margin\nTarget blended gross margin ≈ 55%. Investigate months where COGS as a share of revenue moves materially off trend."
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0ST59VCSR3R3M7C0SJWX",
+          "@type": "rs:Fact",
+          "element": "https://robosystems.ai/concept/driftline:DepreciationPolicyTextBlock",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/2922f6eb4bc9c274",
+          "factType": "nonnumeric",
+          "internalId": "fact_01M1ZK0ST59VCSR3R3M7C0SJWX",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "stringValue": "# Depreciation & Prepaid Policy — Driftline Coffee Roasters\n\n## Depreciation\nStraight-line, no salvage value unless specified. Entry: DR Depreciation Expense (7000) / CR Accumulated Depreciation (1550).\n\n| Asset | Cost | Useful Life | Monthly |\n|---|---|---|---|\n| Roasting & Packaging Equipment | $90,000.00 | 84 months | $1,071.43 |\n| Automated Packaging Line | $24,000.00 | 60 months | $400.00 |\n\n## Prepaid Expense Amortization\nPurchases with a term greater than one month are capitalized and amortized straight-line. Entry: DR expense / CR prepaid account.\n\n| Item | Cost | Term | Monthly | Debit | Credit |\n|---|---|---|---|---|---|\n| Business Insurance | $12,000.00 | 12 months | $1,000.00 | Insurance (6500) | Prepaid Insurance (1200) |\n| Annual Platform Prepay | $6,000.00 | 12 months | $500.00 | Software & Subscriptions (6400) | Prepaid Software (1210) |\n\nDuring each close, review prepaid and fixed-asset accounts for new purchases that lack a schedule, and create one."
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/fact/fact_01M1ZK0ST59VCSR3R3M7C0SJWY",
+          "@type": "rs:Fact",
+          "element": "https://robosystems.ai/concept/driftline:RevenueRecognitionPolicyTextBlock",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/entity/entity_kg1a07f25fc1f9f8def4c4",
+          "factSet": "https://robosystems.ai/factset/2922f6eb4bc9c274",
+          "factType": "nonnumeric",
+          "internalId": "fact_01M1ZK0ST59VCSR3R3M7C0SJWY",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "stringValue": "# Revenue Recognition Policy — Driftline Coffee Roasters\n\n## Standard\nRevenue is recognized under ASC 606 as control of the coffee transfers to the customer.\n\n## Channels\n\n| Channel | Account | Recognition Timing | Cash Timing |\n|---|---|---|---|\n| DTC Subscriptions | Subscription Revenue — DTC (4000) | Ratably as each month's coffee ships | **Prepaid** — billed a quarter ahead into Deferred Subscription Revenue (2300) |\n| DTC Single Orders | Single-Order Revenue — DTC (4200) | On shipment | Immediate (card at checkout) |\n| Wholesale | Wholesale Revenue (4100) | On delivery to the grocer/café | **Net 30** — builds Accounts Receivable (1100) |\n\n## Deferred Subscription Revenue\nSubscriber prepayments are a liability until the coffee ships. Each month:\n- DR Deferred Subscription Revenue (2300) / CR Subscription Revenue — DTC (4000) for the month earned.\n- The deferred balance is cash already collected for future shipments — a source of working capital.\n\n## Wholesale Accounts Receivable\nWholesale sells on net-30 terms. Receivables that age past 60 days, or that concentrate in a single large account, are a working-capital and credit risk — review the AR aging by customer every close."
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/ib/1eae745dbb354952",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/1eae745dbb354952",
+          "internalId": "1eae745dbb354952",
+          "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/1eae745dbb354952"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/ib/2922f6eb4bc9c274",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/2922f6eb4bc9c274",
+          "internalId": "2922f6eb4bc9c274",
+          "prefLabel": "Significant Accounting Policies",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/2922f6eb4bc9c274"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/ib/4d5ede325089bd91",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "internalId": "4d5ede325089bd91",
+          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/4d5ede325089bd91"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/ib/75bf584b3e4aaaa0",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "internalId": "75bf584b3e4aaaa0",
+          "prefLabel": "rs-gaap — Balance Sheet — Classified",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/75bf584b3e4aaaa0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/ib/850c3d8ab3a4a627",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "internalId": "850c3d8ab3a4a627",
+          "prefLabel": "rs-gaap — Income Statement — Multi-step",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/850c3d8ab3a4a627"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/ib/d86840caccad8af9",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/d86840caccad8af9",
+          "internalId": "d86840caccad8af9",
+          "prefLabel": "Inventory Components",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/structure/d86840caccad8af9"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/0b5afc3d-8b59-5ad3-a5bc-1c18551f9f03",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2025",
+          "calendarQuarter": "FY",
+          "calendarYear": "2025",
+          "durationType": "annual",
+          "endDate": "2025-08-31",
+          "periodType": "duration",
+          "startDate": "2024-09-01"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c039dbd6-4f67-5299-a36c-74607d964dbe",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2026",
+          "calendarQuarter": "FY",
+          "calendarYear": "2026",
+          "durationType": "annual",
+          "endDate": "2026-08-31",
+          "periodType": "duration",
+          "startDate": "2025-09-01"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/c166a855-8eda-5b81-9a29-5e81192b7b0e",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2026-08-31",
+          "calendarQuarter": "Q3",
+          "calendarYear": "2026",
+          "instant": "2026-08-31",
+          "periodType": "instant"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/period/f3729c32-d66a-58e2-a0bf-9cf91d5e60d9",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2025-08-31",
+          "calendarQuarter": "Q3",
+          "calendarYear": "2025",
+          "instant": "2025-08-31",
+          "periodType": "instant"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK0SQY3Y6K7RJFQZE651Z8/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785",
+          "@type": "rs:Unit",
+          "measure": "iso4217:USD"
+        },
+        {
+          "@id": "rs-gaap:AccountsPayableCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccountsPayableCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accounts Payable, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Accounts Payable, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AdditionalPaidInCapital",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AdditionalPaidInCapital",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Additional Paid in Capital",
+          "source": "rs-gaap",
+          "standardLabel": "Additional Paid in Capital",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Assets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Assets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfGoodsAndServicesSold",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfGoodsAndServicesSold",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Product and Service Sold",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Product and Service Sold",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Revenue",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Revenue",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DeferredRevenueCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DeferredRevenueCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Deferred Revenue, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Deferred Revenue, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DepreciationDepletionAndAmortization",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DepreciationDepletionAndAmortization",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Depreciation, Depletion and Amortization",
+          "source": "rs-gaap",
+          "standardLabel": "Depreciation, Depletion and Amortization",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GeneralAndAdministrativeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GeneralAndAdministrativeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "General and Administrative Expense",
+          "source": "rs-gaap",
+          "standardLabel": "General and Administrative Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GrossProfit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GrossProfit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gross Profit",
+          "source": "rs-gaap",
+          "standardLabel": "Gross Profit",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperations",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperations",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accounts Receivable",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accounts Receivable",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInInventories",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInInventories",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Inventories",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Inventories",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Prepaid Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Prepaid Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
+          "source": "rs-gaap",
+          "standardLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Liabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Liabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities and Equity",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities and Equity",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Net Income (Loss) Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Net Income (Loss) Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingExpenses",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingExpenses",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Expenses",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Expenses",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Income (Loss)",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Income (Loss)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PrepaidExpenseCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PrepaidExpenseCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Prepaid Expense, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Prepaid Expense, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Issuance of Common Stock",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Issuance of Common Stock",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Property, Plant and Equipment, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Property, Plant and Equipment, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ReceivablesNetCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ReceivablesNetCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Receivables, Net, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Receivables, Net, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Retained Earnings (Accumulated Deficit)",
+          "source": "rs-gaap",
+          "standardLabel": "Retained Earnings (Accumulated Deficit)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Revenues",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Revenues",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenues",
+          "source": "rs-gaap",
+          "standardLabel": "Revenues",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:SellingAndMarketingExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:SellingAndMarketingExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Selling and Marketing Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Selling and Marketing Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:StockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:StockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Stockholders' Equity Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Stockholders' Equity Attributable to Parent",
           "substitutionGroup": "xbrli:item"
         }
       ],

--- a/examples/roboledger_demo/sample_output/roboledger-demo.holon.jsonld
+++ b/examples/roboledger_demo/sample_output/roboledger-demo.holon.jsonld
@@ -4,6 +4,9 @@
       "@id": "https://robosystems.ai/vocab/abstract",
       "@type": "xsd:boolean"
     },
+    "accessionNumber": {
+      "@id": "https://robosystems.ai/vocab/accessionNumber"
+    },
     "altLabel": "skos:altLabel",
     "arcrole": {
       "@id": "xlink:arcrole",
@@ -13,16 +16,30 @@
       "@id": "https://robosystems.ai/vocab/associationType"
     },
     "axis": {
-      "@id": "https://robosystems.ai/vocab/axis"
+      "@id": "https://robosystems.ai/vocab/axis",
+      "@type": "@id"
+    },
+    "axisType": {
+      "@id": "https://robosystems.ai/vocab/axisType"
     },
     "balance": {
       "@id": "xbrli:balance"
+    },
+    "baseType": {
+      "@id": "https://robosystems.ai/vocab/baseType"
     },
     "blockType": {
       "@id": "https://robosystems.ai/vocab/blockType"
     },
     "calendarPeriodKey": {
       "@id": "https://robosystems.ai/vocab/calendarPeriodKey"
+    },
+    "calendarQuarter": {
+      "@id": "https://robosystems.ai/vocab/calendarQuarter"
+    },
+    "calendarYear": {
+      "@id": "https://robosystems.ai/vocab/calendarYear",
+      "@type": "xsd:integer"
     },
     "category": {
       "@id": "https://robosystems.ai/vocab/category"
@@ -47,11 +64,11 @@
       "@id": "https://robosystems.ai/vocab/conceptArrangementPatternRequiresConcept",
       "@type": "@id"
     },
-    "contentType": {
-      "@id": "https://robosystems.ai/vocab/contentType"
-    },
     "country": {
       "@id": "https://robosystems.ai/vocab/country"
+    },
+    "dataType": {
+      "@id": "https://robosystems.ai/vocab/dataType"
     },
     "dcterms": "http://purl.org/dc/terms/",
     "decimals": {
@@ -61,6 +78,12 @@
     "deprecated": {
       "@id": "https://robosystems.ai/vocab/deprecated",
       "@type": "xsd:boolean"
+    },
+    "deprecatedDateLabel": {
+      "@id": "https://robosystems.ai/vocab/deprecatedDateLabel"
+    },
+    "deprecatedLabel": {
+      "@id": "https://robosystems.ai/vocab/deprecatedLabel"
     },
     "derivationRole": {
       "@id": "https://robosystems.ai/vocab/derivationRole"
@@ -87,6 +110,9 @@
     },
     "disclosures": "https://robosystems.ai/taxonomy/rs-gaap/disclosures/v1/",
     "documentation": "rdfs:comment",
+    "durationType": {
+      "@id": "https://robosystems.ai/vocab/durationType"
+    },
     "ein": {
       "@id": "https://robosystems.ai/vocab/ein"
     },
@@ -134,6 +160,10 @@
       "@id": "https://robosystems.ai/vocab/filedAt",
       "@type": "xsd:dateTime"
     },
+    "filingDate": {
+      "@id": "https://robosystems.ai/vocab/filingDate",
+      "@type": "xsd:date"
+    },
     "filingStatus": {
       "@id": "https://robosystems.ai/vocab/filingStatus"
     },
@@ -144,6 +174,18 @@
     "financialReportRequiresDisclosure": {
       "@id": "https://robosystems.ai/vocab/financialReportRequiresDisclosure",
       "@type": "@id"
+    },
+    "fiscalPeriodFocus": {
+      "@id": "https://robosystems.ai/vocab/fiscalPeriodFocus"
+    },
+    "fiscalYearEndMonth": {
+      "@id": "https://robosystems.ai/vocab/fiscalYearEndMonth"
+    },
+    "fiscalYearFocus": {
+      "@id": "https://robosystems.ai/vocab/fiscalYearFocus"
+    },
+    "form": {
+      "@id": "https://robosystems.ai/vocab/form"
     },
     "framework": {
       "@id": "https://robosystems.ai/vocab/framework"
@@ -183,6 +225,18 @@
     "internalId": {
       "@id": "https://robosystems.ai/vocab/internalId"
     },
+    "isExplicit": {
+      "@id": "https://robosystems.ai/vocab/isExplicit",
+      "@type": "xsd:boolean"
+    },
+    "isNil": {
+      "@id": "https://robosystems.ai/vocab/isNil",
+      "@type": "xsd:boolean"
+    },
+    "isTyped": {
+      "@id": "https://robosystems.ai/vocab/isTyped",
+      "@type": "xsd:boolean"
+    },
     "iso4217": "http://www.xbrl.org/2003/iso4217#",
     "itemType": {
       "@id": "https://robosystems.ai/vocab/itemType"
@@ -193,6 +247,9 @@
     },
     "labelRole": {
       "@id": "https://robosystems.ai/vocab/labelRole"
+    },
+    "language": {
+      "@id": "https://robosystems.ai/vocab/language"
     },
     "legalName": {
       "@id": "https://robosystems.ai/vocab/legalName"
@@ -207,7 +264,8 @@
       "@type": "@id"
     },
     "member": {
-      "@id": "https://robosystems.ai/vocab/member"
+      "@id": "https://robosystems.ai/vocab/member",
+      "@type": "@id"
     },
     "mode": {
       "@id": "https://robosystems.ai/vocab/mode"
@@ -219,8 +277,66 @@
     "name": {
       "@id": "https://robosystems.ai/vocab/name"
     },
+    "negated": {
+      "@id": "https://robosystems.ai/vocab/negated"
+    },
+    "negatedLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedLabel"
+    },
+    "negatedNetLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedNetLabel"
+    },
+    "negatedPeriodEnd": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodEnd"
+    },
+    "negatedPeriodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodEndLabel"
+    },
+    "negatedPeriodStart": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodStart"
+    },
+    "negatedPeriodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodStartLabel"
+    },
+    "negatedTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedTerseLabel"
+    },
+    "negatedTotal": {
+      "@id": "https://robosystems.ai/vocab/negatedTotal"
+    },
+    "negatedTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedTotalLabel"
+    },
+    "negativeLabel": {
+      "@id": "https://robosystems.ai/vocab/negativeLabel"
+    },
+    "negativePeriodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodEndLabel"
+    },
+    "negativePeriodEndTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodEndTotalLabel"
+    },
+    "negativePeriodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodStartLabel"
+    },
+    "negativePeriodStartTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodStartTotalLabel"
+    },
+    "negativeTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/negativeTerseLabel"
+    },
+    "negativeVerboseLabel": {
+      "@id": "https://robosystems.ai/vocab/negativeVerboseLabel"
+    },
+    "netLabel": {
+      "@id": "https://robosystems.ai/vocab/netLabel"
+    },
     "networkRoleUri": {
       "@id": "https://robosystems.ai/vocab/networkRoleUri"
+    },
+    "nillable": {
+      "@id": "https://robosystems.ai/vocab/nillable",
+      "@type": "xsd:boolean"
     },
     "nonAuthoritative": {
       "@id": "https://robosystems.ai/vocab/nonAuthoritative",
@@ -243,9 +359,19 @@
       "@id": "https://robosystems.ai/vocab/period",
       "@type": "@id"
     },
+    "periodEndDate": {
+      "@id": "https://robosystems.ai/vocab/periodEndDate",
+      "@type": "xsd:date"
+    },
+    "periodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/periodEndLabel"
+    },
     "periodNodes": {
       "@id": "https://robosystems.ai/vocab/periodNodes",
       "@type": "@id"
+    },
+    "periodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/periodStartLabel"
     },
     "periodType": {
       "@id": "xbrli:periodType"
@@ -254,9 +380,33 @@
       "@id": "https://robosystems.ai/vocab/periods",
       "@type": "@id"
     },
+    "positiveLabel": {
+      "@id": "https://robosystems.ai/vocab/positiveLabel"
+    },
+    "positivePeriodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodEndLabel"
+    },
+    "positivePeriodEndTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodEndTotalLabel"
+    },
+    "positivePeriodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodStartLabel"
+    },
+    "positivePeriodStartTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodStartTotalLabel"
+    },
+    "positiveTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/positiveTerseLabel"
+    },
+    "positiveVerboseLabel": {
+      "@id": "https://robosystems.ai/vocab/positiveVerboseLabel"
+    },
     "prefLabel": "skos:prefLabel",
     "preferredLabel": {
       "@id": "https://robosystems.ai/vocab/preferredLabel"
+    },
+    "preferredLabelRole": {
+      "@id": "https://robosystems.ai/vocab/preferredLabelRole"
     },
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
@@ -294,6 +444,9 @@
     "reportingStyleNetworks": {
       "@id": "https://robosystems.ai/vocab/reportingStyleNetworks"
     },
+    "restatedLabel": {
+      "@id": "https://robosystems.ai/vocab/restatedLabel"
+    },
     "retainedEarningsConcept": {
       "@id": "https://robosystems.ai/vocab/retainedEarningsConcept"
     },
@@ -305,9 +458,7 @@
       "@id": "https://robosystems.ai/vocab/roleUri"
     },
     "rs": "https://robosystems.ai/vocab/",
-    "rs-driver": "https://robosystems.ai/taxonomy/rs-gaap/drivers/v1/",
     "rs-gaap": "https://robosystems.ai/taxonomy/rs-gaap/v1/",
-    "rs-metric": "https://robosystems.ai/taxonomy/rs-gaap/metrics/v1/",
     "ruleCategory": {
       "@id": "https://robosystems.ai/vocab/ruleCategory"
     },
@@ -366,6 +517,10 @@
     "sourceReportId": {
       "@id": "https://robosystems.ai/vocab/sourceReportId"
     },
+    "srt": "http://fasb.org/srt/",
+    "standardLabel": {
+      "@id": "https://robosystems.ai/vocab/standardLabel"
+    },
     "start": {
       "@id": "https://robosystems.ai/vocab/start",
       "@type": "xsd:date"
@@ -381,8 +536,7 @@
       "@id": "https://robosystems.ai/vocab/statementType"
     },
     "stringValue": {
-      "@id": "https://robosystems.ai/vocab/stringValue",
-      "@type": "xsd:string"
+      "@id": "https://robosystems.ai/vocab/stringValue"
     },
     "structure": {
       "@id": "https://robosystems.ai/vocab/structure",
@@ -390,6 +544,10 @@
     },
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
+    },
+    "structureOrder": {
+      "@id": "https://robosystems.ai/vocab/structureOrder",
+      "@type": "xsd:integer"
     },
     "structures": {
       "@id": "https://robosystems.ai/vocab/structures",
@@ -415,11 +573,20 @@
     "taxonomyName": {
       "@id": "https://robosystems.ai/vocab/taxonomyName"
     },
+    "terseLabel": {
+      "@id": "https://robosystems.ai/vocab/terseLabel"
+    },
     "to": {
       "@id": "xlink:to",
       "@type": "@id"
     },
+    "totalLabel": {
+      "@id": "https://robosystems.ai/vocab/totalLabel"
+    },
     "trait": "https://robosystems.ai/taxonomy/fac-traits/v1/",
+    "typedValue": {
+      "@id": "https://robosystems.ai/vocab/typedValue"
+    },
     "unit": {
       "@id": "https://robosystems.ai/vocab/unit",
       "@type": "@id"
@@ -439,6 +606,9 @@
     "variableQname": {
       "@id": "https://robosystems.ai/vocab/variableQname"
     },
+    "verboseLabel": {
+      "@id": "https://robosystems.ai/vocab/verboseLabel"
+    },
     "version": {
       "@id": "https://robosystems.ai/vocab/version"
     },
@@ -450,86 +620,25 @@
     "xbrldt": "http://xbrl.org/2005/xbrldt#",
     "xbrli": "http://www.xbrl.org/2003/instance#",
     "xlink": "http://www.w3.org/1999/xlink#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#"
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "zeroLabel": {
+      "@id": "https://robosystems.ai/vocab/zeroLabel"
+    },
+    "zeroTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/zeroTerseLabel"
+    },
+    "zeroVerboseLabel": {
+      "@id": "https://robosystems.ai/vocab/zeroVerboseLabel"
+    }
   },
   "@graph": [
     {
       "@graph": [
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/13",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:NonoperatingIncomeExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/10",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/calculation/0",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Assets",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AssetsNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/5",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InvestmentIncomeInterest",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/35",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/30",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/1",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -540,385 +649,7 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/3",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingIncomeLoss",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/27",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseLiabilityCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/23",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/17",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingIncomeLoss",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingExpenses",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/24",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AdditionalPaidInCapital",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/15",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InterestExpense",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/7",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingIncomeLoss",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GrossProfit",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/6",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/5",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccountsPayableCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/9",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccruedLiabilitiesCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/11",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:GrossProfit",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfRevenue",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/32",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/3",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:EffectOfExchangeRateOnCash",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/22",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/1",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:GrossProfit",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:Revenues",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/20",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherNonoperatingIncomeExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/10",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostOfOperatingRevenue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/21",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostAndExpenseOperating",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/2",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/16",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredIncomeTaxLiabilitiesNet",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/25",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "406.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:AssetImpairmentCharges",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/15",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DebtCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/21",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/12",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Goodwill",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/19",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:DepreciationDepletionAndAmortization",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/1",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/14",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:StockholdersEquity",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/0",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/calculation/1",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -932,35 +663,161 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/9",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/calculation/2",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:SellingAndMarketingExpense",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:EffectOfExchangeRateOnCash",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/2",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/calculation/3",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperations",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/29",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/0",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Assets",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AssetsNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/1",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DebtCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/10",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ReceivablesNetCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/11",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/12",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredIncomeTaxLiabilitiesNet",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/13",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Goodwill",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/14",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/15",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PrepaidExpenseCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/16",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AdditionalPaidInCapital",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/17",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -974,338 +831,7 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/28",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/26",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseRightOfUseAsset",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/2",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/0",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/1",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/3"
-          ]
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/4",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NetIncomeLoss",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperations",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/17",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PreferredStockValue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/8",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Revenues",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/2",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PropertyPlantAndEquipmentNet",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/7",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CommonStockValue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/37",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:TreasuryStockValue",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/22",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "403.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/13",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Liabilities",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/8",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ShortTermInvestments",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/18",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainLossOnDispositionOfAssets",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/6",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GeneralAndAdministrativeExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/4",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Liabilities",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/3",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Liabilities",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/34",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/20",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/16",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ResearchAndDevelopmentExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/19",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/18",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/33",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/14",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NetIncomeLoss",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/25",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PrepaidExpenseCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/0",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/18",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -1319,7 +845,413 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/24",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/19",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/2",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/20",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Liabilities",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/21",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/22",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/23",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/24",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/25",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/26",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CommonStockValue",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/27",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:TreasuryStockValue",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/28",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/29",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:StockholdersEquity",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/3",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseRightOfUseAsset",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/30",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/31",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/32",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseLiabilityCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/33",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/34",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/35",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccountsPayableCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/36",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Liabilities",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/37",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ShortTermInvestments",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/4",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/5",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccruedLiabilitiesCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/6",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PreferredStockValue",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/7",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Liabilities",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/8",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/9",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseRightOfUseAsset",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/0",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Revenues",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/1",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GeneralAndAdministrativeExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/10",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -1333,140 +1265,80 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/11",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/11",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
+          "from": "rs-gaap:GrossProfit",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:Revenues",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/12",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainLossOnDispositionOfAssets",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/13",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
           "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ReceivablesNetCurrent",
-          "weight": "1.0"
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InterestExpense",
+          "weight": "-1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/18",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/12",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/9",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/21",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/25",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/3",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/0",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/2",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/23",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/6",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/7",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/11",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/8",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/19",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/1",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/15",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/22",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/10",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/4",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/20",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/14",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/5",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/16",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/13",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/24",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/17"
-          ]
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/31",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/14",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseRightOfUseAsset",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/36",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/0",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
           "from": "rs-gaap:CostOfRevenue",
-          "order": "100.0",
+          "order": "200.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfGoodsAndServicesSold",
+          "to": "rs-gaap:OtherCostOfOperatingRevenue",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/30",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/28",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/7",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/11",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/26",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/0",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/3",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/17",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/15",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/12",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/34",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/13",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/21",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/10",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/16",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/31",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/32",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/5",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/2",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/20",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/9",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/19",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/14",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/25",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/23",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/29",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/37",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/1",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/27",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/6",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/8",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/18",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/4",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/22",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/24",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/35",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/36",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/33"
-          ]
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/15",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:DepreciationDepletionAndAmortization",
+          "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/12",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/16",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -1477,10 +1349,234 @@
           "weight": "-1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/23",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/17",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InvestmentIncomeInterest",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/18",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherNonoperatingIncomeExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/19",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NetIncomeLoss",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperations",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/2",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfGoodsAndServicesSold",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/20",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingIncomeLoss",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/21",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "403.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/22",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:SellingAndMarketingExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/23",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostAndExpenseOperating",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/24",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "406.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:AssetImpairmentCharges",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/25",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperations",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/3",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:NonoperatingIncomeExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/4",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingIncomeLoss",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GrossProfit",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/5",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ResearchAndDevelopmentExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/6",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:GrossProfit",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfRevenue",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/7",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NetIncomeLoss",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/8",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingIncomeLoss",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingExpenses",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/9",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -1489,6 +1585,89 @@
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
           "to": "rs-gaap:RestructuringCharges",
           "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/4d5ede325089bd91",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/calculation/3"
+          ]
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/75bf584b3e4aaaa0",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/10",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/11",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/12",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/13",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/14",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/15",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/16",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/17",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/18",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/19",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/20",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/21",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/22",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/23",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/24",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/25",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/26",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/27",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/28",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/29",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/3",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/30",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/31",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/32",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/33",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/34",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/35",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/36",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/37",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/4",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/5",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/6",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/7",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/8",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/calculation/9"
+          ]
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/850c3d8ab3a4a627",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/10",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/11",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/12",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/13",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/14",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/15",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/16",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/17",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/18",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/19",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/20",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/21",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/22",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/23",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/24",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/25",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/3",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/4",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/5",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/6",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/7",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/8",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/calculation/9"
+          ]
         }
       ],
       "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY#boundary"
@@ -1496,524 +1675,7 @@
     {
       "@graph": [
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/18",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30310.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GrossProfit"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/37",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20460.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:TreasuryStockValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/12",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30220.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/21",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10646.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/19",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30320.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/7",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20160.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/13",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30230.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsToAcquireInvestments"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/9",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10420.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ResearchAndDevelopmentExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/26",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "11200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:NetIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/7",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30170.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/20",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30330.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:RepaymentsOfLongTermDebt"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/14",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30240.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:Revenues"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/18",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10630.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainLossOnDispositionOfAssets"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/29",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20324.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/34",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20430.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AdditionalPaidInCapital"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/14",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "10210.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfGoodsAndServicesSold"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/26",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20321.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/22",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:EffectOfExchangeRateOnCash"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/15",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsToAcquireIntangibleAssets"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/10",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20220.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Goodwill"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/23",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20314.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseLiabilityCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/30",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20325.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/6",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/11",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30210.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "@type": [
-            "rs:RollUp",
-            "rs:Structure"
-          ],
-          "blockType": "cash_flow_statement",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/15",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/14",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/18",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/20",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/16",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/10",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/6",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/13",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/7",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/17",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/19",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/11",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/22",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/8",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/21",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/9",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/12"
-          ],
-          "internalId": "5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "structureName": "rs-gaap — Cash Flow Statement — Indirect"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30130.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccountsReceivable"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/12",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10443.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RestructuringCharges"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/20",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20312.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DebtCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/20",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10643.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:NetIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/8",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30180.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccruedLiabilities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Assets",
-          "order": "20100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AssetsCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30120.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:DepreciationDepletionAndAmortization"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfRevenue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/23",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10900.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeTaxExpenseBenefit"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/24",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "11000.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperations"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/31",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "20400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:StockholdersEquity"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/13",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10446.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:AssetImpairmentCharges"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/10",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInInvestingActivities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/25",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "11100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/15",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:NonoperatingIncomeExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/18",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20311.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccountsPayableCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/19",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20311.5",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccruedLiabilitiesCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInOperatingActivities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/2",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/1eae745dbb354952/presentation/0",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -2023,107 +1685,37 @@
           "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/11",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10440.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostAndExpenseOperating"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/36",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/1eae745dbb354952/presentation/1",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
           "from": "rs-gaap:StockholdersEquity",
-          "order": "20450.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax"
+          "order": "40200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/9",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20210.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PropertyPlantAndEquipmentNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20140.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PrepaidExpenseCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/7",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10410.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GeneralAndAdministrativeExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/16",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30260.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromSaleOfIntangibleAssets"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/21",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30340.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/33",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/1eae745dbb354952/presentation/2",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
           "from": "rs-gaap:StockholdersEquity",
-          "order": "20420.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PreferredStockValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/16",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "20300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Liabilities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30110.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "order": "40100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
           "to": "rs-gaap:NetIncomeLoss"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/4",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/1eae745dbb354952/presentation/3",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/1eae745dbb354952/presentation/4",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -2133,249 +1725,7 @@
           "to": "rs-gaap:ShareBasedCompensation"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/8",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Assets",
-          "order": "20200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AssetsNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/21",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20312.5",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "@type": [
-            "rs:Structure",
-            "rs:Hierarchy"
-          ],
-          "blockType": "equity_statement",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/4"
-          ],
-          "internalId": "0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "structureName": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/8",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10415.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:SellingAndMarketingExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/13",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20240.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseRightOfUseAsset"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20120.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ReceivablesNetCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20130.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/27",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20322.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredIncomeTaxLiabilitiesNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/24",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20315.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/22",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20313.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "10230.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostOfOperatingRevenue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInPrepaidExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "@type": [
-            "rs:RollUp",
-            "rs:Structure"
-          ],
-          "blockType": "balance_sheet",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/37",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/22",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/33",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/21",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/12",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/20",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/36",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/27",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/29",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/23",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/34",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/35",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/17",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/9",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/6",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/7",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/32",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/15",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/16",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/24",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/19",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/18",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/31",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/13",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/14",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/10",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/11",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/26",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/28",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/25",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/8",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/30"
-          ],
-          "internalId": "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "prefLabel": "rs-gaap — Balance Sheet — Classified",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "structureName": "rs-gaap — Balance Sheet — Classified"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/25",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Liabilities",
-          "order": "20320.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/12",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20230.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Revenues",
-          "order": "10120.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/6",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingExpenses"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/9",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30190.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/17",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10620.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InterestExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/5",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/1eae745dbb354952/presentation/5",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -2385,87 +1735,157 @@
           "to": "rs-gaap:PaymentsOfDividends"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/32",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/0",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20410.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CommonStockValue"
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30310.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/28",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/1",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20323.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueNoncurrent"
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30230.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsToAcquireInvestments"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/17",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/10",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30220.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/11",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30170.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/12",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30330.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:RepaymentsOfLongTermDebt"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/13",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30240.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/14",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
           "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30300.0",
+          "order": "30400.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities"
+          "to": "rs-gaap:EffectOfExchangeRateOnCash"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/14",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/15",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseRightOfUseAsset"
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInInvestingActivities"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/19",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/16",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10640.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherNonoperatingIncomeExpense"
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30340.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/35",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/17",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20440.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RetainedEarningsAccumulatedDeficit"
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30110.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetIncomeLoss"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/2",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/18",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20115.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ShortTermInvestments"
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30320.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/22",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/19",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10800.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest"
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30210.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/6",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30130.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccountsReceivable"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/20",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInOperatingActivities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/21",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30260.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromSaleOfIntangibleAssets"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/22",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -2475,98 +1895,67 @@
           "to": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/16",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/3",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10610.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InvestmentIncomeInterest"
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30180.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccruedLiabilities"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/1",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/4",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20110.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/15",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20260.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/10",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10430.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30120.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
           "to": "rs-gaap:DepreciationDepletionAndAmortization"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/11",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/5",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20225.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill"
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "@type": [
-            "rs:RollUp",
-            "rs:Structure"
-          ],
-          "blockType": "income_statement",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/21",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/25",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/22",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/8",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/14",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/12",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/13",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/23",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/9",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/18",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/20",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/26",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/24",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/11",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/16",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/15",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/10",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/17",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/6",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/19",
-            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/7"
-          ],
-          "internalId": "47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "prefLabel": "rs-gaap — Income Statement — Multi-step",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "structureName": "rs-gaap — Income Statement — Multi-step"
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/6",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInPrepaidExpense"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/4",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/7",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsToAcquireIntangibleAssets"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/8",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30190.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/9",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -2576,7 +1965,347 @@
           "to": "rs-gaap:IncreaseDecreaseInInventories"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/17",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20160.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20314.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseLiabilityCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/10",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20210.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PropertyPlantAndEquipmentNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/11",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20420.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PreferredStockValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/12",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Assets",
+          "order": "20200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AssetsNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/13",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20240.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseRightOfUseAsset"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/14",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20440.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RetainedEarningsAccumulatedDeficit"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/15",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20260.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/16",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20460.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:TreasuryStockValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/17",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20430.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AdditionalPaidInCapital"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/18",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20311.5",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccruedLiabilitiesCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/19",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20311.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccountsPayableCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20325.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/20",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20450.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/21",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "20300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Liabilities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/22",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20120.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ReceivablesNetCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/23",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20130.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/24",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20322.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredIncomeTaxLiabilitiesNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/25",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20315.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/26",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20313.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/27",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20230.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/28",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20323.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/29",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20110.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/3",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20312.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DebtCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/30",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20225.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/31",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20321.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/32",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "20400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:StockholdersEquity"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/33",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20140.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PrepaidExpenseCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/34",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20312.5",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/35",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Liabilities",
+          "order": "20320.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/36",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseRightOfUseAsset"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/37",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20115.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ShortTermInvestments"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/4",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Assets",
+          "order": "20100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AssetsCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20410.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CommonStockValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/6",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -2584,167 +2313,549 @@
           "order": "20310.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
           "to": "rs-gaap:LiabilitiesCurrent"
-        }
-      ],
-      "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY#projection"
-    },
-    {
-      "@graph": [
-        {
-          "@id": "rs-gaap:LiabilitiesCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "efb036ff-3f30-5deb-bee9-1af4cd4b9800",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Liabilities, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "ff101489-15f4-573d-967b-24f75e0fc0f6",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Payments to Acquire Property, Plant, and Equipment",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/7",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20324.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTS",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:StockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJMB",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTS",
-          "numericValue": "57185.02",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/8",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20220.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Goodwill"
         },
         {
-          "@id": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "353f790f-1ed1-5b91-880d-8029b4b687cf",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/9",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_2",
-          "@type": "rs:Period",
-          "instant": "2024-12-31",
-          "periodType": "instant"
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10420.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ResearchAndDevelopmentExpense"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/ib/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "@type": "rs:InformationBlock",
-          "blockType": "equity_statement",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJMB",
-          "internalId": "0b179e5c-5f02-506d-b8d5-860cb10c7694",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "11200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:NetIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/10",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:NonoperatingIncomeExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/11",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10610.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InvestmentIncomeInterest"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/12",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:Revenues"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/13",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfRevenue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/14",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10446.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:AssetImpairmentCharges"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/15",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10415.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:SellingAndMarketingExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/16",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "10230.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostOfOperatingRevenue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/17",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Revenues",
+          "order": "10120.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/18",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10640.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherNonoperatingIncomeExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/19",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10430.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:DepreciationDepletionAndAmortization"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10443.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RestructuringCharges"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/20",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/21",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "10210.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfGoodsAndServicesSold"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/22",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "11000.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperations"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/23",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10440.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostAndExpenseOperating"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/24",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingExpenses"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/25",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10620.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InterestExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/26",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10800.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/3",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10900.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeTaxExpenseBenefit"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/4",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "11100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10410.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GeneralAndAdministrativeExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/6",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GrossProfit"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/7",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10646.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/8",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10630.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainLossOnDispositionOfAssets"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/9",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10643.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/1eae745dbb354952",
+          "@type": [
+            "rs:Hierarchy",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/1eae745dbb354952",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/1eae745dbb354952/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/1eae745dbb354952/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/1eae745dbb354952/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/1eae745dbb354952/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/1eae745dbb354952/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/1eae745dbb354952/presentation/5"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
           "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "structureName": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
+          "structureOrder": "3"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4F",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DepreciationDepletionAndAmortization",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJMA",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4F",
-          "numericValue": "899.98",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/4d5ede325089bd91",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/10",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/11",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/12",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/13",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/14",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/15",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/16",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/17",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/18",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/19",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/20",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/21",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/22",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/5",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/6",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/7",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/8",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/4d5ede325089bd91/presentation/9"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "structureName": "rs-gaap — Cash Flow Statement — Indirect",
+          "structureOrder": "0"
         },
         {
-          "@id": "rs-gaap:NetIncomeLoss",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/75bf584b3e4aaaa0",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/10",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/11",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/12",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/13",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/14",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/15",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/16",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/17",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/18",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/19",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/20",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/21",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/22",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/23",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/24",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/25",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/26",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/27",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/28",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/29",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/30",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/31",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/32",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/33",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/34",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/35",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/36",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/37",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/5",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/6",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/7",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/8",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/75bf584b3e4aaaa0/presentation/9"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "prefLabel": "rs-gaap — Balance Sheet — Classified",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "structureName": "rs-gaap — Balance Sheet — Classified",
+          "structureOrder": "1"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/850c3d8ab3a4a627",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/10",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/11",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/12",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/13",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/14",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/15",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/16",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/17",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/18",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/19",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/20",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/21",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/22",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/23",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/24",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/25",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/26",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/5",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/6",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/7",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/8",
+            "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/association/850c3d8ab3a4a627/presentation/9"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "prefLabel": "rs-gaap — Income Statement — Multi-step",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "structureName": "rs-gaap — Income Statement — Multi-step",
+          "structureOrder": "2"
+        },
+        {
+          "@id": "rs-gaap:AccountsPayableCurrent",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "27a05717-2370-51c2-a924-db5cbcb48219",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Net Income (Loss) Attributable to Parent",
+          "internalId": "rs-gaap:AccountsPayableCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accounts Payable, Current",
           "source": "rs-gaap",
+          "standardLabel": "Accounts Payable, Current",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTA",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJMB",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTA",
-          "numericValue": "49800.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
+          "@id": "rs-gaap:AccruedLiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccruedLiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accrued Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Accrued Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "@type": "rs:Period",
-          "instant": "2025-12-31",
-          "periodType": "instant"
+          "@id": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accumulated Other Comprehensive Income (Loss), Net of Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Accumulated Other Comprehensive Income (Loss), Net of Tax",
+          "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4S",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJMA",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4S",
-          "numericValue": "7385.02",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
+          "@id": "rs-gaap:AdditionalPaidInCapital",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AdditionalPaidInCapital",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Additional Paid in Capital",
+          "source": "rs-gaap",
+          "standardLabel": "Additional Paid in Capital",
+          "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTK",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJMA",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTK",
-          "numericValue": "49800.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:DepreciationDepletionAndAmortization",
+          "@id": "rs-gaap:AssetImpairmentCharges",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "189a099a-7512-5144-9215-65d837c2c3b5",
-          "monetary": "true",
+          "internalId": "rs-gaap:AssetImpairmentCharges",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "duration",
-          "prefLabel": "Depreciation, Depletion and Amortization",
+          "prefLabel": "Asset Impairment Charges",
           "source": "rs-gaap",
+          "standardLabel": "Asset Impairment Charges",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Assets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Assets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Assets",
           "substitutionGroup": "xbrli:item"
         },
         {
@@ -2753,77 +2864,13 @@
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "0fc9ab7e-c5ce-5277-9530-344cc127fe26",
-          "monetary": "true",
+          "internalId": "rs-gaap:AssetsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "instant",
           "prefLabel": "Assets, Current",
           "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:Revenues",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "b26a6cd4-072f-5bf2-b5d3-ebf928150d6c",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Revenues",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTQ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTQ",
-          "numericValue": "57985.02",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "57ccbf45-c970-5bcd-a381-44d96b6b6d94",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:AccountsPayableCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "9ddbc9d7-c769-5800-8f65-1089d476e5c9",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Accounts Payable, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "811f1cf5-836c-575f-9f3f-cd7fa477e4e5",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
-          "source": "rs-gaap",
+          "standardLabel": "Assets, Current",
           "substitutionGroup": "xbrli:item"
         },
         {
@@ -2832,11 +2879,313 @@
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "841cedeb-4cb0-532a-b0bd-c34846a13a8c",
-          "monetary": "true",
+          "internalId": "rs-gaap:AssetsNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "instant",
           "prefLabel": "Assets, Noncurrent",
           "source": "rs-gaap",
+          "standardLabel": "Assets, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CommonStockValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CommonStockValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Common Stock, Value, Issued",
+          "source": "rs-gaap",
+          "standardLabel": "Common Stock, Value, Issued",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfGoodsAndServicesSold",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfGoodsAndServicesSold",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Product and Service Sold",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Product and Service Sold",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Revenue",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Revenue",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DebtCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DebtCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Debt, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Debt, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DeferredIncomeTaxLiabilitiesNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DeferredIncomeTaxLiabilitiesNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Deferred Income Tax Liabilities, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Deferred Income Tax Liabilities, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DeferredRevenueCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DeferredRevenueCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Deferred Revenue, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Deferred Revenue, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DeferredRevenueNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DeferredRevenueNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Deferred Revenue, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Deferred Revenue, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DepreciationDepletionAndAmortization",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DepreciationDepletionAndAmortization",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Depreciation, Depletion and Amortization",
+          "source": "rs-gaap",
+          "standardLabel": "Depreciation, Depletion and Amortization",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:EffectOfExchangeRateOnCash",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:EffectOfExchangeRateOnCash",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Effect of Exchange Rate on Cash",
+          "source": "rs-gaap",
+          "standardLabel": "Effect of Exchange Rate on Cash",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:FinanceLeaseLiabilityCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:FinanceLeaseLiabilityCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Finance Lease, Liability, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Finance Lease, Liability, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:FinanceLeaseRightOfUseAsset",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:FinanceLeaseRightOfUseAsset",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Finance Lease, Right-of-Use Asset, after Accumulated Amortization",
+          "source": "rs-gaap",
+          "standardLabel": "Finance Lease, Right-of-Use Asset, after Accumulated Amortization",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gain (Loss), Foreign Currency Transaction, before Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Gain (Loss), Foreign Currency Transaction, before Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GainLossOnDispositionOfAssets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GainLossOnDispositionOfAssets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gain (Loss) on Disposition of Property Plant Equipment, Excluding Oil and Gas Property and Timber Property",
+          "source": "rs-gaap",
+          "standardLabel": "Gain (Loss) on Disposition of Property Plant Equipment, Excluding Oil and Gas Property and Timber Property",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gain (Loss) on Extinguishment of Debt",
+          "source": "rs-gaap",
+          "standardLabel": "Gain (Loss) on Extinguishment of Debt",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GeneralAndAdministrativeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GeneralAndAdministrativeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "General and Administrative Expense",
+          "source": "rs-gaap",
+          "standardLabel": "General and Administrative Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Goodwill",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Goodwill",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Goodwill",
+          "source": "rs-gaap",
+          "standardLabel": "Goodwill",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GrossProfit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GrossProfit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gross Profit",
+          "source": "rs-gaap",
+          "standardLabel": "Gross Profit",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperations",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperations",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
           "substitutionGroup": "xbrli:item"
         },
         {
@@ -2845,330 +3194,104 @@
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "6b0b414f-0c76-54f0-8e51-cf53db59ca24",
-          "monetary": "true",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "duration",
           "prefLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
           "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "rs-gaap:ReceivablesNetCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "44686df3-3871-5c1f-8a08-fc542d69dfa0",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Receivables, Net, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTV",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Assets",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTV",
-          "numericValue": "57985.02",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/ib/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "@type": "rs:InformationBlock",
-          "blockType": "cash_flow_statement",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJMA",
-          "internalId": "5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZV0",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:OperatingIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJM9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZV0",
-          "numericValue": "7385.02",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:OperatingExpenses",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "71fcdebb-7145-5f76-b5e0-b4ccbf2c29d2",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Operating Expenses",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4P",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4P",
-          "numericValue": "0.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTP",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AssetsNoncurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTP",
-          "numericValue": "5400.02",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "69b82be1-1145-5686-8613-31da9eb04a72",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "@id": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "30b2801e-e682-5298-82e6-3670e1d508f1",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Liabilities and Equity",
+          "internalId": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Discontinued Operations, Net of Tax, Including Portion Attributable to Noncontrolling Interest",
           "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Discontinued Operations, Net of Tax, Including Portion Attributable to Noncontrolling Interest",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "@id": "rs-gaap:IncomeStatementAbstract",
+          "@type": "rs:Element",
+          "abstract": "true",
+          "balance": "debit",
+          "elementType": "abstract",
+          "internalId": "rs-gaap:IncomeStatementAbstract",
+          "itemType": "string",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income Statement [Abstract]",
+          "source": "rs-gaap",
+          "standardLabel": "Income Statement [Abstract]",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeTaxExpenseBenefit",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "288099af-5cbb-5f78-8f8a-1a85675fb661",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Property, Plant and Equipment, Net",
+          "internalId": "rs-gaap:IncomeTaxExpenseBenefit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income Tax Expense (Benefit)",
           "source": "rs-gaap",
+          "standardLabel": "Income Tax Expense (Benefit)",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "rs-gaap:StockholdersEquity",
+          "@id": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accounts Payable and Accrued Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accounts Payable and Accrued Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "e3796201-9899-5b7b-9477-659550ba8e68",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Stockholders' Equity Attributable to Parent",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accounts Receivable",
           "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accounts Receivable",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4D",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4D",
-          "numericValue": "51085.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTN",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJMA",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTN",
-          "numericValue": "-4800.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTY",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJM9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTY",
-          "numericValue": "7385.02",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTW",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Liabilities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTW",
-          "numericValue": "800.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4A",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AccountsPayableCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4A",
-          "numericValue": "0.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:IncomeLossFromContinuingOperations",
+          "@id": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable",
           "@type": "rs:Element",
           "abstract": "false",
-          "balance": "credit",
+          "balance": "debit",
           "elementType": "concept",
-          "internalId": "d60cabda-7060-5aff-ac98-96371606a738",
-          "monetary": "true",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "duration",
-          "prefLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "prefLabel": "Increase (Decrease) in Income Taxes Payable",
           "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Income Taxes Payable",
           "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTJ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJMA",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTJ",
-          "numericValue": "51085.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTM",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AssetsCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTM",
-          "numericValue": "52585.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4N",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AdditionalPaidInCapital",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4N",
-          "numericValue": "0.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTT",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:StockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTT",
-          "numericValue": "57185.02",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "@type": "rs:Period",
-          "endDate": "2025-12-31",
-          "periodType": "duration",
-          "startDate": "2025-01-01"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTZ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:GrossProfit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJM9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTZ",
-          "numericValue": "100500.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTG",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Revenues",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJM9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTG",
-          "numericValue": "100500.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
         },
         {
           "@id": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
@@ -3176,11 +3299,43 @@
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "e92e6488-dcc7-5877-ad4b-f2498bdf7bae",
-          "monetary": "true",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "duration",
           "prefLabel": "Increase (Decrease) in Accrued Liabilities",
           "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accrued Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInInventories",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInInventories",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Inventories",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Inventories",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
           "substitutionGroup": "xbrli:item"
         },
         {
@@ -3189,480 +3344,73 @@
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "550bb6e5-53d0-5267-adb1-baf78093a0b0",
-          "monetary": "true",
+          "internalId": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "duration",
           "prefLabel": "Increase (Decrease) in Prepaid Expense",
           "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Prepaid Expense",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD",
-          "@type": "rs:Unit",
-          "measure": "iso4217:USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTC",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJMA",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTC",
-          "numericValue": "-1500.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "@id": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "20a6586b-880a-5745-94db-e23d397eb5e1",
-          "monetary": "true",
+          "internalId": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "instant",
-          "prefLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "prefLabel": "Intangible Assets, Net (Excluding Goodwill)",
           "source": "rs-gaap",
+          "standardLabel": "Intangible Assets, Net (Excluding Goodwill)",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4J",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ReceivablesNetCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4J",
-          "numericValue": "0.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZT9",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJMA",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZT9",
-          "numericValue": "49800.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4Q",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJM9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4Q",
-          "numericValue": "7385.02",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4K",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJM9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4K",
-          "numericValue": "100500.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTF",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncomeLossFromContinuingOperations",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJM9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTF",
-          "numericValue": "7385.02",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4G",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:GeneralAndAdministrativeExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJM9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4G",
-          "numericValue": "92215.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "37252918-4301-50e2-8d7e-cf2c76986d15",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:PrepaidExpenseCurrent",
+          "@id": "rs-gaap:InterestExpense",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "2225e348-90bd-53cb-9784-8b5d54980a69",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Prepaid Expense, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4E",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DepreciationDepletionAndAmortization",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJM9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4E",
-          "numericValue": "899.98",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:GrossProfit",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "a92b3181-9fe7-543c-81d9-13ebd12bbefa",
-          "monetary": "true",
+          "internalId": "rs-gaap:InterestExpense",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "duration",
-          "prefLabel": "Gross Profit",
+          "prefLabel": "Interest Expense, Operating and Nonoperating",
           "source": "rs-gaap",
+          "standardLabel": "Interest Expense, Operating and Nonoperating",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4H",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PrepaidExpenseCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4H",
-          "numericValue": "1500.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZT8",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PropertyPlantAndEquipmentNet",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZT8",
-          "numericValue": "5400.02",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4C",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AdditionalPaidInCapital",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4C",
-          "numericValue": "49800.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/ib/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "@type": "rs:InformationBlock",
-          "blockType": "balance_sheet",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "internalId": "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "prefLabel": "rs-gaap — Balance Sheet — Classified",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "rs-gaap:AdditionalPaidInCapital",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "6146605c-0d63-51e1-a523-3450d6abaca3",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Additional Paid in Capital",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4R",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJMB",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4R",
-          "numericValue": "7385.02",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTH",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJMA",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTH",
-          "numericValue": "6085.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:GeneralAndAdministrativeExpense",
+          "@id": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "debit",
           "elementType": "concept",
-          "internalId": "f92ba8cb-7ae2-5d40-9d15-9a94e9e3aed4",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "General and Administrative Expense",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4B",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AccruedLiabilitiesCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4B",
-          "numericValue": "800.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:AccruedLiabilitiesCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "4decfae2-2ca3-5dd3-8c06-88557583c13d",
-          "monetary": "true",
+          "internalId": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "instant",
-          "prefLabel": "Accrued Liabilities, Current",
+          "prefLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
           "source": "rs-gaap",
+          "standardLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
           "substitutionGroup": "xbrli:item"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTB",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJMA",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTB",
-          "numericValue": "-4800.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTR",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTR",
-          "numericValue": "800.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/ib/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "@type": "rs:InformationBlock",
-          "blockType": "income_statement",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJM9",
-          "internalId": "47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "prefLabel": "rs-gaap — Income Statement — Multi-step",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "@id": "rs-gaap:InvestmentIncomeInterest",
           "@type": "rs:Element",
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "a3227fb2-202b-51db-9574-4e60db03c04f",
-          "monetary": "true",
+          "internalId": "rs-gaap:InvestmentIncomeInterest",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "duration",
-          "prefLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "prefLabel": "Investment Income, Interest",
           "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:OperatingIncomeLoss",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "16780828-0201-5609-b572-fbe3ebfcb177",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Operating Income (Loss)",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "@type": "rs:Entity",
-          "country": "US",
-          "internalId": "entity_kg1a078514c0dd31349d58",
-          "legalName": "Cascade Advisory Group LLC",
-          "prefLabel": "Cascade Advisory Group LLC"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTD",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJMA",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTD",
-          "numericValue": "800.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4M",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR56GRGFSB66XBNQJM8",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4M",
-          "numericValue": "7385.02",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "a9c87d60-a1e5-506b-a27e-cbf9e14e5113",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Retained Earnings (Accumulated Deficit)",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTX",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:OperatingExpenses",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJM9",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTX",
-          "numericValue": "93114.98",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:Assets",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "a1f04756-41d8-5d35-b821-23aa2f3b2fae",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Assets",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTE",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZJZPR66GRGFSB66XBNQJMA",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTE",
-          "numericValue": "-1500.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "2eb72b5f-d7e3-5bd5-bf93-be38b6d21820",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Proceeds from Issuance of Common Stock",
-          "source": "rs-gaap",
+          "standardLabel": "Investment Income, Interest",
           "substitutionGroup": "xbrli:item"
         },
         {
@@ -3671,11 +3419,1909 @@
           "abstract": "false",
           "balance": "credit",
           "elementType": "concept",
-          "internalId": "7af273ac-1cba-5fb3-a1c9-5c5d8fdb9bdf",
-          "monetary": "true",
+          "internalId": "rs-gaap:Liabilities",
+          "itemType": "decimal",
+          "monetary": "false",
           "periodType": "instant",
           "prefLabel": "Liabilities",
           "source": "rs-gaap",
+          "standardLabel": "Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities and Equity",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities and Equity",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Debt and Lease Obligation",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Debt and Lease Obligation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermDebtCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermDebtCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Debt, Current Maturities",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Debt, Current Maturities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Investments and Receivables, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Investments and Receivables, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Net Income (Loss) Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Net Income (Loss) Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NonoperatingIncomeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NonoperatingIncomeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Nonoperating Income (Expense)",
+          "source": "rs-gaap",
+          "standardLabel": "Nonoperating Income (Expense)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingExpenses",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingExpenses",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Expenses",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Expenses",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Income (Loss)",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Income (Loss)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Operating Lease, Liability, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Lease, Liability, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingLeaseRightOfUseAsset",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingLeaseRightOfUseAsset",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Operating Lease, Right-of-Use Asset",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Lease, Right-of-Use Asset",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherAssetsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherAssetsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Assets, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Other Assets, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherAssetsNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherAssetsNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Assets, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Other Assets, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Comprehensive Income (Loss), Net of Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Other Comprehensive Income (Loss), Net of Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherCostAndExpenseOperating",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherCostAndExpenseOperating",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Cost and Expense, Operating",
+          "source": "rs-gaap",
+          "standardLabel": "Other Cost and Expense, Operating",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherCostOfOperatingRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherCostOfOperatingRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Cost of Operating Revenue",
+          "source": "rs-gaap",
+          "standardLabel": "Other Cost of Operating Revenue",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherLiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherLiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Other Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherLiabilitiesNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherLiabilitiesNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Liabilities, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Other Liabilities, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherNonoperatingIncomeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherNonoperatingIncomeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Nonoperating Income (Expense)",
+          "source": "rs-gaap",
+          "standardLabel": "Other Nonoperating Income (Expense)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsForRepurchaseOfCommonStock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsForRepurchaseOfCommonStock",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments for Repurchase of Common Stock",
+          "source": "rs-gaap",
+          "standardLabel": "Payments for Repurchase of Common Stock",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsOfDividends",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsOfDividends",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments of Dividends",
+          "source": "rs-gaap",
+          "standardLabel": "Payments of Dividends",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquireIntangibleAssets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquireIntangibleAssets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Intangible Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Intangible Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquireInvestments",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquireInvestments",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Investments",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Investments",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PreferredStockValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PreferredStockValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Preferred Stock, Value, Issued",
+          "source": "rs-gaap",
+          "standardLabel": "Preferred Stock, Value, Issued",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PrepaidExpenseCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PrepaidExpenseCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Prepaid Expense, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Prepaid Expense, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Issuance of Common Stock",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Issuance of Common Stock",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Issuance of Long-Term Debt",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Issuance of Long-Term Debt",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Sale, Maturity and Collection of Investments",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Sale, Maturity and Collection of Investments",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromSaleOfIntangibleAssets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromSaleOfIntangibleAssets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Sale of Intangible Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Sale of Intangible Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Sale of Property, Plant, and Equipment",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Sale of Property, Plant, and Equipment",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Property, Plant and Equipment, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Property, Plant and Equipment, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ReceivablesNetCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ReceivablesNetCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Receivables, Net, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Receivables, Net, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RepaymentsOfLongTermDebt",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RepaymentsOfLongTermDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Repayments of Long-Term Debt",
+          "source": "rs-gaap",
+          "standardLabel": "Repayments of Long-Term Debt",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ResearchAndDevelopmentExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ResearchAndDevelopmentExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Research and Development Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Research and Development Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Restricted Cash and Investments, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Restricted Cash and Investments, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RestructuringCharges",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RestructuringCharges",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Restructuring Charges",
+          "source": "rs-gaap",
+          "standardLabel": "Restructuring Charges",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Retained Earnings (Accumulated Deficit)",
+          "source": "rs-gaap",
+          "standardLabel": "Retained Earnings (Accumulated Deficit)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Revenues",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Revenues",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenues",
+          "source": "rs-gaap",
+          "standardLabel": "Revenues",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:SellingAndMarketingExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:SellingAndMarketingExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Selling and Marketing Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Selling and Marketing Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ShareBasedCompensation",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ShareBasedCompensation",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Share-Based Payment Arrangement, Noncash Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Share-Based Payment Arrangement, Noncash Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ShortTermInvestments",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ShortTermInvestments",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Short-Term Investments",
+          "source": "rs-gaap",
+          "standardLabel": "Short-Term Investments",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:StockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:StockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Stockholders' Equity Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Stockholders' Equity Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:TreasuryStockValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:TreasuryStockValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Treasury Stock, Value",
+          "source": "rs-gaap",
+          "standardLabel": "Treasury Stock, Value",
+          "substitutionGroup": "xbrli:item"
+        }
+      ],
+      "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY#projection"
+    },
+    {
+      "@graph": [
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY",
+          "@type": "rs:Report",
+          "accessionNumber": "rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "mode": "report",
+          "reportingStyle": "sec-as-filed",
+          "serializationVersion": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "@type": "rs:Entity",
+          "internalId": "entity_kg1a078514c0dd31349d58",
+          "legalName": "Cascade Advisory Group LLC",
+          "prefLabel": "Cascade Advisory Group LLC",
+          "scheme": "http://robosystems.ai/entity"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4A",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AccountsPayableCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4A",
+          "numericValue": "0.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4B",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AccruedLiabilitiesCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4B",
+          "numericValue": "800.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4C",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AdditionalPaidInCapital",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4C",
+          "numericValue": "49800.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4D",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4D",
+          "numericValue": "51085.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4E",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DepreciationDepletionAndAmortization",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": [
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4E",
+          "numericValue": "899.98",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4F",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DepreciationDepletionAndAmortization",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": [
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4F",
+          "numericValue": "899.98",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4G",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:GeneralAndAdministrativeExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4G",
+          "numericValue": "92215.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4H",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PrepaidExpenseCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4H",
+          "numericValue": "1500.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4J",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ReceivablesNetCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4J",
+          "numericValue": "0.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4K",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4K",
+          "numericValue": "100500.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4M",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4M",
+          "numericValue": "7385.02",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4N",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AdditionalPaidInCapital",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4N",
+          "numericValue": "0.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/e6bfb85a-3629-5bc3-9b6e-d1baede2e29d",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4P",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4P",
+          "numericValue": "0.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/e6bfb85a-3629-5bc3-9b6e-d1baede2e29d",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4Q",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4Q",
+          "numericValue": "7385.02",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4R",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4R",
+          "numericValue": "7385.02",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPRDY582GAWBJD5GQC4S",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPRDY582GAWBJD5GQC4S",
+          "numericValue": "7385.02",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZT8",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZT8",
+          "numericValue": "5400.02",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZT9",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZT9",
+          "numericValue": "49800.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTA",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTA",
+          "numericValue": "49800.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTB",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTB",
+          "numericValue": "-4800.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTC",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTC",
+          "numericValue": "-1500.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTD",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTD",
+          "numericValue": "800.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTE",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTE",
+          "numericValue": "-1500.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTF",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncomeLossFromContinuingOperations",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTF",
+          "numericValue": "7385.02",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTG",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Revenues",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTG",
+          "numericValue": "100500.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTH",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTH",
+          "numericValue": "6085.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTJ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTJ",
+          "numericValue": "51085.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTK",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTK",
+          "numericValue": "49800.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTM",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AssetsCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTM",
+          "numericValue": "52585.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTN",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTN",
+          "numericValue": "-4800.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTP",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AssetsNoncurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTP",
+          "numericValue": "5400.02",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTQ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTQ",
+          "numericValue": "57985.02",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTR",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTR",
+          "numericValue": "800.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTS",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:StockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTS",
+          "numericValue": "57185.02",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTT",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:StockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTT",
+          "numericValue": "57185.02",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTV",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Assets",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTV",
+          "numericValue": "57985.02",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTW",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Liabilities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTW",
+          "numericValue": "800.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTX",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:OperatingExpenses",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTX",
+          "numericValue": "93114.98",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTY",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTY",
+          "numericValue": "7385.02",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZTZ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:GrossProfit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZTZ",
+          "numericValue": "100500.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/fact/fact_01M1ZJZPREWYAWT3B0Q1SF7ZV0",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:OperatingIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/entity/entity_kg1a078514c0dd31349d58",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZJZPREWYAWT3B0Q1SF7ZV0",
+          "numericValue": "7385.02",
+          "period": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/ib/1eae745dbb354952",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/1eae745dbb354952",
+          "internalId": "1eae745dbb354952",
+          "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/1eae745dbb354952"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/ib/4d5ede325089bd91",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "internalId": "4d5ede325089bd91",
+          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/4d5ede325089bd91"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/ib/75bf584b3e4aaaa0",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "internalId": "75bf584b3e4aaaa0",
+          "prefLabel": "rs-gaap — Balance Sheet — Classified",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/75bf584b3e4aaaa0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/ib/850c3d8ab3a4a627",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "internalId": "850c3d8ab3a4a627",
+          "prefLabel": "rs-gaap — Income Statement — Multi-step",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/structure/850c3d8ab3a4a627"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/06ab6e61-dd5d-59f3-ba02-630883506491",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2025-12-31",
+          "calendarQuarter": "Q4",
+          "calendarYear": "2025",
+          "instant": "2025-12-31",
+          "periodType": "instant"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/7eb2b875-d936-5100-883c-bef12dd4395a",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2025",
+          "calendarQuarter": "FY",
+          "calendarYear": "2025",
+          "durationType": "annual",
+          "endDate": "2025-12-31",
+          "periodType": "duration",
+          "startDate": "2025-01-01"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/period/e6bfb85a-3629-5bc3-9b6e-d1baede2e29d",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2024-12-31",
+          "calendarQuarter": "Q4",
+          "calendarYear": "2024",
+          "instant": "2024-12-31",
+          "periodType": "instant"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZJZPPQMGTQ82ACDY1HE1YY/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785",
+          "@type": "rs:Unit",
+          "measure": "iso4217:USD"
+        },
+        {
+          "@id": "rs-gaap:AccountsPayableCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccountsPayableCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accounts Payable, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Accounts Payable, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AccruedLiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccruedLiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accrued Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Accrued Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AdditionalPaidInCapital",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AdditionalPaidInCapital",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Additional Paid in Capital",
+          "source": "rs-gaap",
+          "standardLabel": "Additional Paid in Capital",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Assets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Assets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DepreciationDepletionAndAmortization",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DepreciationDepletionAndAmortization",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Depreciation, Depletion and Amortization",
+          "source": "rs-gaap",
+          "standardLabel": "Depreciation, Depletion and Amortization",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GeneralAndAdministrativeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GeneralAndAdministrativeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "General and Administrative Expense",
+          "source": "rs-gaap",
+          "standardLabel": "General and Administrative Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GrossProfit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GrossProfit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gross Profit",
+          "source": "rs-gaap",
+          "standardLabel": "Gross Profit",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperations",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperations",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accrued Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accrued Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Prepaid Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Prepaid Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Liabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Liabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities and Equity",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities and Equity",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Net Income (Loss) Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Net Income (Loss) Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingExpenses",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingExpenses",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Expenses",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Expenses",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Income (Loss)",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Income (Loss)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PrepaidExpenseCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PrepaidExpenseCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Prepaid Expense, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Prepaid Expense, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Issuance of Common Stock",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Issuance of Common Stock",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Property, Plant and Equipment, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Property, Plant and Equipment, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ReceivablesNetCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ReceivablesNetCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Receivables, Net, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Receivables, Net, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Retained Earnings (Accumulated Deficit)",
+          "source": "rs-gaap",
+          "standardLabel": "Retained Earnings (Accumulated Deficit)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Revenues",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Revenues",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenues",
+          "source": "rs-gaap",
+          "standardLabel": "Revenues",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:StockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:StockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Stockholders' Equity Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Stockholders' Equity Attributable to Parent",
           "substitutionGroup": "xbrli:item"
         }
       ],

--- a/examples/seattle_method_demo/sample_output/seattle-method-case-1.holon.jsonld
+++ b/examples/seattle_method_demo/sample_output/seattle-method-case-1.holon.jsonld
@@ -4,6 +4,9 @@
       "@id": "https://robosystems.ai/vocab/abstract",
       "@type": "xsd:boolean"
     },
+    "accessionNumber": {
+      "@id": "https://robosystems.ai/vocab/accessionNumber"
+    },
     "altLabel": "skos:altLabel",
     "arcrole": {
       "@id": "xlink:arcrole",
@@ -13,16 +16,30 @@
       "@id": "https://robosystems.ai/vocab/associationType"
     },
     "axis": {
-      "@id": "https://robosystems.ai/vocab/axis"
+      "@id": "https://robosystems.ai/vocab/axis",
+      "@type": "@id"
+    },
+    "axisType": {
+      "@id": "https://robosystems.ai/vocab/axisType"
     },
     "balance": {
       "@id": "xbrli:balance"
+    },
+    "baseType": {
+      "@id": "https://robosystems.ai/vocab/baseType"
     },
     "blockType": {
       "@id": "https://robosystems.ai/vocab/blockType"
     },
     "calendarPeriodKey": {
       "@id": "https://robosystems.ai/vocab/calendarPeriodKey"
+    },
+    "calendarQuarter": {
+      "@id": "https://robosystems.ai/vocab/calendarQuarter"
+    },
+    "calendarYear": {
+      "@id": "https://robosystems.ai/vocab/calendarYear",
+      "@type": "xsd:integer"
     },
     "category": {
       "@id": "https://robosystems.ai/vocab/category"
@@ -47,11 +64,11 @@
       "@id": "https://robosystems.ai/vocab/conceptArrangementPatternRequiresConcept",
       "@type": "@id"
     },
-    "contentType": {
-      "@id": "https://robosystems.ai/vocab/contentType"
-    },
     "country": {
       "@id": "https://robosystems.ai/vocab/country"
+    },
+    "dataType": {
+      "@id": "https://robosystems.ai/vocab/dataType"
     },
     "dcterms": "http://purl.org/dc/terms/",
     "decimals": {
@@ -61,6 +78,12 @@
     "deprecated": {
       "@id": "https://robosystems.ai/vocab/deprecated",
       "@type": "xsd:boolean"
+    },
+    "deprecatedDateLabel": {
+      "@id": "https://robosystems.ai/vocab/deprecatedDateLabel"
+    },
+    "deprecatedLabel": {
+      "@id": "https://robosystems.ai/vocab/deprecatedLabel"
     },
     "derivationRole": {
       "@id": "https://robosystems.ai/vocab/derivationRole"
@@ -87,6 +110,9 @@
     },
     "disclosures": "https://robosystems.ai/taxonomy/rs-gaap/disclosures/v1/",
     "documentation": "rdfs:comment",
+    "durationType": {
+      "@id": "https://robosystems.ai/vocab/durationType"
+    },
     "ein": {
       "@id": "https://robosystems.ai/vocab/ein"
     },
@@ -134,6 +160,10 @@
       "@id": "https://robosystems.ai/vocab/filedAt",
       "@type": "xsd:dateTime"
     },
+    "filingDate": {
+      "@id": "https://robosystems.ai/vocab/filingDate",
+      "@type": "xsd:date"
+    },
     "filingStatus": {
       "@id": "https://robosystems.ai/vocab/filingStatus"
     },
@@ -144,6 +174,18 @@
     "financialReportRequiresDisclosure": {
       "@id": "https://robosystems.ai/vocab/financialReportRequiresDisclosure",
       "@type": "@id"
+    },
+    "fiscalPeriodFocus": {
+      "@id": "https://robosystems.ai/vocab/fiscalPeriodFocus"
+    },
+    "fiscalYearEndMonth": {
+      "@id": "https://robosystems.ai/vocab/fiscalYearEndMonth"
+    },
+    "fiscalYearFocus": {
+      "@id": "https://robosystems.ai/vocab/fiscalYearFocus"
+    },
+    "form": {
+      "@id": "https://robosystems.ai/vocab/form"
     },
     "framework": {
       "@id": "https://robosystems.ai/vocab/framework"
@@ -183,6 +225,18 @@
     "internalId": {
       "@id": "https://robosystems.ai/vocab/internalId"
     },
+    "isExplicit": {
+      "@id": "https://robosystems.ai/vocab/isExplicit",
+      "@type": "xsd:boolean"
+    },
+    "isNil": {
+      "@id": "https://robosystems.ai/vocab/isNil",
+      "@type": "xsd:boolean"
+    },
+    "isTyped": {
+      "@id": "https://robosystems.ai/vocab/isTyped",
+      "@type": "xsd:boolean"
+    },
     "iso4217": "http://www.xbrl.org/2003/iso4217#",
     "itemType": {
       "@id": "https://robosystems.ai/vocab/itemType"
@@ -193,6 +247,9 @@
     },
     "labelRole": {
       "@id": "https://robosystems.ai/vocab/labelRole"
+    },
+    "language": {
+      "@id": "https://robosystems.ai/vocab/language"
     },
     "legalName": {
       "@id": "https://robosystems.ai/vocab/legalName"
@@ -207,7 +264,8 @@
       "@type": "@id"
     },
     "member": {
-      "@id": "https://robosystems.ai/vocab/member"
+      "@id": "https://robosystems.ai/vocab/member",
+      "@type": "@id"
     },
     "mode": {
       "@id": "https://robosystems.ai/vocab/mode"
@@ -219,8 +277,66 @@
     "name": {
       "@id": "https://robosystems.ai/vocab/name"
     },
+    "negated": {
+      "@id": "https://robosystems.ai/vocab/negated"
+    },
+    "negatedLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedLabel"
+    },
+    "negatedNetLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedNetLabel"
+    },
+    "negatedPeriodEnd": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodEnd"
+    },
+    "negatedPeriodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodEndLabel"
+    },
+    "negatedPeriodStart": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodStart"
+    },
+    "negatedPeriodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodStartLabel"
+    },
+    "negatedTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedTerseLabel"
+    },
+    "negatedTotal": {
+      "@id": "https://robosystems.ai/vocab/negatedTotal"
+    },
+    "negatedTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedTotalLabel"
+    },
+    "negativeLabel": {
+      "@id": "https://robosystems.ai/vocab/negativeLabel"
+    },
+    "negativePeriodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodEndLabel"
+    },
+    "negativePeriodEndTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodEndTotalLabel"
+    },
+    "negativePeriodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodStartLabel"
+    },
+    "negativePeriodStartTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodStartTotalLabel"
+    },
+    "negativeTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/negativeTerseLabel"
+    },
+    "negativeVerboseLabel": {
+      "@id": "https://robosystems.ai/vocab/negativeVerboseLabel"
+    },
+    "netLabel": {
+      "@id": "https://robosystems.ai/vocab/netLabel"
+    },
     "networkRoleUri": {
       "@id": "https://robosystems.ai/vocab/networkRoleUri"
+    },
+    "nillable": {
+      "@id": "https://robosystems.ai/vocab/nillable",
+      "@type": "xsd:boolean"
     },
     "nonAuthoritative": {
       "@id": "https://robosystems.ai/vocab/nonAuthoritative",
@@ -243,9 +359,19 @@
       "@id": "https://robosystems.ai/vocab/period",
       "@type": "@id"
     },
+    "periodEndDate": {
+      "@id": "https://robosystems.ai/vocab/periodEndDate",
+      "@type": "xsd:date"
+    },
+    "periodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/periodEndLabel"
+    },
     "periodNodes": {
       "@id": "https://robosystems.ai/vocab/periodNodes",
       "@type": "@id"
+    },
+    "periodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/periodStartLabel"
     },
     "periodType": {
       "@id": "xbrli:periodType"
@@ -254,9 +380,33 @@
       "@id": "https://robosystems.ai/vocab/periods",
       "@type": "@id"
     },
+    "positiveLabel": {
+      "@id": "https://robosystems.ai/vocab/positiveLabel"
+    },
+    "positivePeriodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodEndLabel"
+    },
+    "positivePeriodEndTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodEndTotalLabel"
+    },
+    "positivePeriodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodStartLabel"
+    },
+    "positivePeriodStartTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodStartTotalLabel"
+    },
+    "positiveTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/positiveTerseLabel"
+    },
+    "positiveVerboseLabel": {
+      "@id": "https://robosystems.ai/vocab/positiveVerboseLabel"
+    },
     "prefLabel": "skos:prefLabel",
     "preferredLabel": {
       "@id": "https://robosystems.ai/vocab/preferredLabel"
+    },
+    "preferredLabelRole": {
+      "@id": "https://robosystems.ai/vocab/preferredLabelRole"
     },
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
@@ -294,6 +444,9 @@
     "reportingStyleNetworks": {
       "@id": "https://robosystems.ai/vocab/reportingStyleNetworks"
     },
+    "restatedLabel": {
+      "@id": "https://robosystems.ai/vocab/restatedLabel"
+    },
     "retainedEarningsConcept": {
       "@id": "https://robosystems.ai/vocab/retainedEarningsConcept"
     },
@@ -305,9 +458,7 @@
       "@id": "https://robosystems.ai/vocab/roleUri"
     },
     "rs": "https://robosystems.ai/vocab/",
-    "rs-driver": "https://robosystems.ai/taxonomy/rs-gaap/drivers/v1/",
     "rs-gaap": "https://robosystems.ai/taxonomy/rs-gaap/v1/",
-    "rs-metric": "https://robosystems.ai/taxonomy/rs-gaap/metrics/v1/",
     "ruleCategory": {
       "@id": "https://robosystems.ai/vocab/ruleCategory"
     },
@@ -366,6 +517,10 @@
     "sourceReportId": {
       "@id": "https://robosystems.ai/vocab/sourceReportId"
     },
+    "srt": "http://fasb.org/srt/",
+    "standardLabel": {
+      "@id": "https://robosystems.ai/vocab/standardLabel"
+    },
     "start": {
       "@id": "https://robosystems.ai/vocab/start",
       "@type": "xsd:date"
@@ -381,8 +536,7 @@
       "@id": "https://robosystems.ai/vocab/statementType"
     },
     "stringValue": {
-      "@id": "https://robosystems.ai/vocab/stringValue",
-      "@type": "xsd:string"
+      "@id": "https://robosystems.ai/vocab/stringValue"
     },
     "structure": {
       "@id": "https://robosystems.ai/vocab/structure",
@@ -390,6 +544,10 @@
     },
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
+    },
+    "structureOrder": {
+      "@id": "https://robosystems.ai/vocab/structureOrder",
+      "@type": "xsd:integer"
     },
     "structures": {
       "@id": "https://robosystems.ai/vocab/structures",
@@ -415,11 +573,20 @@
     "taxonomyName": {
       "@id": "https://robosystems.ai/vocab/taxonomyName"
     },
+    "terseLabel": {
+      "@id": "https://robosystems.ai/vocab/terseLabel"
+    },
     "to": {
       "@id": "xlink:to",
       "@type": "@id"
     },
+    "totalLabel": {
+      "@id": "https://robosystems.ai/vocab/totalLabel"
+    },
     "trait": "https://robosystems.ai/taxonomy/fac-traits/v1/",
+    "typedValue": {
+      "@id": "https://robosystems.ai/vocab/typedValue"
+    },
     "unit": {
       "@id": "https://robosystems.ai/vocab/unit",
       "@type": "@id"
@@ -439,6 +606,9 @@
     "variableQname": {
       "@id": "https://robosystems.ai/vocab/variableQname"
     },
+    "verboseLabel": {
+      "@id": "https://robosystems.ai/vocab/verboseLabel"
+    },
     "version": {
       "@id": "https://robosystems.ai/vocab/version"
     },
@@ -450,1595 +620,25 @@
     "xbrldt": "http://xbrl.org/2005/xbrldt#",
     "xbrli": "http://www.xbrl.org/2003/instance#",
     "xlink": "http://www.w3.org/1999/xlink#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#"
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "zeroLabel": {
+      "@id": "https://robosystems.ai/vocab/zeroLabel"
+    },
+    "zeroTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/zeroTerseLabel"
+    },
+    "zeroVerboseLabel": {
+      "@id": "https://robosystems.ai/vocab/zeroVerboseLabel"
+    }
   },
   "@graph": [
     {
       "@graph": [
         {
-          "@id": "rs-gaap:LiabilitiesCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "efb036ff-3f30-5deb-bee9-1af4cd4b9800",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Liabilities, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW9",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZY",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW9",
-          "numericValue": "11000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "ff101489-15f4-573d-967b-24f75e0fc0f6",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Payments to Acquire Property, Plant, and Equipment",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "353f790f-1ed1-5b91-880d-8029b4b687cf",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVZ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZY",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVZ",
-          "numericValue": "10000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWH",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Assets",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWH",
-          "numericValue": "14450.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVR",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVR",
-          "numericValue": "2050.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:NetIncomeLoss",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "27a05717-2370-51c2-a924-db5cbcb48219",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Net Income (Loss) Attributable to Parent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:CostOfGoodsAndServicesSold",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "5ca0e51f-dff1-5c2b-94f5-26620852a5f9",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cost of Product and Service Sold",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW5",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInInventories",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZY",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW5",
-          "numericValue": "-2700.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVJ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:InterestExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZX",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVJ",
-          "numericValue": "150.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW2",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZY",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW2",
-          "numericValue": "-1000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:DepreciationDepletionAndAmortization",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "189a099a-7512-5144-9215-65d837c2c3b5",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Depreciation, Depletion and Amortization",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:AssetsCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "0fc9ab7e-c5ce-5277-9530-344cc127fe26",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Assets, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVX",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZZ",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVX",
-          "numericValue": "2050.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "091373d9-8a82-51bd-adf8-d09b73beb32e",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Long-Term Debt and Lease Obligation",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:Revenues",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "b26a6cd4-072f-5bf2-b5d3-ebf928150d6c",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Revenues",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "57ccbf45-c970-5bcd-a381-44d96b6b6d94",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:AccountsPayableCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "9ddbc9d7-c769-5800-8f65-1089d476e5c9",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Accounts Payable, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWF",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:StockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZZ",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWF",
-          "numericValue": "12050.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "811f1cf5-836c-575f-9f3f-cd7fa477e4e5",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:AssetsNoncurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "841cedeb-4cb0-532a-b0bd-c34846a13a8c",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Assets, Noncurrent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "6b0b414f-0c76-54f0-8e51-cf53db59ca24",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:InterestExpense",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "890e4f8c-8fed-57e2-96fd-e70455201b11",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Interest Expense, Operating and Nonoperating",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:ReceivablesNetCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "44686df3-3871-5c1f-8a08-fc542d69dfa0",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Receivables, Net, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWC",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AssetsNoncurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWC",
-          "numericValue": "900.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVF",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DepreciationDepletionAndAmortization",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZY",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVF",
-          "numericValue": "100.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/ib/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "@type": "rs:InformationBlock",
-          "blockType": "cash_flow_statement",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZY",
-          "internalId": "5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "rs-gaap:OperatingExpenses",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "71fcdebb-7145-5f76-b5e0-b4ccbf2c29d2",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Operating Expenses",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWE",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWE",
-          "numericValue": "1400.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW4",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZY",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW4",
-          "numericValue": "1000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "@type": "rs:Period",
-          "instant": "2024-03-31",
-          "periodType": "instant"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWK",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Liabilities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWK",
-          "numericValue": "2400.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVV",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZY",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVV",
-          "numericValue": "2050.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "69b82be1-1145-5686-8613-31da9eb04a72",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/ib/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "@type": "rs:InformationBlock",
-          "blockType": "income_statement",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZX",
-          "internalId": "47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "prefLabel": "rs-gaap — Income Statement — Multi-step",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "30b2801e-e682-5298-82e6-3670e1d508f1",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Liabilities and Equity",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWQ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZX",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWQ",
-          "numericValue": "2450.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW6",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncomeLossFromContinuingOperations",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZX",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW6",
-          "numericValue": "2050.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:PropertyPlantAndEquipmentNet",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "288099af-5cbb-5f78-8f8a-1a85675fb661",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Property, Plant and Equipment, Net",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:StockholdersEquity",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "e3796201-9899-5b7b-9477-659550ba8e68",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Stockholders' Equity Attributable to Parent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_3",
-          "@type": "rs:Period",
-          "instant": "2023-12-31",
-          "periodType": "instant"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWN",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CostOfRevenue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZX",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWN",
-          "numericValue": "5300.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/ib/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "@type": "rs:InformationBlock",
-          "blockType": "equity_statement",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZZ",
-          "internalId": "0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "rs-gaap:LiabilitiesNoncurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "f41fe34d-88ea-5e20-a781-2d3e256a6abf",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Liabilities, Noncurrent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW0",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZZ",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW0",
-          "numericValue": "10000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:CostOfRevenue",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "12ab7417-5324-55d6-946e-2456adba47c5",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cost of Revenue",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVT",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVT",
-          "numericValue": "0.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:IncomeLossFromContinuingOperations",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "d60cabda-7060-5aff-ac98-96371606a738",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:IncomeTaxExpenseBenefit",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "d629316b-5674-58d9-afcd-b7e7fd34232d",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Income Tax Expense (Benefit)",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWS",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:OperatingIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZX",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWS",
-          "numericValue": "2600.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVG",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DepreciationDepletionAndAmortization",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZX",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVG",
-          "numericValue": "100.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "e92e6488-dcc7-5877-ad4b-f2498bdf7bae",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Increase (Decrease) in Accrued Liabilities",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "20a6586b-880a-5745-94db-e23d397eb5e1",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Cash and Cash Equivalents, at Carrying Value",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWJ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesNoncurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWJ",
-          "numericValue": "1000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW1",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RepaymentsOfLongTermDebt",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZY",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW1",
-          "numericValue": "-1000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW8",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZY",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW8",
-          "numericValue": "10850.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVP",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ReceivablesNetCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVP",
-          "numericValue": "0.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD",
-          "@type": "rs:Unit",
-          "measure": "iso4217:USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVK",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVK",
-          "numericValue": "2700.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:RepaymentsOfLongTermDebt",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "85890c87-aac7-5702-8f69-b1a14139dc41",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Repayments of Long-Term Debt",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW7",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZY",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW7",
-          "numericValue": "850.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "4afa5950-85ac-5a85-a9cb-01c387c6ab08",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWM",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:OperatingExpenses",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZX",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWM",
-          "numericValue": "100.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVE",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CostOfGoodsAndServicesSold",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZX",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVE",
-          "numericValue": "5300.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWG",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:StockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWG",
-          "numericValue": "12050.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVW",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZX",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVW",
-          "numericValue": "2050.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "@type": "rs:Entity",
-          "country": "US",
-          "internalId": "entity_kg1a07f3179e825caf1125",
-          "legalName": "Lemonade Stand (Charlie Hoffman Test Case 1)",
-          "prefLabel": "Lemonade Stand (Charlie Hoffman Test Case 1)"
-        },
-        {
-          "@id": "rs-gaap:GrossProfit",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "a92b3181-9fe7-543c-81d9-13ebd12bbefa",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Gross Profit",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVQ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Revenues",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZX",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVQ",
-          "numericValue": "8000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVM",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVM",
-          "numericValue": "1000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVD",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVD",
-          "numericValue": "10850.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:AdditionalPaidInCapital",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "6146605c-0d63-51e1-a523-3450d6abaca3",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Additional Paid in Capital",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW3",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZY",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW3",
-          "numericValue": "400.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVY",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZY",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVY",
-          "numericValue": "2000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "@type": "rs:Period",
-          "endDate": "2024-03-31",
-          "periodType": "duration",
-          "startDate": "2024-01-01"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWP",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NonoperatingIncomeExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZX",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWP",
-          "numericValue": "-150.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:AccruedLiabilitiesCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "4decfae2-2ca3-5dd3-8c06-88557583c13d",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Accrued Liabilities, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVN",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PropertyPlantAndEquipmentNet",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVN",
-          "numericValue": "900.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWR",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:GrossProfit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZX",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWR",
-          "numericValue": "2700.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVC",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AdditionalPaidInCapital",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVC",
-          "numericValue": "10000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:OperatingIncomeLoss",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "16780828-0201-5609-b572-fbe3ebfcb177",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Operating Income (Loss)",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVB",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AccruedLiabilitiesCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVB",
-          "numericValue": "400.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWB",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZY",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWB",
-          "numericValue": "-1000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "1802f6ae-7d95-5029-af7a-b36015b2c525",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Proceeds from Issuance of Long-Term Debt",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/ib/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "@type": "rs:InformationBlock",
-          "blockType": "balance_sheet",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "internalId": "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "prefLabel": "rs-gaap — Balance Sheet — Classified",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWD",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWD",
-          "numericValue": "14450.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVS",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AdditionalPaidInCapital",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVS",
-          "numericValue": "0.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWA",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AssetsCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWA",
-          "numericValue": "13550.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:NonoperatingIncomeExpense",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "45aae2c2-fa56-50c9-b381-df8079e7d33a",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Nonoperating Income (Expense)",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVH",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncomeTaxExpenseBenefit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZX",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVH",
-          "numericValue": "400.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:IncreaseDecreaseInInventories",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "c8b0722b-7993-592f-8ef1-5b0964ac8a10",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Increase (Decrease) in Inventories",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "a9c87d60-a1e5-506b-a27e-cbf9e14e5113",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Retained Earnings (Accumulated Deficit)",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVA",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AccountsPayableCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK36CYBMM56QM25CC0PCZW",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVA",
-          "numericValue": "1000.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "dc7408c9-cba5-5697-8254-32ac46485214",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Increase (Decrease) in Accounts Payable and Accrued Liabilities",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:Assets",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "a1f04756-41d8-5d35-b821-23aa2f3b2fae",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Assets",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "2eb72b5f-d7e3-5bd5-bf93-be38b6d21820",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Proceeds from Issuance of Common Stock",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:Liabilities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "7af273ac-1cba-5fb3-a1c9-5c5d8fdb9bdf",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Liabilities",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        }
-      ],
-      "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX#scene"
-    },
-    {
-      "@graph": [
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/15",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InterestExpense",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/34",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/8",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ShortTermInvestments",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/10",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/calculation/0",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostOfOperatingRevenue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/17",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingIncomeLoss",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingExpenses",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/36",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/35",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/1",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/27",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseLiabilityCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/6",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GeneralAndAdministrativeExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/25",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "406.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:AssetImpairmentCharges",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/12",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperations",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeTaxExpenseBenefit",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/4",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NetIncomeLoss",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperations",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/29",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/26",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseRightOfUseAsset",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/25",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/24",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/23",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/2"
-          ]
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/14",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:StockholdersEquity",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/37",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:TreasuryStockValue",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/3",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingIncomeLoss",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/20",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/0",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -2049,21 +649,35 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/15",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/calculation/1",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DebtCurrent",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/3",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/calculation/2",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/calculation/3",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -2077,243 +691,38 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/5",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InvestmentIncomeInterest",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/8",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/0",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Revenues",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/16",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ResearchAndDevelopmentExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/19",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:DepreciationDepletionAndAmortization",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/24",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "406.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/21",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
           "from": "rs-gaap:AssetsNoncurrent",
-          "order": "300.0",
+          "order": "600.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
+          "to": "rs-gaap:OtherAssetsNoncurrent",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/3"
-          ]
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/2",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/1",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/25",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
+          "from": "rs-gaap:AssetsNoncurrent",
           "order": "400.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PrepaidExpenseCurrent",
+          "to": "rs-gaap:OperatingLeaseRightOfUseAsset",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/31",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseRightOfUseAsset",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/22",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/10",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "403.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/18",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainLossOnDispositionOfAssets",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/18",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/7",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CommonStockValue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/9",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:SellingAndMarketingExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/22",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/4",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Liabilities",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/6",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -2324,206 +733,10 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/2",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/11",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperations",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/7",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingIncomeLoss",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GrossProfit",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/32",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/20",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherNonoperatingIncomeExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/24",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AdditionalPaidInCapital",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/11",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:GrossProfit",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfRevenue",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/3",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Liabilities",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/9",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccruedLiabilitiesCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/13",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Liabilities",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/28",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/1",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/12",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Goodwill",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/0",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfGoodsAndServicesSold",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/33",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/16",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -2534,24 +747,10 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/13",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/12",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:NonoperatingIncomeExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/11",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -2562,7 +761,273 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/17",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/13",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccruedLiabilitiesCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/14",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/15",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:StockholdersEquity",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/16",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Assets",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AssetsNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/17",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/18",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PrepaidExpenseCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/19",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/2",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/20",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/21",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CommonStockValue",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/22",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/23",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/24",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/25",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Liabilities",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/26",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/27",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:TreasuryStockValue",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/28",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Liabilities",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/29",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Goodwill",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/3",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ShortTermInvestments",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/30",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -2576,38 +1041,38 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/10",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/31",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
           "from": "rs-gaap:Assets",
-          "order": "200.0",
+          "order": "100.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AssetsNoncurrent",
+          "to": "rs-gaap:AssetsCurrent",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/1",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/32",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:GrossProfit",
+          "from": "rs-gaap:AssetsCurrent",
           "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:Revenues",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/2",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/33",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -2618,21 +1083,35 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/23",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/34",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "from": "rs-gaap:StockholdersEquity",
           "order": "300.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueNoncurrent",
+          "to": "rs-gaap:AdditionalPaidInCapital",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/19",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/35",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccountsPayableCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/36",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -2646,10 +1125,304 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/23",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/37",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseLiabilityCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/4",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/5",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseRightOfUseAsset",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/6",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/7",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/8",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Liabilities",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/9",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DebtCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/0",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NetIncomeLoss",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperations",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/1",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Revenues",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/10",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:NonoperatingIncomeExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/11",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:GrossProfit",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:Revenues",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/12",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:SellingAndMarketingExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/13",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostAndExpenseOperating",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/14",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InvestmentIncomeInterest",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/15",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "403.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/16",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GeneralAndAdministrativeExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/17",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostOfOperatingRevenue",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/18",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:GrossProfit",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfRevenue",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/19",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "406.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:AssetImpairmentCharges",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/2",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingIncomeLoss",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingExpenses",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/20",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperations",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeTaxExpenseBenefit",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/21",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -2660,7 +1433,49 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/14",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/22",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperations",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/23",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:DepreciationDepletionAndAmortization",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/24",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainLossOnDispositionOfAssets",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/25",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -2674,103 +1489,185 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/0",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/3",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Assets",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AssetsCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/30",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/21",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
           "from": "rs-gaap:OperatingExpenses",
-          "order": "400.0",
+          "order": "200.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostAndExpenseOperating",
+          "to": "rs-gaap:ResearchAndDevelopmentExpense",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/25",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/26",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/29",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/28",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/30",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/37",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/23",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/33",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/24",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/32",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/36",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/31",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/27",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/34",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/35",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/10"
-          ]
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/5",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/4",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccountsPayableCurrent",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherNonoperatingIncomeExpense",
           "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/5",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingIncomeLoss",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/6",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InterestExpense",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/7",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "406.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/8",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingIncomeLoss",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GrossProfit",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/9",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfGoodsAndServicesSold",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/4d5ede325089bd91",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/calculation/3"
+          ]
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/75bf584b3e4aaaa0",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/23",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/24",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/25",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/26",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/27",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/28",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/29",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/30",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/31",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/32",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/33",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/34",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/35",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/36",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/37",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/calculation/9"
+          ]
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/850c3d8ab3a4a627",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/23",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/24",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/25",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/calculation/9"
+          ]
         }
       ],
       "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX#boundary"
@@ -2778,404 +1675,7 @@
     {
       "@graph": [
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/9",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20210.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PropertyPlantAndEquipmentNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/19",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20311.5",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccruedLiabilitiesCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20115.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ShortTermInvestments"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/14",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseRightOfUseAsset"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/24",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20315.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/22",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20313.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/13",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20240.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseRightOfUseAsset"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/11",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20225.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:ShareBasedCompensation"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/37",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20460.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:TreasuryStockValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/32",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20410.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CommonStockValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/15",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20260.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/26",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20321.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/17",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/22",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10800.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/6",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingExpenses"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/6",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/19",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30320.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/15",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsToAcquireIntangibleAssets"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/11",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10440.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostAndExpenseOperating"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20140.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PrepaidExpenseCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/35",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20440.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RetainedEarningsAccumulatedDeficit"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/11",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30210.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/10",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10430.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:DepreciationDepletionAndAmortization"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/21",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30340.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/20",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30330.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:RepaymentsOfLongTermDebt"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/17",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Liabilities",
-          "order": "20310.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInPrepaidExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "10230.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostOfOperatingRevenue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/12",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10443.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RestructuringCharges"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/33",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20420.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PreferredStockValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/18",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30310.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/16",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "20300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Liabilities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/19",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10640.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherNonoperatingIncomeExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "@type": [
-            "rs:RollUp",
-            "rs:Structure"
-          ],
-          "blockType": "cash_flow_statement",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/21"
-          ],
-          "internalId": "5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "structureName": "rs-gaap — Cash Flow Statement — Indirect"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInOperatingActivities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/5",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/1eae745dbb354952/presentation/0",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -3185,558 +1685,27 @@
           "to": "rs-gaap:PaymentsOfDividends"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GrossProfit"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/12",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30220.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/6",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30160.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/12",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20230.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/30",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20325.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/7",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10410.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GeneralAndAdministrativeExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/21",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10646.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/13",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30230.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsToAcquireInvestments"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/18",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20311.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccountsPayableCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/18",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10630.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainLossOnDispositionOfAssets"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/8",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10415.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:SellingAndMarketingExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "@type": [
-            "rs:Structure",
-            "rs:Hierarchy"
-          ],
-          "blockType": "equity_statement",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/5"
-          ],
-          "internalId": "0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "structureName": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/16",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10610.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InvestmentIncomeInterest"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/0",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/1eae745dbb354952/presentation/1",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
           "from": "rs-gaap:StockholdersEquity",
-          "order": "40100.0",
+          "order": "40500.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:NetIncomeLoss"
+          "to": "rs-gaap:ShareBasedCompensation"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/10",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20220.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Goodwill"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20110.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/8",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Assets",
-          "order": "20200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AssetsNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/10",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInInvestingActivities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/8",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30180.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccruedLiabilities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30130.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccountsReceivable"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/7",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20160.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20120.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ReceivablesNetCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/24",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "11000.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperations"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/36",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/1eae745dbb354952/presentation/2",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
           "from": "rs-gaap:StockholdersEquity",
-          "order": "20450.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/23",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20314.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseLiabilityCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/31",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "20400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:StockholdersEquity"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40300.0",
+          "order": "40200.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
+          "to": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/29",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20324.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/21",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20312.5",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "@type": [
-            "rs:RollUp",
-            "rs:Structure"
-          ],
-          "blockType": "income_statement",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/26",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/24",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/23",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/25",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/18"
-          ],
-          "internalId": "47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "prefLabel": "rs-gaap — Income Statement — Multi-step",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "structureName": "rs-gaap — Income Statement — Multi-step"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/23",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10900.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeTaxExpenseBenefit"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/20",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20312.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DebtCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/14",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/14",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30240.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/20",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10643.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfRevenue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/13",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10446.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:AssetImpairmentCharges"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/25",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "11100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/7",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30170.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/27",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20322.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredIncomeTaxLiabilitiesNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/15",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:NonoperatingIncomeExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/17",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10620.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InterestExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Assets",
-          "order": "20100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AssetsCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/25",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Liabilities",
-          "order": "20320.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "10210.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfGoodsAndServicesSold"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/9",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30190.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/26",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "11200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:NetIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/28",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20323.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30140.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInInventories"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/16",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30260.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromSaleOfIntangibleAssets"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20130.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/3",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/1eae745dbb354952/presentation/3",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -3746,7 +1715,57 @@
           "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/1",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/1eae745dbb354952/presentation/4",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:NetIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/1eae745dbb354952/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsToAcquireIntangibleAssets"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30180.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccruedLiabilities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/10",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30330.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:RepaymentsOfLongTermDebt"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/11",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -3756,17 +1775,117 @@
           "to": "rs-gaap:NetIncomeLoss"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/34",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/12",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20430.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AdditionalPaidInCapital"
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30320.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/2",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/13",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30210.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/14",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30340.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/15",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInPrepaidExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/16",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30310.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/17",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInOperatingActivities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/18",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30230.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsToAcquireInvestments"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/19",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInInvestingActivities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30260.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromSaleOfIntangibleAssets"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/20",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30240.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/21",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30170.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/22",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -3776,17 +1895,67 @@
           "to": "rs-gaap:DepreciationDepletionAndAmortization"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/9",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/3",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10420.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ResearchAndDevelopmentExpense"
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/22",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/4",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30220.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30160.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/6",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30130.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccountsReceivable"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/7",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30190.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/8",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30140.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInInventories"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/9",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -3796,7 +1965,427 @@
           "to": "rs-gaap:EffectOfExchangeRateOnCash"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/1",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20210.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PropertyPlantAndEquipmentNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20313.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/10",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "20300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Liabilities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/11",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20230.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/12",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20450.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/13",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20324.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/14",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20311.5",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccruedLiabilitiesCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/15",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20315.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/16",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20460.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:TreasuryStockValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/17",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20440.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RetainedEarningsAccumulatedDeficit"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/18",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20311.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccountsPayableCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/19",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20110.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20225.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/20",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20120.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ReceivablesNetCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/21",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20312.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DebtCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/22",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20130.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/23",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20430.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AdditionalPaidInCapital"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/24",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20115.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ShortTermInvestments"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/25",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseRightOfUseAsset"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/26",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20240.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseRightOfUseAsset"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/27",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20410.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CommonStockValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/28",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Liabilities",
+          "order": "20310.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/29",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20420.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PreferredStockValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/3",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20321.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/30",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20220.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Goodwill"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/31",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Assets",
+          "order": "20200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AssetsNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/32",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20314.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseLiabilityCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/33",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "20400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:StockholdersEquity"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/34",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20312.5",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/35",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Assets",
+          "order": "20100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AssetsCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/36",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Liabilities",
+          "order": "20320.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/37",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20323.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/4",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20325.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20160.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/6",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20322.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredIncomeTaxLiabilitiesNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/7",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20260.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/8",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/9",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20140.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PrepaidExpenseCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GrossProfit"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10410.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GeneralAndAdministrativeExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/10",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "11200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:NetIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/11",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10420.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ResearchAndDevelopmentExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/12",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -3806,59 +2395,147 @@
           "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "@type": [
-            "rs:RollUp",
-            "rs:Structure"
-          ],
-          "blockType": "balance_sheet",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/29",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/31",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/24",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/26",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/28",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/36",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/27",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/25",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/33",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/35",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/30",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/32",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/34",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/37",
-            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/23"
-          ],
-          "internalId": "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "prefLabel": "rs-gaap — Balance Sheet — Classified",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "structureName": "rs-gaap — Balance Sheet — Classified"
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/13",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10630.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainLossOnDispositionOfAssets"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/0",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/14",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10415.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:SellingAndMarketingExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/15",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "11000.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperations"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/16",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/17",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10440.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostAndExpenseOperating"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/18",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "10230.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostOfOperatingRevenue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/19",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10443.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RestructuringCharges"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfRevenue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/20",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10640.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherNonoperatingIncomeExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/21",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10646.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/22",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10900.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeTaxExpenseBenefit"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/23",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10643.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/24",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10620.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InterestExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/25",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "10210.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfGoodsAndServicesSold"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/26",
           "@type": "rs:Association",
           "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
           "associationType": "presentation",
@@ -3866,9 +2543,2985 @@
           "order": "10100.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
           "to": "rs-gaap:Revenues"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/3",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "11100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/4",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingExpenses"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10800.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/6",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10430.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:DepreciationDepletionAndAmortization"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/7",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10610.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InvestmentIncomeInterest"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/8",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10446.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:AssetImpairmentCharges"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/9",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:NonoperatingIncomeExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/1eae745dbb354952",
+          "@type": [
+            "rs:Hierarchy",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/1eae745dbb354952",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/1eae745dbb354952/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/1eae745dbb354952/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/1eae745dbb354952/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/1eae745dbb354952/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/1eae745dbb354952/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/1eae745dbb354952/presentation/5"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "structureName": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
+          "structureOrder": "3"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/4d5ede325089bd91",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/4d5ede325089bd91/presentation/9"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "structureName": "rs-gaap — Cash Flow Statement — Indirect",
+          "structureOrder": "2"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/75bf584b3e4aaaa0",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/23",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/24",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/25",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/26",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/27",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/28",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/29",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/30",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/31",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/32",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/33",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/34",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/35",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/36",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/37",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/75bf584b3e4aaaa0/presentation/9"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "prefLabel": "rs-gaap — Balance Sheet — Classified",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "structureName": "rs-gaap — Balance Sheet — Classified",
+          "structureOrder": "0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/850c3d8ab3a4a627",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/23",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/24",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/25",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/26",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/association/850c3d8ab3a4a627/presentation/9"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "prefLabel": "rs-gaap — Income Statement — Multi-step",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "structureName": "rs-gaap — Income Statement — Multi-step",
+          "structureOrder": "1"
+        },
+        {
+          "@id": "rs-gaap:AccountsPayableCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccountsPayableCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accounts Payable, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Accounts Payable, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AccruedLiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccruedLiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accrued Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Accrued Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accumulated Other Comprehensive Income (Loss), Net of Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Accumulated Other Comprehensive Income (Loss), Net of Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AdditionalPaidInCapital",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AdditionalPaidInCapital",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Additional Paid in Capital",
+          "source": "rs-gaap",
+          "standardLabel": "Additional Paid in Capital",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetImpairmentCharges",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetImpairmentCharges",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Asset Impairment Charges",
+          "source": "rs-gaap",
+          "standardLabel": "Asset Impairment Charges",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Assets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Assets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CommonStockValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CommonStockValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Common Stock, Value, Issued",
+          "source": "rs-gaap",
+          "standardLabel": "Common Stock, Value, Issued",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfGoodsAndServicesSold",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfGoodsAndServicesSold",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Product and Service Sold",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Product and Service Sold",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Revenue",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Revenue",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DebtCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DebtCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Debt, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Debt, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DeferredIncomeTaxLiabilitiesNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DeferredIncomeTaxLiabilitiesNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Deferred Income Tax Liabilities, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Deferred Income Tax Liabilities, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DeferredRevenueCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DeferredRevenueCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Deferred Revenue, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Deferred Revenue, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DeferredRevenueNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DeferredRevenueNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Deferred Revenue, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Deferred Revenue, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DepreciationDepletionAndAmortization",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DepreciationDepletionAndAmortization",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Depreciation, Depletion and Amortization",
+          "source": "rs-gaap",
+          "standardLabel": "Depreciation, Depletion and Amortization",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:EffectOfExchangeRateOnCash",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:EffectOfExchangeRateOnCash",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Effect of Exchange Rate on Cash",
+          "source": "rs-gaap",
+          "standardLabel": "Effect of Exchange Rate on Cash",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:FinanceLeaseLiabilityCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:FinanceLeaseLiabilityCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Finance Lease, Liability, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Finance Lease, Liability, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:FinanceLeaseRightOfUseAsset",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:FinanceLeaseRightOfUseAsset",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Finance Lease, Right-of-Use Asset, after Accumulated Amortization",
+          "source": "rs-gaap",
+          "standardLabel": "Finance Lease, Right-of-Use Asset, after Accumulated Amortization",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gain (Loss), Foreign Currency Transaction, before Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Gain (Loss), Foreign Currency Transaction, before Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GainLossOnDispositionOfAssets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GainLossOnDispositionOfAssets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gain (Loss) on Disposition of Property Plant Equipment, Excluding Oil and Gas Property and Timber Property",
+          "source": "rs-gaap",
+          "standardLabel": "Gain (Loss) on Disposition of Property Plant Equipment, Excluding Oil and Gas Property and Timber Property",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gain (Loss) on Extinguishment of Debt",
+          "source": "rs-gaap",
+          "standardLabel": "Gain (Loss) on Extinguishment of Debt",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GeneralAndAdministrativeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GeneralAndAdministrativeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "General and Administrative Expense",
+          "source": "rs-gaap",
+          "standardLabel": "General and Administrative Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Goodwill",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Goodwill",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Goodwill",
+          "source": "rs-gaap",
+          "standardLabel": "Goodwill",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GrossProfit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GrossProfit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gross Profit",
+          "source": "rs-gaap",
+          "standardLabel": "Gross Profit",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperations",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperations",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Discontinued Operations, Net of Tax, Including Portion Attributable to Noncontrolling Interest",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Discontinued Operations, Net of Tax, Including Portion Attributable to Noncontrolling Interest",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeStatementAbstract",
+          "@type": "rs:Element",
+          "abstract": "true",
+          "balance": "debit",
+          "elementType": "abstract",
+          "internalId": "rs-gaap:IncomeStatementAbstract",
+          "itemType": "string",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income Statement [Abstract]",
+          "source": "rs-gaap",
+          "standardLabel": "Income Statement [Abstract]",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeTaxExpenseBenefit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeTaxExpenseBenefit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income Tax Expense (Benefit)",
+          "source": "rs-gaap",
+          "standardLabel": "Income Tax Expense (Benefit)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accounts Payable and Accrued Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accounts Payable and Accrued Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accounts Receivable",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accounts Receivable",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Income Taxes Payable",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Income Taxes Payable",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accrued Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accrued Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInInventories",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInInventories",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Inventories",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Inventories",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Prepaid Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Prepaid Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Intangible Assets, Net (Excluding Goodwill)",
+          "source": "rs-gaap",
+          "standardLabel": "Intangible Assets, Net (Excluding Goodwill)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:InterestExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:InterestExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Interest Expense, Operating and Nonoperating",
+          "source": "rs-gaap",
+          "standardLabel": "Interest Expense, Operating and Nonoperating",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
+          "source": "rs-gaap",
+          "standardLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:InvestmentIncomeInterest",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:InvestmentIncomeInterest",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Investment Income, Interest",
+          "source": "rs-gaap",
+          "standardLabel": "Investment Income, Interest",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Liabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Liabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities and Equity",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities and Equity",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Debt and Lease Obligation",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Debt and Lease Obligation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermDebtCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermDebtCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Debt, Current Maturities",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Debt, Current Maturities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Investments and Receivables, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Investments and Receivables, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Net Income (Loss) Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Net Income (Loss) Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NonoperatingIncomeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NonoperatingIncomeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Nonoperating Income (Expense)",
+          "source": "rs-gaap",
+          "standardLabel": "Nonoperating Income (Expense)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingExpenses",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingExpenses",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Expenses",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Expenses",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Income (Loss)",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Income (Loss)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Operating Lease, Liability, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Lease, Liability, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingLeaseRightOfUseAsset",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingLeaseRightOfUseAsset",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Operating Lease, Right-of-Use Asset",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Lease, Right-of-Use Asset",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherAssetsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherAssetsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Assets, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Other Assets, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherAssetsNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherAssetsNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Assets, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Other Assets, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Comprehensive Income (Loss), Net of Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Other Comprehensive Income (Loss), Net of Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherCostAndExpenseOperating",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherCostAndExpenseOperating",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Cost and Expense, Operating",
+          "source": "rs-gaap",
+          "standardLabel": "Other Cost and Expense, Operating",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherCostOfOperatingRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherCostOfOperatingRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Cost of Operating Revenue",
+          "source": "rs-gaap",
+          "standardLabel": "Other Cost of Operating Revenue",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherLiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherLiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Other Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherLiabilitiesNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherLiabilitiesNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Liabilities, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Other Liabilities, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherNonoperatingIncomeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherNonoperatingIncomeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Nonoperating Income (Expense)",
+          "source": "rs-gaap",
+          "standardLabel": "Other Nonoperating Income (Expense)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsForRepurchaseOfCommonStock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsForRepurchaseOfCommonStock",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments for Repurchase of Common Stock",
+          "source": "rs-gaap",
+          "standardLabel": "Payments for Repurchase of Common Stock",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsOfDividends",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsOfDividends",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments of Dividends",
+          "source": "rs-gaap",
+          "standardLabel": "Payments of Dividends",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquireIntangibleAssets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquireIntangibleAssets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Intangible Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Intangible Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquireInvestments",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquireInvestments",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Investments",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Investments",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PreferredStockValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PreferredStockValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Preferred Stock, Value, Issued",
+          "source": "rs-gaap",
+          "standardLabel": "Preferred Stock, Value, Issued",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PrepaidExpenseCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PrepaidExpenseCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Prepaid Expense, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Prepaid Expense, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Issuance of Common Stock",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Issuance of Common Stock",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Issuance of Long-Term Debt",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Issuance of Long-Term Debt",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Sale, Maturity and Collection of Investments",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Sale, Maturity and Collection of Investments",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromSaleOfIntangibleAssets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromSaleOfIntangibleAssets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Sale of Intangible Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Sale of Intangible Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Sale of Property, Plant, and Equipment",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Sale of Property, Plant, and Equipment",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Property, Plant and Equipment, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Property, Plant and Equipment, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ReceivablesNetCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ReceivablesNetCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Receivables, Net, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Receivables, Net, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RepaymentsOfLongTermDebt",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RepaymentsOfLongTermDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Repayments of Long-Term Debt",
+          "source": "rs-gaap",
+          "standardLabel": "Repayments of Long-Term Debt",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ResearchAndDevelopmentExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ResearchAndDevelopmentExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Research and Development Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Research and Development Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Restricted Cash and Investments, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Restricted Cash and Investments, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RestructuringCharges",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RestructuringCharges",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Restructuring Charges",
+          "source": "rs-gaap",
+          "standardLabel": "Restructuring Charges",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Retained Earnings (Accumulated Deficit)",
+          "source": "rs-gaap",
+          "standardLabel": "Retained Earnings (Accumulated Deficit)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Revenues",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Revenues",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenues",
+          "source": "rs-gaap",
+          "standardLabel": "Revenues",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:SellingAndMarketingExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:SellingAndMarketingExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Selling and Marketing Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Selling and Marketing Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ShareBasedCompensation",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ShareBasedCompensation",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Share-Based Payment Arrangement, Noncash Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Share-Based Payment Arrangement, Noncash Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ShortTermInvestments",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ShortTermInvestments",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Short-Term Investments",
+          "source": "rs-gaap",
+          "standardLabel": "Short-Term Investments",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:StockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:StockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Stockholders' Equity Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Stockholders' Equity Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:TreasuryStockValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:TreasuryStockValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Treasury Stock, Value",
+          "source": "rs-gaap",
+          "standardLabel": "Treasury Stock, Value",
+          "substitutionGroup": "xbrli:item"
         }
       ],
       "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX#projection"
+    },
+    {
+      "@graph": [
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX",
+          "@type": "rs:Report",
+          "accessionNumber": "rpt_01M1ZK36C0JBQ76S3K5YVW9TSX",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "mode": "report",
+          "reportingStyle": "sec-as-filed",
+          "serializationVersion": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "@type": "rs:Entity",
+          "internalId": "entity_kg1a07f3179e825caf1125",
+          "legalName": "Lemonade Stand (Charlie Hoffman Test Case 1)",
+          "prefLabel": "Lemonade Stand (Charlie Hoffman Test Case 1)",
+          "scheme": "http://robosystems.ai/entity"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVA",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AccountsPayableCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVA",
+          "numericValue": "1000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVB",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AccruedLiabilitiesCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVB",
+          "numericValue": "400.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVC",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AdditionalPaidInCapital",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVC",
+          "numericValue": "10000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVD",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVD",
+          "numericValue": "10850.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVE",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CostOfGoodsAndServicesSold",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVE",
+          "numericValue": "5300.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVF",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DepreciationDepletionAndAmortization",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": [
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVF",
+          "numericValue": "100.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVG",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DepreciationDepletionAndAmortization",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": [
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVG",
+          "numericValue": "100.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVH",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncomeTaxExpenseBenefit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVH",
+          "numericValue": "400.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVJ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:InterestExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVJ",
+          "numericValue": "150.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVK",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVK",
+          "numericValue": "2700.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVM",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVM",
+          "numericValue": "1000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVN",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVN",
+          "numericValue": "900.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVP",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ReceivablesNetCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVP",
+          "numericValue": "0.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVQ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Revenues",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVQ",
+          "numericValue": "8000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVR",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVR",
+          "numericValue": "2050.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVS",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AdditionalPaidInCapital",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVS",
+          "numericValue": "0.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVT",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVT",
+          "numericValue": "0.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVV",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVV",
+          "numericValue": "2050.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVW",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVW",
+          "numericValue": "2050.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVX",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVX",
+          "numericValue": "2050.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVY",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVY",
+          "numericValue": "2000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SVZ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SVZ",
+          "numericValue": "10000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW0",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW0",
+          "numericValue": "10000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW1",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RepaymentsOfLongTermDebt",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW1",
+          "numericValue": "-1000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW2",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW2",
+          "numericValue": "-1000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW3",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW3",
+          "numericValue": "400.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW4",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW4",
+          "numericValue": "1000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW5",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInInventories",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW5",
+          "numericValue": "-2700.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW6",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncomeLossFromContinuingOperations",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW6",
+          "numericValue": "2050.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW7",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW7",
+          "numericValue": "850.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW8",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW8",
+          "numericValue": "10850.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SW9",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SW9",
+          "numericValue": "11000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWA",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AssetsCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWA",
+          "numericValue": "13550.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWB",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWB",
+          "numericValue": "-1000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWC",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AssetsNoncurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWC",
+          "numericValue": "900.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWD",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWD",
+          "numericValue": "14450.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWE",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWE",
+          "numericValue": "1400.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWF",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:StockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWF",
+          "numericValue": "12050.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWG",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:StockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWG",
+          "numericValue": "12050.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWH",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Assets",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWH",
+          "numericValue": "14450.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWJ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesNoncurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWJ",
+          "numericValue": "1000.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWK",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Liabilities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWK",
+          "numericValue": "2400.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWM",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:OperatingExpenses",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWM",
+          "numericValue": "100.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWN",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CostOfRevenue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWN",
+          "numericValue": "5300.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWP",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NonoperatingIncomeExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWP",
+          "numericValue": "-150.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWQ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWQ",
+          "numericValue": "2450.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWR",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:GrossProfit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWR",
+          "numericValue": "2700.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/fact/fact_01M1ZK36D4ED6R7W7XWGN64SWS",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:OperatingIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/entity/entity_kg1a07f3179e825caf1125",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK36D4ED6R7W7XWGN64SWS",
+          "numericValue": "2600.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/ib/1eae745dbb354952",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/1eae745dbb354952",
+          "internalId": "1eae745dbb354952",
+          "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/1eae745dbb354952"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/ib/4d5ede325089bd91",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "internalId": "4d5ede325089bd91",
+          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/4d5ede325089bd91"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/ib/75bf584b3e4aaaa0",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "internalId": "75bf584b3e4aaaa0",
+          "prefLabel": "rs-gaap — Balance Sheet — Classified",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/75bf584b3e4aaaa0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/ib/850c3d8ab3a4a627",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "internalId": "850c3d8ab3a4a627",
+          "prefLabel": "rs-gaap — Income Statement — Multi-step",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/structure/850c3d8ab3a4a627"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/529b942a-70f8-5aa1-b3d6-ff2317efe56e",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2024Q1",
+          "calendarQuarter": "Q1",
+          "calendarYear": "2024",
+          "durationType": "quarterly",
+          "endDate": "2024-03-31",
+          "periodType": "duration",
+          "startDate": "2024-01-01"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2023-12-31",
+          "calendarQuarter": "Q4",
+          "calendarYear": "2023",
+          "instant": "2023-12-31",
+          "periodType": "instant"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/period/c8aa8182-eae7-5966-afe0-0e1e1fdc6c76",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2024-03-31",
+          "calendarQuarter": "Q1",
+          "calendarYear": "2024",
+          "instant": "2024-03-31",
+          "periodType": "instant"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785",
+          "@type": "rs:Unit",
+          "measure": "iso4217:USD"
+        },
+        {
+          "@id": "rs-gaap:AccountsPayableCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccountsPayableCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accounts Payable, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Accounts Payable, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AccruedLiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccruedLiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accrued Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Accrued Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AdditionalPaidInCapital",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AdditionalPaidInCapital",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Additional Paid in Capital",
+          "source": "rs-gaap",
+          "standardLabel": "Additional Paid in Capital",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Assets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Assets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfGoodsAndServicesSold",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfGoodsAndServicesSold",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Product and Service Sold",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Product and Service Sold",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Revenue",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Revenue",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DepreciationDepletionAndAmortization",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DepreciationDepletionAndAmortization",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Depreciation, Depletion and Amortization",
+          "source": "rs-gaap",
+          "standardLabel": "Depreciation, Depletion and Amortization",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GrossProfit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GrossProfit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gross Profit",
+          "source": "rs-gaap",
+          "standardLabel": "Gross Profit",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperations",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperations",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeTaxExpenseBenefit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeTaxExpenseBenefit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income Tax Expense (Benefit)",
+          "source": "rs-gaap",
+          "standardLabel": "Income Tax Expense (Benefit)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accounts Payable and Accrued Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accounts Payable and Accrued Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accrued Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accrued Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInInventories",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInInventories",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Inventories",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Inventories",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:InterestExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:InterestExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Interest Expense, Operating and Nonoperating",
+          "source": "rs-gaap",
+          "standardLabel": "Interest Expense, Operating and Nonoperating",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
+          "source": "rs-gaap",
+          "standardLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Liabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Liabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities and Equity",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities and Equity",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Debt and Lease Obligation",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Debt and Lease Obligation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Net Income (Loss) Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Net Income (Loss) Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NonoperatingIncomeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NonoperatingIncomeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Nonoperating Income (Expense)",
+          "source": "rs-gaap",
+          "standardLabel": "Nonoperating Income (Expense)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingExpenses",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingExpenses",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Expenses",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Expenses",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Income (Loss)",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Income (Loss)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Issuance of Common Stock",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Issuance of Common Stock",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Issuance of Long-Term Debt",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Issuance of Long-Term Debt",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Property, Plant and Equipment, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Property, Plant and Equipment, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ReceivablesNetCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ReceivablesNetCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Receivables, Net, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Receivables, Net, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RepaymentsOfLongTermDebt",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RepaymentsOfLongTermDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Repayments of Long-Term Debt",
+          "source": "rs-gaap",
+          "standardLabel": "Repayments of Long-Term Debt",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Retained Earnings (Accumulated Deficit)",
+          "source": "rs-gaap",
+          "standardLabel": "Retained Earnings (Accumulated Deficit)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Revenues",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Revenues",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenues",
+          "source": "rs-gaap",
+          "standardLabel": "Revenues",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:StockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:StockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Stockholders' Equity Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Stockholders' Equity Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        }
+      ],
+      "@id": "https://robosystems.ai/report/rpt_01M1ZK36C0JBQ76S3K5YVW9TSX#scene"
     }
   ]
 }

--- a/examples/seattle_method_world_online/sample_output/world-online.holon.jsonld
+++ b/examples/seattle_method_world_online/sample_output/world-online.holon.jsonld
@@ -4,6 +4,9 @@
       "@id": "https://robosystems.ai/vocab/abstract",
       "@type": "xsd:boolean"
     },
+    "accessionNumber": {
+      "@id": "https://robosystems.ai/vocab/accessionNumber"
+    },
     "altLabel": "skos:altLabel",
     "arcrole": {
       "@id": "xlink:arcrole",
@@ -13,16 +16,30 @@
       "@id": "https://robosystems.ai/vocab/associationType"
     },
     "axis": {
-      "@id": "https://robosystems.ai/vocab/axis"
+      "@id": "https://robosystems.ai/vocab/axis",
+      "@type": "@id"
+    },
+    "axisType": {
+      "@id": "https://robosystems.ai/vocab/axisType"
     },
     "balance": {
       "@id": "xbrli:balance"
+    },
+    "baseType": {
+      "@id": "https://robosystems.ai/vocab/baseType"
     },
     "blockType": {
       "@id": "https://robosystems.ai/vocab/blockType"
     },
     "calendarPeriodKey": {
       "@id": "https://robosystems.ai/vocab/calendarPeriodKey"
+    },
+    "calendarQuarter": {
+      "@id": "https://robosystems.ai/vocab/calendarQuarter"
+    },
+    "calendarYear": {
+      "@id": "https://robosystems.ai/vocab/calendarYear",
+      "@type": "xsd:integer"
     },
     "category": {
       "@id": "https://robosystems.ai/vocab/category"
@@ -47,11 +64,11 @@
       "@id": "https://robosystems.ai/vocab/conceptArrangementPatternRequiresConcept",
       "@type": "@id"
     },
-    "contentType": {
-      "@id": "https://robosystems.ai/vocab/contentType"
-    },
     "country": {
       "@id": "https://robosystems.ai/vocab/country"
+    },
+    "dataType": {
+      "@id": "https://robosystems.ai/vocab/dataType"
     },
     "dcterms": "http://purl.org/dc/terms/",
     "decimals": {
@@ -61,6 +78,12 @@
     "deprecated": {
       "@id": "https://robosystems.ai/vocab/deprecated",
       "@type": "xsd:boolean"
+    },
+    "deprecatedDateLabel": {
+      "@id": "https://robosystems.ai/vocab/deprecatedDateLabel"
+    },
+    "deprecatedLabel": {
+      "@id": "https://robosystems.ai/vocab/deprecatedLabel"
     },
     "derivationRole": {
       "@id": "https://robosystems.ai/vocab/derivationRole"
@@ -87,6 +110,9 @@
     },
     "disclosures": "https://robosystems.ai/taxonomy/rs-gaap/disclosures/v1/",
     "documentation": "rdfs:comment",
+    "durationType": {
+      "@id": "https://robosystems.ai/vocab/durationType"
+    },
     "ein": {
       "@id": "https://robosystems.ai/vocab/ein"
     },
@@ -134,6 +160,10 @@
       "@id": "https://robosystems.ai/vocab/filedAt",
       "@type": "xsd:dateTime"
     },
+    "filingDate": {
+      "@id": "https://robosystems.ai/vocab/filingDate",
+      "@type": "xsd:date"
+    },
     "filingStatus": {
       "@id": "https://robosystems.ai/vocab/filingStatus"
     },
@@ -144,6 +174,18 @@
     "financialReportRequiresDisclosure": {
       "@id": "https://robosystems.ai/vocab/financialReportRequiresDisclosure",
       "@type": "@id"
+    },
+    "fiscalPeriodFocus": {
+      "@id": "https://robosystems.ai/vocab/fiscalPeriodFocus"
+    },
+    "fiscalYearEndMonth": {
+      "@id": "https://robosystems.ai/vocab/fiscalYearEndMonth"
+    },
+    "fiscalYearFocus": {
+      "@id": "https://robosystems.ai/vocab/fiscalYearFocus"
+    },
+    "form": {
+      "@id": "https://robosystems.ai/vocab/form"
     },
     "framework": {
       "@id": "https://robosystems.ai/vocab/framework"
@@ -183,6 +225,18 @@
     "internalId": {
       "@id": "https://robosystems.ai/vocab/internalId"
     },
+    "isExplicit": {
+      "@id": "https://robosystems.ai/vocab/isExplicit",
+      "@type": "xsd:boolean"
+    },
+    "isNil": {
+      "@id": "https://robosystems.ai/vocab/isNil",
+      "@type": "xsd:boolean"
+    },
+    "isTyped": {
+      "@id": "https://robosystems.ai/vocab/isTyped",
+      "@type": "xsd:boolean"
+    },
     "iso4217": "http://www.xbrl.org/2003/iso4217#",
     "itemType": {
       "@id": "https://robosystems.ai/vocab/itemType"
@@ -193,6 +247,9 @@
     },
     "labelRole": {
       "@id": "https://robosystems.ai/vocab/labelRole"
+    },
+    "language": {
+      "@id": "https://robosystems.ai/vocab/language"
     },
     "legalName": {
       "@id": "https://robosystems.ai/vocab/legalName"
@@ -207,7 +264,8 @@
       "@type": "@id"
     },
     "member": {
-      "@id": "https://robosystems.ai/vocab/member"
+      "@id": "https://robosystems.ai/vocab/member",
+      "@type": "@id"
     },
     "mode": {
       "@id": "https://robosystems.ai/vocab/mode"
@@ -219,8 +277,66 @@
     "name": {
       "@id": "https://robosystems.ai/vocab/name"
     },
+    "negated": {
+      "@id": "https://robosystems.ai/vocab/negated"
+    },
+    "negatedLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedLabel"
+    },
+    "negatedNetLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedNetLabel"
+    },
+    "negatedPeriodEnd": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodEnd"
+    },
+    "negatedPeriodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodEndLabel"
+    },
+    "negatedPeriodStart": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodStart"
+    },
+    "negatedPeriodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedPeriodStartLabel"
+    },
+    "negatedTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedTerseLabel"
+    },
+    "negatedTotal": {
+      "@id": "https://robosystems.ai/vocab/negatedTotal"
+    },
+    "negatedTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/negatedTotalLabel"
+    },
+    "negativeLabel": {
+      "@id": "https://robosystems.ai/vocab/negativeLabel"
+    },
+    "negativePeriodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodEndLabel"
+    },
+    "negativePeriodEndTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodEndTotalLabel"
+    },
+    "negativePeriodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodStartLabel"
+    },
+    "negativePeriodStartTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/negativePeriodStartTotalLabel"
+    },
+    "negativeTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/negativeTerseLabel"
+    },
+    "negativeVerboseLabel": {
+      "@id": "https://robosystems.ai/vocab/negativeVerboseLabel"
+    },
+    "netLabel": {
+      "@id": "https://robosystems.ai/vocab/netLabel"
+    },
     "networkRoleUri": {
       "@id": "https://robosystems.ai/vocab/networkRoleUri"
+    },
+    "nillable": {
+      "@id": "https://robosystems.ai/vocab/nillable",
+      "@type": "xsd:boolean"
     },
     "nonAuthoritative": {
       "@id": "https://robosystems.ai/vocab/nonAuthoritative",
@@ -243,9 +359,19 @@
       "@id": "https://robosystems.ai/vocab/period",
       "@type": "@id"
     },
+    "periodEndDate": {
+      "@id": "https://robosystems.ai/vocab/periodEndDate",
+      "@type": "xsd:date"
+    },
+    "periodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/periodEndLabel"
+    },
     "periodNodes": {
       "@id": "https://robosystems.ai/vocab/periodNodes",
       "@type": "@id"
+    },
+    "periodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/periodStartLabel"
     },
     "periodType": {
       "@id": "xbrli:periodType"
@@ -254,9 +380,33 @@
       "@id": "https://robosystems.ai/vocab/periods",
       "@type": "@id"
     },
+    "positiveLabel": {
+      "@id": "https://robosystems.ai/vocab/positiveLabel"
+    },
+    "positivePeriodEndLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodEndLabel"
+    },
+    "positivePeriodEndTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodEndTotalLabel"
+    },
+    "positivePeriodStartLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodStartLabel"
+    },
+    "positivePeriodStartTotalLabel": {
+      "@id": "https://robosystems.ai/vocab/positivePeriodStartTotalLabel"
+    },
+    "positiveTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/positiveTerseLabel"
+    },
+    "positiveVerboseLabel": {
+      "@id": "https://robosystems.ai/vocab/positiveVerboseLabel"
+    },
     "prefLabel": "skos:prefLabel",
     "preferredLabel": {
       "@id": "https://robosystems.ai/vocab/preferredLabel"
+    },
+    "preferredLabelRole": {
+      "@id": "https://robosystems.ai/vocab/preferredLabelRole"
     },
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
@@ -294,6 +444,9 @@
     "reportingStyleNetworks": {
       "@id": "https://robosystems.ai/vocab/reportingStyleNetworks"
     },
+    "restatedLabel": {
+      "@id": "https://robosystems.ai/vocab/restatedLabel"
+    },
     "retainedEarningsConcept": {
       "@id": "https://robosystems.ai/vocab/retainedEarningsConcept"
     },
@@ -305,9 +458,7 @@
       "@id": "https://robosystems.ai/vocab/roleUri"
     },
     "rs": "https://robosystems.ai/vocab/",
-    "rs-driver": "https://robosystems.ai/taxonomy/rs-gaap/drivers/v1/",
     "rs-gaap": "https://robosystems.ai/taxonomy/rs-gaap/v1/",
-    "rs-metric": "https://robosystems.ai/taxonomy/rs-gaap/metrics/v1/",
     "ruleCategory": {
       "@id": "https://robosystems.ai/vocab/ruleCategory"
     },
@@ -366,6 +517,10 @@
     "sourceReportId": {
       "@id": "https://robosystems.ai/vocab/sourceReportId"
     },
+    "srt": "http://fasb.org/srt/",
+    "standardLabel": {
+      "@id": "https://robosystems.ai/vocab/standardLabel"
+    },
     "start": {
       "@id": "https://robosystems.ai/vocab/start",
       "@type": "xsd:date"
@@ -381,8 +536,7 @@
       "@id": "https://robosystems.ai/vocab/statementType"
     },
     "stringValue": {
-      "@id": "https://robosystems.ai/vocab/stringValue",
-      "@type": "xsd:string"
+      "@id": "https://robosystems.ai/vocab/stringValue"
     },
     "structure": {
       "@id": "https://robosystems.ai/vocab/structure",
@@ -390,6 +544,10 @@
     },
     "structureName": {
       "@id": "https://robosystems.ai/vocab/structureName"
+    },
+    "structureOrder": {
+      "@id": "https://robosystems.ai/vocab/structureOrder",
+      "@type": "xsd:integer"
     },
     "structures": {
       "@id": "https://robosystems.ai/vocab/structures",
@@ -415,11 +573,20 @@
     "taxonomyName": {
       "@id": "https://robosystems.ai/vocab/taxonomyName"
     },
+    "terseLabel": {
+      "@id": "https://robosystems.ai/vocab/terseLabel"
+    },
     "to": {
       "@id": "xlink:to",
       "@type": "@id"
     },
+    "totalLabel": {
+      "@id": "https://robosystems.ai/vocab/totalLabel"
+    },
     "trait": "https://robosystems.ai/taxonomy/fac-traits/v1/",
+    "typedValue": {
+      "@id": "https://robosystems.ai/vocab/typedValue"
+    },
     "unit": {
       "@id": "https://robosystems.ai/vocab/unit",
       "@type": "@id"
@@ -439,6 +606,9 @@
     "variableQname": {
       "@id": "https://robosystems.ai/vocab/variableQname"
     },
+    "verboseLabel": {
+      "@id": "https://robosystems.ai/vocab/verboseLabel"
+    },
     "version": {
       "@id": "https://robosystems.ai/vocab/version"
     },
@@ -450,2480 +620,78 @@
     "xbrldt": "http://xbrl.org/2005/xbrldt#",
     "xbrli": "http://www.xbrl.org/2003/instance#",
     "xlink": "http://www.w3.org/1999/xlink#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#"
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "zeroLabel": {
+      "@id": "https://robosystems.ai/vocab/zeroLabel"
+    },
+    "zeroTerseLabel": {
+      "@id": "https://robosystems.ai/vocab/zeroTerseLabel"
+    },
+    "zeroVerboseLabel": {
+      "@id": "https://robosystems.ai/vocab/zeroVerboseLabel"
+    }
   },
   "@graph": [
     {
       "@graph": [
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/25",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "11100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/31",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "20400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:StockholdersEquity"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/6",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/11",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30210.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/35",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20440.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RetainedEarningsAccumulatedDeficit"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/6",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingExpenses"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/9",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30190.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/14",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseRightOfUseAsset"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/37",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20460.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:TreasuryStockValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/6",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30160.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/15",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsToAcquireIntangibleAssets"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GrossProfit"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Assets",
-          "order": "20100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AssetsCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/22",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20313.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/15",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20260.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/13",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10446.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:AssetImpairmentCharges"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/29",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20324.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/18",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10630.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainLossOnDispositionOfAssets"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/11",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10440.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostAndExpenseOperating"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:Revenues"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/20",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10643.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20140.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PrepaidExpenseCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/8",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Assets",
-          "order": "20200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AssetsNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30120.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:DepreciationDepletionAndAmortization"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/7",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30170.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/17",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10620.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InterestExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/34",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20430.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AdditionalPaidInCapital"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/20",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30330.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:RepaymentsOfLongTermDebt"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/calculation/0",
           "@type": [
-            "rs:Hierarchy",
-            "rs:Structure"
-          ],
-          "blockType": "equity_statement",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/4"
-          ],
-          "internalId": "0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "structureName": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/13",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20240.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseRightOfUseAsset"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/8",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10415.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:SellingAndMarketingExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/21",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10646.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/12",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30220.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/24",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "11000.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperations"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/22",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:EffectOfExchangeRateOnCash"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30140.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInInventories"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/28",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20323.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "10230.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostOfOperatingRevenue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/30",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20325.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/16",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30260.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromSaleOfIntangibleAssets"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/14",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30240.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/9",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10420.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ResearchAndDevelopmentExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/10",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10430.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:DepreciationDepletionAndAmortization"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/10",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20220.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Goodwill"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/26",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20321.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/20",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20312.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DebtCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/9",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20210.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PropertyPlantAndEquipmentNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:ShareBasedCompensation"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:PaymentsOfDividends"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/7",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10410.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GeneralAndAdministrativeExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/22",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10800.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/18",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30310.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/24",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20315.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/32",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20410.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CommonStockValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/15",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:NonoperatingIncomeExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/27",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "20322.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredIncomeTaxLiabilitiesNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/19",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20311.5",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccruedLiabilitiesCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/16",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "20300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Liabilities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/21",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20312.5",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "@type": [
-            "rs:RollUp",
-            "rs:Structure"
-          ],
-          "blockType": "cash_flow_statement",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/16"
-          ],
-          "internalId": "5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "structureName": "rs-gaap — Cash Flow Statement — Indirect"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/17",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/17",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Liabilities",
-          "order": "20310.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "10210.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfGoodsAndServicesSold"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/14",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/12",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "10443.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RestructuringCharges"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/36",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20450.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/19",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30320.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/25",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Liabilities",
-          "order": "20320.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesNoncurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20110.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/18",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20311.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccountsPayableCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInOperatingActivities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30110.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/19",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10640.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherNonoperatingIncomeExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/8",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30180.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccruedLiabilities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20115.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ShortTermInvestments"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/21",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "order": "30340.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/11",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20225.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/2",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfRevenue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/16",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "10610.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InvestmentIncomeInterest"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/13",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "order": "30230.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:PaymentsToAcquireInvestments"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/5",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInPrepaidExpense"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/1",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:Revenues",
-          "order": "10120.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/23",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "20314.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseLiabilityCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/33",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "20420.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PreferredStockValue"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/12",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "20230.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "order": "30130.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:IncreaseDecreaseInAccountsReceivable"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "@type": [
-            "rs:RollUp",
-            "rs:Structure"
-          ],
-          "blockType": "income_statement",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/25",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/23",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/24",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/26",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/7"
-          ],
-          "internalId": "47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "prefLabel": "rs-gaap — Income Statement — Multi-step",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "structureName": "rs-gaap — Income Statement — Multi-step"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/presentation/10",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "30200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInInvestingActivities"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/4",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20130.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/7",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20160.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/3",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "20120.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ReceivablesNetCurrent"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/0b179e5c-5f02-506d-b8d5-860cb10c7694/presentation/0",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "40100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
-          "to": "rs-gaap:NetIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/23",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "10900.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeTaxExpenseBenefit"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/presentation/26",
-          "@type": "rs:Association",
-          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
-          "associationType": "presentation",
-          "from": "rs-gaap:IncomeStatementAbstract",
-          "order": "11200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:NetIncomeLoss"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "@type": [
-            "rs:RollUp",
-            "rs:Structure"
-          ],
-          "blockType": "balance_sheet",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/25",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/23",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/26",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/24",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/32",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/29",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/30",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/27",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/34",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/33",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/37",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/31",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/28",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/36",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/35",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/presentation/14"
-          ],
-          "internalId": "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "prefLabel": "rs-gaap — Balance Sheet — Classified",
-          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "structureName": "rs-gaap — Balance Sheet — Classified"
-        }
-      ],
-      "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7#projection"
-    },
-    {
-      "@graph": [
-        {
-          "@id": "rs-gaap:LiabilitiesCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "efb036ff-3f30-5deb-bee9-1af4cd4b9800",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Liabilities, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA0",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AssetsCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA0",
-          "numericValue": "1838758.52",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "353f790f-1ed1-5b91-880d-8029b4b687cf",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "@type": "rs:Period",
-          "instant": "2028-12-31",
-          "periodType": "instant"
-        },
-        {
-          "@id": "rs-gaap:NetIncomeLoss",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "27a05717-2370-51c2-a924-db5cbcb48219",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Net Income (Loss) Attributable to Parent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:CostOfGoodsAndServicesSold",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "5ca0e51f-dff1-5c2b-94f5-26620852a5f9",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cost of Product and Service Sold",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/ib/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "@type": "rs:InformationBlock",
-          "blockType": "cash_flow_statement",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7T",
-          "internalId": "5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ96",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:GeneralAndAdministrativeExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7S",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ96",
-          "numericValue": "3049867.27",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA2",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA2",
-          "numericValue": "3084325.68",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:DepreciationDepletionAndAmortization",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "189a099a-7512-5144-9215-65d837c2c3b5",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Depreciation, Depletion and Amortization",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:AssetsCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "0fc9ab7e-c5ce-5277-9530-344cc127fe26",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Assets, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "091373d9-8a82-51bd-adf8-d09b73beb32e",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Long-Term Debt and Lease Obligation",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:Revenues",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "b26a6cd4-072f-5bf2-b5d3-ebf928150d6c",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Revenues",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9P",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7S",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9P",
-          "numericValue": "-1351122.32",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9C",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Revenues",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7S",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9C",
-          "numericValue": "2604048.36",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9K",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PropertyPlantAndEquipmentNet",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9K",
-          "numericValue": "1266995.32",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAP",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesNoncurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAP",
-          "numericValue": "361285.69",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "57ccbf45-c970-5bcd-a381-44d96b6b6d94",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:AccountsPayableCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "9ddbc9d7-c769-5800-8f65-1089d476e5c9",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Accounts Payable, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAH",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAH",
-          "numericValue": "3364281.75",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAK",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:StockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7V",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAK",
-          "numericValue": "1407646.64",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:AssetsNoncurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "841cedeb-4cb0-532a-b0bd-c34846a13a8c",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Assets, Noncurrent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "6b0b414f-0c76-54f0-8e51-cf53db59ca24",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:InterestExpense",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "890e4f8c-8fed-57e2-96fd-e70455201b11",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Interest Expense, Operating and Nonoperating",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:ReceivablesNetCurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "44686df3-3871-5c1f-8a08-fc542d69dfa0",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Receivables, Net, Current",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAN",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Assets",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAN",
-          "numericValue": "3364281.75",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:OperatingExpenses",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "71fcdebb-7145-5f76-b5e0-b4ccbf2c29d2",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Operating Expenses",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAQ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Liabilities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAQ",
-          "numericValue": "1956635.11",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ98",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ98",
-          "numericValue": "451842.19",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "30b2801e-e682-5298-82e6-3670e1d508f1",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Liabilities and Equity",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "93175d59-983c-5012-910f-3dfbf07ce327",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Increase (Decrease) in Accounts Receivable",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ93",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CostOfGoodsAndServicesSold",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7S",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ93",
-          "numericValue": "886041.18",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9G",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9G",
-          "numericValue": "398937.76",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:PropertyPlantAndEquipmentNet",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "288099af-5cbb-5f78-8f8a-1a85675fb661",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Property, Plant and Equipment, Net",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:StockholdersEquity",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "e3796201-9899-5b7b-9477-659550ba8e68",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Stockholders' Equity Attributable to Parent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/ib/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "@type": "rs:InformationBlock",
-          "blockType": "income_statement",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7S",
-          "internalId": "47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "prefLabel": "rs-gaap — Income Statement — Multi-step",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "rs-gaap:LiabilitiesNoncurrent",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "f41fe34d-88ea-5e20-a781-2d3e256a6abf",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Liabilities, Noncurrent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA4",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:StockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7V",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA4",
-          "numericValue": "56524.32",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9Q",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7V",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9Q",
-          "numericValue": "-1351122.32",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9S",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7T",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9S",
-          "numericValue": "-804129.8",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:CostOfRevenue",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "12ab7417-5324-55d6-946e-2456adba47c5",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Cost of Revenue",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:IncomeLossFromContinuingOperations",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "d60cabda-7060-5aff-ac98-96371606a738",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ97",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:InterestExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7S",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ97",
-          "numericValue": "-2165.93",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ99",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ99",
-          "numericValue": "338349.05",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/ib/0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "@type": "rs:InformationBlock",
-          "blockType": "equity_statement",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7V",
-          "internalId": "0b179e5c-5f02-506d-b8d5-860cb10c7694",
-          "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9E",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AccountsPayableCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9E",
-          "numericValue": "1595349.42",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAG",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AssetsNoncurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAG",
-          "numericValue": "1266995.32",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ95",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DepreciationDepletionAndAmortization",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7T",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ95",
-          "numericValue": "21428.16",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAB",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NonoperatingIncomeExpense",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7S",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAB",
-          "numericValue": "2165.93",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9F",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AdditionalPaidInCapital",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9F",
-          "numericValue": "1407646.64",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA6",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Assets",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA6",
-          "numericValue": "3084325.68",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAM",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:StockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAM",
-          "numericValue": "1407646.64",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/ib/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "@type": "rs:InformationBlock",
-          "blockType": "balance_sheet",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "internalId": "b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "prefLabel": "rs-gaap — Balance Sheet — Classified",
-          "taxonomyId": "cf7178a0-e2d4-58df-995a-2f0233d15466",
-          "taxonomyName": "rs-gaap-presentation v1"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9X",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncomeLossFromContinuingOperations",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7S",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9X",
-          "numericValue": "-1351122.32",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "@type": "rs:Period",
-          "instant": "2023-12-31",
-          "periodType": "instant"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ90",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AccountsPayableCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ90",
-          "numericValue": "2689452.31",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "20a6586b-880a-5745-94db-e23d397eb5e1",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Cash and Cash Equivalents, at Carrying Value",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9T",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7T",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9T",
-          "numericValue": "1094102.89",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9Y",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7T",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9Y",
-          "numericValue": "-1047489.7",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9B",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ReceivablesNetCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9B",
-          "numericValue": "2035468.27",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9H",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9H",
-          "numericValue": "467010.2",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9M",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:ReceivablesNetCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9M",
-          "numericValue": "1231338.47",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9V",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInInventories",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7T",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9V",
-          "numericValue": "15168.01",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9J",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9J",
-          "numericValue": "361285.69",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAJ",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAJ",
-          "numericValue": "1595349.42",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9R",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:NetIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7T",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9R",
-          "numericValue": "-1351122.32",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9A",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:PropertyPlantAndEquipmentNet",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9A",
-          "numericValue": "1245567.16",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9D",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9D",
-          "numericValue": "-1351122.32",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ94",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:DepreciationDepletionAndAmortization",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7S",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ94",
-          "numericValue": "21428.16",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA3",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA3",
-          "numericValue": "2689452.31",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "@type": "rs:Period",
-          "endDate": "2028-12-31",
-          "periodType": "duration",
-          "startDate": "2024-01-01"
-        },
-        {
-          "@id": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "4afa5950-85ac-5a85-a9cb-01c387c6ab08",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9N",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9N",
-          "numericValue": "0.0",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAC",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7S",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAC",
-          "numericValue": "-1351122.32",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:GrossProfit",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "a92b3181-9fe7-543c-81d9-13ebd12bbefa",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Gross Profit",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAD",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:GrossProfit",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7S",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAD",
-          "numericValue": "1718007.18",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:AdditionalPaidInCapital",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "6146605c-0d63-51e1-a523-3450d6abaca3",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Additional Paid in Capital",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA5",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:StockholdersEquity",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA5",
-          "numericValue": "56524.32",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAA",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CostOfRevenue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7S",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAA",
-          "numericValue": "886041.18",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:GeneralAndAdministrativeExpense",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "f92ba8cb-7ae2-5d40-9d15-9a94e9e3aed4",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "General and Administrative Expense",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD",
-          "@type": "rs:Unit",
-          "measure": "iso4217:USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9W",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7T",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9W",
-          "numericValue": "-22936.64",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAE",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:OperatingIncomeLoss",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7S",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAE",
-          "numericValue": "-1353288.25",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA1",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AssetsNoncurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA1",
-          "numericValue": "1245567.16",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ92",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ92",
-          "numericValue": "-648551.94",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA9",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:OperatingExpenses",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7S",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA9",
-          "numericValue": "3071295.43",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:OperatingIncomeLoss",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "16780828-0201-5609-b572-fbe3ebfcb177",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Operating Income (Loss)",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "a3227fb2-202b-51db-9574-4e60db03c04f",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA7",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:LiabilitiesNoncurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA7",
-          "numericValue": "338349.05",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAF",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AssetsCurrent",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAF",
-          "numericValue": "2097286.43",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_3",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:NonoperatingIncomeExpense",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "45aae2c2-fa56-50c9-b381-df8079e7d33a",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Nonoperating Income (Expense)",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:IncreaseDecreaseInInventories",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "c8b0722b-7993-592f-8ef1-5b0964ac8a10",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Increase (Decrease) in Inventories",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "a9c87d60-a1e5-506b-a27e-cbf9e14e5113",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Retained Earnings (Accumulated Deficit)",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ91",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:AdditionalPaidInCapital",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ91",
-          "numericValue": "1407646.64",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA8",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:Liabilities",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7R",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA8",
-          "numericValue": "3027801.36",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_1",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "@type": "rs:Entity",
-          "country": "US",
-          "internalId": "entity_kg1a07f3227a7878a9d882",
-          "legalName": "The World Online (Charlie Hoffman demo)",
-          "prefLabel": "The World Online (Charlie Hoffman demo)"
-        },
-        {
-          "@id": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "dc7408c9-cba5-5697-8254-32ac46485214",
-          "monetary": "true",
-          "periodType": "duration",
-          "prefLabel": "Increase (Decrease) in Accounts Payable and Accrued Liabilities",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9Z",
-          "@type": "rs:Fact",
-          "decimals": "INF",
-          "element": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
-          "factSet": "https://robosystems.ai/factset/fs_01M1ZK6QTD5A2N12WYSQCKBV7T",
-          "factType": "numeric",
-          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9Z",
-          "numericValue": "-1047489.7",
-          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/p_2",
-          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/u_USD"
-        },
-        {
-          "@id": "rs-gaap:Assets",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "debit",
-          "elementType": "concept",
-          "internalId": "a1f04756-41d8-5d35-b821-23aa2f3b2fae",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Assets",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        },
-        {
-          "@id": "rs-gaap:Liabilities",
-          "@type": "rs:Element",
-          "abstract": "false",
-          "balance": "credit",
-          "elementType": "concept",
-          "internalId": "7af273ac-1cba-5fb3-a1c9-5c5d8fdb9bdf",
-          "monetary": "true",
-          "periodType": "instant",
-          "prefLabel": "Liabilities",
-          "source": "rs-gaap",
-          "substitutionGroup": "xbrli:item"
-        }
-      ],
-      "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7#scene"
-    },
-    {
-      "@graph": [
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/3",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/calculation/1",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:EffectOfExchangeRateOnCash",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/calculation/2",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/calculation/3",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
           "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingIncomeLoss",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/11",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ReceivablesNetCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/10",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostOfOperatingRevenue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/30",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/0",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/0",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -2937,91 +705,7 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/20",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherNonoperatingIncomeExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/4",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Liabilities",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/14",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:StockholdersEquity",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/35",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherAssetsCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/37",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "600.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:TreasuryStockValue",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/13",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:NonoperatingIncomeExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/36",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/1",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -3035,108 +719,24 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/18",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/10",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GainLossOnDispositionOfAssets",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/29",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:RetainedEarningsAccumulatedDeficit",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/26",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseRightOfUseAsset",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/12",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperations",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeTaxExpenseBenefit",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/1",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
           "order": "100.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "to": "rs-gaap:Liabilities",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/6",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/11",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/5",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccountsPayableCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/17",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
@@ -3147,552 +747,21 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/15",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DebtCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/25",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/12",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "406.6667",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:AssetImpairmentCharges",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/1",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/9",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:SellingAndMarketingExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/21",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/16",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ResearchAndDevelopmentExpense",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/1",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:GrossProfit",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:Revenues",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/10",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Assets",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AssetsNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/8",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Revenues",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/7",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:CommonStockValue",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/7",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingIncomeLoss",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GrossProfit",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/32",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/5",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InvestmentIncomeInterest",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/8",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
           "from": "rs-gaap:AssetsCurrent",
-          "order": "150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:ShortTermInvestments",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/24",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AdditionalPaidInCapital",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/25",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:PrepaidExpenseCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/9",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "150.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccruedLiabilitiesCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/4",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NetIncomeLoss",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperations",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/2",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/22",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "403.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/23",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "403.3333",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:RestructuringCharges",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/2",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:IncomeLossFromContinuingOperations",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/27",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseLiabilityCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/23",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:DeferredRevenueNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/28",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/20",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsCurrent",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/19",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "300.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:DepreciationDepletionAndAmortization",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/3",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:EffectOfExchangeRateOnCash",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/13",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:Liabilities",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LiabilitiesNoncurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/33",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesNoncurrent",
           "order": "500.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:OtherLiabilitiesNoncurrent",
+          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/5473639a-2dac-56a6-b9e5-38480ea38bc1",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/1"
-          ]
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/25",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/24",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/31",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/17",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/37",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/32",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/30",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/36",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/33",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/27",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/28",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/29",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/26",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/34",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/23",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/35"
-          ]
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/34",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:StockholdersEquity",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/47cd6544-03d1-5bc1-8c28-31c0cfa450f9",
-          "hasAssociation": [
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/3",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/16",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/4",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/11",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/0",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/10",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/24",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/21",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/7",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/19",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/12",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/22",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/8",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/23",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/13",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/25",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/14",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/6",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/1",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/5",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/18",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/9",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/15",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/2",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/20",
-            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/17"
-          ]
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/15",
-          "@type": [
-            "rs:Association",
-            "rs:RollUpRelationship"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:NonoperatingIncomeExpense",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:InterestExpense",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/0",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CostOfRevenue",
-          "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfGoodsAndServicesSold",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/2",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/13",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -3706,105 +775,63 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/31",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "500.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:FinanceLeaseRightOfUseAsset",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/11",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:GrossProfit",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:CostOfRevenue",
-          "weight": "-1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/19",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/14",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:LiabilitiesCurrent",
-          "order": "250.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:LongTermDebtCurrent",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/5473639a-2dac-56a6-b9e5-38480ea38bc1/calculation/0",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
           "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
-          "to": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/21",
-          "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
-          ],
-          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
-          "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
-          "order": "400.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OtherCostAndExpenseOperating",
-          "weight": "1.0"
-        },
-        {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/14",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/15",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:NetIncomeLoss",
-          "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/18",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/16",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ShortTermInvestments",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/17",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
           "from": "rs-gaap:AssetsNoncurrent",
-          "order": "250.0",
+          "order": "400.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
+          "to": "rs-gaap:OperatingLeaseRightOfUseAsset",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/22",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/18",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -3818,35 +845,147 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/12",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/19",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:AssetsNoncurrent",
-          "order": "200.0",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "250.0",
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
-          "to": "rs-gaap:Goodwill",
+          "to": "rs-gaap:LongTermDebtCurrent",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/17",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/2",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:OperatingIncomeLoss",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/20",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Assets",
           "order": "200.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:OperatingExpenses",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AssetsNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/21",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/22",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/23",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ReceivablesNetCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/24",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/25",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PrepaidExpenseCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/26",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Liabilities",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/27",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:TreasuryStockValue",
           "weight": "-1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/16",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/28",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -3860,21 +999,49 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/6",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/29",
           "@type": [
-            "rs:RollUpRelationship",
-            "rs:Association"
+            "rs:Association",
+            "rs:RollUpRelationship"
           ],
           "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
           "associationType": "calculation",
-          "from": "rs-gaap:OperatingExpenses",
+          "from": "rs-gaap:StockholdersEquity",
           "order": "100.0",
-          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
-          "to": "rs-gaap:GeneralAndAdministrativeExpense",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CommonStockValue",
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/b6dfb8d2-8ee9-5597-9a3b-8aeee625ff0d/calculation/3",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/3",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AdditionalPaidInCapital",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/30",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/31",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -3888,7 +1055,497 @@
           "weight": "1.0"
         },
         {
-          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/47cd6544-03d1-5bc1-8c28-31c0cfa450f9/calculation/24",
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/32",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DebtCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/33",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseLiabilityCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/34",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/35",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/36",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/37",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseRightOfUseAsset",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/4",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccruedLiabilitiesCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/5",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Goodwill",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/6",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:StockholdersEquity",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/7",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccountsPayableCurrent",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/8",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/9",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/0",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:NonoperatingIncomeExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/1",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InterestExpense",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/10",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainLossOnDispositionOfAssets",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/11",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperations",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/12",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherNonoperatingIncomeExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/13",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingIncomeLoss",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/14",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingIncomeLoss",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GrossProfit",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/15",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:Revenues",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/16",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GeneralAndAdministrativeExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/17",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "406.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:AssetImpairmentCharges",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/18",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ResearchAndDevelopmentExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/19",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "403.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RestructuringCharges",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/2",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:IncomeLossFromContinuingOperations",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeTaxExpenseBenefit",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/20",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostAndExpenseOperating",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/21",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:DepreciationDepletionAndAmortization",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/22",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NetIncomeLoss",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperations",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/23",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostOfOperatingRevenue",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/24",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "403.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/25",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NetIncomeLoss",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/3",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:GrossProfit",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:Revenues",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/4",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingIncomeLoss",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingExpenses",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/5",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InvestmentIncomeInterest",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/6",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:GrossProfit",
+          "order": "200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfRevenue",
+          "weight": "-1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/7",
           "@type": [
             "rs:Association",
             "rs:RollUpRelationship"
@@ -3900,9 +1557,3984 @@
           "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
           "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
           "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/8",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:SellingAndMarketingExpense",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/9",
+          "@type": [
+            "rs:Association",
+            "rs:RollUpRelationship"
+          ],
+          "arcrole": "http://www.xbrl.org/2003/arcrole/summation-item",
+          "associationType": "calculation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfGoodsAndServicesSold",
+          "weight": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/4d5ede325089bd91",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/calculation/3"
+          ]
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/75bf584b3e4aaaa0",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/23",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/24",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/25",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/26",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/27",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/28",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/29",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/30",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/31",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/32",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/33",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/34",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/35",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/36",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/37",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/calculation/9"
+          ]
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/850c3d8ab3a4a627",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/23",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/24",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/25",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/calculation/9"
+          ]
         }
       ],
       "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7#boundary"
+    },
+    {
+      "@graph": [
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/1eae745dbb354952/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/1eae745dbb354952/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:PaymentsOfDividends"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/1eae745dbb354952/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:ShareBasedCompensation"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/1eae745dbb354952/presentation/3",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/1eae745dbb354952/presentation/4",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/1eae745dbb354952/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "40100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "to": "rs-gaap:NetIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30330.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:RepaymentsOfLongTermDebt"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:EffectOfExchangeRateOnCash"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/10",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30180.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccruedLiabilities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/11",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30230.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsToAcquireInvestments"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/12",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInPrepaidExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/13",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30130.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccountsReceivable"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/14",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInInvestingActivities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/15",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsToAcquireIntangibleAssets"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/16",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30260.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromSaleOfIntangibleAssets"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/17",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30320.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/18",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30210.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/19",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30120.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:DepreciationDepletionAndAmortization"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30240.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/20",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30170.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/21",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInFinancingActivities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/22",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30340.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:PaymentsForRepurchaseOfCommonStock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/3",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30190.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/4",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30160.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "order": "30220.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/6",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30140.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:IncreaseDecreaseInInventories"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/7",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "order": "30310.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:ProceedsFromIssuanceOfCommonStock"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/8",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "order": "30100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetCashProvidedByUsedInOperatingActivities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/9",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "order": "30110.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "to": "rs-gaap:NetIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20150.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RestrictedCashAndInvestmentsCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20250.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseRightOfUseAsset"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/10",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20120.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ReceivablesNetCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/11",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "20400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:StockholdersEquity"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/12",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20460.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:TreasuryStockValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/13",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Assets",
+          "order": "20100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AssetsCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/14",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20140.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PrepaidExpenseCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/15",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20325.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/16",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20321.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtAndCapitalLeaseObligations"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/17",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "order": "20300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Liabilities"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/18",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20450.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/19",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20311.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccountsPayableCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20260.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/20",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20225.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:IntangibleAssetsNetExcludingGoodwill"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/21",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20324.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseLiabilityNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/22",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20240.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OperatingLeaseRightOfUseAsset"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/23",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20323.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/24",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20220.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:Goodwill"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/25",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20312.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DebtCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/26",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20312.5",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermDebtCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/27",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20110.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CashAndCashEquivalentsAtCarryingValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/28",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20115.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:ShortTermInvestments"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/29",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20420.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PreferredStockValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/3",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20430.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AdditionalPaidInCapital"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/30",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20160.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherAssetsCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/31",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20440.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:RetainedEarningsAccumulatedDeficit"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/32",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20313.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredRevenueCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/33",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Assets",
+          "order": "20200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AssetsNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/34",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20315.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:OtherLiabilitiesCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/35",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesNoncurrent",
+          "order": "20322.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:DeferredIncomeTaxLiabilitiesNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/36",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20311.5",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:AccruedLiabilitiesCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/37",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20230.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LongTermInvestmentsAndReceivablesNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/4",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsNoncurrent",
+          "order": "20210.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:PropertyPlantAndEquipmentNet"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:StockholdersEquity",
+          "order": "20410.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:CommonStockValue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/6",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Liabilities",
+          "order": "20310.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/7",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Liabilities",
+          "order": "20320.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:LiabilitiesNoncurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/8",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:LiabilitiesCurrent",
+          "order": "20314.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:FinanceLeaseLiabilityCurrent"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/9",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:AssetsCurrent",
+          "order": "20130.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "to": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/0",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10446.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:AssetImpairmentCharges"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/1",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10440.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostAndExpenseOperating"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/10",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10300.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GrossProfit"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/11",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:Revenues"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/12",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10620.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InterestExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/13",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10420.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ResearchAndDevelopmentExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/14",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "10210.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfGoodsAndServicesSold"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/15",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "11200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:NetIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/16",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "11100.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/17",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10400.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingExpenses"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/18",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10630.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainLossOnDispositionOfAssets"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/19",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10643.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/2",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10500.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OperatingIncomeLoss"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/20",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10415.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:SellingAndMarketingExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/21",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "11000.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperations"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/22",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:CostOfRevenue",
+          "order": "10230.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherCostOfOperatingRevenue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/23",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10430.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:DepreciationDepletionAndAmortization"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/24",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10410.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GeneralAndAdministrativeExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/25",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:OperatingExpenses",
+          "order": "10443.3333",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RestructuringCharges"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/26",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10900.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeTaxExpenseBenefit"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/3",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10200.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:CostOfRevenue"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/4",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10610.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:InvestmentIncomeInterest"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/5",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10646.6667",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:GainsLossesOnExtinguishmentOfDebt"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/6",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10800.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/7",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:IncomeStatementAbstract",
+          "order": "10600.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:NonoperatingIncomeExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/8",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:NonoperatingIncomeExpense",
+          "order": "10640.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:OtherNonoperatingIncomeExpense"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/9",
+          "@type": "rs:Association",
+          "arcrole": "http://www.xbrl.org/2003/arcrole/parent-child",
+          "associationType": "presentation",
+          "from": "rs-gaap:Revenues",
+          "order": "10120.0",
+          "role": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "to": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/1eae745dbb354952",
+          "@type": [
+            "rs:Hierarchy",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/1eae745dbb354952",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/1eae745dbb354952/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/1eae745dbb354952/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/1eae745dbb354952/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/1eae745dbb354952/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/1eae745dbb354952/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/1eae745dbb354952/presentation/5"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/Equity-rollforward",
+          "structureName": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
+          "structureOrder": "2"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/4d5ede325089bd91",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/4d5ede325089bd91/presentation/9"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/CashFlow-indirect",
+          "structureName": "rs-gaap — Cash Flow Statement — Indirect",
+          "structureOrder": "3"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/75bf584b3e4aaaa0",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/23",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/24",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/25",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/26",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/27",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/28",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/29",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/30",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/31",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/32",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/33",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/34",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/35",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/36",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/37",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/75bf584b3e4aaaa0/presentation/9"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "prefLabel": "rs-gaap — Balance Sheet — Classified",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/BS-classified",
+          "structureName": "rs-gaap — Balance Sheet — Classified",
+          "structureOrder": "0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/850c3d8ab3a4a627",
+          "@type": [
+            "rs:RollUp",
+            "rs:Structure"
+          ],
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "hasAssociation": [
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/0",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/1",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/10",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/11",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/12",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/13",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/14",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/15",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/16",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/17",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/18",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/19",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/2",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/20",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/21",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/22",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/23",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/24",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/25",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/26",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/3",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/4",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/5",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/6",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/7",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/8",
+            "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/association/850c3d8ab3a4a627/presentation/9"
+          ],
+          "internalId": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "prefLabel": "rs-gaap — Income Statement — Multi-step",
+          "roleUri": "https://robosystems.ai/seattle/cm-roles/roles/rs-gaap-presentation/IS-multistep",
+          "structureName": "rs-gaap — Income Statement — Multi-step",
+          "structureOrder": "1"
+        },
+        {
+          "@id": "rs-gaap:AccountsPayableCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccountsPayableCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accounts Payable, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Accounts Payable, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AccruedLiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccruedLiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accrued Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Accrued Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accumulated Other Comprehensive Income (Loss), Net of Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Accumulated Other Comprehensive Income (Loss), Net of Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AdditionalPaidInCapital",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AdditionalPaidInCapital",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Additional Paid in Capital",
+          "source": "rs-gaap",
+          "standardLabel": "Additional Paid in Capital",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetImpairmentCharges",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetImpairmentCharges",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Asset Impairment Charges",
+          "source": "rs-gaap",
+          "standardLabel": "Asset Impairment Charges",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Assets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Assets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CommonStockValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CommonStockValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Common Stock, Value, Issued",
+          "source": "rs-gaap",
+          "standardLabel": "Common Stock, Value, Issued",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfGoodsAndServicesSold",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfGoodsAndServicesSold",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Product and Service Sold",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Product and Service Sold",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Revenue",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Revenue",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DebtCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DebtCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Debt, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Debt, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DeferredIncomeTaxLiabilitiesNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DeferredIncomeTaxLiabilitiesNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Deferred Income Tax Liabilities, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Deferred Income Tax Liabilities, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DeferredRevenueCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DeferredRevenueCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Deferred Revenue, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Deferred Revenue, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DeferredRevenueNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DeferredRevenueNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Deferred Revenue, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Deferred Revenue, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DepreciationDepletionAndAmortization",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DepreciationDepletionAndAmortization",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Depreciation, Depletion and Amortization",
+          "source": "rs-gaap",
+          "standardLabel": "Depreciation, Depletion and Amortization",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:EffectOfExchangeRateOnCash",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:EffectOfExchangeRateOnCash",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Effect of Exchange Rate on Cash",
+          "source": "rs-gaap",
+          "standardLabel": "Effect of Exchange Rate on Cash",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:FinanceLeaseLiabilityCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:FinanceLeaseLiabilityCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Finance Lease, Liability, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Finance Lease, Liability, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:FinanceLeaseRightOfUseAsset",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:FinanceLeaseRightOfUseAsset",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Finance Lease, Right-of-Use Asset, after Accumulated Amortization",
+          "source": "rs-gaap",
+          "standardLabel": "Finance Lease, Right-of-Use Asset, after Accumulated Amortization",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ForeignCurrencyTransactionGainLossBeforeTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gain (Loss), Foreign Currency Transaction, before Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Gain (Loss), Foreign Currency Transaction, before Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GainLossOnDispositionOfAssets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GainLossOnDispositionOfAssets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gain (Loss) on Disposition of Property Plant Equipment, Excluding Oil and Gas Property and Timber Property",
+          "source": "rs-gaap",
+          "standardLabel": "Gain (Loss) on Disposition of Property Plant Equipment, Excluding Oil and Gas Property and Timber Property",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GainsLossesOnExtinguishmentOfDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gain (Loss) on Extinguishment of Debt",
+          "source": "rs-gaap",
+          "standardLabel": "Gain (Loss) on Extinguishment of Debt",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GeneralAndAdministrativeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GeneralAndAdministrativeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "General and Administrative Expense",
+          "source": "rs-gaap",
+          "standardLabel": "General and Administrative Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Goodwill",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Goodwill",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Goodwill",
+          "source": "rs-gaap",
+          "standardLabel": "Goodwill",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GrossProfit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GrossProfit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gross Profit",
+          "source": "rs-gaap",
+          "standardLabel": "Gross Profit",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperations",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperations",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromDiscontinuedOperationsNetOfTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Discontinued Operations, Net of Tax, Including Portion Attributable to Noncontrolling Interest",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Discontinued Operations, Net of Tax, Including Portion Attributable to Noncontrolling Interest",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeStatementAbstract",
+          "@type": "rs:Element",
+          "abstract": "true",
+          "balance": "debit",
+          "elementType": "abstract",
+          "internalId": "rs-gaap:IncomeStatementAbstract",
+          "itemType": "string",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income Statement [Abstract]",
+          "source": "rs-gaap",
+          "standardLabel": "Income Statement [Abstract]",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeTaxExpenseBenefit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeTaxExpenseBenefit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income Tax Expense (Benefit)",
+          "source": "rs-gaap",
+          "standardLabel": "Income Tax Expense (Benefit)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accounts Payable and Accrued Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accounts Payable and Accrued Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accounts Receivable",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accounts Receivable",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccruedIncomeTaxesPayable",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Income Taxes Payable",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Income Taxes Payable",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccruedLiabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accrued Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accrued Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInInventories",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInInventories",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Inventories",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Inventories",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInPrepaidExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Prepaid Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Prepaid Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IntangibleAssetsNetExcludingGoodwill",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Intangible Assets, Net (Excluding Goodwill)",
+          "source": "rs-gaap",
+          "standardLabel": "Intangible Assets, Net (Excluding Goodwill)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:InterestExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:InterestExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Interest Expense, Operating and Nonoperating",
+          "source": "rs-gaap",
+          "standardLabel": "Interest Expense, Operating and Nonoperating",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
+          "source": "rs-gaap",
+          "standardLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:InvestmentIncomeInterest",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:InvestmentIncomeInterest",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Investment Income, Interest",
+          "source": "rs-gaap",
+          "standardLabel": "Investment Income, Interest",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Liabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Liabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities and Equity",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities and Equity",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Debt and Lease Obligation",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Debt and Lease Obligation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermDebtCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermDebtCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Debt, Current Maturities",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Debt, Current Maturities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermInvestmentsAndReceivablesNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Investments and Receivables, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Investments and Receivables, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInFinancingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Financing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInInvestingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Investing Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Net Income (Loss) Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Net Income (Loss) Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NonoperatingIncomeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NonoperatingIncomeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Nonoperating Income (Expense)",
+          "source": "rs-gaap",
+          "standardLabel": "Nonoperating Income (Expense)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingExpenses",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingExpenses",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Expenses",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Expenses",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Income (Loss)",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Income (Loss)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingLeaseLiabilityNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Operating Lease, Liability, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Lease, Liability, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingLeaseRightOfUseAsset",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingLeaseRightOfUseAsset",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Operating Lease, Right-of-Use Asset",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Lease, Right-of-Use Asset",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherAssetsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherAssetsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Assets, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Other Assets, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherAssetsNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherAssetsNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Assets, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Other Assets, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherComprehensiveIncomeLossNetOfTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Comprehensive Income (Loss), Net of Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Other Comprehensive Income (Loss), Net of Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherCostAndExpenseOperating",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherCostAndExpenseOperating",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Cost and Expense, Operating",
+          "source": "rs-gaap",
+          "standardLabel": "Other Cost and Expense, Operating",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherCostOfOperatingRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherCostOfOperatingRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Cost of Operating Revenue",
+          "source": "rs-gaap",
+          "standardLabel": "Other Cost of Operating Revenue",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherLiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherLiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Other Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherLiabilitiesNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherLiabilitiesNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Other Liabilities, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Other Liabilities, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OtherNonoperatingIncomeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OtherNonoperatingIncomeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Other Nonoperating Income (Expense)",
+          "source": "rs-gaap",
+          "standardLabel": "Other Nonoperating Income (Expense)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsForRepurchaseOfCommonStock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsForRepurchaseOfCommonStock",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments for Repurchase of Common Stock",
+          "source": "rs-gaap",
+          "standardLabel": "Payments for Repurchase of Common Stock",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsOfDividends",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsOfDividends",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments of Dividends",
+          "source": "rs-gaap",
+          "standardLabel": "Payments of Dividends",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquireIntangibleAssets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquireIntangibleAssets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Intangible Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Intangible Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquireInvestments",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquireInvestments",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Investments",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Investments",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PaymentsToAcquirePropertyPlantAndEquipment",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "source": "rs-gaap",
+          "standardLabel": "Payments to Acquire Property, Plant, and Equipment",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PreferredStockValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PreferredStockValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Preferred Stock, Value, Issued",
+          "source": "rs-gaap",
+          "standardLabel": "Preferred Stock, Value, Issued",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PrepaidExpenseCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PrepaidExpenseCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Prepaid Expense, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Prepaid Expense, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromIssuanceOfCommonStock",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Issuance of Common Stock",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Issuance of Common Stock",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromIssuanceOfLongTermDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Issuance of Long-Term Debt",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Issuance of Long-Term Debt",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromSaleMaturityAndCollectionsOfInvestments",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Sale, Maturity and Collection of Investments",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Sale, Maturity and Collection of Investments",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromSaleOfIntangibleAssets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromSaleOfIntangibleAssets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Sale of Intangible Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Sale of Intangible Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ProceedsFromSaleOfPropertyPlantAndEquipment",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Proceeds from Sale of Property, Plant, and Equipment",
+          "source": "rs-gaap",
+          "standardLabel": "Proceeds from Sale of Property, Plant, and Equipment",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Property, Plant and Equipment, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Property, Plant and Equipment, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ReceivablesNetCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ReceivablesNetCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Receivables, Net, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Receivables, Net, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RepaymentsOfLongTermDebt",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RepaymentsOfLongTermDebt",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Repayments of Long-Term Debt",
+          "source": "rs-gaap",
+          "standardLabel": "Repayments of Long-Term Debt",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ResearchAndDevelopmentExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ResearchAndDevelopmentExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Research and Development Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Research and Development Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RestrictedCashAndInvestmentsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Restricted Cash and Investments, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Restricted Cash and Investments, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RestructuringCharges",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RestructuringCharges",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Restructuring Charges",
+          "source": "rs-gaap",
+          "standardLabel": "Restructuring Charges",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Retained Earnings (Accumulated Deficit)",
+          "source": "rs-gaap",
+          "standardLabel": "Retained Earnings (Accumulated Deficit)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "source": "rs-gaap",
+          "standardLabel": "Revenue from Contract with Customer, Excluding Assessed Tax",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Revenues",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Revenues",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenues",
+          "source": "rs-gaap",
+          "standardLabel": "Revenues",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:SellingAndMarketingExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:SellingAndMarketingExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Selling and Marketing Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Selling and Marketing Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ShareBasedCompensation",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ShareBasedCompensation",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Share-Based Payment Arrangement, Noncash Expense",
+          "source": "rs-gaap",
+          "standardLabel": "Share-Based Payment Arrangement, Noncash Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ShortTermInvestments",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ShortTermInvestments",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Short-Term Investments",
+          "source": "rs-gaap",
+          "standardLabel": "Short-Term Investments",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:StockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:StockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Stockholders' Equity Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Stockholders' Equity Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:TreasuryStockValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:TreasuryStockValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Treasury Stock, Value",
+          "source": "rs-gaap",
+          "standardLabel": "Treasury Stock, Value",
+          "substitutionGroup": "xbrli:item"
+        }
+      ],
+      "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7#projection"
+    },
+    {
+      "@graph": [
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7",
+          "@type": "rs:Report",
+          "accessionNumber": "rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "mode": "report",
+          "reportingStyle": "sec-as-filed",
+          "serializationVersion": "1.0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "@type": "rs:Entity",
+          "internalId": "entity_kg1a07f3227a7878a9d882",
+          "legalName": "The World Online (Charlie Hoffman demo)",
+          "prefLabel": "The World Online (Charlie Hoffman demo)",
+          "scheme": "http://robosystems.ai/entity"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ90",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AccountsPayableCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ90",
+          "numericValue": "2689452.31",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ91",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AdditionalPaidInCapital",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ91",
+          "numericValue": "1407646.64",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ92",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ92",
+          "numericValue": "-648551.94",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ93",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CostOfGoodsAndServicesSold",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ93",
+          "numericValue": "886041.18",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ94",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DepreciationDepletionAndAmortization",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": [
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ94",
+          "numericValue": "21428.16",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ95",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:DepreciationDepletionAndAmortization",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": [
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ95",
+          "numericValue": "21428.16",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ96",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:GeneralAndAdministrativeExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ96",
+          "numericValue": "3049867.27",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ97",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:InterestExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ97",
+          "numericValue": "-2165.93",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ98",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ98",
+          "numericValue": "451842.19",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ99",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ99",
+          "numericValue": "338349.05",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9A",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9A",
+          "numericValue": "1245567.16",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9B",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ReceivablesNetCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9B",
+          "numericValue": "2035468.27",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9C",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Revenues",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9C",
+          "numericValue": "2604048.36",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9D",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9D",
+          "numericValue": "-1351122.32",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9E",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AccountsPayableCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9E",
+          "numericValue": "1595349.42",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9F",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AdditionalPaidInCapital",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9F",
+          "numericValue": "1407646.64",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9G",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9G",
+          "numericValue": "398937.76",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9H",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9H",
+          "numericValue": "467010.2",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9J",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9J",
+          "numericValue": "361285.69",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9K",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9K",
+          "numericValue": "1266995.32",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9M",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:ReceivablesNetCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9M",
+          "numericValue": "1231338.47",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9N",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9N",
+          "numericValue": "0.0",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9P",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9P",
+          "numericValue": "-1351122.32",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9Q",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9Q",
+          "numericValue": "-1351122.32",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9R",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/4d5ede325089bd91",
+            "https://robosystems.ai/factset/850c3d8ab3a4a627"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9R",
+          "numericValue": "-1351122.32",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9S",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9S",
+          "numericValue": "-804129.8",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9T",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9T",
+          "numericValue": "1094102.89",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9V",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInInventories",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9V",
+          "numericValue": "15168.01",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9W",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9W",
+          "numericValue": "-22936.64",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9X",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncomeLossFromContinuingOperations",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9X",
+          "numericValue": "-1351122.32",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9Y",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9Y",
+          "numericValue": "-1047489.7",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQ9Z",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQ9Z",
+          "numericValue": "-1047489.7",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA0",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AssetsCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA0",
+          "numericValue": "1838758.52",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA1",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AssetsNoncurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA1",
+          "numericValue": "1245567.16",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA2",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA2",
+          "numericValue": "3084325.68",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA3",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA3",
+          "numericValue": "2689452.31",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA4",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:StockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA4",
+          "numericValue": "56524.32",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA5",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:StockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA5",
+          "numericValue": "56524.32",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA6",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Assets",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA6",
+          "numericValue": "3084325.68",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA7",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesNoncurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA7",
+          "numericValue": "338349.05",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA8",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Liabilities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA8",
+          "numericValue": "3027801.36",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQA9",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:OperatingExpenses",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQA9",
+          "numericValue": "3071295.43",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAA",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:CostOfRevenue",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAA",
+          "numericValue": "886041.18",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAB",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:NonoperatingIncomeExpense",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAB",
+          "numericValue": "2165.93",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAC",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAC",
+          "numericValue": "-1351122.32",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAD",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:GrossProfit",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAD",
+          "numericValue": "1718007.18",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAE",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:OperatingIncomeLoss",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAE",
+          "numericValue": "-1353288.25",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAF",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AssetsCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAF",
+          "numericValue": "2097286.43",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAG",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:AssetsNoncurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAG",
+          "numericValue": "1266995.32",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAH",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAH",
+          "numericValue": "3364281.75",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAJ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesCurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAJ",
+          "numericValue": "1595349.42",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAK",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:StockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAK",
+          "numericValue": "1407646.64",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAM",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:StockholdersEquity",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": [
+            "https://robosystems.ai/factset/1eae745dbb354952",
+            "https://robosystems.ai/factset/75bf584b3e4aaaa0"
+          ],
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAM",
+          "numericValue": "1407646.64",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAN",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Assets",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAN",
+          "numericValue": "3364281.75",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAP",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:LiabilitiesNoncurrent",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAP",
+          "numericValue": "361285.69",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/fact/fact_01M1ZK6QTJZWV3VPM0JSFWEQAQ",
+          "@type": "rs:Fact",
+          "decimals": "INF",
+          "element": "rs-gaap:Liabilities",
+          "entity": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/entity/entity_kg1a07f3227a7878a9d882",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "factType": "numeric",
+          "internalId": "fact_01M1ZK6QTJZWV3VPM0JSFWEQAQ",
+          "numericValue": "1956635.11",
+          "period": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "unit": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/ib/1eae745dbb354952",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/1eae745dbb354952",
+          "internalId": "1eae745dbb354952",
+          "prefLabel": "rs-gaap — Statement of Changes in Equity — Roll Forward (Total)",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/1eae745dbb354952"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/ib/4d5ede325089bd91",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/4d5ede325089bd91",
+          "internalId": "4d5ede325089bd91",
+          "prefLabel": "rs-gaap — Cash Flow Statement — Indirect",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/4d5ede325089bd91"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/ib/75bf584b3e4aaaa0",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/75bf584b3e4aaaa0",
+          "internalId": "75bf584b3e4aaaa0",
+          "prefLabel": "rs-gaap — Balance Sheet — Classified",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/75bf584b3e4aaaa0"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/ib/850c3d8ab3a4a627",
+          "@type": "rs:InformationBlock",
+          "factSet": "https://robosystems.ai/factset/850c3d8ab3a4a627",
+          "internalId": "850c3d8ab3a4a627",
+          "prefLabel": "rs-gaap — Income Statement — Multi-step",
+          "structure": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/structure/850c3d8ab3a4a627"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/5a0a659f-2a80-50c3-8c7f-0fef47d930af",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2023-12-31",
+          "calendarQuarter": "Q4",
+          "calendarYear": "2023",
+          "instant": "2023-12-31",
+          "periodType": "instant"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/b9c86810-3103-5168-ad3c-5b2c396cfcd3",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2024-01-01/2028-12-31",
+          "calendarYear": "2028",
+          "durationType": "other",
+          "endDate": "2028-12-31",
+          "periodType": "duration",
+          "startDate": "2024-01-01"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/period/dbc9e67a-a2bc-58ef-9d68-86b794b241c7",
+          "@type": "rs:Period",
+          "calendarPeriodKey": "2028-12-31",
+          "calendarQuarter": "Q4",
+          "calendarYear": "2028",
+          "instant": "2028-12-31",
+          "periodType": "instant"
+        },
+        {
+          "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7/unit/9cc6cd0b-cfdf-5f15-ad6d-7918bace1785",
+          "@type": "rs:Unit",
+          "measure": "iso4217:USD"
+        },
+        {
+          "@id": "rs-gaap:AccountsPayableCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AccountsPayableCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Accounts Payable, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Accounts Payable, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AdditionalPaidInCapital",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AdditionalPaidInCapital",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Additional Paid in Capital",
+          "source": "rs-gaap",
+          "standardLabel": "Additional Paid in Capital",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Assets",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Assets",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets",
+          "source": "rs-gaap",
+          "standardLabel": "Assets",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:AssetsNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:AssetsNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Assets, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Assets, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsAtCarryingValue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, at Carrying Value",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CashAndCashEquivalentsPeriodIncreaseDecrease",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "source": "rs-gaap",
+          "standardLabel": "Cash and Cash Equivalents, Period Increase (Decrease)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfGoodsAndServicesSold",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfGoodsAndServicesSold",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Product and Service Sold",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Product and Service Sold",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:CostOfRevenue",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:CostOfRevenue",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cost of Revenue",
+          "source": "rs-gaap",
+          "standardLabel": "Cost of Revenue",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:DepreciationDepletionAndAmortization",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:DepreciationDepletionAndAmortization",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Depreciation, Depletion and Amortization",
+          "source": "rs-gaap",
+          "standardLabel": "Depreciation, Depletion and Amortization",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GeneralAndAdministrativeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GeneralAndAdministrativeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "General and Administrative Expense",
+          "source": "rs-gaap",
+          "standardLabel": "General and Administrative Expense",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:GrossProfit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:GrossProfit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Gross Profit",
+          "source": "rs-gaap",
+          "standardLabel": "Gross Profit",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperations",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperations",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations, Net of Tax, Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "source": "rs-gaap",
+          "standardLabel": "Income (Loss) from Continuing Operations before Income Taxes, Noncontrolling Interest",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccountsPayableAndAccruedLiabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accounts Payable and Accrued Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accounts Payable and Accrued Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInAccountsReceivable",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Accounts Receivable",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Accounts Receivable",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInInventories",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInInventories",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Inventories",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Inventories",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:IncreaseDecreaseInOtherOperatingCapitalNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Increase (Decrease) in Other Operating Assets and Liabilities, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:InterestExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:InterestExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Interest Expense, Operating and Nonoperating",
+          "source": "rs-gaap",
+          "standardLabel": "Interest Expense, Operating and Nonoperating",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
+          "source": "rs-gaap",
+          "standardLabel": "Inventory, Net of Allowances, Customer Advances and Progress Billings",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Liabilities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Liabilities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesAndStockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities and Equity",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities and Equity",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LiabilitiesNoncurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LiabilitiesNoncurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Liabilities, Noncurrent",
+          "source": "rs-gaap",
+          "standardLabel": "Liabilities, Noncurrent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:LongTermDebtAndCapitalLeaseObligations",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Long-Term Debt and Lease Obligation",
+          "source": "rs-gaap",
+          "standardLabel": "Long-Term Debt and Lease Obligation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetCashProvidedByUsedInOperatingActivities",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "source": "rs-gaap",
+          "standardLabel": "Cash Provided by (Used in) Operating Activity, Including Discontinued Operation",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NetIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NetIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Net Income (Loss) Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Net Income (Loss) Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:NonoperatingIncomeExpense",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:NonoperatingIncomeExpense",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Nonoperating Income (Expense)",
+          "source": "rs-gaap",
+          "standardLabel": "Nonoperating Income (Expense)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingExpenses",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingExpenses",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Expenses",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Expenses",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:OperatingIncomeLoss",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:OperatingIncomeLoss",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Operating Income (Loss)",
+          "source": "rs-gaap",
+          "standardLabel": "Operating Income (Loss)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:PropertyPlantAndEquipmentNet",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Property, Plant and Equipment, Net",
+          "source": "rs-gaap",
+          "standardLabel": "Property, Plant and Equipment, Net",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:ReceivablesNetCurrent",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "debit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:ReceivablesNetCurrent",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Receivables, Net, Current",
+          "source": "rs-gaap",
+          "standardLabel": "Receivables, Net, Current",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:RetainedEarningsAccumulatedDeficit",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Retained Earnings (Accumulated Deficit)",
+          "source": "rs-gaap",
+          "standardLabel": "Retained Earnings (Accumulated Deficit)",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:Revenues",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:Revenues",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "duration",
+          "prefLabel": "Revenues",
+          "source": "rs-gaap",
+          "standardLabel": "Revenues",
+          "substitutionGroup": "xbrli:item"
+        },
+        {
+          "@id": "rs-gaap:StockholdersEquity",
+          "@type": "rs:Element",
+          "abstract": "false",
+          "balance": "credit",
+          "elementType": "concept",
+          "internalId": "rs-gaap:StockholdersEquity",
+          "itemType": "decimal",
+          "monetary": "false",
+          "periodType": "instant",
+          "prefLabel": "Stockholders' Equity Attributable to Parent",
+          "source": "rs-gaap",
+          "standardLabel": "Stockholders' Equity Attributable to Parent",
+          "substitutionGroup": "xbrli:item"
+        }
+      ],
+      "@id": "https://robosystems.ai/report/rpt_01M1ZK6QJ9JD5MVYDYHVYQB3J7#scene"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up to #1373. The other four tracked `.holon.jsonld` samples were still the old partition's output — each missing 52–59 element declarations for the rows its arcs reach. Regenerated offline from the flat JSON-LD beside each, through `write_holon_jsonld` (the DataBook converter), the same path the SaaS sample took in #1373. No code change.

| sample | undeclared endpoints before | after | concepts / labelled |
|---|---|---|---|
| coffee-roaster-demo | 56 | 0 | 101 / 93 |
| roboledger-demo | 59 | 0 | 93 / 93 |
| seattle-method-case-1 | 52 | 0 | 93 / 93 |
| world-online | 58 | 0 | 93 / 93 |

Each file loads in xbrlkit with the report id as its accession; facts are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQNt2hdNJqbJwfoSRshaXo
