### PR TITLE
feat(ledger): native accounting cutover: provider guard, sever, chart templates

### DIFF
--- a/examples/roboledger_demo/data.py
+++ b/examples/roboledger_demo/data.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 
 from datetime import date
 
+from robosystems.operations.taxonomy_block.chart_templates.services import (
+  ACCOUNTS as ACCOUNTS,
+)
+
 # ---------------------------------------------------------------------------
 # Evergreen reference dates
 # ---------------------------------------------------------------------------
@@ -87,62 +91,7 @@ def get_month_date(start: date, offset: int, day: int = 1) -> date:
 # Chart of Accounts
 # ---------------------------------------------------------------------------
 
-ACCOUNTS = [
-  # code, name, classification, sub_classification, balance_type, parent_code
-  # Assets
-  ("1000", "Operating Checking", "asset", "cash_and_equivalents", "debit", None),
-  ("1100", "Accounts Receivable", "asset", "accounts_receivable", "debit", None),
-  ("1200", "Prepaid Insurance", "asset", "other_current_assets", "debit", None),
-  ("1210", "Prepaid Software", "asset", "other_current_assets", "debit", None),
-  ("1220", "Prepaid Cloud Hosting", "asset", "other_current_assets", "debit", None),
-  ("1300", "Computer Equipment", "asset", "fixed_assets", "debit", None),
-  ("1310", "Office Furniture", "asset", "fixed_assets", "debit", None),
-  ("1350", "Accumulated Depreciation", "asset", "fixed_assets", "credit", None),
-  # Liabilities
-  ("2000", "Accounts Payable", "liability", "accounts_payable", "credit", None),
-  (
-    "2100",
-    "Accrued Liabilities",
-    "liability",
-    "other_current_liabilities",
-    "credit",
-    None,
-  ),
-  (
-    "2200",
-    "Payroll Taxes Payable",
-    "liability",
-    "other_current_liabilities",
-    "credit",
-    None,
-  ),
-  # Equity
-  ("3000", "Owner's Equity", "equity", "equity", "credit", None),
-  ("3100", "Retained Earnings", "equity", "equity", "credit", None),
-  # Revenue
-  ("4000", "Consulting Revenue", "revenue", "operating_revenue", "credit", None),
-  ("4100", "Strategy Advisory Revenue", "revenue", "operating_revenue", "credit", None),
-  (
-    "4200",
-    "Implementation Services Revenue",
-    "revenue",
-    "operating_revenue",
-    "credit",
-    None,
-  ),
-  # Expenses
-  ("5000", "Salaries & Wages", "expense", "operating_expense", "debit", None),
-  ("5100", "Payroll Taxes", "expense", "operating_expense", "debit", None),
-  ("5200", "Health Insurance", "expense", "operating_expense", "debit", None),
-  ("6000", "Office Rent", "expense", "operating_expense", "debit", None),
-  ("6100", "Software Subscriptions", "expense", "operating_expense", "debit", None),
-  ("6200", "Cloud Hosting", "expense", "operating_expense", "debit", None),
-  ("6300", "Professional Development", "expense", "operating_expense", "debit", None),
-  ("6400", "Business Insurance", "expense", "operating_expense", "debit", None),
-  ("6500", "Office Supplies", "expense", "operating_expense", "debit", None),
-  ("6600", "Travel & Entertainment", "expense", "operating_expense", "debit", None),
-  ("7000", "Depreciation Expense", "expense", "operating_expense", "debit", None),
-]
+# ``ACCOUNTS`` is the shipped chart template — one copy, in core.
 
 
 # ---------------------------------------------------------------------------

--- a/examples/roboledger_demo/mappings.py
+++ b/examples/roboledger_demo/mappings.py
@@ -45,81 +45,10 @@ The demo resolves rs-gaap qnames → element IDs at runtime against the
 library in the entity graph.
 """
 
-# (coa_code, rs_gaap_qname)
-MAPPINGS: list[tuple[str, str]] = [
-  # Assets
-  ("1000", "rs-gaap:CashAndCashEquivalentsAtCarryingValue"),  # Cash
-  ("1100", "rs-gaap:ReceivablesNetCurrent"),  # Accounts Receivable
-  ("1200", "rs-gaap:PrepaidExpenseCurrent"),  # Prepaid Insurance
-  ("1210", "rs-gaap:PrepaidExpenseCurrent"),  # Prepaid Software
-  ("1220", "rs-gaap:PrepaidExpenseCurrent"),  # Prepaid Cloud Hosting
-  ("1300", "rs-gaap:PropertyPlantAndEquipmentGross"),  # Computer Equipment
-  ("1310", "rs-gaap:PropertyPlantAndEquipmentGross"),  # Office Furniture
-  (
-    "1350",
-    "rs-gaap:AccumulatedDepreciationDepletionAndAmortizationPropertyPlantAndEquipment",
-  ),  # Accumulated Depreciation (contra-asset)
-  # Liabilities
-  ("2000", "rs-gaap:AccountsPayableCurrent"),  # Accounts Payable
-  ("2100", "rs-gaap:AccruedLiabilitiesCurrent"),  # Accrued Liabilities
-  ("2200", "rs-gaap:AccruedLiabilitiesCurrent"),  # Payroll Taxes Payable
-  # Equity
-  ("3000", "rs-gaap:AdditionalPaidInCapital"),  # Owner's Equity
-  ("3100", "rs-gaap:RetainedEarningsAccumulatedDeficit"),  # Retained Earnings
-  # Revenue — services firm, no goods sold; everything is revenue from
-  # contracts with customers (ASC 606)
-  (
-    "4000",
-    "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-  ),  # Consulting Revenue
-  (
-    "4100",
-    "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-  ),  # Strategy Advisory Revenue
-  (
-    "4200",
-    "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax",
-  ),  # Implementation Services Revenue
-  # Operating expenses — this back-office services firm's costs are all
-  # General & Administrative (Selling & Marketing is a sibling line, unused
-  # here). Depreciation gets its own line.
-  ("5000", "rs-gaap:GeneralAndAdministrativeExpense"),  # Salaries & Wages
-  ("5100", "rs-gaap:GeneralAndAdministrativeExpense"),  # Payroll Taxes
-  ("5200", "rs-gaap:GeneralAndAdministrativeExpense"),  # Health Insurance
-  ("6000", "rs-gaap:GeneralAndAdministrativeExpense"),  # Office Rent
-  ("6100", "rs-gaap:GeneralAndAdministrativeExpense"),  # Software Subscriptions
-  ("6200", "rs-gaap:GeneralAndAdministrativeExpense"),  # Cloud Hosting
-  ("6300", "rs-gaap:GeneralAndAdministrativeExpense"),  # Professional Development
-  ("6400", "rs-gaap:GeneralAndAdministrativeExpense"),  # Business Insurance
-  ("6500", "rs-gaap:GeneralAndAdministrativeExpense"),  # Office Supplies
-  ("6600", "rs-gaap:GeneralAndAdministrativeExpense"),  # Travel & Entertainment
-  ("7000", "rs-gaap:DepreciationDepletionAndAmortization"),  # Depreciation Expense
-]
+# The mapping is the shipped chart template's — one copy, in core.
+from robosystems.operations.taxonomy_block.chart_templates.services import (
+  MAPPINGS,
+  mappings_for,
+)
 
-
-# Equity CoA (3000 Owner's Equity, 3100 Retained Earnings) maps to the
-# rs-gaap capital concept appropriate to the entity's legal form, so the
-# equity-form Reporting Style (BSC-{CORP,PART,LLC}-…) renders its native
-# capital line. Non-equity mappings are identical across forms.
-_EQUITY_BY_FORM: dict[str, list[tuple[str, str]]] = {
-  "corporation": [
-    ("3000", "rs-gaap:AdditionalPaidInCapital"),
-    ("3100", "rs-gaap:RetainedEarningsAccumulatedDeficit"),
-  ],
-  "partnership": [
-    ("3000", "rs-gaap:PartnersCapital"),
-    ("3100", "rs-gaap:PartnersCapital"),
-  ],
-  "llc": [
-    ("3000", "rs-gaap:MembersEquity"),
-    ("3100", "rs-gaap:MembersEquity"),
-  ],
-}
-
-
-def mappings_for(entity_type: str = "corporation") -> list[tuple[str, str]]:
-  """CoA→rs-gaap mappings with equity rows tuned to the entity legal form."""
-  form = (entity_type or "corporation").strip().lower()
-  equity = _EQUITY_BY_FORM.get(form, _EQUITY_BY_FORM["corporation"])
-  base = [m for m in MAPPINGS if m[0] not in ("3000", "3100")]
-  return base + equity
+__all__ = ["MAPPINGS", "mappings_for"]

--- a/examples/saas_startup_demo/data.py
+++ b/examples/saas_startup_demo/data.py
@@ -37,6 +37,7 @@ from examples._scenario.engine import (
   trailing_year,
   validate,
 )
+from robosystems.operations.taxonomy_block.chart_templates.saas import ACCOUNTS
 
 MONTHS = 16
 
@@ -44,41 +45,7 @@ MONTHS = 16
 # Chart of Accounts — (code, name, trait, sub_classification, balance_type, description)
 # ---------------------------------------------------------------------------
 
-ACCOUNTS: list[tuple[str, str, str, str, str, str | None]] = [
-  # Assets
-  ("1000", "Cash", "asset", "cash_and_equivalents", "debit", None),
-  ("1100", "Accounts Receivable", "asset", "accounts_receivable", "debit", None),
-  ("1200", "Prepaid Software", "asset", "other_current_assets", "debit", None),
-  ("1210", "Prepaid Insurance", "asset", "other_current_assets", "debit", None),
-  ("1300", "Computer Equipment", "asset", "fixed_assets", "debit", None),
-  ("1350", "Accumulated Depreciation", "asset", "fixed_assets", "credit", None),
-  # Liabilities
-  ("2000", "Accounts Payable", "liability", "accounts_payable", "credit", None),
-  (
-    "2100",
-    "Accrued Liabilities",
-    "liability",
-    "other_current_liabilities",
-    "credit",
-    None,
-  ),
-  ("2300", "Deferred Revenue", "liability", "deferred_revenue", "credit", None),
-  # Equity
-  ("3000", "Paid-in Capital", "equity", "equity", "credit", None),
-  ("3100", "Accumulated Deficit", "equity", "equity", "credit", None),
-  # Revenue
-  ("4000", "Subscription Revenue", "revenue", "operating_revenue", "credit", None),
-  ("4100", "Professional Services", "revenue", "operating_revenue", "credit", None),
-  # Cost of revenue
-  ("5000", "Cost of Revenue", "expense", "cost_of_goods_sold", "debit", None),
-  # Operating expenses
-  ("6000", "Research & Development", "expense", "operating_expense", "debit", None),
-  ("6100", "Sales & Marketing", "expense", "operating_expense", "debit", None),
-  ("6200", "General & Administrative", "expense", "operating_expense", "debit", None),
-  ("6300", "Rent", "expense", "operating_expense", "debit", None),
-  ("6400", "Software & Tools", "expense", "operating_expense", "debit", None),
-  ("7000", "Depreciation Expense", "expense", "operating_expense", "debit", None),
-]
+# ``ACCOUNTS`` is the shipped chart template — one copy, in core.
 
 # B2B customer logos — annual contracts (prepaid) + onboarding services (net-30).
 LOGOS = [

--- a/examples/saas_startup_demo/mappings.py
+++ b/examples/saas_startup_demo/mappings.py
@@ -12,59 +12,10 @@ Every target is a verified leaf of the Default Reporting Style's Networks
   support; drives the ~78% gross margin and the GrossProfit subtotal).
 """
 
-# (coa_code, rs_gaap_qname)
-MAPPINGS: list[tuple[str, str]] = [
-  # Assets
-  ("1000", "rs-gaap:CashAndCashEquivalentsAtCarryingValue"),
-  ("1100", "rs-gaap:ReceivablesNetCurrent"),
-  ("1200", "rs-gaap:PrepaidExpenseCurrent"),
-  ("1210", "rs-gaap:PrepaidExpenseCurrent"),
-  ("1300", "rs-gaap:PropertyPlantAndEquipmentGross"),
-  (
-    "1350",
-    "rs-gaap:AccumulatedDepreciationDepletionAndAmortizationPropertyPlantAndEquipment",
-  ),
-  # Liabilities
-  ("2000", "rs-gaap:AccountsPayableCurrent"),
-  ("2100", "rs-gaap:AccruedLiabilitiesCurrent"),
-  ("2300", "rs-gaap:DeferredRevenueCurrent"),  # annual-prepay float — the reveal
-  # Equity
-  ("3000", "rs-gaap:AdditionalPaidInCapital"),
-  ("3100", "rs-gaap:RetainedEarningsAccumulatedDeficit"),
-  # Revenue — subscription + services, both ASC 606
-  ("4000", "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"),
-  ("4100", "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"),
-  # Cost of revenue
-  ("5000", "rs-gaap:CostOfGoodsAndServicesSold"),
-  # Operating expenses — the SaaS burn, by function
-  ("6000", "rs-gaap:ResearchAndDevelopmentExpense"),
-  ("6100", "rs-gaap:SellingAndMarketingExpense"),
-  ("6200", "rs-gaap:GeneralAndAdministrativeExpense"),
-  ("6300", "rs-gaap:GeneralAndAdministrativeExpense"),
-  ("6400", "rs-gaap:GeneralAndAdministrativeExpense"),
-  ("7000", "rs-gaap:DepreciationDepletionAndAmortization"),
-]
+# The mapping is the shipped chart template's — one copy, in core.
+from robosystems.operations.taxonomy_block.chart_templates.saas import (
+  MAPPINGS,
+  mappings_for,
+)
 
-
-_EQUITY_BY_FORM: dict[str, list[tuple[str, str]]] = {
-  "corporation": [
-    ("3000", "rs-gaap:AdditionalPaidInCapital"),
-    ("3100", "rs-gaap:RetainedEarningsAccumulatedDeficit"),
-  ],
-  "partnership": [
-    ("3000", "rs-gaap:PartnersCapital"),
-    ("3100", "rs-gaap:PartnersCapital"),
-  ],
-  "llc": [
-    ("3000", "rs-gaap:MembersEquity"),
-    ("3100", "rs-gaap:MembersEquity"),
-  ],
-}
-
-
-def mappings_for(entity_type: str = "corporation") -> list[tuple[str, str]]:
-  """CoA→rs-gaap mappings with equity rows tuned to the entity legal form."""
-  form = (entity_type or "corporation").strip().lower()
-  equity = _EQUITY_BY_FORM.get(form, _EQUITY_BY_FORM["corporation"])
-  base = [m for m in MAPPINGS if m[0] not in ("3000", "3100")]
-  return base + equity
+__all__ = ["MAPPINGS", "mappings_for"]

--- a/robosystems/graphql/resolvers/ledger.py
+++ b/robosystems/graphql/resolvers/ledger.py
@@ -38,6 +38,7 @@ from robosystems.graphql.types.ledger import (
   AccountTreeNode,
   Agent,
   BlockedSourceGraphList,
+  ChartTemplate,
   ClosingBookStructures,
   Element,
   ElementList,
@@ -128,6 +129,9 @@ from robosystems.operations.roboledger.reports.network_picker import (
   load_primary_reporting_style,
 )
 from robosystems.operations.roboledger.schedules import ScheduleService
+from robosystems.operations.taxonomy_block.chart_templates import (
+  list_templates as list_chart_templates,
+)
 
 # Services are stateless and cheap to keep as module-level singletons —
 # matches the router-level `_svc` pattern already in place.
@@ -799,6 +803,22 @@ class LedgerQuery:
     except (ValueError, ProgrammingError):
       _raise_ledger_not_initialized()
     return PeriodCloseStatus.from_pydantic(response)
+
+  # ── Chart templates ─────────────────────────────────────────────────────
+
+  @strawberry.field
+  def chart_templates(self, info: Info[GraphQLContext, None]) -> list[ChartTemplate]:
+    """Shipped chart-of-accounts templates for `initialize-chart-of-accounts`."""
+    require_graph_id(info)
+    return [
+      ChartTemplate(
+        key=template.key,
+        display_name=template.display_name,
+        description=template.description,
+        account_count=template.account_count,
+      )
+      for template in list_chart_templates()
+    ]
 
   # ── Fiscal calendar ─────────────────────────────────────────────────────
 

--- a/robosystems/graphql/types/ledger.py
+++ b/robosystems/graphql/types/ledger.py
@@ -791,3 +791,19 @@ class MappedTrialBalanceRow:
 @pydantic_type(model=PydanticMappedTrialBalanceResponse, all_fields=True)
 class MappedTrialBalance:
   """Trial balance rolled up to reporting concepts via mapping associations."""
+
+
+# ── Chart templates ───────────────────────────────────────────────────────
+
+
+@strawberry.type(
+  description=(
+    "A shipped chart-of-accounts template for `initialize-chart-of-accounts` "
+    "— the fresh-company path to native books."
+  )
+)
+class ChartTemplate:
+  key: str
+  display_name: str
+  description: str
+  account_count: int

--- a/robosystems/models/api/extensions/__init__.py
+++ b/robosystems/models/api/extensions/__init__.py
@@ -15,6 +15,11 @@ from .ar_ap import (
   OpenBalanceAggregate,
   OpenBalanceByAgent,
 )
+from .chart_of_accounts import (
+  ChartTemplateSummary,
+  InitializeChartOfAccountsRequest,
+  InitializeChartOfAccountsResponse,
+)
 from .closing_book import (
   ClosingBookCategory,
   ClosingBookItem,
@@ -91,6 +96,7 @@ __all__ = [
   "AnalyticalStatementFactRow",
   "BindTextBlockRequest",
   "BindTextBlockResponse",
+  "ChartTemplateSummary",
   "ClosingBookCategory",
   "ClosingBookItem",
   "ClosingBookStructuresResponse",
@@ -106,6 +112,8 @@ __all__ = [
   "HoldingResponse",
   "HoldingSecuritySummary",
   "HoldingsListResponse",
+  "InitializeChartOfAccountsRequest",
+  "InitializeChartOfAccountsResponse",
   "LedgerEntryResponse",
   "LedgerJournalEntryListResponse",
   "LedgerJournalEntryResponse",

--- a/robosystems/models/api/extensions/chart_of_accounts.py
+++ b/robosystems/models/api/extensions/chart_of_accounts.py
@@ -1,0 +1,87 @@
+"""Chart-of-accounts initialization models.
+
+A graph with no chart of accounts — a company that never synced
+QuickBooks — initializes one from a shipped template. The operation is
+one-time (409 once a chart exists) and creates the chart, its
+``coa_mapping`` structure and the template's CoA → rs-gaap mapping
+associations atomically. Customization afterwards is
+``update-taxonomy-block``.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ChartTemplateKey = Literal["saas", "services", "product"]
+
+
+class InitializeChartOfAccountsRequest(BaseModel):
+  """Create the graph's chart of accounts from a shipped template.
+
+  Refused (409) when the graph already has an active ``chart_of_accounts``
+  taxonomy — a QuickBooks-synced tenant never needs this, and a chart is
+  never replaced. The template's equity rows are mapped by the entity's
+  legal form (``entity_type``: corporation / llc / partnership); omit it
+  to use the graph's primary entity, falling back to corporation.
+  """
+
+  template: ChartTemplateKey = Field(
+    ...,
+    description=(
+      "Template key: `saas` (subscription software — deferred revenue, "
+      "cost of revenue, R&D / S&M / G&A), `services` (professional "
+      "services — no inventory, no COGS), `product` (inventory and cost "
+      "of goods sold, direct + wholesale + subscription revenue)."
+    ),
+  )
+  entity_type: str | None = Field(
+    None,
+    description=(
+      "Legal form for the equity mapping: `corporation`, `llc` or "
+      "`partnership`. Defaults to the graph's primary entity, then to "
+      "corporation."
+    ),
+  )
+  name: str | None = Field(
+    None,
+    max_length=200,
+    description="Chart display name. Defaults to 'Chart of Accounts'.",
+  )
+
+  model_config = ConfigDict(
+    json_schema_extra={
+      "examples": [
+        {"template": "saas"},
+        {"template": "services", "entity_type": "llc", "name": "Cascade Books"},
+      ]
+    }
+  )
+
+
+class ChartTemplateSummary(BaseModel):
+  """One shipped chart template, for pickers."""
+
+  key: ChartTemplateKey
+  display_name: str
+  description: str
+  account_count: int = Field(..., description="Rows the template creates.")
+
+
+class InitializeChartOfAccountsResponse(BaseModel):
+  taxonomy_id: str = Field(..., description="The new chart's taxonomy id.")
+  name: str
+  template: ChartTemplateKey
+  entity_type: str = Field(
+    ..., description="Legal form the equity rows were mapped for."
+  )
+  elements_created: int
+  mappings_created: int
+  unresolved: list[str] = Field(
+    default_factory=list,
+    description=(
+      "rs-gaap qnames the template maps to that the library did not "
+      "resolve; the accounts exist and can be mapped by hand. Non-fatal."
+    ),
+  )

--- a/robosystems/models/core/connection/connection.py
+++ b/robosystems/models/core/connection/connection.py
@@ -26,6 +26,12 @@ class ConnectionStatus(str, Enum):
   longer valid (Intuit revoked / rotated past grace / scope insufficient)
   and the operator must re-OAuth. UI surfaces this as a "Reconnect" CTA
   rather than a generic "sync failed" message.
+
+  `SEVERED` is the native-accounting cutover: the tenant kept the chart the
+  synced provider created and went native. A severed row is soft-deleted
+  like any disconnect but is never revived by a later re-OAuth — the
+  provider cannot resume over books kept natively since
+  (``specs/ledger/native-accounting-cutover.md`` §3).
   """
 
   PENDING_OAUTH = "pending_oauth"
@@ -33,6 +39,7 @@ class ConnectionStatus(str, Enum):
   ERROR = "error"
   NEEDS_REAUTH = "needs_reauth"
   DISCONNECTED = "disconnected"
+  SEVERED = "severed"
 
 
 class WritePolicy(str, Enum):
@@ -315,7 +322,8 @@ class Connection(Model):
     Returns the most-recently-deleted soft-deleted connection matching
     the (graph_id, provider, realm_id) triple. Used by the OAuth
     callback to revive a prior connection rather than mint a new one
-    when the user reconnects to the same QB realm.
+    when the user reconnects to the same QB realm. A ``severed`` row is
+    never a candidate: the tenant went native on that chart.
     """
     return (
       session.query(cls)
@@ -324,6 +332,7 @@ class Connection(Model):
         cls.provider == provider,
         cls.realm_id == realm_id,
         cls.deleted_at.is_not(None),
+        cls.status != ConnectionStatus.SEVERED.value,
       )
       .order_by(cls.deleted_at.desc())
       .first()
@@ -477,9 +486,15 @@ class Connection(Model):
       raise
 
   def restore(self, session: Session) -> None:
-    """Revive a soft-deleted connection (re-OAuth reuse path)."""
+    """Revive a soft-deleted connection (re-OAuth reuse path).
+
+    Disconnect resets ``write_policy`` to ``native`` (no active
+    authoritative external GL); revival re-applies the provider default so
+    a reconnected QuickBooks is authoritative again from the first sync.
+    """
     self.deleted_at = None
     self.updated_at = datetime.now(UTC)
+    self.write_policy = default_write_policy_for_provider(self.provider)
     try:
       session.commit()
       session.refresh(self)

--- a/robosystems/operations/connection_service.py
+++ b/robosystems/operations/connection_service.py
@@ -9,9 +9,11 @@ kernel shared by the REST sync endpoint and the `sync-connection` MCP
 tool, so both surfaces validate, lock, and dispatch identically.
 """
 
+from collections.abc import Callable
 from datetime import date
 from typing import Any
 
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm import Session
 
 from robosystems.database import SessionFactory
@@ -24,6 +26,7 @@ from robosystems.models.core.connection.connection import (
 from robosystems.models.core.connection.connection_credentials import (
   ConnectionCredentials,
 )
+from robosystems.operations.roboledger.commands.connections import SEVERABLE_SOURCES
 
 # System user ID for internal operations (Dagster, background tasks)
 SYSTEM_USER_ID = "system"
@@ -590,7 +593,9 @@ class ConnectionService:
 
 # Providers that ARE the general ledger while connected: their chart is the
 # chart and their sync writes posted rows. A bank feed cannot sit beside one.
-SYNCED_LEDGER_PROVIDERS: frozenset[str] = frozenset({"quickbooks"})
+# The same set is what `sever_synced_chart` can stamp — a synced ledger is by
+# definition the thing a cutover severs — so there is one definition.
+SYNCED_LEDGER_PROVIDERS: frozenset[str] = SEVERABLE_SOURCES
 
 # Providers that capture bank activity into the inbox of natively-kept
 # books. They need a chart to resolve against and no synced GL in the way.
@@ -654,29 +659,41 @@ def assert_provider_compatible(graph_id: str, provider: str, session: Session) -
 
 
 def _graph_has_chart(graph_id: str) -> bool:
-  from robosystems.db.extensions import extensions_session
   from robosystems.operations.roboledger.reads.books import graph_has_chart
 
-  try:
-    with extensions_session(graph_id) as ext:
-      return graph_has_chart(ext)
-  except RuntimeError:
-    # No extensions schema yet (never provisioned, or deprovisioned): there
-    # is no chart to resolve against.
-    return False
+  return _probe_books(graph_id, graph_has_chart)
 
 
 def _graph_has_native_books(graph_id: str, *, synced_source: str) -> bool:
-  from robosystems.db.extensions import extensions_session
   from robosystems.operations.roboledger.reads.books import (
     graph_has_native_line_items,
   )
 
+  return _probe_books(
+    graph_id, lambda ext: graph_has_native_line_items(ext, synced_source=synced_source)
+  )
+
+
+def _probe_books(graph_id: str, predicate: Callable[[Session], bool]) -> bool:
+  """Run a books predicate on the graph's extensions schema.
+
+  A graph with no tenant schema — never provisioned (subgraphs get theirs
+  lazily from the loader's first sync), or already torn down — has no chart
+  and no books, and reads as ``False``. `extensions_session` fails closed on
+  that case with ``invalid_schema_name`` (SQLSTATE 3F000), which SQLAlchemy
+  raises as `ProgrammingError`; every other programming error is a fault and
+  surfaces.
+  """
+  from robosystems.db.extensions import extensions_session
+  from robosystems.middleware.extensions import is_schema_missing
+
   try:
     with extensions_session(graph_id) as ext:
-      return graph_has_native_line_items(ext, synced_source=synced_source)
-  except RuntimeError:
-    return False
+      return predicate(ext)
+  except ProgrammingError as exc:
+    if is_schema_missing(exc):
+      return False
+    raise
 
 
 class ConnectionSyncError(Exception):

--- a/robosystems/operations/connection_service.py
+++ b/robosystems/operations/connection_service.py
@@ -16,7 +16,11 @@ from sqlalchemy.orm import Session
 
 from robosystems.database import SessionFactory
 from robosystems.logger import logger
-from robosystems.models.core.connection.connection import Connection
+from robosystems.models.core.connection.connection import (
+  Connection,
+  ConnectionStatus,
+  WritePolicy,
+)
 from robosystems.models.core.connection.connection_credentials import (
   ConnectionCredentials,
 )
@@ -280,7 +284,13 @@ class ConnectionService:
     tenant-side events/agents/elements scoped to its ``connection_id``
     stay attached. Re-OAuthing to the same QB realm later revives this
     row in place via the OAuth callback's reuse path
-    (`routers/graphs/connections/oauth.py`).
+    (`routers/graphs/connections/oauth.py`) — unless it was severed
+    (`sever_connection`), which is the one-way cutover to native books.
+
+    ``write_policy`` falls back to ``native`` on the way out: it describes
+    a graph with an *active* authoritative external GL, and after this
+    call there is none. `Connection.restore` re-applies the provider
+    default on revival.
 
     Pass `graph_id` (the authorized URL scope) so a guessed `connection_id`
     can't delete another graph's connection.
@@ -302,6 +312,9 @@ class ConnectionService:
       if cred:
         cred.deactivate(session)
 
+      if conn.write_policy != WritePolicy.NATIVE.value:
+        conn.write_policy = WritePolicy.NATIVE.value
+
       conn.soft_delete(session)
       logger.info(f"Soft-deleted connection {connection_id}")
       return True
@@ -309,6 +322,64 @@ class ConnectionService:
     except Exception:
       logger.error("Failed to delete connection %s", connection_id, exc_info=True)
       return False
+    finally:
+      if session_created:
+        session.close()
+
+  @staticmethod
+  async def sever_connection(
+    connection_id: str,
+    user_id: str,
+    graph_id: str | None = None,
+    db_session: Session | None = None,
+  ) -> dict[str, Any]:
+    """The native-accounting cutover for a synced-ledger connection.
+
+    Stamps the chart the provider created as native-owned on the graph
+    (`sever_synced_chart`), drops ``write_policy`` to ``native`` and marks
+    the row ``severed`` so a later re-OAuth never revives it. Does NOT
+    delete the row: the caller runs provider cleanup and
+    `delete_connection` afterwards, so a failed stamp leaves the
+    connection exactly as it was.
+
+    Raises `ConnectionNotFoundError` (also for a wrong graph scope) and
+    `SeverNotSupportedError` for providers that are not a synced GL.
+    """
+    session = db_session or SessionFactory()
+    session_created = db_session is None
+
+    try:
+      conn = Connection.get_by_id(connection_id, session)
+      if not conn or (graph_id and conn.graph_id != graph_id):
+        raise ConnectionNotFoundError(connection_id)
+
+      provider = (conn.provider or "").lower()
+      if provider not in SYNCED_LEDGER_PROVIDERS:
+        raise SeverNotSupportedError(provider)
+
+      from robosystems.db.extensions import extensions_session
+      from robosystems.operations.roboledger.commands.connections import (
+        sever_synced_chart,
+      )
+
+      target_graph_id = graph_id or conn.graph_id
+      with extensions_session(target_graph_id) as ext:
+        stamped = sever_synced_chart(ext, connection_id, source=provider)
+
+      conn.set_write_policy(session, WritePolicy.NATIVE.value)
+      conn.update_status(ConnectionStatus.SEVERED.value, session)
+      logger.info(
+        "Severed connection %s (%s) on graph %s: %d elements now native",
+        connection_id,
+        provider,
+        target_graph_id,
+        stamped,
+      )
+      return {
+        "connection_id": connection_id,
+        "provider": provider,
+        "elements_severed": stamped,
+      }
     finally:
       if session_created:
         session.close()
@@ -512,12 +583,119 @@ class ConnectionService:
         session.close()
 
 
+# ---------------------------------------------------------------------------
+# Provider compatibility — native and synced ledgers never mix
+# (specs/ledger/native-accounting-cutover.md §2).
+# ---------------------------------------------------------------------------
+
+# Providers that ARE the general ledger while connected: their chart is the
+# chart and their sync writes posted rows. A bank feed cannot sit beside one.
+SYNCED_LEDGER_PROVIDERS: frozenset[str] = frozenset({"quickbooks"})
+
+# Providers that capture bank activity into the inbox of natively-kept
+# books. They need a chart to resolve against and no synced GL in the way.
+BANK_FEED_PROVIDERS: frozenset[str] = frozenset({"mercury"})
+
+
+class ProviderConflictError(Exception):
+  """A provider cannot be connected given the books the graph keeps.
+
+  ``code`` is stable for clients: ``QUICKBOOKS_ACTIVE``, ``CHART_REQUIRED``,
+  ``NATIVE_BOOKS_PRESENT``.
+  """
+
+  def __init__(self, code: str, message: str) -> None:
+    super().__init__(message)
+    self.code = code
+    self.message = message
+
+
+def assert_provider_compatible(graph_id: str, provider: str, session: Session) -> None:
+  """Refuse a provider that would mix native and synced books.
+
+  - a bank feed while a synced GL is live → ``QUICKBOOKS_ACTIVE``;
+  - a bank feed on a graph with no chart of accounts → ``CHART_REQUIRED``;
+  - a synced GL over native books (posted line items on elements it did not
+    create, or a live bank feed) → ``NATIVE_BOOKS_PRESENT``.
+
+  Anything else (``external`` sources, a second SEC repo …) passes.
+  """
+  wanted = (provider or "").lower()
+  live = {
+    (c.provider or "").lower() for c in Connection.get_all_for_graph(graph_id, session)
+  }
+
+  if wanted in BANK_FEED_PROVIDERS:
+    blocking = sorted(live & SYNCED_LEDGER_PROVIDERS)
+    if blocking:
+      raise ProviderConflictError(
+        "QUICKBOOKS_ACTIVE",
+        f"Sever the {blocking[0]} connection first — a bank feed is native "
+        "accounting, and while it is connected the synced ledger is the "
+        "source of truth for bank transactions.",
+      )
+    if not _graph_has_chart(graph_id):
+      raise ProviderConflictError(
+        "CHART_REQUIRED",
+        "Initialize a chart of accounts first (from a template, or by "
+        "severing a synced QuickBooks connection to keep its chart).",
+      )
+    return
+
+  if wanted in SYNCED_LEDGER_PROVIDERS:
+    if live & BANK_FEED_PROVIDERS or _graph_has_native_books(
+      graph_id, synced_source=wanted
+    ):
+      raise ProviderConflictError(
+        "NATIVE_BOOKS_PRESENT",
+        "This graph keeps its books natively; a synced ledger cannot become "
+        "the source of truth over them.",
+      )
+
+
+def _graph_has_chart(graph_id: str) -> bool:
+  from robosystems.db.extensions import extensions_session
+  from robosystems.operations.roboledger.reads.books import graph_has_chart
+
+  try:
+    with extensions_session(graph_id) as ext:
+      return graph_has_chart(ext)
+  except RuntimeError:
+    # No extensions schema yet (never provisioned, or deprovisioned): there
+    # is no chart to resolve against.
+    return False
+
+
+def _graph_has_native_books(graph_id: str, *, synced_source: str) -> bool:
+  from robosystems.db.extensions import extensions_session
+  from robosystems.operations.roboledger.reads.books import (
+    graph_has_native_line_items,
+  )
+
+  try:
+    with extensions_session(graph_id) as ext:
+      return graph_has_native_line_items(ext, synced_source=synced_source)
+  except RuntimeError:
+    return False
+
+
 class ConnectionSyncError(Exception):
   """Base for connection-sync dispatch failures."""
 
 
 class ConnectionNotFoundError(ConnectionSyncError):
   """Connection missing, outside the graph scope, or not owned by the caller."""
+
+
+class SeverNotSupportedError(ConnectionSyncError):
+  """Only a synced-ledger connection (QuickBooks) can be severed."""
+
+  def __init__(self, provider: str) -> None:
+    super().__init__(
+      f"Only a synced ledger connection can be severed; {provider!r} is not one. "
+      "Disconnect it instead."
+    )
+    self.provider = provider
 
 
 class ProviderUnavailableError(ConnectionSyncError):

--- a/robosystems/operations/extensions/loader.py
+++ b/robosystems/operations/extensions/loader.py
@@ -1902,15 +1902,11 @@ class OLTPLoader:
     return out
 
   # Adopts whatever active chart_of_accounts taxonomy exists, or creates one.
-
   # It never runs over natively-kept books: `assert_provider_compatible`
-
-  # (connection_service) refuses a synced GL on a graph that has any
-
+  # (connection_service) refuses a synced GL on a graph that has posted line
+  # items on elements the provider did not create
   # (specs/ledger/native-accounting-cutover.md §2), and a severed chart's
-
   # elements leave the upsert key, so the backfill below cannot touch them.
-
   def _ensure_mapping_structure(
     self,
     graph_id: str,

--- a/robosystems/operations/extensions/loader.py
+++ b/robosystems/operations/extensions/loader.py
@@ -1901,6 +1901,16 @@ class OLTPLoader:
 
     return out
 
+  # Adopts whatever active chart_of_accounts taxonomy exists, or creates one.
+
+  # It never runs over natively-kept books: `assert_provider_compatible`
+
+  # (connection_service) refuses a synced GL on a graph that has any
+
+  # (specs/ledger/native-accounting-cutover.md §2), and a severed chart's
+
+  # elements leave the upsert key, so the backfill below cannot touch them.
+
   def _ensure_mapping_structure(
     self,
     graph_id: str,

--- a/robosystems/operations/roboledger/commands/chart_of_accounts.py
+++ b/robosystems/operations/roboledger/commands/chart_of_accounts.py
@@ -1,0 +1,228 @@
+"""Initialize a chart of accounts from a shipped template.
+
+The fresh-company half of the native accounting cutover
+(``specs/ledger/native-accounting-cutover.md`` §4). A QuickBooks-synced
+tenant never needs this — its chart arrives with the sync and stays the
+chart after a sever. A company with no chart initializes one here, once,
+and customizes it with ``update-taxonomy-block``.
+
+Two steps, one transaction: the Taxonomy Block envelope (chart + the
+``coa_mapping`` structure) through the declarative CoA handler, then the
+template's CoA → rs-gaap mapping associations resolved against the library.
+The handler resolves association refs only against envelope-local qnames,
+so the library targets are a second step — the demo runner does the same
+two steps over HTTP; here they are one unit of work.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from robosystems.logger import logger
+from robosystems.models.api.extensions.chart_of_accounts import (
+  InitializeChartOfAccountsRequest,
+  InitializeChartOfAccountsResponse,
+)
+from robosystems.models.api.extensions.taxonomies import (
+  CreateMappingAssociationOperation,
+)
+from robosystems.models.api.taxonomy_block import (
+  CreateTaxonomyBlockRequest,
+  TaxonomyBlockElementRequest,
+  TaxonomyBlockStructureRequest,
+)
+from robosystems.models.extensions import Element, Structure, Taxonomy
+from robosystems.operations.roboledger.commands.taxonomies import (
+  MappingAssociationExistsError,
+  create_mapping_association,
+)
+from robosystems.operations.roboledger.reads.entity import resolve_parent_entity
+from robosystems.operations.taxonomy_block.chart_of_accounts import (
+  create as create_chart_block,
+)
+from robosystems.operations.taxonomy_block.chart_templates import get_template
+
+COA_TAXONOMY_TYPE = "chart_of_accounts"
+MAPPING_STRUCTURE_NAME = "CoA to US GAAP Mapping"
+DEFAULT_CHART_NAME = "Chart of Accounts"
+DEFAULT_ENTITY_TYPE = "corporation"
+
+
+class ChartAlreadyExistsError(ValueError):
+  """The graph already has an active chart of accounts."""
+
+  def __init__(self, taxonomy_id: str) -> None:
+    super().__init__(
+      "This graph already has a chart of accounts; a chart is never "
+      "replaced. Customize it with update-taxonomy-block."
+    )
+    self.taxonomy_id = taxonomy_id
+
+
+class ChartTemplateNotFoundError(LookupError):
+  def __init__(self, key: str) -> None:
+    super().__init__(f"Unknown chart template {key!r}.")
+    self.key = key
+
+
+def active_chart_id(session: Session) -> str | None:
+  """The graph's active ``chart_of_accounts`` taxonomy id, if any."""
+  return session.execute(
+    select(Taxonomy.id)
+    .where(
+      Taxonomy.taxonomy_type == COA_TAXONOMY_TYPE,
+      Taxonomy.is_active.is_(True),
+    )
+    .order_by(Taxonomy.created_at)
+    .limit(1)
+  ).scalar_one_or_none()
+
+
+def initialize_chart_of_accounts(
+  session: Session,
+  body: InitializeChartOfAccountsRequest,
+  created_by: str,
+) -> InitializeChartOfAccountsResponse:
+  template = get_template(body.template)
+  if template is None:
+    raise ChartTemplateNotFoundError(body.template)
+
+  existing = active_chart_id(session)
+  if existing is not None:
+    raise ChartAlreadyExistsError(existing)
+
+  entity_type = _resolve_entity_type(session, body.entity_type)
+  name = (body.name or "").strip() or DEFAULT_CHART_NAME
+
+  payload = CreateTaxonomyBlockRequest(
+    name=name,
+    taxonomy_type=COA_TAXONOMY_TYPE,
+    description=f"{template.display_name} chart, initialized from a template.",
+    elements=[
+      TaxonomyBlockElementRequest(
+        qname=f"coa:{code}",
+        name=account_name,
+        trait=trait,
+        balance_type=balance_type,
+        description=description,
+        code=code,
+        sub_classification=sub_classification,
+      )
+      for (
+        code,
+        account_name,
+        trait,
+        sub_classification,
+        balance_type,
+        description,
+      ) in template.accounts
+    ],
+    structures=[
+      TaxonomyBlockStructureRequest(
+        name=MAPPING_STRUCTURE_NAME,
+        block_type="coa_mapping",
+        description="Maps the chart of accounts to rs-gaap reporting concepts.",
+      )
+    ],
+    metadata={"template": template.key, "entity_type": entity_type},
+  )
+  taxonomy_id = create_chart_block(session, payload, created_by)
+
+  mappings_created, unresolved = _create_template_mappings(
+    session,
+    taxonomy_id=taxonomy_id,
+    mappings=template.mappings_for(entity_type),
+    created_by=created_by,
+  )
+
+  logger.info(
+    "Initialized chart of accounts %s from template %s (%d elements, "
+    "%d mappings, %d unresolved)",
+    taxonomy_id,
+    template.key,
+    len(template.accounts),
+    mappings_created,
+    len(unresolved),
+  )
+  return InitializeChartOfAccountsResponse(
+    taxonomy_id=taxonomy_id,
+    name=name,
+    template=template.key,  # type: ignore[arg-type]
+    entity_type=entity_type,
+    elements_created=len(template.accounts),
+    mappings_created=mappings_created,
+    unresolved=unresolved,
+  )
+
+
+def _resolve_entity_type(session: Session, requested: str | None) -> str:
+  if requested and requested.strip():
+    return requested.strip().lower()
+  entity = resolve_parent_entity(session)
+  form = getattr(entity, "entity_type", None) if entity is not None else None
+  return (form or DEFAULT_ENTITY_TYPE).strip().lower()
+
+
+def _create_template_mappings(
+  session: Session,
+  *,
+  taxonomy_id: str,
+  mappings: list[tuple[str, str]],
+  created_by: str,
+) -> tuple[int, list[str]]:
+  """Map the new chart's elements to the library; return (created, unresolved)."""
+  structure_id = session.execute(
+    select(Structure.id).where(
+      Structure.taxonomy_id == taxonomy_id,
+      Structure.block_type == "coa_mapping",
+    )
+  ).scalar_one()
+
+  coa_rows = session.execute(
+    select(Element.code, Element.id).where(Element.taxonomy_id == taxonomy_id)
+  ).all()
+  coa_by_code: dict[str, str] = {str(code): str(eid) for code, eid in coa_rows}
+
+  targets = sorted({qname for _code, qname in mappings})
+  library_rows = session.execute(
+    select(Element.qname, Element.id).where(
+      Element.source == "rs-gaap", Element.qname.in_(targets)
+    )
+  ).all()
+  library_by_qname: dict[str, str] = {
+    str(qname): str(eid) for qname, eid in library_rows
+  }
+
+  created = 0
+  unresolved: list[str] = []
+  for code, qname in mappings:
+    from_id = coa_by_code.get(code)
+    to_id = library_by_qname.get(qname)
+    if from_id is None:
+      # A template whose mapping names a code it does not declare is a
+      # template bug; report it as unresolved rather than failing the
+      # chart the customer can already use.
+      unresolved.append(f"{code} -> {qname} (no such account in template)")
+      continue
+    if to_id is None:
+      if qname not in unresolved:
+        unresolved.append(qname)
+      continue
+    try:
+      create_mapping_association(
+        session,
+        CreateMappingAssociationOperation(
+          mapping_id=structure_id,
+          from_element_id=from_id,
+          to_element_id=to_id,
+          association_type="mapping",
+          suggested_by="template",
+        ),
+        created_by,
+      )
+    except MappingAssociationExistsError:
+      continue
+    created += 1
+
+  return created, unresolved

--- a/robosystems/operations/roboledger/commands/chart_of_accounts.py
+++ b/robosystems/operations/roboledger/commands/chart_of_accounts.py
@@ -42,11 +42,11 @@ from robosystems.operations.taxonomy_block.chart_of_accounts import (
   create as create_chart_block,
 )
 from robosystems.operations.taxonomy_block.chart_templates import get_template
+from robosystems.operations.taxonomy_block.chart_templates._forms import resolve_form
 
 COA_TAXONOMY_TYPE = "chart_of_accounts"
 MAPPING_STRUCTURE_NAME = "CoA to US GAAP Mapping"
 DEFAULT_CHART_NAME = "Chart of Accounts"
-DEFAULT_ENTITY_TYPE = "corporation"
 
 
 class ChartAlreadyExistsError(ValueError):
@@ -157,11 +157,14 @@ def initialize_chart_of_accounts(
 
 
 def _resolve_entity_type(session: Session, requested: str | None) -> str:
+  """The legal form the equity rows are mapped for — always one of the
+  forms `_forms.EQUITY_BY_FORM` knows, so the response and the taxonomy
+  metadata record what was actually applied rather than the request string."""
   if requested and requested.strip():
-    return requested.strip().lower()
+    return resolve_form(requested)
   entity = resolve_parent_entity(session)
   form = getattr(entity, "entity_type", None) if entity is not None else None
-  return (form or DEFAULT_ENTITY_TYPE).strip().lower()
+  return resolve_form(form)
 
 
 def _create_template_mappings(

--- a/robosystems/operations/roboledger/commands/connections.py
+++ b/robosystems/operations/roboledger/commands/connections.py
@@ -1,0 +1,49 @@
+"""Graph-side effects of a connection lifecycle event.
+
+The sever half of the native accounting cutover
+(``specs/ledger/native-accounting-cutover.md`` §3): when a QuickBooks
+tenant goes native, the chart QuickBooks created becomes the tenant's own.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import update
+from sqlalchemy.orm import Session
+
+from robosystems.models.extensions import Element
+
+SEVERABLE_SOURCES: frozenset[str] = frozenset({"quickbooks"})
+
+
+def sever_synced_chart(
+  session: Session, connection_id: str, *, source: str = "quickbooks"
+) -> int:
+  """Stamp the elements a synced connection created as native-owned.
+
+  One statement does three jobs. Nulling ``external_source`` /
+  ``connection_id`` / ``external_id`` takes the rows out of the loader's
+  upsert key (``idx_elements_upsert_key``), so a later sync of the same
+  provider can neither overwrite nor re-adopt them and the trait heal never
+  sees them. ``source='native'`` keeps them visible as chart accounts
+  (``native`` is in ``COA_SOURCES``) and marks them editable. The qname is
+  kept: facts, associations, line items and reports reference element ids,
+  and a rename would reopen the adapter's qname-collision path.
+
+  Returns the number of elements stamped.
+  """
+  if source not in SEVERABLE_SOURCES:
+    raise ValueError(f"{source!r} connections cannot be severed")
+  result = session.execute(
+    update(Element)
+    .where(
+      Element.external_source == source,
+      Element.connection_id == connection_id,
+    )
+    .values(
+      source="native",
+      external_source=None,
+      connection_id=None,
+      external_id=None,
+    )
+  )
+  return int(result.rowcount or 0)

--- a/robosystems/operations/roboledger/reads/books.py
+++ b/robosystems/operations/roboledger/reads/books.py
@@ -1,0 +1,50 @@
+"""What kind of books a graph keeps — the predicates behind the provider guard.
+
+``specs/ledger/native-accounting-cutover.md`` §2: native and synced ledgers
+never mix. A bank feed needs a chart to resolve against and cannot sit
+beside a live QuickBooks connection; QuickBooks cannot become the source
+of truth over books a tenant already keeps natively.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import exists, select
+from sqlalchemy.orm import Session
+
+from robosystems.models.extensions import Element, LineItem, Taxonomy
+
+COA_TAXONOMY_TYPE = "chart_of_accounts"
+
+
+def graph_has_chart(session: Session) -> bool:
+  """True when the graph has an active ``chart_of_accounts`` taxonomy."""
+  return bool(
+    session.execute(
+      select(
+        exists().where(
+          Taxonomy.taxonomy_type == COA_TAXONOMY_TYPE,
+          Taxonomy.is_active.is_(True),
+        )
+      )
+    ).scalar()
+  )
+
+
+def graph_has_native_line_items(session: Session, *, synced_source: str) -> bool:
+  """True when posted line items sit on elements ``synced_source`` did not create.
+
+  A tenant whose only chart came from ``synced_source`` (and whose manual
+  entries post to that chart) has none. A severed tenant has them by
+  construction — its elements are ``native`` and carry the history — which
+  is what makes the QuickBooks → native lifecycle one-way.
+  """
+  return bool(
+    session.execute(
+      select(
+        exists().where(
+          LineItem.element_id == Element.id,
+          Element.source != synced_source,
+        )
+      )
+    ).scalar()
+  )

--- a/robosystems/operations/taxonomy_block/chart_templates/__init__.py
+++ b/robosystems/operations/taxonomy_block/chart_templates/__init__.py
@@ -1,0 +1,97 @@
+"""Shipped chart-of-accounts templates — read-only starting points.
+
+A template is a chart (``ACCOUNTS`` rows) plus its CoA → rs-gaap mapping
+(``mappings_for(entity_type)``), promoted out of ``examples/`` so a fresh
+company can initialize its books from one operation
+(``initialize-chart-of-accounts``) instead of importing them. Templates
+are starting points, never a lock-in: customization is
+``update-taxonomy-block`` afterwards.
+
+Doctrine (``specs/ledger/native-accounting-cutover.md`` §4, from the
+Mercury adapter spec §8.1): no chart is ever created by default, native
+and synced ledgers never mix, and initializing a chart is an explicit
+action.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from . import product, saas, services
+
+# One chart row: (code, name, trait, sub_classification, balance_type,
+# description). ``trait`` is the FASB metamodel trait (asset / liability /
+# equity / revenue / expense); ``balance_type`` is "debit" | "credit".
+Account = tuple[str, str, str, str, str, str | None]
+
+
+@dataclass(frozen=True)
+class ChartTemplate:
+  key: str
+  display_name: str
+  description: str
+  accounts: list[Account]
+  mappings_for: Callable[[str], list[tuple[str, str]]]
+
+  @property
+  def account_count(self) -> int:
+    return len(self.accounts)
+
+
+CHART_TEMPLATES: dict[str, ChartTemplate] = {
+  "saas": ChartTemplate(
+    key="saas",
+    display_name="SaaS / subscription software",
+    description=(
+      "Recurring revenue with annual prepayment (deferred revenue), cost of "
+      "revenue, and operating expenses by function — R&D, sales & marketing, "
+      "G&A. Cash, AR, prepaids, equipment."
+    ),
+    accounts=saas.ACCOUNTS,
+    mappings_for=saas.mappings_for,
+  ),
+  "services": ChartTemplate(
+    key="services",
+    display_name="Professional services",
+    description=(
+      "Consulting, advisory and implementation revenue; payroll-led operating "
+      "expenses; no inventory and no cost of goods sold. Cash, AR, prepaids, "
+      "equipment, payroll liabilities."
+    ),
+    accounts=services.ACCOUNTS,
+    mappings_for=services.mappings_for,
+  ),
+  "product": ChartTemplate(
+    key="product",
+    display_name="Product business (inventory and COGS)",
+    description=(
+      "Goods sold direct and wholesale, subscription revenue with deferred "
+      "revenue, three-stage inventory (raw materials, work in process, "
+      "finished goods), cost of goods sold, production equipment, "
+      "fulfillment and marketing expenses."
+    ),
+    accounts=product.ACCOUNTS,
+    mappings_for=product.mappings_for,
+  ),
+}
+
+TEMPLATE_KEYS: tuple[str, ...] = tuple(CHART_TEMPLATES)
+
+
+def get_template(key: str) -> ChartTemplate | None:
+  return CHART_TEMPLATES.get((key or "").strip().lower())
+
+
+def list_templates() -> list[ChartTemplate]:
+  return list(CHART_TEMPLATES.values())
+
+
+__all__ = [
+  "CHART_TEMPLATES",
+  "TEMPLATE_KEYS",
+  "Account",
+  "ChartTemplate",
+  "get_template",
+  "list_templates",
+]

--- a/robosystems/operations/taxonomy_block/chart_templates/_forms.py
+++ b/robosystems/operations/taxonomy_block/chart_templates/_forms.py
@@ -26,14 +26,23 @@ EQUITY_BY_FORM: dict[str, list[tuple[str, str]]] = {
 }
 
 
+DEFAULT_FORM = "corporation"
+
+
+def resolve_form(entity_type: str | None) -> str:
+  """The legal form the equity rows are mapped for.
+
+  Unknown or empty forms resolve to ``corporation`` — this is the value a
+  caller should record and report, not the raw request string.
+  """
+  form = (entity_type or "").strip().lower()
+  return form if form in EQUITY_BY_FORM else DEFAULT_FORM
+
+
 def form_aware(
   mappings: list[tuple[str, str]], entity_type: str | None
 ) -> list[tuple[str, str]]:
-  """``mappings`` with the equity rows swapped for the entity's legal form.
-
-  Unknown or empty forms fall back to the corporation rows.
-  """
-  form = (entity_type or "corporation").strip().lower()
-  equity = EQUITY_BY_FORM.get(form, EQUITY_BY_FORM["corporation"])
+  """``mappings`` with the equity rows swapped for the entity's legal form."""
+  equity = EQUITY_BY_FORM[resolve_form(entity_type)]
   base = [m for m in mappings if m[0] not in EQUITY_CODES]
   return base + equity

--- a/robosystems/operations/taxonomy_block/chart_templates/_forms.py
+++ b/robosystems/operations/taxonomy_block/chart_templates/_forms.py
@@ -1,0 +1,39 @@
+"""Equity rows by entity legal form — shared by every template.
+
+The two equity accounts (3000 / 3100) map to the rs-gaap capital concept
+that matches the entity's legal form, so the equity-form Reporting Style
+renders its native capital line. Non-equity mappings are identical across
+forms.
+"""
+
+from __future__ import annotations
+
+EQUITY_CODES: tuple[str, str] = ("3000", "3100")
+
+EQUITY_BY_FORM: dict[str, list[tuple[str, str]]] = {
+  "corporation": [
+    ("3000", "rs-gaap:AdditionalPaidInCapital"),
+    ("3100", "rs-gaap:RetainedEarningsAccumulatedDeficit"),
+  ],
+  "partnership": [
+    ("3000", "rs-gaap:PartnersCapital"),
+    ("3100", "rs-gaap:PartnersCapital"),
+  ],
+  "llc": [
+    ("3000", "rs-gaap:MembersEquity"),
+    ("3100", "rs-gaap:MembersEquity"),
+  ],
+}
+
+
+def form_aware(
+  mappings: list[tuple[str, str]], entity_type: str | None
+) -> list[tuple[str, str]]:
+  """``mappings`` with the equity rows swapped for the entity's legal form.
+
+  Unknown or empty forms fall back to the corporation rows.
+  """
+  form = (entity_type or "corporation").strip().lower()
+  equity = EQUITY_BY_FORM.get(form, EQUITY_BY_FORM["corporation"])
+  base = [m for m in mappings if m[0] not in EQUITY_CODES]
+  return base + equity

--- a/robosystems/operations/taxonomy_block/chart_templates/product.py
+++ b/robosystems/operations/taxonomy_block/chart_templates/product.py
@@ -1,0 +1,118 @@
+"""Product business — the ``product`` chart template.
+
+Derived from ``examples/coffee_roaster_demo`` (Driftline Coffee Roasters):
+same codes, traits, sub-classifications and mappings, with the
+roaster-specific names generalized (``Inventory — Green Coffee`` →
+``Inventory — Raw Materials``, ``Roastery Rent`` → ``Facility Rent`` …).
+The demo keeps its own names; ``tests/operations/taxonomy_block/
+test_chart_templates.py`` pins the structural equality so the two cannot
+drift on anything but the label.
+
+The leaves that make a product company's working-capital story renderable
+under the Default Reporting Style, and that a services business never
+needs: inventory → ``rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings``
+(the Classified-BS inventory leaf), deferred subscription revenue →
+``rs-gaap:DeferredRevenueCurrent``, COGS → ``rs-gaap:CostOfGoodsAndServicesSold``
+(the Multi-step IS leaf behind ``GrossProfit``).
+"""
+
+from __future__ import annotations
+
+from ._forms import form_aware
+
+# (code, name, trait, sub_classification, balance_type, description)
+ACCOUNTS: list[tuple[str, str, str, str, str, str | None]] = [
+  # Assets
+  ("1000", "Operating Checking", "asset", "cash_and_equivalents", "debit", None),
+  ("1100", "Accounts Receivable", "asset", "accounts_receivable", "debit", None),
+  ("1200", "Prepaid Insurance", "asset", "other_current_assets", "debit", None),
+  ("1210", "Prepaid Software", "asset", "other_current_assets", "debit", None),
+  ("1220", "Prepaid Fulfillment", "asset", "other_current_assets", "debit", None),
+  ("1400", "Inventory — Raw Materials", "asset", "inventory", "debit", None),
+  ("1410", "Inventory — Work in Process", "asset", "inventory", "debit", None),
+  ("1420", "Inventory — Finished Goods", "asset", "inventory", "debit", None),
+  ("1500", "Production Equipment", "asset", "fixed_assets", "debit", None),
+  ("1550", "Accumulated Depreciation", "asset", "fixed_assets", "credit", None),
+  # Liabilities
+  ("2000", "Accounts Payable", "liability", "accounts_payable", "credit", None),
+  (
+    "2100",
+    "Accrued Liabilities",
+    "liability",
+    "other_current_liabilities",
+    "credit",
+    None,
+  ),
+  (
+    "2300",
+    "Deferred Subscription Revenue",
+    "liability",
+    "deferred_revenue",
+    "credit",
+    None,
+  ),
+  # Equity
+  ("3000", "Paid-in Capital", "equity", "equity", "credit", None),
+  ("3100", "Retained Earnings", "equity", "equity", "credit", None),
+  # Revenue
+  ("4000", "Subscription Revenue", "revenue", "operating_revenue", "credit", None),
+  ("4100", "Wholesale Revenue", "revenue", "operating_revenue", "credit", None),
+  ("4200", "Direct Sales Revenue", "revenue", "operating_revenue", "credit", None),
+  # Cost of goods sold
+  ("5000", "Cost of Goods Sold", "expense", "cost_of_goods_sold", "debit", None),
+  # Operating expenses
+  ("6000", "Salaries & Wages", "expense", "operating_expense", "debit", None),
+  ("6100", "Facility Rent", "expense", "operating_expense", "debit", None),
+  ("6200", "Fulfillment & Shipping", "expense", "operating_expense", "debit", None),
+  ("6300", "Marketing & Advertising", "expense", "operating_expense", "debit", None),
+  ("6400", "Software & Subscriptions", "expense", "operating_expense", "debit", None),
+  ("6500", "Insurance", "expense", "operating_expense", "debit", None),
+  ("6600", "Utilities & Supplies", "expense", "operating_expense", "debit", None),
+  ("7000", "Depreciation Expense", "expense", "operating_expense", "debit", None),
+]
+
+# (coa_code, rs_gaap_qname) — corporation form; see ``mappings_for``.
+MAPPINGS: list[tuple[str, str]] = [
+  # Assets
+  ("1000", "rs-gaap:CashAndCashEquivalentsAtCarryingValue"),
+  ("1100", "rs-gaap:ReceivablesNetCurrent"),
+  ("1200", "rs-gaap:PrepaidExpenseCurrent"),
+  ("1210", "rs-gaap:PrepaidExpenseCurrent"),
+  ("1220", "rs-gaap:PrepaidExpenseCurrent"),
+  # All three inventory stages map to the same Classified-BS leaf.
+  ("1400", "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"),
+  ("1410", "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"),
+  ("1420", "rs-gaap:InventoryNetOfAllowancesCustomerAdvancesAndProgressBillings"),
+  ("1500", "rs-gaap:PropertyPlantAndEquipmentGross"),
+  (
+    "1550",
+    "rs-gaap:AccumulatedDepreciationDepletionAndAmortizationPropertyPlantAndEquipment",
+  ),
+  # Liabilities
+  ("2000", "rs-gaap:AccountsPayableCurrent"),
+  ("2100", "rs-gaap:AccruedLiabilitiesCurrent"),
+  ("2300", "rs-gaap:DeferredRevenueCurrent"),
+  # Equity
+  ("3000", "rs-gaap:AdditionalPaidInCapital"),
+  ("3100", "rs-gaap:RetainedEarningsAccumulatedDeficit"),
+  # Revenue — all ASC 606 revenue from contracts with customers
+  ("4000", "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"),
+  ("4100", "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"),
+  ("4200", "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"),
+  # COGS — a clean gross margin line
+  ("5000", "rs-gaap:CostOfGoodsAndServicesSold"),
+  # Operating expenses — back-office costs are G&A; demand-gen is Selling & Marketing
+  ("6000", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("6100", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("6200", "rs-gaap:SellingAndMarketingExpense"),
+  ("6300", "rs-gaap:SellingAndMarketingExpense"),
+  ("6400", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("6500", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("6600", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("7000", "rs-gaap:DepreciationDepletionAndAmortization"),
+]
+
+
+def mappings_for(entity_type: str = "corporation") -> list[tuple[str, str]]:
+  """CoA→rs-gaap mappings with equity rows tuned to the entity legal form."""
+  return form_aware(MAPPINGS, entity_type)

--- a/robosystems/operations/taxonomy_block/chart_templates/saas.py
+++ b/robosystems/operations/taxonomy_block/chart_templates/saas.py
@@ -1,0 +1,86 @@
+"""SaaS / subscription software — the ``saas`` chart template.
+
+Lifted verbatim from ``examples/saas_startup_demo`` (Cadence Labs), which
+now imports it from here so there is one copy. Every mapping target is a
+leaf admitted by the Default Reporting Style's Networks (Classified BS /
+Multi-step IS); a fact mapped outside them is dropped as out of structure.
+"""
+
+from __future__ import annotations
+
+from ._forms import form_aware
+
+# (code, name, trait, sub_classification, balance_type, description)
+ACCOUNTS: list[tuple[str, str, str, str, str, str | None]] = [
+  # Assets
+  ("1000", "Cash", "asset", "cash_and_equivalents", "debit", None),
+  ("1100", "Accounts Receivable", "asset", "accounts_receivable", "debit", None),
+  ("1200", "Prepaid Software", "asset", "other_current_assets", "debit", None),
+  ("1210", "Prepaid Insurance", "asset", "other_current_assets", "debit", None),
+  ("1300", "Computer Equipment", "asset", "fixed_assets", "debit", None),
+  ("1350", "Accumulated Depreciation", "asset", "fixed_assets", "credit", None),
+  # Liabilities
+  ("2000", "Accounts Payable", "liability", "accounts_payable", "credit", None),
+  (
+    "2100",
+    "Accrued Liabilities",
+    "liability",
+    "other_current_liabilities",
+    "credit",
+    None,
+  ),
+  ("2300", "Deferred Revenue", "liability", "deferred_revenue", "credit", None),
+  # Equity
+  ("3000", "Paid-in Capital", "equity", "equity", "credit", None),
+  ("3100", "Accumulated Deficit", "equity", "equity", "credit", None),
+  # Revenue
+  ("4000", "Subscription Revenue", "revenue", "operating_revenue", "credit", None),
+  ("4100", "Professional Services", "revenue", "operating_revenue", "credit", None),
+  # Cost of revenue
+  ("5000", "Cost of Revenue", "expense", "cost_of_goods_sold", "debit", None),
+  # Operating expenses
+  ("6000", "Research & Development", "expense", "operating_expense", "debit", None),
+  ("6100", "Sales & Marketing", "expense", "operating_expense", "debit", None),
+  ("6200", "General & Administrative", "expense", "operating_expense", "debit", None),
+  ("6300", "Rent", "expense", "operating_expense", "debit", None),
+  ("6400", "Software & Tools", "expense", "operating_expense", "debit", None),
+  ("7000", "Depreciation Expense", "expense", "operating_expense", "debit", None),
+]
+
+# (coa_code, rs_gaap_qname) — corporation form; see ``mappings_for``.
+MAPPINGS: list[tuple[str, str]] = [
+  # Assets
+  ("1000", "rs-gaap:CashAndCashEquivalentsAtCarryingValue"),
+  ("1100", "rs-gaap:ReceivablesNetCurrent"),
+  ("1200", "rs-gaap:PrepaidExpenseCurrent"),
+  ("1210", "rs-gaap:PrepaidExpenseCurrent"),
+  ("1300", "rs-gaap:PropertyPlantAndEquipmentGross"),
+  (
+    "1350",
+    "rs-gaap:AccumulatedDepreciationDepletionAndAmortizationPropertyPlantAndEquipment",
+  ),
+  # Liabilities
+  ("2000", "rs-gaap:AccountsPayableCurrent"),
+  ("2100", "rs-gaap:AccruedLiabilitiesCurrent"),
+  ("2300", "rs-gaap:DeferredRevenueCurrent"),
+  # Equity
+  ("3000", "rs-gaap:AdditionalPaidInCapital"),
+  ("3100", "rs-gaap:RetainedEarningsAccumulatedDeficit"),
+  # Revenue — subscription + services, both ASC 606
+  ("4000", "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"),
+  ("4100", "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"),
+  # Cost of revenue
+  ("5000", "rs-gaap:CostOfGoodsAndServicesSold"),
+  # Operating expenses — the SaaS burn, by function
+  ("6000", "rs-gaap:ResearchAndDevelopmentExpense"),
+  ("6100", "rs-gaap:SellingAndMarketingExpense"),
+  ("6200", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("6300", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("6400", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("7000", "rs-gaap:DepreciationDepletionAndAmortization"),
+]
+
+
+def mappings_for(entity_type: str = "corporation") -> list[tuple[str, str]]:
+  """CoA→rs-gaap mappings with equity rows tuned to the entity legal form."""
+  return form_aware(MAPPINGS, entity_type)

--- a/robosystems/operations/taxonomy_block/chart_templates/services.py
+++ b/robosystems/operations/taxonomy_block/chart_templates/services.py
@@ -1,0 +1,113 @@
+"""Professional services — the ``services`` chart template.
+
+Lifted verbatim from ``examples/roboledger_demo`` (Cascade Advisory
+Group), which now imports it from here so there is one copy. A services
+firm has no goods sold and no R&D: revenue is ASC 606 revenue from
+contracts with customers, and every operating cost that is not
+depreciation rolls to General & Administrative.
+"""
+
+from __future__ import annotations
+
+from ._forms import form_aware
+
+# (code, name, trait, sub_classification, balance_type, description)
+ACCOUNTS: list[tuple[str, str, str, str, str, str | None]] = [
+  # Assets
+  ("1000", "Operating Checking", "asset", "cash_and_equivalents", "debit", None),
+  ("1100", "Accounts Receivable", "asset", "accounts_receivable", "debit", None),
+  ("1200", "Prepaid Insurance", "asset", "other_current_assets", "debit", None),
+  ("1210", "Prepaid Software", "asset", "other_current_assets", "debit", None),
+  ("1220", "Prepaid Cloud Hosting", "asset", "other_current_assets", "debit", None),
+  ("1300", "Computer Equipment", "asset", "fixed_assets", "debit", None),
+  ("1310", "Office Furniture", "asset", "fixed_assets", "debit", None),
+  ("1350", "Accumulated Depreciation", "asset", "fixed_assets", "credit", None),
+  # Liabilities
+  ("2000", "Accounts Payable", "liability", "accounts_payable", "credit", None),
+  (
+    "2100",
+    "Accrued Liabilities",
+    "liability",
+    "other_current_liabilities",
+    "credit",
+    None,
+  ),
+  (
+    "2200",
+    "Payroll Taxes Payable",
+    "liability",
+    "other_current_liabilities",
+    "credit",
+    None,
+  ),
+  # Equity
+  ("3000", "Owner's Equity", "equity", "equity", "credit", None),
+  ("3100", "Retained Earnings", "equity", "equity", "credit", None),
+  # Revenue
+  ("4000", "Consulting Revenue", "revenue", "operating_revenue", "credit", None),
+  ("4100", "Strategy Advisory Revenue", "revenue", "operating_revenue", "credit", None),
+  (
+    "4200",
+    "Implementation Services Revenue",
+    "revenue",
+    "operating_revenue",
+    "credit",
+    None,
+  ),
+  # Expenses
+  ("5000", "Salaries & Wages", "expense", "operating_expense", "debit", None),
+  ("5100", "Payroll Taxes", "expense", "operating_expense", "debit", None),
+  ("5200", "Health Insurance", "expense", "operating_expense", "debit", None),
+  ("6000", "Office Rent", "expense", "operating_expense", "debit", None),
+  ("6100", "Software Subscriptions", "expense", "operating_expense", "debit", None),
+  ("6200", "Cloud Hosting", "expense", "operating_expense", "debit", None),
+  ("6300", "Professional Development", "expense", "operating_expense", "debit", None),
+  ("6400", "Business Insurance", "expense", "operating_expense", "debit", None),
+  ("6500", "Office Supplies", "expense", "operating_expense", "debit", None),
+  ("6600", "Travel & Entertainment", "expense", "operating_expense", "debit", None),
+  ("7000", "Depreciation Expense", "expense", "operating_expense", "debit", None),
+]
+
+# (coa_code, rs_gaap_qname) — corporation form; see ``mappings_for``.
+MAPPINGS: list[tuple[str, str]] = [
+  # Assets
+  ("1000", "rs-gaap:CashAndCashEquivalentsAtCarryingValue"),
+  ("1100", "rs-gaap:ReceivablesNetCurrent"),
+  ("1200", "rs-gaap:PrepaidExpenseCurrent"),
+  ("1210", "rs-gaap:PrepaidExpenseCurrent"),
+  ("1220", "rs-gaap:PrepaidExpenseCurrent"),
+  ("1300", "rs-gaap:PropertyPlantAndEquipmentGross"),
+  ("1310", "rs-gaap:PropertyPlantAndEquipmentGross"),
+  (
+    "1350",
+    "rs-gaap:AccumulatedDepreciationDepletionAndAmortizationPropertyPlantAndEquipment",
+  ),
+  # Liabilities
+  ("2000", "rs-gaap:AccountsPayableCurrent"),
+  ("2100", "rs-gaap:AccruedLiabilitiesCurrent"),
+  ("2200", "rs-gaap:AccruedLiabilitiesCurrent"),
+  # Equity
+  ("3000", "rs-gaap:AdditionalPaidInCapital"),
+  ("3100", "rs-gaap:RetainedEarningsAccumulatedDeficit"),
+  # Revenue — services firm, all ASC 606 revenue from contracts with customers
+  ("4000", "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"),
+  ("4100", "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"),
+  ("4200", "rs-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"),
+  # Operating expenses — all G&A for a back-office firm; depreciation on its own line
+  ("5000", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("5100", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("5200", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("6000", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("6100", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("6200", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("6300", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("6400", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("6500", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("6600", "rs-gaap:GeneralAndAdministrativeExpense"),
+  ("7000", "rs-gaap:DepreciationDepletionAndAmortization"),
+]
+
+
+def mappings_for(entity_type: str = "corporation") -> list[tuple[str, str]]:
+  """CoA→rs-gaap mappings with equity rows tuned to the entity legal form."""
+  return form_aware(MAPPINGS, entity_type)

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -117,6 +117,10 @@ from robosystems.models.api.extensions.blocked_source_graphs import (
   BlockSourceGraphResult,
   UnblockSourceGraphRequest,
 )
+from robosystems.models.api.extensions.chart_of_accounts import (
+  InitializeChartOfAccountsRequest,
+  InitializeChartOfAccountsResponse,
+)
 from robosystems.models.api.extensions.entity import (
   ChangeReportingStyleRequest,
   ChangeReportingStyleResponse,
@@ -291,6 +295,13 @@ from robosystems.operations.roboledger.commands.blocked_source_graphs import (
 )
 from robosystems.operations.roboledger.commands.blocked_source_graphs import (
   unblock_source_graph as cmd_unblock_source_graph,
+)
+from robosystems.operations.roboledger.commands.chart_of_accounts import (
+  ChartAlreadyExistsError,
+  ChartTemplateNotFoundError,
+)
+from robosystems.operations.roboledger.commands.chart_of_accounts import (
+  initialize_chart_of_accounts as cmd_initialize_chart_of_accounts,
 )
 from robosystems.operations.roboledger.commands.entity import (
   ParentEntityNotFoundError,
@@ -983,6 +994,38 @@ create_taxonomy_block_op = _registrar.register(
       NotImplementedError: 501,
     },
     mark_stale_reason="taxonomy_block_created",
+  )
+)
+
+initialize_chart_of_accounts_op = _registrar.register(
+  OperationSpec(
+    name="initialize-chart-of-accounts",
+    summary="Initialize Chart of Accounts",
+    description=(
+      "Create the graph's chart of accounts from a shipped template — the "
+      "fresh-company path to native books. Use when the graph has NO chart "
+      "(a QuickBooks-synced tenant never needs this: its chart arrives with "
+      "the sync and stays after a sever) and before connecting a bank feed, "
+      "which needs a chart to resolve against. Templates: `saas` "
+      "(subscription software), `services` (professional services), "
+      "`product` (inventory and COGS) — the `chartTemplates` GraphQL field "
+      "lists them with names and account counts. Creates the chart, its "
+      "`coa_mapping` structure and the template's CoA → rs-gaap mapping "
+      "associations in one transaction, with the equity rows mapped by the "
+      "entity's legal form (`entity_type`, defaulting to the graph's primary "
+      "entity). One-time: 409 once a chart exists — a chart is never "
+      "replaced. Customize afterwards with update-taxonomy-block; accounts "
+      "that carry activity are never deleted."
+    ),
+    command=cmd_initialize_chart_of_accounts,
+    request_model=InitializeChartOfAccountsRequest,
+    result_type=InitializeChartOfAccountsResponse,
+    business_event_type="ledger_initialize_chart_of_accounts",
+    error_map={
+      ChartAlreadyExistsError: 409,
+      ChartTemplateNotFoundError: 422,
+    },
+    mark_stale_reason="chart_of_accounts_initialized",
   )
 )
 

--- a/robosystems/routers/graphs/connections/management.py
+++ b/robosystems/routers/graphs/connections/management.py
@@ -3,6 +3,7 @@ Connection management endpoints (create, list, get, delete).
 """
 
 import asyncio
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from sqlalchemy.orm import Session
@@ -28,7 +29,13 @@ from robosystems.models.api.graphs.connections import (
   SetWritePolicyRequest,
 )
 from robosystems.models.core import GraphUser, User
-from robosystems.operations.connection_service import ConnectionService
+from robosystems.operations.connection_service import (
+  ConnectionService,
+  ProviderConflictError,
+  SeverNotSupportedError,
+  assert_provider_compatible,
+)
+from robosystems.security.audit_logger import SecurityAuditLogger, SecurityEventType
 
 from .utils import (
   create_robustness_components,
@@ -121,6 +128,18 @@ async def create_connection(
       config = request.external_config
     # Validate provider is enabled before any database operations
     provider_registry.get_provider(request.provider)
+
+    # Native and synced ledgers never mix — a bank feed needs a chart and no
+    # live QuickBooks; QuickBooks cannot take over natively-kept books
+    # (specs/ledger/native-accounting-cutover.md §2).
+    try:
+      assert_provider_compatible(graph_id, request.provider, db)
+    except ProviderConflictError as conflict:
+      raise create_error_response(
+        status_code=status.HTTP_409_CONFLICT,
+        detail=conflict.message,
+        code=conflict.code,
+      )
 
     # Prevent duplicate connections: one connection per provider per graph —
     # except 'external', where the identity is the source_name (a graph can
@@ -460,7 +479,13 @@ async def set_connection_write_policy(
   "/{connection_id}",
   response_model=SuccessResponse,
   summary="Delete Connection",
-  description="Removes the connection and revokes credentials. Imported data is preserved in the graph. Requires admin role.",
+  description=(
+    "Removes the connection and revokes credentials. Imported data is "
+    "preserved in the graph. Requires admin role. `disposition=sever` "
+    "(QuickBooks only) is the cutover to native books: the chart QuickBooks "
+    "created becomes the tenant's own and QuickBooks can never resume over "
+    "it; the default `disconnect` keeps the connection reconnectable."
+  ),
   operation_id="deleteConnection",
   responses={**RESOURCE_ERROR_RESPONSES},
 )
@@ -469,6 +494,16 @@ async def delete_connection(
     ..., description="Graph database identifier", pattern=GRAPH_OR_SUBGRAPH_ID_PATTERN
   ),
   connection_id: str = Path(..., description="Connection identifier"),
+  disposition: Literal["disconnect", "sever"] = Query(
+    "disconnect",
+    description=(
+      "`disconnect` (default): soft-delete; a later re-OAuth to the same "
+      "realm revives the connection. `sever`: the native-accounting "
+      "cutover — QuickBooks only; the chart it created is stamped native-"
+      "owned, write_policy drops to native, and the connection is never "
+      "revived."
+    ),
+  ),
   current_user: User = Depends(get_current_user_with_graph),
   db: Session = Depends(get_db_session),
   _rate_limit: None = Depends(subscription_aware_rate_limit_dependency),
@@ -495,8 +530,37 @@ async def delete_connection(
         code=ErrorCode.NOT_FOUND,
       )
 
-    # Provider-specific cleanup BEFORE deletion (e.g., revoke OAuth tokens)
     provider = connection["provider"].lower()
+
+    # Sever first: stamping the chart is the one step that must not be lost
+    # if a later step fails. Nothing below it is destructive to the books.
+    elements_severed: int | None = None
+    if disposition == "sever":
+      try:
+        severed = await ConnectionService.sever_connection(
+          connection_id, current_user.id, graph_id
+        )
+      except SeverNotSupportedError as exc:
+        raise create_error_response(
+          status_code=status.HTTP_400_BAD_REQUEST,
+          detail=str(exc),
+          code=ErrorCode.INVALID_INPUT,
+        )
+      elements_severed = int(severed["elements_severed"])
+      SecurityAuditLogger.log_security_event(
+        event_type=SecurityEventType.CONNECTION_SEVERED,
+        user_id=str(current_user.id),
+        endpoint="/v1/graphs/{graph_id}/connections/{connection_id}",
+        details={
+          "graph_id": graph_id,
+          "connection_id": connection_id,
+          "provider": provider,
+          "elements_severed": elements_severed,
+        },
+        risk_level="medium",
+      )
+
+    # Provider-specific cleanup BEFORE deletion (e.g., revoke OAuth tokens)
     try:
       provider_registry.get_provider(provider)
       await provider_registry.cleanup_connection(provider, connection, graph_id)
@@ -524,7 +588,12 @@ async def delete_connection(
     return SuccessResponse(
       success=True,
       message=f"Connection {connection_id} deleted successfully",
-      data={"connection_id": connection_id, "provider": provider},
+      data={
+        "connection_id": connection_id,
+        "provider": provider,
+        "disposition": disposition,
+        "elements_severed": elements_severed,
+      },
     )
 
   except HTTPException:

--- a/robosystems/routers/graphs/connections/oauth.py
+++ b/robosystems/routers/graphs/connections/oauth.py
@@ -27,7 +27,11 @@ from robosystems.models.api.oauth import (
   OAuthInitResponse,
 )
 from robosystems.models.core import User
-from robosystems.operations.connection_service import ConnectionService
+from robosystems.operations.connection_service import (
+  ConnectionService,
+  ProviderConflictError,
+  assert_provider_compatible,
+)
 
 from .utils import provider_registry
 
@@ -75,6 +79,17 @@ async def init_oauth(
         status_code=status.HTTP_400_BAD_REQUEST,
         detail=f"OAuth not supported for provider: {provider}",
         code=ErrorCode.PROVIDER_ERROR,
+      )
+
+    # The callback can revive a soft-deleted connection, so the books guard
+    # runs here too (specs/ledger/native-accounting-cutover.md §2).
+    try:
+      assert_provider_compatible(graph_id, provider, db)
+    except ProviderConflictError as conflict:
+      raise create_error_response(
+        status_code=status.HTTP_409_CONFLICT,
+        detail=conflict.message,
+        code=conflict.code,
       )
 
     # Get OAuth handler for provider

--- a/robosystems/security/audit_logger.py
+++ b/robosystems/security/audit_logger.py
@@ -68,6 +68,9 @@ class SecurityEventType(Enum):
   GRAPH_MEMBER_ADDED = "graph_member_added"
   GRAPH_MEMBER_ROLE_CHANGED = "graph_member_role_changed"
   GRAPH_MEMBER_REMOVED = "graph_member_removed"
+
+  # Connection lifecycle — the native accounting cutover
+  CONNECTION_SEVERED = "connection_severed"
   # Every authenticated request to the admin surface (SOC 2 CC6.1: privileged
   # access is restricted AND what it did is recorded). Evidence, not alerts:
   # no metric, like the membership and SCIM lifecycle events — the admin

--- a/tests/models/core/connection/test_connection.py
+++ b/tests/models/core/connection/test_connection.py
@@ -22,6 +22,7 @@ class TestConnectionStatus:
     assert ConnectionStatus.ERROR == "error"
     assert ConnectionStatus.NEEDS_REAUTH == "needs_reauth"
     assert ConnectionStatus.DISCONNECTED == "disconnected"
+    assert ConnectionStatus.SEVERED == "severed"
 
   def test_is_string_enum(self):
     assert isinstance(ConnectionStatus.CONNECTED, str)
@@ -647,3 +648,69 @@ class TestConnectionToDictWithSoftDelete:
 
     assert "deleted_at" in result
     assert result["deleted_at"] is None
+
+
+@pytest.mark.unit
+class TestConnectionRestore:
+  def test_restore_clears_deleted_at_and_reapplies_provider_write_policy(self):
+    """Disconnect drops write_policy to native; revival re-applies the
+    provider default so a reconnected QuickBooks is authoritative again."""
+    session = MagicMock()
+    conn = Connection(
+      graph_id="kg_test",
+      user_id="usr_1",
+      provider="quickbooks",
+      write_policy="native",
+    )
+    conn.deleted_at = datetime.now(UTC)
+
+    conn.restore(session)
+
+    assert conn.deleted_at is None
+    assert conn.write_policy == "qb_authoritative"
+    session.commit.assert_called_once()
+
+  def test_restore_keeps_native_for_providers_without_an_external_gl(self):
+    session = MagicMock()
+    conn = Connection(
+      graph_id="kg_test", user_id="usr_1", provider="sec", write_policy="native"
+    )
+    conn.deleted_at = datetime.now(UTC)
+
+    conn.restore(session)
+
+    assert conn.write_policy == "native"
+
+
+@pytest.mark.unit
+class TestFindSoftDeletedForRealm:
+  def test_returns_most_recently_deleted_match(self):
+    session = MagicMock()
+    prior = MagicMock(spec=Connection)
+    session.query.return_value.filter.return_value.order_by.return_value.first.return_value = prior
+
+    result = Connection.find_soft_deleted_for_realm(
+      "kg_test", "quickbooks", "9341452700148642", session
+    )
+
+    assert result is prior
+
+  def test_a_severed_row_is_never_a_revival_candidate(self):
+    """The filter carries the severed exclusion — a tenant that went native
+    on that chart is not revived by a later re-OAuth."""
+    from sqlalchemy.dialects import postgresql
+
+    session = MagicMock()
+    Connection.find_soft_deleted_for_realm(
+      "kg_test", "quickbooks", "9341452700148642", session
+    )
+
+    clauses = session.query.return_value.filter.call_args.args
+    compiled = [
+      str(
+        c.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})
+      )
+      for c in clauses
+    ]
+    assert any("connections.deleted_at IS NOT NULL" in c for c in compiled)
+    assert any("connections.status != 'severed'" in c for c in compiled), compiled

--- a/tests/operations/roboledger/commands/test_chart_of_accounts.py
+++ b/tests/operations/roboledger/commands/test_chart_of_accounts.py
@@ -157,6 +157,21 @@ class TestInitializeChartOfAccounts:
     assert response.entity_type == "partnership"
     self.entity.assert_not_called()
 
+  def test_unknown_entity_type_reports_the_form_actually_used(self) -> None:
+    """An unrecognised legal form maps the corporation equity rows; the
+    response and the chart's metadata say so instead of echoing the input."""
+    session = _session_for("saas")
+
+    response = initialize_chart_of_accounts(
+      session,
+      InitializeChartOfAccountsRequest(template="saas", entity_type="sole-prop"),
+      "usr_1",
+    )
+
+    assert response.entity_type == "corporation"
+    payload = self.create.call_args.args[1]
+    assert payload.metadata["entity_type"] == "corporation"
+
   def test_library_misses_are_reported_not_fatal(self) -> None:
     missing = "rs-gaap:DeferredRevenueCurrent"
     session = _session_for("saas", library_misses={missing})

--- a/tests/operations/roboledger/commands/test_chart_of_accounts.py
+++ b/tests/operations/roboledger/commands/test_chart_of_accounts.py
@@ -1,0 +1,195 @@
+"""Unit tests for ``initialize_chart_of_accounts`` (mocked session).
+
+The declarative CoA handler and the mapping command are each covered by
+their own suites; here they are stubbed so the tests pin the orchestration:
+the one-time rule, the template lookup, the entity-form default, the
+envelope handed to the handler, and how library misses are reported.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robosystems.models.api.extensions.chart_of_accounts import (
+  InitializeChartOfAccountsRequest,
+)
+from robosystems.operations.roboledger.commands.chart_of_accounts import (
+  DEFAULT_CHART_NAME,
+  MAPPING_STRUCTURE_NAME,
+  ChartAlreadyExistsError,
+  ChartTemplateNotFoundError,
+  initialize_chart_of_accounts,
+)
+from robosystems.operations.roboledger.commands.taxonomies import (
+  MappingAssociationExistsError,
+)
+from robosystems.operations.taxonomy_block.chart_templates import CHART_TEMPLATES
+
+_MOD = "robosystems.operations.roboledger.commands.chart_of_accounts"
+
+
+def _row_result(rows):
+  result = MagicMock()
+  result.all.return_value = rows
+  return result
+
+
+def _scalar_result(value):
+  result = MagicMock()
+  result.scalar_one_or_none.return_value = value
+  result.scalar_one.return_value = value
+  return result
+
+
+def _session_for(template_key: str, *, existing_chart=None, library_misses=()):
+  """A session whose ``execute`` answers, in call order: the active-chart
+  probe, the mapping-structure lookup, the new chart's elements, and the
+  library elements for the template's targets (minus ``library_misses``)."""
+  template = CHART_TEMPLATES[template_key]
+  coa_rows = [(code, f"elem_{code}") for code, *_ in template.accounts]
+  targets = sorted({q for _c, q in template.mappings_for("corporation")})
+  library_rows = [
+    (qname, f"lib_{i}")
+    for i, qname in enumerate(targets)
+    if qname not in library_misses
+  ]
+  session = MagicMock()
+  session.execute.side_effect = [
+    _scalar_result(existing_chart),
+    _scalar_result("struct_map"),
+    _row_result(coa_rows),
+    _row_result(library_rows),
+  ]
+  return session
+
+
+@pytest.mark.unit
+class TestInitializeChartOfAccounts:
+  @pytest.fixture(autouse=True)
+  def _stubs(self):
+    with (
+      patch(f"{_MOD}.create_chart_block", return_value="tax_new") as create,
+      patch(f"{_MOD}.create_mapping_association") as map_assoc,
+      patch(f"{_MOD}.resolve_parent_entity", return_value=None) as entity,
+    ):
+      self.create = create
+      self.map_assoc = map_assoc
+      self.entity = entity
+      yield
+
+  def test_refuses_when_a_chart_exists(self) -> None:
+    session = _session_for("saas", existing_chart="tax_existing")
+    with pytest.raises(ChartAlreadyExistsError) as exc:
+      initialize_chart_of_accounts(
+        session, InitializeChartOfAccountsRequest(template="saas"), "usr_1"
+      )
+    assert exc.value.taxonomy_id == "tax_existing"
+    self.create.assert_not_called()
+
+  def test_unknown_template_is_refused_before_any_query(self) -> None:
+    session = MagicMock()
+    body = InitializeChartOfAccountsRequest.model_construct(template="retail")
+    with pytest.raises(ChartTemplateNotFoundError):
+      initialize_chart_of_accounts(session, body, "usr_1")
+    session.execute.assert_not_called()
+
+  def test_creates_chart_then_maps_every_row(self) -> None:
+    session = _session_for("saas")
+    response = initialize_chart_of_accounts(
+      session, InitializeChartOfAccountsRequest(template="saas"), "usr_1"
+    )
+
+    template = CHART_TEMPLATES["saas"]
+    payload = self.create.call_args.args[1]
+    assert payload.taxonomy_type == "chart_of_accounts"
+    assert payload.name == DEFAULT_CHART_NAME
+    assert [e.qname for e in payload.elements] == [
+      f"coa:{code}" for code, *_ in template.accounts
+    ]
+    assert [e.code for e in payload.elements] == [c for c, *_ in template.accounts]
+    assert all(e.trait for e in payload.elements)
+    assert [s.block_type for s in payload.structures] == ["coa_mapping"]
+    assert payload.structures[0].name == MAPPING_STRUCTURE_NAME
+    assert payload.metadata == {"template": "saas", "entity_type": "corporation"}
+
+    expected = template.mappings_for("corporation")
+    assert self.map_assoc.call_count == len(expected)
+    first = self.map_assoc.call_args_list[0].args[1]
+    assert first.mapping_id == "struct_map"
+    assert first.from_element_id == f"elem_{expected[0][0]}"
+    assert first.association_type == "mapping"
+    assert first.suggested_by == "template"
+
+    assert response.taxonomy_id == "tax_new"
+    assert response.template == "saas"
+    assert response.entity_type == "corporation"
+    assert response.elements_created == template.account_count
+    assert response.mappings_created == len(expected)
+    assert response.unresolved == []
+
+  def test_entity_type_defaults_to_the_graphs_entity(self) -> None:
+    entity = MagicMock()
+    entity.entity_type = "LLC"
+    self.entity.return_value = entity
+    session = _session_for("services")
+
+    response = initialize_chart_of_accounts(
+      session, InitializeChartOfAccountsRequest(template="services"), "usr_1"
+    )
+
+    assert response.entity_type == "llc"
+    targets = {call.args[1].to_element_id for call in self.map_assoc.call_args_list}
+    assert targets  # mapped through the llc equity rows without error
+
+  def test_explicit_entity_type_wins_over_the_entity(self) -> None:
+    entity = MagicMock()
+    entity.entity_type = "corporation"
+    self.entity.return_value = entity
+    session = _session_for("product")
+
+    response = initialize_chart_of_accounts(
+      session,
+      InitializeChartOfAccountsRequest(template="product", entity_type="Partnership"),
+      "usr_1",
+    )
+    assert response.entity_type == "partnership"
+    self.entity.assert_not_called()
+
+  def test_library_misses_are_reported_not_fatal(self) -> None:
+    missing = "rs-gaap:DeferredRevenueCurrent"
+    session = _session_for("saas", library_misses={missing})
+
+    response = initialize_chart_of_accounts(
+      session, InitializeChartOfAccountsRequest(template="saas"), "usr_1"
+    )
+
+    expected = CHART_TEMPLATES["saas"].mappings_for("corporation")
+    misses = [c for c, q in expected if q == missing]
+    assert response.unresolved == [missing]
+    assert response.mappings_created == len(expected) - len(misses)
+
+  def test_duplicate_mapping_is_skipped_quietly(self) -> None:
+    self.map_assoc.side_effect = [MappingAssociationExistsError("m", "a", "b")] + [
+      None
+    ] * 100
+    session = _session_for("saas")
+
+    response = initialize_chart_of_accounts(
+      session, InitializeChartOfAccountsRequest(template="saas"), "usr_1"
+    )
+
+    expected = CHART_TEMPLATES["saas"].mappings_for("corporation")
+    assert response.mappings_created == len(expected) - 1
+    assert response.unresolved == []
+
+  def test_custom_name_is_kept(self) -> None:
+    session = _session_for("saas")
+    response = initialize_chart_of_accounts(
+      session,
+      InitializeChartOfAccountsRequest(template="saas", name="  Cadence Books "),
+      "usr_1",
+    )
+    assert response.name == "Cadence Books"
+    assert self.create.call_args.args[1].name == "Cadence Books"

--- a/tests/operations/roboledger/commands/test_connections.py
+++ b/tests/operations/roboledger/commands/test_connections.py
@@ -1,0 +1,56 @@
+"""Unit tests for ``sever_synced_chart`` — the graph-side stamp of a cutover."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from robosystems.operations.roboledger.commands.connections import (
+  SEVERABLE_SOURCES,
+  sever_synced_chart,
+)
+
+
+def _compiled(statement) -> str:
+  return str(
+    statement.compile(
+      dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+    )
+  )
+
+
+@pytest.mark.unit
+class TestSeverSyncedChart:
+  def test_only_quickbooks_is_severable(self) -> None:
+    assert frozenset({"quickbooks"}) == SEVERABLE_SOURCES
+    session = MagicMock()
+    with pytest.raises(ValueError, match="cannot be severed"):
+      sever_synced_chart(session, "conn_1", source="mercury")
+    session.execute.assert_not_called()
+
+  def test_stamps_only_this_connections_quickbooks_elements(self) -> None:
+    session = MagicMock()
+    session.execute.return_value.rowcount = 29
+
+    stamped = sever_synced_chart(session, "conn_1")
+
+    assert stamped == 29
+    statement = session.execute.call_args.args[0]
+    sql = _compiled(statement)
+    assert sql.startswith("UPDATE elements SET")
+    assert "source='native'" in sql
+    assert "external_source=NULL" in sql
+    assert "connection_id=NULL" in sql
+    assert "external_id=NULL" in sql
+    assert "elements.external_source = 'quickbooks'" in sql
+    assert "elements.connection_id = 'conn_1'" in sql
+    # The qname is deliberately kept — nothing else is touched.
+    assert "qname" not in sql
+    assert "taxonomy_id" not in sql
+
+  def test_missing_rowcount_reads_as_zero(self) -> None:
+    session = MagicMock()
+    session.execute.return_value.rowcount = None
+    assert sever_synced_chart(session, "conn_1") == 0

--- a/tests/operations/taxonomy_block/test_chart_templates.py
+++ b/tests/operations/taxonomy_block/test_chart_templates.py
@@ -35,6 +35,7 @@ from robosystems.operations.taxonomy_block.chart_templates import (
 from robosystems.operations.taxonomy_block.chart_templates._forms import (
   EQUITY_BY_FORM,
   EQUITY_CODES,
+  resolve_form,
 )
 
 RS_GAAP_SOURCE = (
@@ -108,6 +109,13 @@ class TestRegistry:
       )
       assert len(mapped_codes) == len(set(mapped_codes)), (key, form, "duplicate")
       assert set(EQUITY_CODES) <= set(mapped_codes), (key, form, "equity unmapped")
+
+  def test_resolve_form_normalises_and_falls_back(self) -> None:
+    assert resolve_form(" LLC ") == "llc"
+    assert resolve_form("Partnership") == "partnership"
+    assert resolve_form("sole-prop") == "corporation"
+    assert resolve_form("") == "corporation"
+    assert resolve_form(None) == "corporation"
 
   def test_equity_forms_swap_only_the_equity_rows(self) -> None:
     template = CHART_TEMPLATES["saas"]

--- a/tests/operations/taxonomy_block/test_chart_templates.py
+++ b/tests/operations/taxonomy_block/test_chart_templates.py
@@ -1,0 +1,167 @@
+"""The shipped chart-of-accounts templates stay honest.
+
+Three invariants, none of which need a database:
+
+1. Every template is internally consistent — unique codes, every mapped
+   code is an account, every equity form maps both equity accounts.
+2. Every mapping target is a real rs-gaap concept in the framework source
+   the library is seeded from, so a library rename surfaces here instead
+   of as ``unresolved`` on a customer's first day.
+3. The demos and the templates are one thing: ``saas`` and ``services``
+   are imported by their demos; ``product`` is the coffee roaster's chart
+   with generalized names, pinned structurally (codes, traits,
+   sub-classifications, balance types, mappings).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from examples.coffee_roaster_demo import data as coffee_data
+from examples.coffee_roaster_demo import mappings as coffee_mappings
+from examples.roboledger_demo import data as services_demo_data
+from examples.roboledger_demo import mappings as services_demo_mappings
+from examples.saas_startup_demo import data as saas_demo_data
+from examples.saas_startup_demo import mappings as saas_demo_mappings
+from robosystems.operations.taxonomy_block.chart_templates import (
+  CHART_TEMPLATES,
+  TEMPLATE_KEYS,
+  get_template,
+  list_templates,
+)
+from robosystems.operations.taxonomy_block.chart_templates._forms import (
+  EQUITY_BY_FORM,
+  EQUITY_CODES,
+)
+
+RS_GAAP_SOURCE = (
+  Path(__file__).resolve().parents[3]
+  / "frameworks"
+  / "rs-gaap"
+  / "packages"
+  / "rs-gaap"
+  / "v1"
+  / "taxonomy.jsonld"
+)
+
+VALID_TRAITS = {"asset", "liability", "equity", "revenue", "expense"}
+
+
+@pytest.fixture(scope="module")
+def rs_gaap_qnames() -> set[str]:
+  graph = json.loads(RS_GAAP_SOURCE.read_text())
+  nodes = graph.get("@graph", graph)
+  ids: set[str] = set()
+
+  def walk(node: object) -> None:
+    if isinstance(node, dict):
+      identifier = node.get("@id")
+      if isinstance(identifier, str) and identifier.startswith("rs-gaap:"):
+        ids.add(identifier)
+      for value in node.values():
+        walk(value)
+    elif isinstance(node, list):
+      for item in node:
+        walk(item)
+
+  walk(nodes)
+  assert len(ids) > 1000, "rs-gaap source did not parse into concept ids"
+  return ids
+
+
+@pytest.mark.unit
+class TestRegistry:
+  def test_three_templates_with_stable_keys(self) -> None:
+    assert TEMPLATE_KEYS == ("saas", "services", "product")
+    assert [t.key for t in list_templates()] == list(TEMPLATE_KEYS)
+
+  def test_lookup_is_case_and_whitespace_tolerant(self) -> None:
+    assert get_template(" SaaS ") is CHART_TEMPLATES["saas"]
+    assert get_template("nope") is None
+    assert get_template("") is None
+
+  @pytest.mark.parametrize("key", TEMPLATE_KEYS)
+  def test_template_is_internally_consistent(self, key: str) -> None:
+    template = CHART_TEMPLATES[key]
+    codes = [row[0] for row in template.accounts]
+    assert len(codes) == len(set(codes)), f"{key}: duplicate account codes"
+    assert template.account_count == len(codes)
+    assert template.display_name and template.description
+
+    for code, name, trait, sub_classification, balance_type, _desc in template.accounts:
+      assert code.isdigit() and len(code) == 4, (key, code)
+      assert name.strip(), (key, code)
+      assert trait in VALID_TRAITS, (key, code, trait)
+      assert sub_classification, (key, code)
+      assert balance_type in ("debit", "credit"), (key, code, balance_type)
+
+    for form in ("corporation", "llc", "partnership", "unknown-form", ""):
+      mappings = template.mappings_for(form)
+      mapped_codes = [code for code, _q in mappings]
+      assert set(mapped_codes) <= set(codes), (
+        key,
+        form,
+        set(mapped_codes) - set(codes),
+      )
+      assert len(mapped_codes) == len(set(mapped_codes)), (key, form, "duplicate")
+      assert set(EQUITY_CODES) <= set(mapped_codes), (key, form, "equity unmapped")
+
+  def test_equity_forms_swap_only_the_equity_rows(self) -> None:
+    template = CHART_TEMPLATES["saas"]
+    corp = dict(template.mappings_for("corporation"))
+    llc = dict(template.mappings_for("llc"))
+    partnership = dict(template.mappings_for("partnership"))
+    for code in corp:
+      if code in EQUITY_CODES:
+        continue
+      assert corp[code] == llc[code] == partnership[code], code
+    assert llc["3000"] == "rs-gaap:MembersEquity"
+    assert partnership["3100"] == "rs-gaap:PartnersCapital"
+    assert dict(EQUITY_BY_FORM["corporation"])["3100"] == corp["3100"]
+
+
+@pytest.mark.unit
+class TestLibraryTargets:
+  @pytest.mark.parametrize("key", TEMPLATE_KEYS)
+  def test_every_mapping_target_is_an_rs_gaap_concept(
+    self, key: str, rs_gaap_qnames: set[str]
+  ) -> None:
+    template = CHART_TEMPLATES[key]
+    targets = {
+      qname for form in EQUITY_BY_FORM for _code, qname in template.mappings_for(form)
+    }
+    missing = sorted(targets - rs_gaap_qnames)
+    assert not missing, f"{key}: not in rs-gaap source: {missing}"
+
+
+@pytest.mark.unit
+class TestDemosAreTheTemplates:
+  def test_saas_demo_imports_the_template(self) -> None:
+    assert saas_demo_data.ACCOUNTS is CHART_TEMPLATES["saas"].accounts
+    assert saas_demo_mappings.mappings_for is CHART_TEMPLATES["saas"].mappings_for
+
+  def test_services_demo_imports_the_template(self) -> None:
+    assert services_demo_data.ACCOUNTS is CHART_TEMPLATES["services"].accounts
+    assert (
+      services_demo_mappings.mappings_for is CHART_TEMPLATES["services"].mappings_for
+    )
+
+  def test_product_template_is_the_coffee_chart_with_general_names(self) -> None:
+    """Same codes, traits, sub-classifications, balances and mappings; only
+    the roaster-flavoured names differ."""
+    template = CHART_TEMPLATES["product"]
+
+    def structure(rows):
+      return [(code, trait, sub, balance) for code, _n, trait, sub, balance, _d in rows]
+
+    assert structure(template.accounts) == structure(coffee_data.ACCOUNTS)
+    for form in EQUITY_BY_FORM:
+      assert template.mappings_for(form) == coffee_mappings.mappings_for(form), form
+    renamed = {row[1] for row in template.accounts} ^ {
+      row[1] for row in coffee_data.ACCOUNTS
+    }
+    assert "Inventory — Green Coffee" in renamed
+    assert "Inventory — Raw Materials" in renamed

--- a/tests/operations/test_connection_service.py
+++ b/tests/operations/test_connection_service.py
@@ -495,6 +495,30 @@ class TestDeleteConnection:
 
   @pytest.mark.asyncio
   @pytest.mark.unit
+  async def test_delete_resets_write_policy_to_native(self):
+    """After a disconnect there is no active authoritative external GL, so
+    the row goes out as `native`; `Connection.restore` re-applies the
+    provider default on revival."""
+    mock_session = MagicMock()
+    mock_conn = _make_mock_connection()
+    mock_conn.write_policy = "qb_authoritative"
+
+    with (
+      patch(f"{MODULE}.Connection") as MockConn,
+      patch(f"{MODULE}.ConnectionCredentials") as MockCreds,
+    ):
+      MockConn.get_by_id.return_value = mock_conn
+      MockCreds.get_by_connection_id.return_value = None
+
+      assert await ConnectionService.delete_connection(
+        connection_id="conn_1", user_id="usr_123", db_session=mock_session
+      )
+
+    assert mock_conn.write_policy == "native"
+    mock_conn.soft_delete.assert_called_once()
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
   async def test_wrong_graph_returns_false(self):
     """A connection in a different graph must not be deletable by guessing
     its id from another graph's scope (IDOR guard)."""
@@ -1537,3 +1561,241 @@ class TestDispatchConnectionSync:
     release.assert_called_once()
     assert release.call_args.kwargs["lock_key"] == "qb_sync:conn_1"
     assert release.call_args.kwargs["lock_id"] == "lock_abc"
+
+
+# ---------------------------------------------------------------------------
+# Native and synced ledgers never mix — the provider guard
+# ---------------------------------------------------------------------------
+
+
+class TestProviderCompatibility:
+  """`assert_provider_compatible` — specs/ledger/native-accounting-cutover.md §2."""
+
+  @staticmethod
+  def _live(*providers: str) -> list:
+    return [_make_mock_connection(provider=p) for p in providers]
+
+  @pytest.mark.unit
+  def test_bank_feed_refused_while_quickbooks_is_live(self):
+    from robosystems.operations.connection_service import (
+      ProviderConflictError,
+      assert_provider_compatible,
+    )
+
+    with (
+      patch(f"{MODULE}.Connection") as MockConn,
+      patch(f"{MODULE}._graph_has_chart", return_value=True) as has_chart,
+    ):
+      MockConn.get_all_for_graph.return_value = self._live("quickbooks", "external")
+      with pytest.raises(ProviderConflictError) as exc:
+        assert_provider_compatible("kg_test", "mercury", MagicMock())
+
+    assert exc.value.code == "QUICKBOOKS_ACTIVE"
+    assert "quickbooks" in exc.value.message
+    has_chart.assert_not_called()
+
+  @pytest.mark.unit
+  def test_bank_feed_needs_a_chart(self):
+    from robosystems.operations.connection_service import (
+      ProviderConflictError,
+      assert_provider_compatible,
+    )
+
+    with (
+      patch(f"{MODULE}.Connection") as MockConn,
+      patch(f"{MODULE}._graph_has_chart", return_value=False),
+    ):
+      MockConn.get_all_for_graph.return_value = []
+      with pytest.raises(ProviderConflictError) as exc:
+        assert_provider_compatible("kg_test", "Mercury", MagicMock())
+
+    assert exc.value.code == "CHART_REQUIRED"
+
+  @pytest.mark.unit
+  def test_bank_feed_allowed_with_a_chart_and_no_synced_ledger(self):
+    from robosystems.operations.connection_service import assert_provider_compatible
+
+    with (
+      patch(f"{MODULE}.Connection") as MockConn,
+      patch(f"{MODULE}._graph_has_chart", return_value=True),
+    ):
+      MockConn.get_all_for_graph.return_value = self._live("external")
+      assert_provider_compatible("kg_test", "mercury", MagicMock())
+
+  @pytest.mark.unit
+  def test_quickbooks_refused_over_native_line_items(self):
+    from robosystems.operations.connection_service import (
+      ProviderConflictError,
+      assert_provider_compatible,
+    )
+
+    with (
+      patch(f"{MODULE}.Connection") as MockConn,
+      patch(f"{MODULE}._graph_has_native_books", return_value=True) as native,
+    ):
+      MockConn.get_all_for_graph.return_value = []
+      with pytest.raises(ProviderConflictError) as exc:
+        assert_provider_compatible("kg_test", "quickbooks", MagicMock())
+
+    assert exc.value.code == "NATIVE_BOOKS_PRESENT"
+    native.assert_called_once_with("kg_test", synced_source="quickbooks")
+
+  @pytest.mark.unit
+  def test_quickbooks_refused_beside_a_live_bank_feed(self):
+    from robosystems.operations.connection_service import (
+      ProviderConflictError,
+      assert_provider_compatible,
+    )
+
+    with (
+      patch(f"{MODULE}.Connection") as MockConn,
+      patch(f"{MODULE}._graph_has_native_books", return_value=False) as native,
+    ):
+      MockConn.get_all_for_graph.return_value = self._live("mercury")
+      with pytest.raises(ProviderConflictError) as exc:
+        assert_provider_compatible("kg_test", "quickbooks", MagicMock())
+
+    assert exc.value.code == "NATIVE_BOOKS_PRESENT"
+    native.assert_not_called()
+
+  @pytest.mark.unit
+  def test_quickbooks_allowed_on_a_fresh_graph(self):
+    from robosystems.operations.connection_service import assert_provider_compatible
+
+    with (
+      patch(f"{MODULE}.Connection") as MockConn,
+      patch(f"{MODULE}._graph_has_native_books", return_value=False),
+    ):
+      MockConn.get_all_for_graph.return_value = []
+      assert_provider_compatible("kg_test", "quickbooks", MagicMock())
+
+  @pytest.mark.unit
+  def test_other_providers_pass_without_touching_the_graph(self):
+    from robosystems.operations.connection_service import assert_provider_compatible
+
+    with (
+      patch(f"{MODULE}.Connection") as MockConn,
+      patch(f"{MODULE}._graph_has_chart") as has_chart,
+      patch(f"{MODULE}._graph_has_native_books") as native,
+    ):
+      MockConn.get_all_for_graph.return_value = self._live("quickbooks")
+      assert_provider_compatible("kg_test", "external", MagicMock())
+      assert_provider_compatible("kg_test", "sec", MagicMock())
+
+    has_chart.assert_not_called()
+    native.assert_not_called()
+
+  @pytest.mark.unit
+  def test_a_missing_extensions_schema_reads_as_no_books(self):
+    """A never-provisioned or deprovisioned graph has no chart (so a bank
+    feed is refused) and no native books (so QuickBooks is allowed)."""
+    from robosystems.operations.connection_service import (
+      _graph_has_chart,
+      _graph_has_native_books,
+    )
+
+    with patch(
+      "robosystems.db.extensions.extensions_session",
+      side_effect=RuntimeError("schema missing"),
+    ):
+      assert _graph_has_chart("kg_test") is False
+      assert _graph_has_native_books("kg_test", synced_source="quickbooks") is False
+
+
+# ---------------------------------------------------------------------------
+# sever_connection — the native accounting cutover
+# ---------------------------------------------------------------------------
+
+
+class TestSeverConnection:
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_sever_stamps_the_chart_then_marks_the_row(self):
+    mock_conn = _make_mock_connection(provider="quickbooks", graph_id="kg_test")
+    ext = MagicMock()
+
+    with (
+      patch(f"{MODULE}.Connection") as MockConn,
+      patch("robosystems.db.extensions.extensions_session") as ext_session,
+      patch(
+        "robosystems.operations.roboledger.commands.connections.sever_synced_chart",
+        return_value=7,
+      ) as stamp,
+    ):
+      MockConn.get_by_id.return_value = mock_conn
+      ext_session.return_value.__enter__.return_value = ext
+
+      result = await ConnectionService.sever_connection(
+        "conn_1", "usr_123", "kg_test", db_session=MagicMock()
+      )
+
+    ext_session.assert_called_once_with("kg_test")
+    stamp.assert_called_once_with(ext, "conn_1", source="quickbooks")
+    assert mock_conn.set_write_policy.call_args.args[1] == "native"
+    assert mock_conn.update_status.call_args.args[0] == "severed"
+    assert result == {
+      "connection_id": "conn_1",
+      "provider": "quickbooks",
+      "elements_severed": 7,
+    }
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_sever_refuses_a_provider_that_is_not_a_synced_ledger(self):
+    from robosystems.operations.connection_service import SeverNotSupportedError
+
+    mock_conn = _make_mock_connection(provider="external", graph_id="kg_test")
+
+    with (
+      patch(f"{MODULE}.Connection") as MockConn,
+      patch(
+        "robosystems.operations.roboledger.commands.connections.sever_synced_chart"
+      ) as stamp,
+    ):
+      MockConn.get_by_id.return_value = mock_conn
+      with pytest.raises(SeverNotSupportedError):
+        await ConnectionService.sever_connection(
+          "conn_1", "usr_123", "kg_test", db_session=MagicMock()
+        )
+
+    stamp.assert_not_called()
+    mock_conn.update_status.assert_not_called()
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_sever_outside_the_graph_scope_is_not_found(self):
+    from robosystems.operations.connection_service import ConnectionNotFoundError
+
+    mock_conn = _make_mock_connection(provider="quickbooks", graph_id="kg_other")
+
+    with patch(f"{MODULE}.Connection") as MockConn:
+      MockConn.get_by_id.return_value = mock_conn
+      with pytest.raises(ConnectionNotFoundError):
+        await ConnectionService.sever_connection(
+          "conn_1", "usr_123", "kg_test", db_session=MagicMock()
+        )
+
+    mock_conn.update_status.assert_not_called()
+
+  @pytest.mark.asyncio
+  @pytest.mark.unit
+  async def test_a_failed_stamp_leaves_the_row_untouched(self):
+    mock_conn = _make_mock_connection(provider="quickbooks", graph_id="kg_test")
+
+    with (
+      patch(f"{MODULE}.Connection") as MockConn,
+      patch("robosystems.db.extensions.extensions_session") as ext_session,
+      patch(
+        "robosystems.operations.roboledger.commands.connections.sever_synced_chart",
+        side_effect=RuntimeError("boom"),
+      ),
+    ):
+      MockConn.get_by_id.return_value = mock_conn
+      ext_session.return_value.__enter__.return_value = MagicMock()
+      with pytest.raises(RuntimeError):
+        await ConnectionService.sever_connection(
+          "conn_1", "usr_123", "kg_test", db_session=MagicMock()
+        )
+
+    mock_conn.set_write_policy.assert_not_called()
+    mock_conn.update_status.assert_not_called()

--- a/tests/operations/test_connection_service.py
+++ b/tests/operations/test_connection_service.py
@@ -1688,18 +1688,54 @@ class TestProviderCompatibility:
   @pytest.mark.unit
   def test_a_missing_extensions_schema_reads_as_no_books(self):
     """A never-provisioned or deprovisioned graph has no chart (so a bank
-    feed is refused) and no native books (so QuickBooks is allowed)."""
+    feed is refused) and no native books (so QuickBooks is allowed).
+
+    `extensions_session` fails closed on a missing tenant schema with
+    ``invalid_schema_name`` (3F000) on the first statement — a
+    `ProgrammingError`, not a `RuntimeError` — so that is what the probe
+    must absorb."""
+    from sqlalchemy.exc import ProgrammingError
+
     from robosystems.operations.connection_service import (
       _graph_has_chart,
       _graph_has_native_books,
     )
 
+    missing = ProgrammingError(
+      "DO $$ BEGIN ... END $$",
+      {},
+      Exception('tenant schema "kg_test" does not exist'),
+    )
+    session_cm = MagicMock()
+    session_cm.__enter__.side_effect = missing
+
     with patch(
       "robosystems.db.extensions.extensions_session",
-      side_effect=RuntimeError("schema missing"),
+      return_value=session_cm,
     ):
       assert _graph_has_chart("kg_test") is False
       assert _graph_has_native_books("kg_test", synced_source="quickbooks") is False
+
+  @pytest.mark.unit
+  def test_any_other_programming_error_surfaces(self):
+    """Only the missing-schema case reads as "no books"; a SQL fault or a
+    migration that has not reached the tenant must not be translated into a
+    silently-allowed provider."""
+    from sqlalchemy.exc import ProgrammingError
+
+    from robosystems.operations.connection_service import _graph_has_chart
+
+    fault = ProgrammingError(
+      "SELECT ...", {}, Exception('column "is_active" does not exist')
+    )
+    session_cm = MagicMock()
+    session_cm.__enter__.side_effect = fault
+
+    with (
+      patch("robosystems.db.extensions.extensions_session", return_value=session_cm),
+      pytest.raises(ProgrammingError),
+    ):
+      _graph_has_chart("kg_test")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/routers/graphs/connections/test_management.py
+++ b/tests/routers/graphs/connections/test_management.py
@@ -117,7 +117,12 @@ class TestCreateConnection:
     """These tests use synthetic users with no GraphUser row, so the write-role
     + lifecycle gate would 403 before reaching handler logic. The deny path is
     covered in tests/routers/graphs/test_write_role_gates.py; bypass it here."""
-    with patch(f"{MANAGEMENT_MODULE}.require_graph_write_role"):
+    with (
+      patch(f"{MANAGEMENT_MODULE}.require_graph_write_role"),
+      # The books guard opens an extensions session; its matrix is covered in
+      # tests/operations/test_connection_service.py and its 409 below.
+      patch(f"{MANAGEMENT_MODULE}.assert_provider_compatible"),
+    ):
       yield
 
   @pytest.mark.unit
@@ -1311,3 +1316,229 @@ class TestExternalConnectionConfigValidation:
         quickbooks_config=QuickBooksConnectionConfig(),
         external_config=ExternalConnectionConfig(source_name="salesforce"),
       )
+
+
+# ---------------------------------------------------------------------------
+# Native and synced ledgers never mix — the books guard on create
+# ---------------------------------------------------------------------------
+
+
+class TestCreateConnectionBooksGuard:
+  @pytest.fixture(autouse=True)
+  def _bypass_write_role(self):
+    with patch(f"{MANAGEMENT_MODULE}.require_graph_write_role"):
+      yield
+
+  @pytest.mark.unit
+  @pytest.mark.asyncio
+  async def test_conflict_is_409_with_the_stable_code(self):
+    """A ProviderConflictError surfaces as 409 carrying its code, before any
+    connection row is created."""
+    from robosystems.operations.connection_service import ProviderConflictError
+
+    mock_user = _make_mock_user()
+    mock_db = MagicMock()
+    request = _make_create_request(provider="quickbooks")
+    components = _make_robustness_components()
+
+    with (
+      patch(
+        f"{MANAGEMENT_MODULE}.create_robustness_components",
+        return_value=components,
+      ),
+      patch(f"{MANAGEMENT_MODULE}.record_operation_start"),
+      patch(f"{MANAGEMENT_MODULE}.record_operation_failure"),
+      patch(f"{MANAGEMENT_MODULE}.provider_registry") as mock_registry,
+      patch(
+        f"{MANAGEMENT_MODULE}.assert_provider_compatible",
+        side_effect=ProviderConflictError("NATIVE_BOOKS_PRESENT", "native books"),
+      ) as guard,
+      patch(
+        f"{MANAGEMENT_MODULE}.ConnectionService.list_connections",
+        new_callable=AsyncMock,
+      ) as mock_list,
+      pytest.raises(HTTPException) as exc_info,
+    ):
+      mock_registry.get_provider = MagicMock(return_value=MagicMock())
+      mock_registry.create_connection = AsyncMock()
+      await create_connection(
+        graph_id=GRAPH_ID,
+        request=request,
+        current_user=mock_user,
+        db=mock_db,
+        _rate_limit=None,
+      )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["code"] == "NATIVE_BOOKS_PRESENT"
+    assert exc_info.value.detail["detail"] == "native books"
+    guard.assert_called_once_with(GRAPH_ID, "quickbooks", mock_db)
+    mock_list.assert_not_awaited()
+    mock_registry.create_connection.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# delete_connection?disposition=sever — the native accounting cutover
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteConnectionSever:
+  @pytest.fixture(autouse=True)
+  def _grant_graph_admin(self):
+    with patch(
+      f"{MANAGEMENT_MODULE}.GraphUser.user_has_admin_access",
+      return_value=True,
+    ):
+      yield
+
+  @pytest.mark.unit
+  @pytest.mark.asyncio
+  async def test_sever_stamps_first_then_cleans_up_then_deletes_and_audits(self):
+    from robosystems.security.audit_logger import SecurityEventType
+
+    mock_user = _make_mock_user()
+    mock_db = MagicMock()
+    connection_dict = _make_connection_dict(provider="quickbooks")
+    order: list[str] = []
+
+    async def sever(*_args, **_kwargs):
+      order.append("sever")
+      return {
+        "connection_id": CONNECTION_ID,
+        "provider": "quickbooks",
+        "elements_severed": 29,
+      }
+
+    async def cleanup(*_args, **_kwargs):
+      order.append("cleanup")
+
+    async def delete(*_args, **_kwargs):
+      order.append("delete")
+      return True
+
+    with (
+      patch(
+        f"{MANAGEMENT_MODULE}.ConnectionService.get_connection",
+        new_callable=AsyncMock,
+        return_value=connection_dict,
+      ),
+      patch(
+        f"{MANAGEMENT_MODULE}.ConnectionService.sever_connection",
+        new_callable=AsyncMock,
+        side_effect=sever,
+      ) as mock_sever,
+      patch(
+        f"{MANAGEMENT_MODULE}.ConnectionService.delete_connection",
+        new_callable=AsyncMock,
+        side_effect=delete,
+      ),
+      patch(f"{MANAGEMENT_MODULE}.provider_registry") as mock_registry,
+      patch(f"{MANAGEMENT_MODULE}.SecurityAuditLogger.log_security_event") as audit,
+    ):
+      mock_registry.get_provider = MagicMock(return_value=MagicMock())
+      mock_registry.cleanup_connection = AsyncMock(side_effect=cleanup)
+
+      result = await delete_connection(
+        graph_id=GRAPH_ID,
+        connection_id=CONNECTION_ID,
+        disposition="sever",
+        current_user=mock_user,
+        db=mock_db,
+        _rate_limit=None,
+      )
+
+    assert order == ["sever", "cleanup", "delete"]
+    mock_sever.assert_awaited_once_with(CONNECTION_ID, USER_ID, GRAPH_ID)
+    assert result.success is True
+    assert result.data["disposition"] == "sever"
+    assert result.data["elements_severed"] == 29
+    audit.assert_called_once()
+    audit_kwargs = audit.call_args.kwargs
+    assert audit_kwargs["event_type"] == SecurityEventType.CONNECTION_SEVERED
+    assert audit_kwargs["user_id"] == USER_ID
+    assert audit_kwargs["details"]["connection_id"] == CONNECTION_ID
+    assert audit_kwargs["details"]["elements_severed"] == 29
+
+  @pytest.mark.unit
+  @pytest.mark.asyncio
+  async def test_sever_on_a_non_synced_provider_is_400_and_deletes_nothing(self):
+    from robosystems.operations.connection_service import SeverNotSupportedError
+
+    mock_user = _make_mock_user()
+    mock_db = MagicMock()
+    connection_dict = _make_connection_dict(provider="external", source_name="hubspot")
+
+    with (
+      patch(
+        f"{MANAGEMENT_MODULE}.ConnectionService.get_connection",
+        new_callable=AsyncMock,
+        return_value=connection_dict,
+      ),
+      patch(
+        f"{MANAGEMENT_MODULE}.ConnectionService.sever_connection",
+        new_callable=AsyncMock,
+        side_effect=SeverNotSupportedError("external"),
+      ),
+      patch(
+        f"{MANAGEMENT_MODULE}.ConnectionService.delete_connection",
+        new_callable=AsyncMock,
+      ) as mock_delete,
+      patch(f"{MANAGEMENT_MODULE}.provider_registry") as mock_registry,
+      patch(f"{MANAGEMENT_MODULE}.SecurityAuditLogger.log_security_event") as audit,
+      pytest.raises(HTTPException) as exc_info,
+    ):
+      mock_registry.cleanup_connection = AsyncMock()
+      await delete_connection(
+        graph_id=GRAPH_ID,
+        connection_id=CONNECTION_ID,
+        disposition="sever",
+        current_user=mock_user,
+        db=mock_db,
+        _rate_limit=None,
+      )
+
+    assert exc_info.value.status_code == 400
+    mock_registry.cleanup_connection.assert_not_awaited()
+    mock_delete.assert_not_awaited()
+    audit.assert_not_called()
+
+  @pytest.mark.unit
+  @pytest.mark.asyncio
+  async def test_plain_disconnect_never_severs(self):
+    mock_user = _make_mock_user()
+    mock_db = MagicMock()
+    connection_dict = _make_connection_dict(provider="quickbooks")
+
+    with (
+      patch(
+        f"{MANAGEMENT_MODULE}.ConnectionService.get_connection",
+        new_callable=AsyncMock,
+        return_value=connection_dict,
+      ),
+      patch(
+        f"{MANAGEMENT_MODULE}.ConnectionService.sever_connection",
+        new_callable=AsyncMock,
+      ) as mock_sever,
+      patch(
+        f"{MANAGEMENT_MODULE}.ConnectionService.delete_connection",
+        new_callable=AsyncMock,
+        return_value=True,
+      ) as mock_delete,
+      patch(f"{MANAGEMENT_MODULE}.provider_registry") as mock_registry,
+    ):
+      mock_registry.get_provider = MagicMock(return_value=MagicMock())
+      mock_registry.cleanup_connection = AsyncMock()
+
+      result = await delete_connection(
+        graph_id=GRAPH_ID,
+        connection_id=CONNECTION_ID,
+        disposition="disconnect",
+        current_user=mock_user,
+        db=mock_db,
+        _rate_limit=None,
+      )
+
+    mock_sever.assert_not_awaited()
+    mock_delete.assert_awaited_once()
+    assert result.data["disposition"] == "disconnect"
+    assert result.data["elements_severed"] is None

--- a/tests/routers/graphs/connections/test_oauth.py
+++ b/tests/routers/graphs/connections/test_oauth.py
@@ -91,7 +91,12 @@ class TestInitOAuth:
     """These tests use synthetic users with no GraphUser row, so the write-role
     + lifecycle gate would 403 before reaching handler logic. The deny path is
     covered in tests/routers/graphs/test_write_role_gates.py; bypass it here."""
-    with patch(f"{OAUTH_MODULE}.require_graph_write_role"):
+    with (
+      patch(f"{OAUTH_MODULE}.require_graph_write_role"),
+      # The books guard opens an extensions session; its matrix lives in
+      # tests/operations/test_connection_service.py, its 409 below.
+      patch(f"{OAUTH_MODULE}.assert_provider_compatible"),
+    ):
       yield
 
   @pytest.mark.unit
@@ -1128,3 +1133,54 @@ class TestOAuthCallback:
     call_kwargs = mock_oauth_handler.store_tokens.call_args
     # user_id should be passed as keyword arg
     assert call_kwargs.kwargs.get("user_id") == "usr_specific_789"
+
+
+class TestInitOAuthBooksGuard:
+  """The callback can revive a soft-deleted connection, so the books guard
+  also runs at init — a QuickBooks re-OAuth over natively-kept books is
+  refused before any authorize URL is minted."""
+
+  @pytest.fixture(autouse=True)
+  def _bypass_write_role(self):
+    with patch(f"{OAUTH_MODULE}.require_graph_write_role"):
+      yield
+
+  @pytest.mark.unit
+  @pytest.mark.asyncio
+  async def test_conflict_is_409_before_the_authorize_url(self):
+    from robosystems.operations.connection_service import ProviderConflictError
+
+    mock_user = _make_mock_user()
+    mock_db = MagicMock()
+    request = _make_oauth_init_request()
+    connection_dict = _make_connection_dict(provider="quickbooks")
+    mock_oauth_handler = MagicMock()
+
+    with (
+      patch(
+        f"{OAUTH_MODULE}.ConnectionService.get_connection",
+        new_callable=AsyncMock,
+        return_value=connection_dict,
+      ),
+      patch(
+        f"{OAUTH_MODULE}.assert_provider_compatible",
+        side_effect=ProviderConflictError("NATIVE_BOOKS_PRESENT", "native books"),
+      ) as guard,
+      patch(
+        "robosystems.operations.providers.quickbooks_provider.quickbooks_oauth_handler",
+        mock_oauth_handler,
+      ),
+      pytest.raises(HTTPException) as exc_info,
+    ):
+      await init_oauth(
+        graph_id=GRAPH_ID,
+        request=request,
+        current_user=mock_user,
+        db=mock_db,
+        _rate_limit=None,
+      )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["code"] == "NATIVE_BOOKS_PRESENT"
+    guard.assert_called_once_with(GRAPH_ID, "quickbooks", mock_db)
+    mock_oauth_handler.get_authorization_url.assert_not_called()


### PR DESCRIPTION
## Summary

Native and synced ledgers never mix, and a bank feed needs a chart of accounts. This PR is the prerequisite for the in-core Mercury bank-feed connector: a provider-compatibility guard, a `sever` disposition that cuts a QuickBooks tenant over to native books while keeping the chart QuickBooks created, and a one-time `initialize-chart-of-accounts` operation that gives a fresh company a chart from a shipped template. No database migration. Design record: `local/RoboSystems/specs/ledger/native-accounting-cutover.md`.

## Changes

**Provider guard** (`operations/connection_service.py`, `routers/graphs/connections/management.py`, `routers/graphs/connections/oauth.py`)
- `assert_provider_compatible(graph_id, provider, session)` raises `ProviderConflictError` with a stable code: a bank feed (`mercury`) while a QuickBooks connection is live → `QUICKBOOKS_ACTIVE`; a bank feed on a graph with no active `chart_of_accounts` taxonomy → `CHART_REQUIRED`; QuickBooks over natively-kept books (posted line items on elements it did not create, or a live bank feed) → `NATIVE_BOOKS_PRESENT`. Other providers pass without touching the graph. A missing extensions schema reads as no books.
- Wired into `create_connection` (after the provider-enabled check, before the duplicate short-circuit) and OAuth init (the callback can revive a soft-deleted row, so the guard runs before any authorize URL). Both surface as HTTP 409 with the code in the error body.
- Graph-side predicates live in `operations/roboledger/reads/books.py`.

**Sever — the cutover** (`models/core/connection/connection.py`, `operations/connection_service.py`, `operations/roboledger/commands/connections.py`, `security/audit_logger.py`)
- `ConnectionStatus.SEVERED` (string column, no migration). `deleteConnection` gains `disposition=disconnect|sever` (default `disconnect`, today's behaviour). `sever` is QuickBooks-only (400 otherwise) and runs first: `sever_synced_chart` stamps the connection's elements `source='native'` and nulls `external_source` / `connection_id` / `external_id`, which takes them out of the loader's upsert key so a later sync can neither overwrite nor re-adopt them; qnames are kept. Then `write_policy` drops to `native`, the row is marked `severed`, provider cleanup and the soft-delete follow. Recorded as a `connection_severed` security-audit event.
- `find_soft_deleted_for_realm` excludes severed rows, so a later re-OAuth mints a fresh connection (which the guard then refuses over native books) instead of reviving the severed one.
- Plain disconnect now also resets `write_policy` to `native`; `Connection.restore` re-applies the provider default on revival. Reviewers: this is a behaviour change on the existing disconnect path, deliberate — `native` describes a graph with no active authoritative external GL.

**Chart of accounts from a template** (`operations/taxonomy_block/chart_templates/`, `operations/roboledger/commands/chart_of_accounts.py`, `models/api/extensions/chart_of_accounts.py`, `routers/extensions/roboledger/operations.py`, `graphql/`)
- Three shipped templates — `saas` (20 accounts), `services` (27), `product` (27) — each an `ACCOUNTS` list plus form-aware rs-gaap mappings (`_forms.py` swaps the equity rows by entity legal form). `saas` and `services` are the SaaS and RoboLedger demo charts promoted into core, and those demos now import them back so there is one copy; `product` is the coffee-roaster chart with the roaster-specific names generalized.
- `initialize_chart_of_accounts` refuses (409) when an active chart exists, builds the Taxonomy Block envelope (elements `coa:<code>`, a `coa_mapping` structure) through the existing declarative CoA handler, then resolves the template's rs-gaap targets against the library and creates the mapping associations in the same session. Library misses are reported in `unresolved`, never fatal. `entity_type` defaults to the graph's primary entity, then corporation.
- Registered through the operation registrar as `initialize-chart-of-accounts` (REST op + MCP tool from one spec; `mark_stale_reason="chart_of_accounts_initialized"`). The template catalogue is the new `chartTemplates` GraphQL field on the ledger query.
- A comment on the loader's `_ensure_mapping_structure` records why it may still assume an empty-or-own chart.

**Tests**
- New: `tests/operations/taxonomy_block/test_chart_templates.py` (registry consistency; every mapping target verified against the rs-gaap framework source; demos-are-the-templates, including the structural pin between `product` and the coffee demo), `tests/operations/roboledger/commands/test_chart_of_accounts.py`, `tests/operations/roboledger/commands/test_connections.py`.
- Extended: guard matrix + `sever_connection` + write-policy reset in `tests/operations/test_connection_service.py`; 409 and sever-disposition cases in the management and OAuth router suites (their autouse fixtures now patch the guard, since it opens an extensions session); severed-row exclusion and `restore` write-policy in the Connection model tests.

## Breaking Changes

None. Additive surface only — a new operation, a new optional query parameter on `deleteConnection`, a new GraphQL field, a new `ConnectionStatus` value and three new 409 codes — so this rides a client **minor** on the next SDK regen (generated tier; nothing the integration template imports changes). The Python client's GraphQL drift gate will pick up `chartTemplates` on its next `just refresh-schema`.

## Testing

- `just test` — 14,314 passed, 42 skipped.
- `just test-code` — ruff, format, basedpyright, cf-lint all passed.
- Not exercised end-to-end against a live graph in this session; the sever and initialize paths are covered by unit tests with mocked sessions, and the template tests read the rs-gaap framework source directly.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNVVqyL2inzXtxnWZp68Rb
