### PR TITLE
feat(mcp): trim search hits to decision fields and page section reads

### DIFF
--- a/robosystems/middleware/mcp/README.md
+++ b/robosystems/middleware/mcp/README.md
@@ -198,10 +198,18 @@ Gated by `SEMANTIC_SEARCH_ENABLED`.
 | `create-document` / `update-document` | no |
 
 Document management additionally skips shared repositories — SEC searches
-OpenSearch directly and has no Postgres document rows. `search-documents`
-results on iXBRL disclosures carry `xbrl_elements`, the XBRL fact tags in that
-section, which cross-reference into the graph via `resolve-element` or
-`read-graph-cypher`.
+OpenSearch directly and has no Postgres document rows.
+
+A tool result is context the model pays for on every later turn, so these two
+tools return less than the REST models they wrap (`search_tools.py`). A
+`search-documents` hit carries what a model needs to choose it — id, label,
+score, snippet (`snippet_chars`, default 400) — with null fields dropped and
+the filing fields hoisted to the result root when every hit shares them; the
+per-section `xbrl_elements` list is left to `get-document-section`, which
+carries it for the hit the model picked and cross-references into the graph
+via `resolve-element` or `read-graph-cypher`. `get-document-section` returns
+a window (`offset` + `length`, default 4,000, max 8,000) and a `next_offset`
+while more of the part follows, the same paging as xbrlkit's `read_text`.
 
 ### Layer 4 — graph lifecycle, subgraph writes, memory
 

--- a/robosystems/middleware/mcp/tools/search_tools.py
+++ b/robosystems/middleware/mcp/tools/search_tools.py
@@ -6,12 +6,98 @@ Two-tool pattern:
 
 All searches use hybrid mode combining keyword matching (BM25) with vector
 similarity (KNN) via a normalization pipeline for balanced scoring.
+
+A tool result is context the model pays for on every later turn, so a hit
+carries what is needed to choose it and the section call carries what is
+needed to answer. The REST surface keeps the full response models; the
+trimming lives here, in ``compact_search_response`` and ``window_section``.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from robosystems.logger import logger
 from robosystems.security.error_handling import safe_error_message
+
+if TYPE_CHECKING:
+  from robosystems.models.api.search import DocumentSection, SearchResponse
+
+# Bounds mirror SearchRequest.snippet_chars; the default is the tool's own.
+SNIPPET_CHARS_DEFAULT = 400
+SNIPPET_CHARS_MIN = 80
+SNIPPET_CHARS_MAX = 1500
+
+# The window a section read returns, matching xbrlkit's read_text so the
+# hosted and local document tools page the same way.
+SECTION_READ_DEFAULT = 4000
+SECTION_READ_MAX = 8000
+
+# Filing fields that repeat identically on every hit of a single-filing
+# search; they move to the result root when every hit agrees.
+HOISTED_HIT_FIELDS = (
+  "entity_ticker",
+  "entity_name",
+  "form_type",
+  "filing_date",
+  "fiscal_year",
+)
+
+# The element qnames of every fact in a section were 44% of the measured
+# search payload and never used to choose a hit; get-document-section
+# carries them for the hit the model picks.
+DROPPED_HIT_FIELDS = ("xbrl_elements",)
+
+
+def compact_search_response(response: "SearchResponse") -> dict[str, Any]:
+  """The search response as a model reads it: decision fields only.
+
+  Drops null fields and the per-hit element list, and hoists the filing
+  fields to the root when every hit shares the same value. Hits that span
+  filings keep those fields on each hit.
+  """
+  hits = [hit.model_dump(exclude_none=True) for hit in response.hits]
+  for hit in hits:
+    for field in DROPPED_HIT_FIELDS:
+      hit.pop(field, None)
+
+  result: dict[str, Any] = {
+    "total": response.total,
+    "query": response.query,
+    "graph_id": response.graph_id,
+  }
+  if hits:
+    for field in HOISTED_HIT_FIELDS:
+      values = {hit.get(field) for hit in hits}
+      if len(values) != 1:
+        continue
+      value = values.pop()
+      if value is None:
+        continue
+      result[field] = value
+      for hit in hits:
+        hit.pop(field, None)
+  result["hits"] = hits
+  return result
+
+
+def window_section(
+  section: "DocumentSection", offset: int, length: int
+) -> dict[str, Any]:
+  """One window of a section's content, with the offset to read on from."""
+  content = section.content
+  total = len(content)
+  if offset and offset >= total:
+    return {
+      "error": f"offset {offset} is past the end of this part ({total} chars)",
+    }
+  end = min(total, offset + length)
+
+  data = section.model_dump(exclude_none=True)
+  data["content"] = content[offset:end]
+  data["content_length"] = total
+  data["offset"] = offset
+  if end < total:
+    data["next_offset"] = end
+  return data
 
 
 class _SearchToolMixin:
@@ -60,33 +146,43 @@ class SearchDocumentsTool(_SearchToolMixin):
 - `semantic` — adds KNN to the BM25 pass; defaults to false, so a plain call
   is keyword-only
 - `entity`, `form_type`, `section`, `element`, `fiscal_year`, `size` — filters
+- `snippet_chars` — approximate snippet budget per hit (default 400, max 1500);
+  raise it when the snippets are too short to choose between hits
 
 **RELATED TOOLS:**
+- get-document-section / get-document — read what a hit points at
 - read-graph-cypher — structured data (numbers, relationships), not prose
 - list-documents — browses by metadata; does not search content
-- get-document-section / get-document — retrieve what a hit points at
+- resolve-element — takes a qname from get-document-section's xbrl_elements on
+  to its structured values
 
 **RETURNS:**
-- Ranked results with relevance scores and text snippets
-- Each result includes a document_id — use get-document-section for the full section text
+- Ranked hits, each with document_id, score, source_type, section_label,
+  section_id, snippet, content_length and content_url (element_qname for an
+  iXBRL disclosure)
+- Filing fields every hit shares (entity_ticker, entity_name, form_type,
+  filing_date, fiscal_year) appear once at the result root; when the hits span
+  filings they stay on each hit
+- A snippet is an excerpt around the match, not the passage — read the section
+  with get-document-section before quoting a figure from it
 - A long section (an MD&A, a commitments note) is indexed in parts of about 25K
   characters; a hit carries part / part_count and the parts share a
   parent_document_id. get-document-section returns one part and its next_document_id
 - For user docs, use get-document to retrieve the complete document
-- iXBRL results include xbrl_elements for graph cross-reference
 
 **NOTES:**
 - Searches user-uploaded documents (created via create-document), SEC filing
   text blocks and narrative sections, and iXBRL disclosure sections
-- iXBRL results carry xbrl_elements (e.g. us-gaap:Goodwill). Look one up with
-  resolve-element, then read-graph-cypher for its structured values — this is
-  the bridge from narrative context to financial facts. Note resolve-element
-  is only published on graphs with semantic enrichment
+- To tie narrative back to reported numbers: get-document-section returns an
+  iXBRL disclosure's xbrl_elements (e.g. us-gaap:Goodwill); look one up with
+  resolve-element, then read-graph-cypher for its structured values. Note
+  resolve-element is only published on graphs with semantic enrichment
 - Natural language queries work well ("depreciation policy", "month end close procedures")
 - Use entity filter to focus on one company's filings
 - Use section filter (item_1a, item_7) to target specific filing sections, or an
   element qname (us-gaap:CommitmentsAndContingenciesDisclosureTextBlock) to
-  target one iXBRL disclosure across filings""",
+  target one iXBRL disclosure across filings; the `element` filter finds the
+  disclosures that contain a given fact""",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -124,6 +220,11 @@ class SearchDocumentsTool(_SearchToolMixin):
             "description": "Max results (default 10, max 50)",
             "default": 10,
           },
+          "snippet_chars": {
+            "type": "integer",
+            "description": f"Approximate snippet budget per hit in characters (default {SNIPPET_CHARS_DEFAULT}, max {SNIPPET_CHARS_MAX})",
+            "default": SNIPPET_CHARS_DEFAULT,
+          },
         },
         "required": ["query"],
       },
@@ -142,6 +243,7 @@ class SearchDocumentsTool(_SearchToolMixin):
     # Subgraphs are a storage split, not a search boundary.
     graph_id = self._resolve_search_graph_id()
 
+    snippet_chars = int(arguments.get("snippet_chars") or SNIPPET_CHARS_DEFAULT)
     request = SearchRequest(
       query=arguments["query"],
       entity=arguments.get("entity"),
@@ -151,13 +253,14 @@ class SearchDocumentsTool(_SearchToolMixin):
       fiscal_year=arguments.get("fiscal_year"),
       semantic=arguments.get("semantic", False),
       size=min(arguments.get("size", 10), 50),
+      snippet_chars=max(SNIPPET_CHARS_MIN, min(snippet_chars, SNIPPET_CHARS_MAX)),
     )
 
     logger.info(f"MCP search-documents: query='{request.query}' graph_id={graph_id}")
 
     try:
       response = service.search_documents(graph_id, request)
-      return response.model_dump()
+      return compact_search_response(response)
     except Exception as e:
       # opensearch-py exception text embeds the endpoint hostname and query
       # internals — the LLM-facing result gets the fixed message instead.
@@ -170,7 +273,7 @@ class SearchDocumentsTool(_SearchToolMixin):
 
 
 class GetDocumentSectionTool(_SearchToolMixin):
-  """Retrieve the full text of a document section found via search."""
+  """Retrieve the text of a document section found via search, a window at a time."""
 
   def __init__(self, graph_client):
     self.client = graph_client
@@ -178,27 +281,45 @@ class GetDocumentSectionTool(_SearchToolMixin):
   def get_tool_definition(self) -> dict[str, Any]:
     return {
       "name": "get-document-section",
-      "description": """Retrieve the full text of a document section by ID. Use this after search-documents to read the complete narrative content of a relevant result.
+      "description": f"""Read a document section by ID, a window at a time. Use this after search-documents to read the text behind a hit before answering from it.
 
 **WHEN TO USE:**
-- After search-documents returns results, use the document_id from a hit to get the full section
-- When you need the complete text of an MD&A, risk factor, or business description
+- After search-documents returns results, use the document_id from a hit to read the section
+- When you need the text of an MD&A, risk factor, or business description
 - To read the full context around a search snippet
 
+**PARAMETERS:**
+- `document_id` (required) — from a search-documents hit, or the next_document_id of a part
+- `offset` — character offset to start from (default 0)
+- `length` — characters to return (default {SECTION_READ_DEFAULT}, max {SECTION_READ_MAX})
+
 **RETURNS:**
-- The section text with entity, filing, and section metadata
+- `content` — the requested window. `content_length` is the whole part, and
+  `next_offset` is present when more of it follows: call again with it as
+  `offset` to read on rather than answering from a partial read
+- Entity, filing, and section metadata
 - A long section is stored in parts of about 25K characters: the result is one
   part (part of part_count, section_label like "MD&A (2/6)") and carries
-  next_document_id — call again with it to read on; parent_document_id is shared
-  by the section's parts
+  next_document_id — call again with it to read the next part; parent_document_id
+  is shared by the section's parts
 - content_url for the CDN-hosted clean text (when available)
-- For iXBRL disclosures: xbrl_elements list of XBRL fact tags in this section — use resolve-element or read-graph-cypher to cross-reference with the knowledge graph""",
+- For iXBRL disclosures: xbrl_elements, the XBRL fact tags in this section — use resolve-element or read-graph-cypher to cross-reference with the knowledge graph""",
       "inputSchema": {
         "type": "object",
         "properties": {
           "document_id": {
             "type": "string",
             "description": "Document ID from a search-documents result, or the next_document_id of a part",
+          },
+          "offset": {
+            "type": "integer",
+            "description": "Character offset to start from (default 0); pass a result's next_offset to read on",
+            "default": 0,
+          },
+          "length": {
+            "type": "integer",
+            "description": f"Characters to return (default {SECTION_READ_DEFAULT}, max {SECTION_READ_MAX})",
+            "default": SECTION_READ_DEFAULT,
           },
         },
         "required": ["document_id"],
@@ -215,6 +336,10 @@ class GetDocumentSectionTool(_SearchToolMixin):
     # Search indexes use the parent graph_id (e.g. "sec" not "sec_historical")
     graph_id = self._resolve_search_graph_id()
     document_id = arguments["document_id"]
+    offset = max(0, int(arguments.get("offset") or 0))
+    length = max(
+      1, min(int(arguments.get("length") or SECTION_READ_DEFAULT), SECTION_READ_MAX)
+    )
 
     logger.info(f"MCP get-document-section: doc_id={document_id} graph_id={graph_id}")
 
@@ -222,7 +347,7 @@ class GetDocumentSectionTool(_SearchToolMixin):
       result = service.get_document_section(graph_id, document_id)
       if result is None:
         return {"error": f"Document {document_id} not found"}
-      return result.model_dump()
+      return window_section(result, offset, length)
     except Exception as e:
       logger.error(f"get-document-section failed: {e}", exc_info=True)
       return {

--- a/robosystems/models/api/search.py
+++ b/robosystems/models/api/search.py
@@ -41,6 +41,13 @@ class SearchRequest(BaseModel):
   )
   size: int = Field(10, ge=1, le=50, description="Max results to return")
   offset: int = Field(0, ge=0, description="Pagination offset")
+  snippet_chars: int | None = Field(
+    None,
+    ge=80,
+    le=1500,
+    description="Approximate snippet budget per hit in characters; the default "
+    "is three highlight fragments of about 200",
+  )
 
 
 class SearchHit(BaseModel):

--- a/robosystems/operations/operators/implementations/analyst.py
+++ b/robosystems/operations/operators/implementations/analyst.py
@@ -446,7 +446,7 @@ Reach for `read-graph-cypher` when no curated tool fits, or to drill into specif
         prompt += f"""
 NARRATIVE DISCLOSURES (qualitative filing text — NOT in the Cypher fact graph):
 - Questions about risk factors, MD&A, business description, legal proceedings, competition, or other management commentary are answered from filing TEXT, not the XBRL facts. Cypher can't surface this — use `search-documents` over filing sections{schema_skip_note}. It is keyword (BM25) search by default; pass `semantic=true` when the question is about meaning rather than a specific term, or when a keyword pass returns nothing useful.
-- `search-documents` returns ranked snippets, each with a document_id. Call `get-document-section` with that id to read the full section before you answer. When the question names a section, narrow with the section filter (e.g. item_1a for risk factors, item_7 for MD&A).
+- `search-documents` returns ranked snippets, each with a document_id. Call `get-document-section` with that id to read the section before you answer; it returns a window and a `next_offset` when more follows, so page on with `offset` rather than answering from a partial read. When the question names a section, narrow with the section filter (e.g. item_1a for risk factors, item_7 for MD&A).
 - A section may carry `xbrl_elements`; use `resolve-element` or `read-graph-cypher` to tie the narrative back to the reported numbers when the question needs both text and figures.
 """
       else:
@@ -455,7 +455,7 @@ NARRATIVE DISCLOSURES (qualitative filing text — NOT in the Cypher fact graph)
         prompt += f"""
 DOCUMENTS (qualitative written context — accounting policies, procedures, memos, notes — NOT in the Cypher fact graph):
 - Questions about this company's accounting policies, close procedures, memos, or other written context are answered from its uploaded DOCUMENTS, not the ledger facts. Cypher can't surface this — use `search-documents` over this graph's documents{schema_skip_note}. It is keyword (BM25) search by default; pass `semantic=true` when the question is about meaning rather than a specific term (a policy, a treatment, "how do we handle X"), or when a keyword pass returns nothing useful.
-- `search-documents` returns ranked snippets, each with a document_id. Call `get-document-section` with that id to read the full section before you answer.
+- `search-documents` returns ranked snippets, each with a document_id. Call `get-document-section` with that id to read the section before you answer; it returns a window and a `next_offset` when more follows, so page on with `offset` rather than answering from a partial read.
 - When a question needs both the written policy and the reported figures, combine the two: search for the text, then query the ledger with `read-graph-cypher`.
 """
     if has_memory:

--- a/robosystems/operations/search/client.py
+++ b/robosystems/operations/search/client.py
@@ -17,6 +17,11 @@ from robosystems.logger import logger
 # Without this, BM25 scores (~10-40) drown out KNN cosine scores (~0-1).
 # The normalization processor maps both to [0,1] before combining.
 HYBRID_PIPELINE_NAME = "hybrid-search-pipeline"
+
+# A hit's snippet is highlight fragments joined with " ... ": the standard
+# shape is three of about 200 characters.
+HIGHLIGHT_FRAGMENT_SIZE = 200
+HIGHLIGHT_FRAGMENTS = 3
 HYBRID_PIPELINE_BODY: dict[str, Any] = {
   "description": "Normalizes and combines BM25 + KNN scores for hybrid search",
   "phase_results_processors": [
@@ -364,13 +369,24 @@ class OpenSearchClient:
     return filter_clauses
 
   @staticmethod
-  def _highlight_config() -> dict[str, Any]:
-    """Standard highlight configuration for search results."""
+  def _highlight_config(snippet_chars: int | None = None) -> dict[str, Any]:
+    """Highlight configuration for search results.
+
+    ``snippet_chars`` is an approximate per-hit budget: fragments stay at
+    the standard size and the budget sets how many of them a hit may carry,
+    so a smaller budget means fewer matches shown, not shorter ones. None
+    keeps the standard three fragments.
+    """
+    fragment_size = HIGHLIGHT_FRAGMENT_SIZE
+    fragments = HIGHLIGHT_FRAGMENTS
+    if snippet_chars is not None:
+      fragment_size = min(fragment_size, snippet_chars)
+      fragments = max(1, snippet_chars // fragment_size)
     return {
       "fields": {
         "content": {
-          "fragment_size": 200,
-          "number_of_fragments": 3,
+          "fragment_size": fragment_size,
+          "number_of_fragments": fragments,
           "pre_tags": [""],
           "post_tags": [""],
         }
@@ -384,6 +400,7 @@ class OpenSearchClient:
     filters: dict[str, Any] | None = None,
     size: int = 10,
     offset: int = 0,
+    snippet_chars: int | None = None,
   ) -> dict[str, Any]:
     """BM25 text search with mandatory graph_id filtering.
 
@@ -413,7 +430,7 @@ class OpenSearchClient:
           "filter": filter_clauses,
         }
       },
-      "highlight": self._highlight_config(),
+      "highlight": self._highlight_config(snippet_chars),
       "size": size,
       "from": offset,
       "_source": {
@@ -431,6 +448,7 @@ class OpenSearchClient:
     filters: dict[str, Any] | None = None,
     size: int = 10,
     offset: int = 0,
+    snippet_chars: int | None = None,
   ) -> dict[str, Any]:
     """Hybrid text + vector search with mandatory graph_id filtering.
 
@@ -507,7 +525,7 @@ class OpenSearchClient:
           ],
         }
       },
-      "highlight": self._highlight_config(),
+      "highlight": self._highlight_config(snippet_chars),
       "size": size,
       "from": offset,
       "_source": {

--- a/robosystems/operations/search/service.py
+++ b/robosystems/operations/search/service.py
@@ -82,6 +82,7 @@ class SearchService:
         filters=filters if filters else None,
         size=request.size,
         offset=request.offset,
+        snippet_chars=request.snippet_chars,
       )
     else:
       result = self.client.search(
@@ -90,6 +91,7 @@ class SearchService:
         filters=filters if filters else None,
         size=request.size,
         offset=request.offset,
+        snippet_chars=request.snippet_chars,
       )
 
     hits = []

--- a/tests/middleware/mcp/tools/test_search_tools.py
+++ b/tests/middleware/mcp/tools/test_search_tools.py
@@ -5,9 +5,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from robosystems.middleware.mcp.tools.search_tools import (
+  SECTION_READ_DEFAULT,
+  SECTION_READ_MAX,
+  SNIPPET_CHARS_DEFAULT,
+  SNIPPET_CHARS_MAX,
+  SNIPPET_CHARS_MIN,
   GetDocumentSectionTool,
   SearchDocumentsTool,
+  compact_search_response,
+  window_section,
 )
+from robosystems.models.api.search import DocumentSection, SearchHit, SearchResponse
 
 
 @pytest.fixture
@@ -15,6 +23,49 @@ def mock_graph_client():
   client = MagicMock()
   client.graph_id = "sec"
   return client
+
+
+def _hit(document_id: str, **overrides) -> SearchHit:
+  fields = {
+    "document_id": document_id,
+    "score": 9.1,
+    "source_type": "ixbrl_disclosure",
+    "entity_ticker": "MMM",
+    "entity_name": "3M CO",
+    "form_type": "10-K",
+    "filing_date": "2025-02-05",
+    "fiscal_year": 2024,
+    "section_label": "Research, Development and Related Expenses",
+    "section_id": "us-gaap:ResearchDevelopmentAndComputerSoftwareDisclosureTextBlock",
+    "xbrl_elements": ["us-gaap:ResearchAndDevelopmentExpense"] * 20,
+    "snippet": "... research and development ...",
+    "content_length": 1655,
+    "content_url": "https://cdn.example/sec/x.txt",
+  }
+  fields.update(overrides)
+  return SearchHit(**fields)
+
+
+def _response(*hits: SearchHit) -> SearchResponse:
+  return SearchResponse(total=len(hits), hits=list(hits), query="r&d", graph_id="sec")
+
+
+def _section(content: str, **overrides) -> DocumentSection:
+  fields = {
+    "document_id": "doc1",
+    "graph_id": "sec",
+    "source_type": "narrative_section",
+    "entity_ticker": "MMM",
+    "section_label": "MD&A (1/4)",
+    "part": 1,
+    "part_count": 4,
+    "next_document_id": "doc2",
+    "xbrl_elements": ["us-gaap:Revenues"],
+    "content": content,
+    "content_length": len(content),
+  }
+  fields.update(overrides)
+  return DocumentSection(**fields)
 
 
 class TestSearchDocumentsTool:
@@ -25,22 +76,23 @@ class TestSearchDocumentsTool:
     assert defn["name"] == "search-documents"
     assert "inputSchema" in defn
     assert "query" in defn["inputSchema"]["properties"]
+    assert "snippet_chars" in defn["inputSchema"]["properties"]
     assert defn["inputSchema"]["required"] == ["query"]
+
+  def test_description_no_longer_promises_elements_on_a_hit(self, mock_graph_client):
+    """The element list moved to get-document-section; the prompt must say so,
+    or the model reads a hit expecting a field that is not there."""
+    defn = SearchDocumentsTool(mock_graph_client).get_tool_definition()
+    desc = " ".join(defn["description"].split())
+    assert "get-document-section returns an iXBRL disclosure's xbrl_elements" in desc
+    assert "A snippet is an excerpt around the match" in desc
 
   @pytest.mark.asyncio
   async def test_execute_calls_service(self, mock_graph_client):
     tool = SearchDocumentsTool(mock_graph_client)
 
-    mock_response = MagicMock()
-    mock_response.model_dump.return_value = {
-      "total": 1,
-      "hits": [{"document_id": "doc1"}],
-      "query": "test",
-      "graph_id": "sec",
-    }
-
     mock_service = MagicMock()
-    mock_service.search_documents.return_value = mock_response
+    mock_service.search_documents.return_value = _response(_hit("doc1"))
 
     with patch(
       "robosystems.operations.search.get_search_service",
@@ -48,7 +100,27 @@ class TestSearchDocumentsTool:
     ):
       result = await tool.execute({"query": "tariff risk", "size": 5})
       assert result["total"] == 1
+      assert result["hits"][0]["document_id"] == "doc1"
       mock_service.search_documents.assert_called_once()
+      request = mock_service.search_documents.call_args[0][1]
+      assert request.snippet_chars == SNIPPET_CHARS_DEFAULT
+
+  @pytest.mark.asyncio
+  @pytest.mark.parametrize(
+    ("asked", "sent"),
+    [(5000, SNIPPET_CHARS_MAX), (10, SNIPPET_CHARS_MIN), (800, 800)],
+  )
+  async def test_snippet_chars_is_clamped(self, mock_graph_client, asked, sent):
+    tool = SearchDocumentsTool(mock_graph_client)
+    mock_service = MagicMock()
+    mock_service.search_documents.return_value = _response()
+
+    with patch(
+      "robosystems.operations.search.get_search_service",
+      return_value=mock_service,
+    ):
+      await tool.execute({"query": "x", "snippet_chars": asked})
+    assert mock_service.search_documents.call_args[0][1].snippet_chars == sent
 
   @pytest.mark.asyncio
   async def test_returns_error_when_service_unavailable(self, mock_graph_client):
@@ -68,21 +140,18 @@ class TestGetDocumentSectionTool:
     defn = tool.get_tool_definition()
 
     assert defn["name"] == "get-document-section"
-    assert "document_id" in defn["inputSchema"]["properties"]
+    props = defn["inputSchema"]["properties"]
+    assert "document_id" in props
+    assert props["offset"]["default"] == 0
+    assert props["length"]["default"] == SECTION_READ_DEFAULT
     assert defn["inputSchema"]["required"] == ["document_id"]
 
   @pytest.mark.asyncio
   async def test_execute_returns_section(self, mock_graph_client):
     tool = GetDocumentSectionTool(mock_graph_client)
 
-    mock_section = MagicMock()
-    mock_section.model_dump.return_value = {
-      "document_id": "doc1",
-      "content": "Full text...",
-    }
-
     mock_service = MagicMock()
-    mock_service.get_document_section.return_value = mock_section
+    mock_service.get_document_section.return_value = _section("Full text...")
 
     with patch(
       "robosystems.operations.search.get_search_service",
@@ -90,6 +159,31 @@ class TestGetDocumentSectionTool:
     ):
       result = await tool.execute({"document_id": "doc1"})
       assert result["content"] == "Full text..."
+      assert "next_offset" not in result
+
+  @pytest.mark.asyncio
+  async def test_execute_pages_with_offset_and_length(self, mock_graph_client):
+    tool = GetDocumentSectionTool(mock_graph_client)
+    text = "".join(f"{i % 10}" for i in range(20_000))
+
+    mock_service = MagicMock()
+    mock_service.get_document_section.return_value = _section(text)
+
+    with patch(
+      "robosystems.operations.search.get_search_service",
+      return_value=mock_service,
+    ):
+      first = await tool.execute({"document_id": "doc1"})
+      assert first["content"] == text[:SECTION_READ_DEFAULT]
+      assert first["content_length"] == 20_000
+      assert first["next_offset"] == SECTION_READ_DEFAULT
+
+      rest = await tool.execute(
+        {"document_id": "doc1", "offset": first["next_offset"], "length": 50_000}
+      )
+      # length is capped, so the read stops short of the end and says so
+      assert rest["content"] == text[SECTION_READ_DEFAULT:][:SECTION_READ_MAX]
+      assert rest["next_offset"] == SECTION_READ_DEFAULT + SECTION_READ_MAX
 
   @pytest.mark.asyncio
   async def test_returns_error_when_not_found(self, mock_graph_client):
@@ -187,3 +281,103 @@ class TestSearchToolErrorSanitization:
     assert result["error"] == "search_failed"
     assert "amazonaws.com" not in result["message"]
     assert "see server logs" in result["message"]
+
+
+class TestCompactSearchResponse:
+  """A hit carries what a model needs to choose it; the rest is a follow-up."""
+
+  def test_drops_element_list_and_null_fields(self):
+    result = compact_search_response(_response(_hit("doc1")))
+    hit = result["hits"][0]
+    assert "xbrl_elements" not in hit
+    assert "element_qname" not in hit  # None on the input
+    assert hit["document_id"] == "doc1"
+    assert hit["snippet"] == "... research and development ..."
+    assert hit["section_label"] and hit["score"] and hit["content_url"]
+
+  def test_hoists_filing_fields_shared_by_every_hit(self):
+    result = compact_search_response(_response(_hit("doc1"), _hit("doc2")))
+    assert result["entity_ticker"] == "MMM"
+    assert result["entity_name"] == "3M CO"
+    assert result["form_type"] == "10-K"
+    assert result["filing_date"] == "2025-02-05"
+    assert result["fiscal_year"] == 2024
+    for hit in result["hits"]:
+      for field in ("entity_ticker", "entity_name", "form_type", "filing_date"):
+        assert field not in hit
+
+  def test_keeps_filing_fields_on_hits_that_span_filings(self):
+    result = compact_search_response(
+      _response(_hit("doc1"), _hit("doc2", entity_ticker="NVDA", fiscal_year=2025))
+    )
+    assert "entity_ticker" not in result
+    assert "fiscal_year" not in result
+    # fields that still agree are hoisted independently of the ones that differ
+    assert result["form_type"] == "10-K"
+    assert [h["entity_ticker"] for h in result["hits"]] == ["MMM", "NVDA"]
+
+  def test_a_field_missing_on_one_hit_is_not_hoisted(self):
+    result = compact_search_response(
+      _response(_hit("doc1"), _hit("doc2", filing_date=None))
+    )
+    assert "filing_date" not in result
+    assert result["hits"][0]["filing_date"] == "2025-02-05"
+    assert "filing_date" not in result["hits"][1]
+
+  def test_empty_result_keeps_the_envelope(self):
+    assert compact_search_response(_response()) == {
+      "total": 0,
+      "query": "r&d",
+      "graph_id": "sec",
+      "hits": [],
+    }
+
+  def test_long_section_part_fields_survive(self):
+    hit = _hit(
+      "p2", part=2, part_count=4, parent_document_id="p", next_document_id="p3"
+    )
+    compact = compact_search_response(_response(hit))["hits"][0]
+    assert (compact["part"], compact["part_count"]) == (2, 4)
+    assert compact["parent_document_id"] == "p"
+    assert compact["next_document_id"] == "p3"
+
+  def test_payload_shrinks_by_more_than_half_on_a_single_filing_search(self):
+    """The measured shape: ten iXBRL hits from one 10-K, each carrying its
+    section's element list."""
+    import json
+
+    response = _response(*(_hit(f"doc{i}") for i in range(10)))
+    before = len(json.dumps(response.model_dump()))
+    after = len(json.dumps(compact_search_response(response)))
+    assert after < before / 2
+
+
+class TestWindowSection:
+  def test_short_content_is_returned_whole(self):
+    result = window_section(_section("short"), 0, 4000)
+    assert result["content"] == "short"
+    assert result["content_length"] == 5
+    assert result["offset"] == 0
+    assert "next_offset" not in result
+
+  def test_window_and_next_offset(self):
+    text = "a" * 100
+    result = window_section(_section(text), 0, 40)
+    assert result["content"] == "a" * 40
+    assert result["next_offset"] == 40
+    tail = window_section(_section(text), 40, 100)
+    assert tail["content"] == "a" * 60
+    assert "next_offset" not in tail
+
+  def test_offset_past_the_end_is_an_error(self):
+    assert "error" in window_section(_section("abc"), 3, 10)
+    assert "error" in window_section(_section("abc"), 99, 10)
+
+  def test_empty_content_at_offset_zero_is_not_an_error(self):
+    assert window_section(_section(""), 0, 10)["content"] == ""
+
+  def test_keeps_elements_and_drops_null_fields(self):
+    result = window_section(_section("x"), 0, 10)
+    assert result["xbrl_elements"] == ["us-gaap:Revenues"]
+    assert "document_title" not in result
+    assert result["next_document_id"] == "doc2"

--- a/tests/operations/search/test_client.py
+++ b/tests/operations/search/test_client.py
@@ -442,3 +442,36 @@ class TestDeleteByAccession:
       {"term": {"source_type": "narrative_section"}},
       {"term": {"accession_number": "0000066740-25-000006"}},
     ]
+
+
+class TestSnippetBudget:
+  """snippet_chars sets how many standard fragments a hit may carry."""
+
+  def _highlight(self, client, mock_opensearch, **kwargs):
+    mock_opensearch.search.return_value = {"hits": {"total": {"value": 0}, "hits": []}}
+    client.search("test", graph_id="sec", **kwargs)
+    return mock_opensearch.search.call_args.kwargs["body"]["highlight"]["fields"][
+      "content"
+    ]
+
+  def test_default_is_three_standard_fragments(self, client, mock_opensearch):
+    hl = self._highlight(client, mock_opensearch)
+    assert (hl["fragment_size"], hl["number_of_fragments"]) == (200, 3)
+
+  def test_budget_sets_fragment_count(self, client, mock_opensearch):
+    hl = self._highlight(client, mock_opensearch, snippet_chars=400)
+    assert (hl["fragment_size"], hl["number_of_fragments"]) == (200, 2)
+
+  def test_budget_below_a_fragment_shrinks_the_fragment(self, client, mock_opensearch):
+    hl = self._highlight(client, mock_opensearch, snippet_chars=120)
+    assert (hl["fragment_size"], hl["number_of_fragments"]) == (120, 1)
+
+  def test_hybrid_search_takes_the_same_budget(self, client, mock_opensearch):
+    mock_opensearch.search.return_value = {"hits": {"total": {"value": 0}, "hits": []}}
+    client.search_hybrid(
+      "test", query_embedding=[0.1] * 384, graph_id="sec", snippet_chars=1000
+    )
+    hl = mock_opensearch.search.call_args.kwargs["body"]["highlight"]["fields"][
+      "content"
+    ]
+    assert (hl["fragment_size"], hl["number_of_fragments"]) == (200, 5)

--- a/tests/operations/search/test_service.py
+++ b/tests/operations/search/test_service.py
@@ -287,3 +287,15 @@ class TestSectionParts:
     assert (section.part, section.part_count) == (3, 6)
     assert section.parent_document_id == "a1b2c3d4e5f60718"
     assert section.next_document_id == "9e8d7c6b5a493827"
+
+
+class TestSnippetCharsPassThrough:
+  def test_request_budget_reaches_the_client(self, service, mock_client):
+    mock_client.search.return_value = {"hits": {"total": {"value": 0}, "hits": []}}
+    service.search_documents("sec", SearchRequest(query="x", snippet_chars=400))
+    assert mock_client.search.call_args.kwargs["snippet_chars"] == 400
+
+  def test_default_budget_is_none(self, service, mock_client):
+    mock_client.search.return_value = {"hits": {"total": {"value": 0}, "hits": []}}
+    service.search_documents("sec", SearchRequest(query="x"))
+    assert mock_client.search.call_args.kwargs["snippet_chars"] is None


### PR DESCRIPTION
## Summary

A tool result is context the model pays for on every later turn. Measured across both published Filing Ladder runs (2,280 records, 9,900 tool calls), `search-documents` was a median 10K characters per call, 44% of it the per-section `xbrl_elements` list that no transcript used to choose a hit, and `get-document-section` returned whole ~25K-character parts to read one paragraph. This PR shrinks what those two MCP tools say while answering, without changing what they can answer. The REST search models and the graph-side retrieval (ranking, chunking, what is indexed) are untouched.

Design and measurement: `local/RoboSystems/specs/ai-operators/mcp-response-economy.md` (changes 1–4 of the six there; 5 and 6 are re-scoped in the spec rather than built).

## Changes

**`search-documents` — `middleware/mcp/tools/search_tools.py`**
- New pure function `compact_search_response`: drops `xbrl_elements` from hits (it stays on `get-document-section` for the hit the model picks, and the `element` filter still runs the other direction), drops null fields, and hoists the filing fields (`entity_ticker`, `entity_name`, `form_type`, `filing_date`, `fiscal_year`) to the result root when every hit shares the same value. Hits that span filings keep them per hit.
- New `snippet_chars` argument (default 400, min 80, max 1500), clamped in the tool.
- Description rewritten to match: a hit no longer promises `xbrl_elements`; a snippet is described as an excerpt to be read from the section before a figure is quoted from it (the description half of the *snippets get quoted as answers* row in the ai-operators README); the hoist and the new parameter are stated.

**`get-document-section` — same file**
- New `offset` + `length` arguments (default 4,000, max 8,000 — xbrlkit `read_text`'s caps, so the hosted and local document tools page the same way) via `window_section`. The result carries `content_length` for the whole part and `next_offset` while more follows; an offset past the end is an error. `xbrl_elements` and the part chain (`next_document_id`) are unchanged.

**Snippet budget plumbing** — `models/api/search.py`, `operations/search/client.py`, `operations/search/service.py`
- `SearchRequest.snippet_chars: int | None` (additive; `None` keeps today's REST behaviour).
- `OpenSearchClient._highlight_config(snippet_chars)`: fragments stay at the standard 200 characters and the budget sets how many a hit may carry, so a smaller budget shows fewer matches, not shorter ones. Threaded through both `search` and `search_hybrid`.

**Prompts and docs**
- `operations/operators/implementations/analyst.py`: the analyst's two `search-documents` guidance lines now say the section tool returns a window and to page on with `offset` rather than answering from a partial read.
- `middleware/mcp/README.md` Layer 3: describes the new hit and section shapes.

**Measured on the local MMM FY2024 10-K** (same query, before → after):

| Call | Before | After |
|---|---|---|
| 10-hit iXBRL disclosure search | 17,092 chars | 8,407 |
| 4-hit MD&A search | 4,590 | 3,240 |
| One MD&A part read (default window) | 25,227 | 4,813 |

The re-run that proves the spec's cost claim is the Filing Ladder `7a-tagged` control against a deploy carrying this change — accuracy must not move, cost should fall. Not run here; the ladder reads whatever the tools return, so it measures the change rather than breaking on it.

## Breaking Changes

None. The MCP response shape is a tool-layer change; the REST `/v1/graphs/{graph_id}/search` models are unchanged apart from the additive `snippet_chars` request field (generated tier, free — an SDK regen opportunity, not a coordinated release). Nothing outside the generated SDK models reads `xbrl_elements` from a search hit (checked the three apps, `robosystems-mcp-client`, and the Filing Ladder runner, which reads only document ids).

## Testing

- `just test-code` — passed (ruff, format, basedpyright, cf-lint).
- Targeted suites: `tests/middleware/mcp`, `tests/operations/search`, `tests/operations/operators`, `tests/routers/graphs/mcp`, `tests/routers/graphs/test_search.py`, `tests/routers/graphs/test_documents.py`, `tests/models` — 2,324 passed. New tests cover the compaction rule (drop, hoist, span-filings, missing-on-one-hit, empty, part fields, payload halves on the measured shape), the section window (whole-when-short, paging, capped length, offset past end, empty content), the snippet clamp, and the highlight config for both search modes.
- The tool-description contract test passes on the rewritten descriptions.
- Full `just test-all` not run in-session.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQNt2hdNJqbJwfoSRshaXo
