### PR TITLE
feat(ledger): retire chart accounts — is_active patch and a posting guard

### DIFF
--- a/robosystems/models/api/taxonomy_block.py
+++ b/robosystems/models/api/taxonomy_block.py
@@ -423,6 +423,15 @@ class ElementUpdatePatch(BaseModel):
   code: str | None = None
   parent_ref: str | None = None
   metadata: dict[str, Any] | None = None
+  is_active: bool | None = Field(
+    None,
+    description=(
+      "Retire (`false`) or reactivate (`true`) a chart account. Retiring keeps "
+      "its history and hides it from account pickers and the chart tree, and "
+      "new line items on it are refused — the way to take an account with "
+      "activity out of use, since removal needs no facts and no line items."
+    ),
+  )
 
 
 class StructureUpdatePatch(BaseModel):

--- a/robosystems/operations/roboledger/commands/_guards.py
+++ b/robosystems/operations/roboledger/commands/_guards.py
@@ -8,13 +8,16 @@ opens) — they require DB access.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import date
 from typing import Any
 
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 
+from robosystems.models.extensions import Element
 from robosystems.operations.locking import acquire_shared_period_fence
+from robosystems.operations.roboledger.commands.connections import SEVERABLE_SOURCES
 
 _LIBRARY_SEEDER = "library-seeder"
 
@@ -146,3 +149,50 @@ def assert_period_not_closed(session: Session, *posting_dates: date) -> None:
     row = _period_covering(session, posting_date)
     if row is not None and row.status == "closed":
       raise ClosedPeriodError(row.name, posting_date)
+
+
+class InactiveAccountError(ValueError):
+  """A line item names a retired (``is_active=false``) chart account.
+
+  Retiring an account keeps its history and closes it to new activity — the
+  QuickBooks meaning of "inactive". Reactivate it with
+  ``update-taxonomy-block`` (``elements_to_update[].is_active=true``) or pick
+  another account.
+  """
+
+  def __init__(self, accounts: list[tuple[str, str | None, str | None]]) -> None:
+    self.accounts = accounts
+    named = ", ".join(
+      f"{code or '?'} {name or ''}".strip() + f" ({element_id})"
+      for element_id, code, name in accounts
+    )
+    super().__init__(
+      f"Cannot post to inactive account(s): {named}. Reactivate the account "
+      "(update-taxonomy-block, is_active=true) or choose another one."
+    )
+
+
+def assert_accounts_postable(
+  session: Session, element_ids: Iterable[str], *, source: str | None = None
+) -> None:
+  """Raise `InactiveAccountError` if any line-item element is retired.
+
+  Applies to authored postings — manual entries, event handlers, bank feeds.
+  A synced ledger's own history is exempt: QuickBooks retires accounts
+  after they carry activity, and a full rebuild replays every historical
+  entry against them verbatim, so a ``source`` in `SEVERABLE_SOURCES`
+  passes through untouched.
+  """
+  if source and source.lower() in SEVERABLE_SOURCES:
+    return
+  ids = sorted({str(eid) for eid in element_ids if eid})
+  if not ids:
+    return
+  rows = session.execute(
+    select(Element.id, Element.code, Element.name).where(
+      Element.id.in_(ids), Element.is_active.is_(False)
+    )
+  ).all()
+  inactive = [(str(eid), code, name) for eid, code, name in rows]
+  if inactive:
+    raise InactiveAccountError(inactive)

--- a/robosystems/operations/roboledger/commands/_guards.py
+++ b/robosystems/operations/roboledger/commands/_guards.py
@@ -181,7 +181,11 @@ def assert_accounts_postable(
   A synced ledger's own history is exempt: QuickBooks retires accounts
   after they carry activity, and a full rebuild replays every historical
   entry against them verbatim, so a ``source`` in `SEVERABLE_SOURCES`
-  passes through untouched.
+  passes through untouched. Callers pass ``source`` only for the replay
+  shape (the loader posts history as ``status='posted'``); a draft that
+  merely names a synced source is authored and is checked. A tenant can
+  still hand-author a posted event under its own live QuickBooks source —
+  that is its own graph and its own books, accepted as in scope.
   """
   if source and source.lower() in SEVERABLE_SOURCES:
     return

--- a/robosystems/operations/roboledger/commands/journal_entries.py
+++ b/robosystems/operations/roboledger/commands/journal_entries.py
@@ -409,15 +409,21 @@ def create_journal_entry(
     `ClosedPeriodError` (422) if `posting_date` falls in a closed period.
     `UnbalancedJournalEntryError` (422) if total debits ≠ total credits.
     `InactiveAccountError` (422) if a line names a retired account — except
-      for a synced ledger's own replayed history (`body.source`).
+      for a synced ledger's own replayed history (`body.source` is a synced
+      provider and `status='posted'`, the shape the loader produces).
     `ValueError` (422) for invalid line items (negative amounts, missing
       element_id, both debit and credit set, etc.).
   """
   assert_period_not_closed(session, body.posting_date)
 
   normalized, total_debit, _total_credit = validate_and_normalize_lines(body.line_items)
+  # A synced ledger's replayed history arrives `posted` (the loader stamps
+  # it so); a draft is authored whatever source it names, so only the
+  # posted shape carries the source into the guard's exemption.
   assert_accounts_postable(
-    session, (li["element_id"] for li in normalized), source=body.source
+    session,
+    (li["element_id"] for li in normalized),
+    source=body.source if body.status == "posted" else None,
   )
 
   status = body.status

--- a/robosystems/operations/roboledger/commands/journal_entries.py
+++ b/robosystems/operations/roboledger/commands/journal_entries.py
@@ -55,6 +55,7 @@ from robosystems.models.extensions.roboledger.line_item import LineItem
 from robosystems.models.extensions.roboledger.transaction import Transaction
 from robosystems.operations.locking import RowLockedError, lock_by_id
 from robosystems.operations.roboledger.commands._guards import (
+  assert_accounts_postable,
   assert_period_not_closed,
 )
 
@@ -407,12 +408,17 @@ def create_journal_entry(
   Raises:
     `ClosedPeriodError` (422) if `posting_date` falls in a closed period.
     `UnbalancedJournalEntryError` (422) if total debits ≠ total credits.
+    `InactiveAccountError` (422) if a line names a retired account — except
+      for a synced ledger's own replayed history (`body.source`).
     `ValueError` (422) for invalid line items (negative amounts, missing
       element_id, both debit and credit set, etc.).
   """
   assert_period_not_closed(session, body.posting_date)
 
   normalized, total_debit, _total_credit = validate_and_normalize_lines(body.line_items)
+  assert_accounts_postable(
+    session, (li["element_id"] for li in normalized), source=body.source
+  )
 
   status = body.status
   now = datetime.now(UTC) if status == "posted" else None
@@ -533,6 +539,9 @@ def update_journal_entry(
       for li in replacement_lines
     ]
     normalized, _dr, _cr = validate_and_normalize_lines(new_line_inputs)
+    # A draft edit is authored, whatever the entry's provenance: retired
+    # accounts are closed to it.
+    assert_accounts_postable(session, (li["element_id"] for li in normalized))
 
     session.query(LineItem).filter(LineItem.entry_id == entry.id).delete(
       synchronize_session=False

--- a/robosystems/operations/taxonomy_block/update_apply.py
+++ b/robosystems/operations/taxonomy_block/update_apply.py
@@ -306,6 +306,8 @@ def apply_elements_to_update(
       element.code = patch.code
     if patch.metadata is not None:
       element.metadata_ = dict(patch.metadata)
+    if patch.is_active is not None:
+      element.is_active = patch.is_active
     if patch.parent_ref is not None:
       if patch.parent_ref == "":
         element.parent_id = None

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -1037,6 +1037,11 @@ update_taxonomy_block_op = _registrar.register(
       "Incrementally mutate a taxonomy block via typed delta lists "
       "(elements/structures/associations/rules to add, update, remove). "
       "Dispatches by the target taxonomy's stored `taxonomy_type`. "
+      "For a chart of accounts: add, rename and reclassify accounts freely; "
+      "an account with facts or line items is never removed — retire it "
+      "with `elements_to_update[].is_active=false` (history stays, new "
+      "postings are refused, pickers hide it; `true` reactivates). Removal "
+      "and whole-chart delete work only with no activity. "
       "Library-origin block types (`reporting_standard`) surface 501. "
       "`reporting_extension` / `custom_ontology` authoring may be "
       "disabled per environment (TAXONOMY_AUTHORING_ENABLED) — "
@@ -1867,7 +1872,8 @@ update_journal_entry_op = _registrar.register(
       "must be corrected via "
       "`create-event-block(event_type='journal_entry_reversed')`. If "
       "line_items is provided, existing line items are replaced "
-      "atomically and the new set must balance."
+      "atomically, the new set must balance, and a line on a retired "
+      "(`is_active=false`) account is refused."
     ),
     command=cmd_update_journal_entry,
     request_model=UpdateJournalEntryRequest,

--- a/tests/operations/roboledger/commands/test_guards_accounts.py
+++ b/tests/operations/roboledger/commands/test_guards_accounts.py
@@ -1,0 +1,85 @@
+"""Unit tests for ``assert_accounts_postable`` — the inactive-account guard
+behind every authored posting (journal entries, event handlers)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from robosystems.operations.roboledger.commands._guards import (
+  InactiveAccountError,
+  assert_accounts_postable,
+)
+
+
+def _session_with_inactive(rows):
+  session = MagicMock()
+  session.execute.return_value.all.return_value = rows
+  return session
+
+
+@pytest.mark.unit
+class TestAssertAccountsPostable:
+  def test_passes_when_no_line_names_a_retired_account(self) -> None:
+    session = _session_with_inactive([])
+    assert_accounts_postable(session, ["elem_a", "elem_b"])
+    statement = session.execute.call_args.args[0]
+    sql = str(
+      statement.compile(
+        dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+      )
+    )
+    assert "elements.is_active IS false" in sql
+    assert "'elem_a'" in sql and "'elem_b'" in sql
+
+  def test_refuses_and_names_every_retired_account(self) -> None:
+    session = _session_with_inactive(
+      [("elem_a", "1000", "Operating Checking"), ("elem_c", "6100", None)]
+    )
+    with pytest.raises(InactiveAccountError) as exc:
+      assert_accounts_postable(session, ["elem_a", "elem_b", "elem_c"])
+    message = str(exc.value)
+    assert "1000 Operating Checking (elem_a)" in message
+    assert "6100 (elem_c)" in message
+    assert "is_active=true" in message
+    assert exc.value.accounts == [
+      ("elem_a", "1000", "Operating Checking"),
+      ("elem_c", "6100", None),
+    ]
+
+  def test_is_a_value_error_so_the_envelope_maps_it_to_422(self) -> None:
+    assert issubclass(InactiveAccountError, ValueError)
+
+  def test_a_synced_ledgers_own_history_replays_untouched(self) -> None:
+    """QuickBooks retires accounts after they carry activity and a full
+    rebuild replays that history; the guard must not block it."""
+    session = _session_with_inactive([("elem_a", "1000", "Old Checking")])
+    assert_accounts_postable(session, ["elem_a"], source="quickbooks")
+    assert_accounts_postable(session, ["elem_a"], source="QuickBooks")
+    session.execute.assert_not_called()
+
+  def test_other_sources_are_authored_and_checked(self) -> None:
+    session = _session_with_inactive([("elem_a", "1000", "Old Checking")])
+    with pytest.raises(InactiveAccountError):
+      assert_accounts_postable(session, ["elem_a"], source="mercury")
+    with pytest.raises(InactiveAccountError):
+      assert_accounts_postable(session, ["elem_a"], source="native")
+
+  def test_empty_or_blank_ids_skip_the_query(self) -> None:
+    session = _session_with_inactive([])
+    assert_accounts_postable(session, [])
+    assert_accounts_postable(session, ["", None])  # type: ignore[list-item]
+    session.execute.assert_not_called()
+
+  def test_duplicate_ids_are_queried_once(self) -> None:
+    session = _session_with_inactive([])
+    assert_accounts_postable(session, ["elem_a", "elem_a", "elem_b"])
+    statement = session.execute.call_args.args[0]
+    sql = str(
+      statement.compile(
+        dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+      )
+    )
+    assert sql.count("'elem_a'") == 1

--- a/tests/operations/roboledger/commands/test_journal_entries.py
+++ b/tests/operations/roboledger/commands/test_journal_entries.py
@@ -960,12 +960,18 @@ class TestInactiveAccountGuard:
   @patch(f"{MODULE}._entry_to_response")
   @patch(f"{MODULE}.assert_period_not_closed")
   @patch(f"{MODULE}.resolve_flow_element_id", return_value=None)
-  def test_create_checks_every_line_with_the_entry_source(
+  def test_create_checks_every_line_with_the_replay_source(
     self, _mock_resolve, _mock_guard, _mock_resp, _accounts_postable
   ):
+    """A synced ledger's replayed history is `posted` with its source; that
+    is the one shape whose source reaches the guard's exemption."""
     session = MagicMock()
     body = CreateJournalEntryRequest(
-      posting_date=_DATE, memo="m", line_items=_balanced_lines(), source="quickbooks"
+      posting_date=_DATE,
+      memo="m",
+      line_items=_balanced_lines(),
+      source="quickbooks",
+      status="posted",
     )
     create_journal_entry(session, body, "usr_1")
 
@@ -974,6 +980,23 @@ class TestInactiveAccountGuard:
     assert args[0] is session
     assert sorted(args[1]) == ["elem_cash", "elem_revenue"]
     assert kwargs == {"source": "quickbooks"}
+
+  @patch(f"{MODULE}._entry_to_response")
+  @patch(f"{MODULE}.assert_period_not_closed")
+  @patch(f"{MODULE}.resolve_flow_element_id", return_value=None)
+  def test_a_draft_naming_a_synced_source_is_still_authored(
+    self, _mock_resolve, _mock_guard, _mock_resp, _accounts_postable
+  ):
+    """Naming `source='quickbooks'` on a draft does not buy the replay
+    exemption — the source is dropped and the lines are checked."""
+    session = MagicMock()
+    body = CreateJournalEntryRequest(
+      posting_date=_DATE, memo="m", line_items=_balanced_lines(), source="quickbooks"
+    )
+    create_journal_entry(session, body, "usr_1")
+
+    _args, kwargs = _accounts_postable.call_args
+    assert kwargs == {"source": None}
 
   @patch(f"{MODULE}.assert_period_not_closed")
   @patch(f"{MODULE}.resolve_flow_element_id", return_value=None)

--- a/tests/operations/roboledger/commands/test_journal_entries.py
+++ b/tests/operations/roboledger/commands/test_journal_entries.py
@@ -46,6 +46,15 @@ MODULE = "robosystems.operations.roboledger.commands.journal_entries"
 _DATE = date(2026, 1, 15)
 
 
+@pytest.fixture(autouse=True)
+def _accounts_postable():
+  """The inactive-account guard reads Element rows; every test here runs on a
+  MagicMock session, so it is stubbed module-wide. `TestInactiveAccountGuard`
+  asserts what it is called with; `test_guards_accounts.py` tests the guard."""
+  with patch(f"{MODULE}.assert_accounts_postable") as guard:
+    yield guard
+
+
 # ── Helpers ──────────────────────────────────────────────────────────────
 
 
@@ -941,3 +950,66 @@ class TestProvenanceForSource:
     # The regression itself: before this, every branch returned
     # "manual_entry" and "what came from QuickBooks?" was unanswerable.
     assert provenance_for_source("quickbooks") != "manual_entry"
+
+
+# ── Inactive-account guard ─────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestInactiveAccountGuard:
+  @patch(f"{MODULE}._entry_to_response")
+  @patch(f"{MODULE}.assert_period_not_closed")
+  @patch(f"{MODULE}.resolve_flow_element_id", return_value=None)
+  def test_create_checks_every_line_with_the_entry_source(
+    self, _mock_resolve, _mock_guard, _mock_resp, _accounts_postable
+  ):
+    session = MagicMock()
+    body = CreateJournalEntryRequest(
+      posting_date=_DATE, memo="m", line_items=_balanced_lines(), source="quickbooks"
+    )
+    create_journal_entry(session, body, "usr_1")
+
+    _accounts_postable.assert_called_once()
+    args, kwargs = _accounts_postable.call_args
+    assert args[0] is session
+    assert sorted(args[1]) == ["elem_cash", "elem_revenue"]
+    assert kwargs == {"source": "quickbooks"}
+
+  @patch(f"{MODULE}.assert_period_not_closed")
+  @patch(f"{MODULE}.resolve_flow_element_id", return_value=None)
+  def test_create_refuses_before_any_line_is_written(
+    self, _mock_resolve, _mock_guard, _accounts_postable
+  ):
+    from robosystems.operations.roboledger.commands._guards import (
+      InactiveAccountError,
+    )
+
+    _accounts_postable.side_effect = InactiveAccountError(
+      [("elem_cash", "1000", "Operating Checking")]
+    )
+    session = MagicMock()
+    body = CreateJournalEntryRequest(
+      posting_date=_DATE, memo="m", line_items=_balanced_lines()
+    )
+    with pytest.raises(InactiveAccountError, match="1000 Operating Checking"):
+      create_journal_entry(session, body, "usr_1")
+    session.add.assert_not_called()
+
+  @patch(f"{MODULE}._entry_to_response")
+  @patch(f"{MODULE}.assert_period_not_closed")
+  @patch(f"{MODULE}.resolve_flow_element_id", return_value=None)
+  @patch(f"{MODULE}.lock_by_id")
+  def test_update_checks_replacement_lines_as_authored(
+    self, mock_lock, _mock_resolve, _mock_guard, _mock_resp, _accounts_postable
+  ):
+    entry = _mock_entry(status="draft")
+    mock_lock.return_value = entry
+    session = _session_for_entry(entry)
+    session.query.return_value.filter.return_value.all.return_value = []
+    body = UpdateJournalEntryRequest(entry_id="entry_01", line_items=_balanced_lines())
+
+    update_journal_entry(session, body)
+
+    args, kwargs = _accounts_postable.call_args
+    assert sorted(args[1]) == ["elem_cash", "elem_revenue"]
+    assert kwargs == {}

--- a/tests/operations/taxonomy_block/test_update.py
+++ b/tests/operations/taxonomy_block/test_update.py
@@ -703,3 +703,44 @@ class TestResolveForeignElementQnames:
     _resolve_foreign_element_qnames(session, qname_by_id, elements, associations)
 
     session.execute.assert_not_called()
+
+
+@pytest.mark.unit
+class TestApplyIsActive:
+  """``is_active`` on an element patch retires or reactivates the account in
+  place; an omitted field leaves it alone (the FiscalCalendar/QuickBooks
+  loader owns the column for synced charts, so a no-op patch must not
+  clobber it)."""
+
+  def _apply(self, patch_kwargs: dict, *, current: bool = True):
+    from robosystems.operations.taxonomy_block.update_apply import (
+      apply_elements_to_update,
+    )
+
+    element = MagicMock()
+    element.id = "elem_1"
+    element.qname = "coa:1000"
+    element.is_active = current
+    session = MagicMock()
+    session.execute.return_value.scalars.return_value.all.return_value = [element]
+    taxonomy = MagicMock()
+    taxonomy.id = "tax_1"
+    payload = UpdateTaxonomyBlockRequest(
+      taxonomy_id="tax_1",
+      elements_to_update=[ElementUpdatePatch(qname="coa:1000", **patch_kwargs)],
+    )
+    apply_elements_to_update(session, taxonomy, payload, "usr_1")
+    return element
+
+  def test_retires_an_account(self) -> None:
+    element = self._apply({"is_active": False})
+    assert element.is_active is False
+
+  def test_reactivates_an_account(self) -> None:
+    element = self._apply({"is_active": True}, current=False)
+    assert element.is_active is True
+
+  def test_omitted_leaves_the_flag_alone(self) -> None:
+    element = self._apply({"name": "Renamed"}, current=False)
+    assert element.is_active is False
+    assert element.name == "Renamed"


### PR DESCRIPTION
## Summary

A chart of accounts changes constantly, but an account that carries facts or line items is never removed. This adds the lane natively kept books were missing: retire an account with `is_active=false` on an `update-taxonomy-block` element patch, and refuse new postings to a retired account. Spec: `local/RoboSystems/specs/taxonomy/chart-templates-as-data.md` §5.3.

## Changes

**Patch field** (`models/api/taxonomy_block.py`, `operations/taxonomy_block/update_apply.py`)
- `ElementUpdatePatch.is_active: bool | None` (additive, optional). Applied in place beside the other scalar fields; omitted leaves the column alone, so a rename never clobbers the flag the QuickBooks loader lands from QuickBooks' Active. Library immutability and the unknown-qname check already cover element patches generically, so the validator is unchanged.

**Posting guard** (`operations/roboledger/commands/_guards.py`, `commands/journal_entries.py`)
- `assert_accounts_postable(session, element_ids, *, source=None)` and `InactiveAccountError(ValueError)`, which names each retired account by code, name and id and says how to reactivate. `ValueError` already maps to 422 on every write operation, so no registrar change.
- Called in `create_journal_entry` after line normalization with `source=body.source`, and in `update_journal_entry` on replacement lines as an authored edit. Both event-handler paths (`journal_entry_recorded`, nested and flat) funnel into `create_journal_entry`, so manual entries and approved events share the one guard.
- Exemption: a `source` in `SEVERABLE_SOURCES` (QuickBooks) passes through, **and only for the replay shape** — `create_journal_entry` forwards the source to the guard only when `status='posted'`, which is what the loader stamps on every replayed entry; a draft that merely names a synced source is authored and is checked. QuickBooks retires accounts after they carry activity and a full rebuild replays that history verbatim; blocking it would break re-syncs. Bank feeds and native postings are checked. **Accepted limitation** (from the review): a tenant with a live QuickBooks connection can still hand-author a `posted` event under `source='quickbooks'` and post to its own retired account. That is its own graph and its own books; the guard is a safety on authored work, not a boundary, and the exemption is documented on the guard.

**Reads**: no change needed. `get_account_tree` already hides inactive accounts unless `include_inactive=True`, and `list_accounts` filters on `is_active`; both response models already carry the flag.

**Tool descriptions** (`routers/extensions/roboledger/operations.py`)
- `update-taxonomy-block` now says how to retire an account and that removal and whole-chart delete need no activity. `update-journal-entry` notes that a line on a retired account is refused. Both reach the MCP tools through the registrar.

**Tests**
- New `tests/operations/roboledger/commands/test_guards_accounts.py`: passes on no retired rows, names every retired account, is a `ValueError`, the QuickBooks exemption is case-insensitive, other sources are checked, blank ids skip the query, duplicates are queried once.
- `test_journal_entries.py`: a module-wide autouse stub for the guard (every test there runs on a mocked session), plus three tests pinning what create and update pass to it and that a refusal writes nothing.
- `test_update.py`: `TestApplyIsActive` covers retire, reactivate, and omitted-leaves-alone.

**Not in this PR**: schedule-generated entries (`schedules/service.py` writes `LineItem` rows directly to elements chosen at schedule creation); an app editor for retiring accounts.

## Breaking Changes

None. Additive optional request field on `update-taxonomy-block` (generated tier, client minor on the next regen; the integration template's emit path is untouched). New behaviour: an authored posting to an account that was already `is_active=false` now returns 422 instead of succeeding, which is the intended semantic of the flag.

## Testing

- `just test-code`: ruff, format, basedpyright, cf-lint all passed.
- `uv run pytest` over `tests/operations/roboledger/commands`, `tests/operations/taxonomy_block`, `tests/operations/event_block`, `tests/routers/extensions/roboledger`, `tests/middleware/mcp` with `-m "not slow"`: 1,348 passed against the local stack, including the DB-backed state-transition suite that posts real entries through the guard.
- Not run: the full `just test` in this session. Not exercised end-to-end against a live graph.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188CbjDiNBtxdEYjSJ5Y7mX
