### PR TITLE
feat(ledger): the bank-feed classify loop — classify, then commit

### DIFF
--- a/robosystems/middleware/mcp/tools/instructions.py
+++ b/robosystems/middleware/mcp/tools/instructions.py
@@ -119,6 +119,44 @@ def build_instructions(
       )
     )
 
+  # The inbox loop for bank-feed lines: classify, then commit.
+  if has("update-event-block") and has("list-event-blocks"):
+    inbox_lines = [
+      "INBOX / BANK FEED",
+      (
+        "- A bank feed (Mercury) lands every posted transaction `captured` "
+        "with `metadata.suggested_element_id` + `suggested_account_name`; "
+        "nothing posts until it is classified. Find them → "
+        "`list-event-blocks(source='mercury', status='captured')`."
+      ),
+      (
+        "- Classify one → `update-event-block(event_id, "
+        "transition_to='classified', metadata_patch={classified_element_id, "
+        "classified_by: 'claude', basis})`. A split: `classified_allocations: "
+        "[{element_id, amount}]` summing to the amount. To take the "
+        "suggestion as-is: `metadata_patch={accept_suggestion: true}`."
+      ),
+      (
+        "- Post it → `transition_to='committed'` (a person, or you when "
+        "asked): the handler writes DR/CR against the linked bank account as "
+        "a draft that close posts. An unclassified bank line is refused at "
+        "commit — never force it. Internal transfers are pre-classified "
+        "(both bank legs known) and commit as they are."
+      ),
+    ]
+    if has("recall") and has("remember"):
+      inbox_lines.append(
+        "- `recall` the counterparty before deciding, and `remember` each "
+        "decision ('Stripe payouts → Subscription revenue') so the next line "
+        "from that counterparty classifies itself."
+      )
+    if has("preview-event-block"):
+      inbox_lines.append(
+        "- Unsure what a commit would write? `preview-event-block` shows the "
+        "planned entry."
+      )
+    sections.append(_block(*inbox_lines))
+
   # Reporting & analysis — only the bits that are live.
   report_bits: list[str] = []
   if has("live-financial-statement"):

--- a/robosystems/models/api/event_block.py
+++ b/robosystems/models/api/event_block.py
@@ -499,12 +499,13 @@ class UpdateEventBlockRequest(BaseModel):
 
   # Status transition
   transition_to: (
-    Literal["committed", "pending", "fulfilled", "voided", "superseded"] | None
+    Literal["classified", "committed", "pending", "fulfilled", "voided", "superseded"]
+    | None
   ) = Field(
     None,
     description=(
       "Status transition. Valid moves depend on current status: "
-      "captured → committed | voided | superseded; "
+      "captured → classified | committed | voided | superseded; "
       "classified → committed | pending | fulfilled | voided | superseded; "
       "committed → pending | fulfilled | voided | superseded; "
       "pending → fulfilled | voided | superseded; "
@@ -512,8 +513,11 @@ class UpdateEventBlockRequest(BaseModel):
       "is final and is refused from any status once the event's ledger "
       "rows have posted or it has published to QuickBooks — reverse the "
       "posted entries instead. "
-      "Note: classified and fulfilled are usually set by handlers, not by "
-      "callers, but the transition is allowed for corrections."
+      "captured → classified records an account choice without posting "
+      "(bank-feed lines: patch classified_element_id, or "
+      "accept_suggestion: true, in the same call); the later commit fires "
+      "the handler. Note: classified and fulfilled are otherwise set by "
+      "handlers, not by callers, but the transition is allowed for corrections."
     ),
   )
   superseded_by_id: str | None = Field(

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -157,8 +157,14 @@ class DuplicateEventError(Exception):
 # What gates a retraction is `_assert_retractable`, which asks whether the
 # event's rows have landed — never which status it is being retracted from.
 # The table decides reachability; the guard decides safety.
+#
+# `captured → classified` is the inbox's "account chosen, awaiting post" — a
+# bank-feed line whose classification a person or Claude recorded without
+# posting it yet. Handlers set `classified` on their own at capture; the
+# transition is open to callers so the choice can be recorded ahead of the
+# commit that fires the handler.
 _VALID_TRANSITIONS: dict[str, frozenset[str]] = {
-  "captured": frozenset({"committed", "voided", "superseded"}),
+  "captured": frozenset({"classified", "committed", "voided", "superseded"}),
   "classified": frozenset(
     {"committed", "pending", "fulfilled", "voided", "superseded"}
   ),

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -35,7 +35,6 @@ from robosystems.models.api.event_handler import (
   PreviewEventBlockResponse,
   TransactionPreview,
 )
-from robosystems.models.extensions.roboledger.agent import Agent
 from robosystems.models.extensions.roboledger.dimension_junctions import (
   event_dimensions,
 )
@@ -56,7 +55,12 @@ from robosystems.operations.roboledger.reads.event_block import (
   _to_envelope,
 )
 
-from .engine import EngineValidationError, apply_handler, posting_date_for_event
+from .engine import (
+  EngineValidationError,
+  apply_handler,
+  posting_date_for_event,
+  resolve_agent_type,
+)
 from .python_handlers import get_python_handler
 from .python_handlers.types import HandlerMetadataValidationError
 from .registry import (
@@ -265,16 +269,6 @@ def _assert_retractable(session: Session, event: Event) -> None:
 # event is an idempotent no-op instead (see ``qb_external_id`` / status
 # checks in ``execute_event_block``), so it stays out of this set.
 _UNPUBLISHABLE_STATUSES = frozenset({"voided", "superseded"})
-
-
-def _resolve_agent_type(session: Session, agent_id: str | None) -> str | None:
-  """Load the counterparty's agent_type for DSL handler matching."""
-  if agent_id is None:
-    return None
-  agent = session.get(Agent, agent_id)
-  if agent is None:
-    return None
-  return agent.agent_type
 
 
 # Platform-emitted sources — always valid, no registration involved. Adapter
@@ -513,7 +507,7 @@ def create_event_block_in_session(
       return event, envelope
 
     # 2. Fall through to the DSL registry
-    agent_type = _resolve_agent_type(session, body.agent_id)
+    agent_type = resolve_agent_type(session, body.agent_id)
     handler = resolve_handler(
       session,
       event_type=body.event_type,
@@ -843,7 +837,7 @@ def preview_event_block(
   errors: list[str] = []
   matched_handler_response = None
   planned: list[TransactionPreview] = []
-  agent_type = _resolve_agent_type(session, body.agent_id)
+  agent_type = resolve_agent_type(session, body.agent_id)
 
   try:
     handler = resolve_handler(

--- a/robosystems/operations/event_block/engine.py
+++ b/robosystems/operations/event_block/engine.py
@@ -12,6 +12,7 @@ from datetime import UTC, date, datetime
 
 from sqlalchemy.orm import Session
 
+from robosystems.models.extensions.roboledger.agent import Agent
 from robosystems.models.extensions.roboledger.entry import Entry
 from robosystems.models.extensions.roboledger.event import Event
 from robosystems.models.extensions.roboledger.event_handler import EventHandler
@@ -31,6 +32,19 @@ from .template import (
 
 class EngineValidationError(Exception):
   """Template produced invalid or unbalanced GL entries."""
+
+
+def resolve_agent_type(session: Session, agent_id: str | None) -> str | None:
+  """The counterparty's ``agent_type`` for DSL handler matching, or ``None``.
+
+  Shared by the capture path (``commands``) and the handlers that consult
+  the rule floor at commit (``python_handlers.bank_feed``): both sit above
+  this module, so the lookup lives here rather than in either.
+  """
+  if agent_id is None:
+    return None
+  agent = session.get(Agent, agent_id)
+  return agent.agent_type if agent is not None else None
 
 
 def posting_date_for_event(

--- a/robosystems/operations/event_block/python_handlers/bank_feed.py
+++ b/robosystems/operations/event_block/python_handlers/bank_feed.py
@@ -45,12 +45,12 @@ from robosystems.models.api.event_block import CreateEventBlockRequest
 from robosystems.models.api.extensions.journal_entries import (
   JournalEntryLineItemInput,
 )
-from robosystems.models.extensions.roboledger.agent import Agent
 from robosystems.models.extensions.roboledger.entry import Entry
 from robosystems.models.extensions.roboledger.event import Event
 from robosystems.operations.event_block.engine import (
   apply_handler,
   posting_date_for_event,
+  resolve_agent_type,
 )
 from robosystems.operations.event_block.registry import (
   HandlerAmbiguousError,
@@ -239,13 +239,6 @@ def _memo(event: Event) -> str:
   return (event.description or event.event_type or "Bank transaction")[:255]
 
 
-def _agent_type(session: Session, agent_id: str | None) -> str | None:
-  if agent_id is None:
-    return None
-  agent = session.get(Agent, agent_id)
-  return agent.agent_type if agent is not None else None
-
-
 def _apply_dsl_floor(session: Session, event: Event, created_by: str) -> HandlerResult:
   """An unclassified bank event posts through a matching tenant rule, if any."""
   try:
@@ -254,7 +247,7 @@ def _apply_dsl_floor(session: Session, event: Event, created_by: str) -> Handler
       event_type=event.event_type,
       event_category=event.event_category,
       source=event.source,
-      agent_type=_agent_type(session, event.agent_id),
+      agent_type=resolve_agent_type(session, event.agent_id),
       resource_type=event.resource_type,
       metadata=dict(event.metadata_ or {}),
     )

--- a/robosystems/operations/event_block/python_handlers/bank_feed.py
+++ b/robosystems/operations/event_block/python_handlers/bank_feed.py
@@ -1,0 +1,389 @@
+"""Bank-feed event handlers — post a classified bank line.
+
+A bank feed (Mercury today) captures every posted transaction as an event
+with the bank leg on ``resource_element_id`` and a Tier-0 suggestion on
+``metadata.suggested_element_id``. Nothing posts at capture: the inbox is
+where a person, or Claude over MCP, chooses the account. This module is
+the other half — when a classified bank event is committed, it writes the
+entry.
+
+The classification lives in the event's metadata, patched through
+``update-event-block``:
+
+- ``classified_element_id`` — the contra account for the whole amount.
+- ``classified_allocations`` — a split: ``[{element_id, amount}]`` in
+  cents, summing to the transaction amount.
+- ``accept_suggestion: true`` — take ``suggested_element_id`` as the
+  classification (the one-click approve).
+- ``from_element_id`` / ``to_element_id`` — an internal transfer's two bank
+  legs; the feed sets both when it pairs the legs.
+
+Money in (``amount > 0``): DR bank / CR contra. Money out: DR contra / CR
+bank. The entry is a draft on the event's posting date, in the local lane
+(a bank line is never published anywhere), and posts at close like any
+other draft. The GL write itself is ``journal_entry_recorded``'s, so the
+closed-period fence, balance check and the postability guard (a retired
+account takes no new lines) are the ledger's own.
+
+An unclassified event falls back to the tenant's DSL rules — the
+deterministic floor for a counterparty that never varies — and, when no
+rule matches, refuses to commit: a bank event must never land
+``committed`` with no rows behind it.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from robosystems.logger import logger
+from robosystems.models.api.event_block import CreateEventBlockRequest
+from robosystems.models.api.extensions.journal_entries import (
+  JournalEntryLineItemInput,
+)
+from robosystems.models.extensions.roboledger.agent import Agent
+from robosystems.models.extensions.roboledger.entry import Entry
+from robosystems.models.extensions.roboledger.event import Event
+from robosystems.operations.event_block.engine import (
+  apply_handler,
+  posting_date_for_event,
+)
+from robosystems.operations.event_block.registry import (
+  HandlerAmbiguousError,
+  HandlerNotFoundError,
+  resolve_handler,
+)
+
+from .journal_entry_recorded import JournalEntryRecordedMetadata
+from .journal_entry_recorded import dispatch as journal_dispatch
+from .journal_entry_recorded import dispatch_preview as journal_dispatch_preview
+from .types import (
+  EventBlockPythonHandler,
+  HandlerMetadataValidationError,
+  HandlerPreview,
+  HandlerResult,
+)
+
+BANK_TRANSACTION = "bank_transaction"
+BANK_FEE = "bank_fee"
+EXTERNAL_TRANSFER = "external_transfer"
+INTERNAL_TRANSFER = "internal_transfer"
+BANK_EVENT_TYPES: tuple[str, ...] = (
+  BANK_TRANSACTION,
+  BANK_FEE,
+  EXTERNAL_TRANSFER,
+  INTERNAL_TRANSFER,
+)
+
+
+class BankEventNotClassifiedError(HandlerMetadataValidationError):
+  """The event carries no account choice and no rule matches it."""
+
+
+class BankAllocation(BaseModel):
+  element_id: str = Field(..., min_length=1)
+  amount: int = Field(..., gt=0, description="Cents; shares the line's direction.")
+
+
+class BankFeedMetadata(BaseModel):
+  """What the handler reads from a bank event's metadata.
+
+  Everything the feed captured (the Mercury payload keys, the suggestion,
+  the routing ``connection_id``) rides along untouched — the schema is
+  open, and only the classification keys are typed.
+  """
+
+  model_config = ConfigDict(extra="allow")
+
+  classified_element_id: str | None = None
+  classified_allocations: list[BankAllocation] | None = None
+  accept_suggestion: bool = False
+  suggested_element_id: str | None = None
+  from_element_id: str | None = None
+  to_element_id: str | None = None
+  classified_by: str | None = None
+  basis: str | None = None
+  connection_id: str | None = None
+
+
+def contra_allocations(
+  metadata: BankFeedMetadata, *, amount: int
+) -> list[BankAllocation] | None:
+  """The contra side of a bank line, or ``None`` when nothing chose one.
+
+  A split wins over a single account; the suggestion counts only when the
+  caller accepted it. Amounts are validated against the transaction.
+  """
+  magnitude = abs(amount)
+  if metadata.classified_allocations:
+    total = sum(a.amount for a in metadata.classified_allocations)
+    if total != magnitude:
+      raise HandlerMetadataValidationError(
+        f"classified_allocations sum to {total} but the transaction is "
+        f"{magnitude}; a split must account for the whole amount."
+      )
+    return list(metadata.classified_allocations)
+  element_id = metadata.classified_element_id
+  if not element_id and metadata.accept_suggestion:
+    element_id = metadata.suggested_element_id
+  if not element_id:
+    return None
+  return [BankAllocation(element_id=element_id, amount=magnitude)]
+
+
+def plan_lines(
+  *,
+  event_type: str,
+  resource_element_id: str | None,
+  amount: int | None,
+  metadata: BankFeedMetadata,
+) -> list[JournalEntryLineItemInput] | None:
+  """The balanced entry for one bank event, or ``None`` when unclassified.
+
+  Pure: reads the event's fields and its metadata, touches no session.
+  Raises on shapes that can never post (no bank leg, no amount, a split
+  that does not add up).
+  """
+  if amount is None or amount == 0:
+    raise HandlerMetadataValidationError(
+      "A bank event needs a non-zero amount to post."
+    )
+  magnitude = abs(amount)
+
+  if event_type == INTERNAL_TRANSFER:
+    to_element = metadata.to_element_id or resource_element_id
+    from_element = metadata.from_element_id
+    if not to_element or not from_element:
+      raise HandlerMetadataValidationError(
+        "An internal transfer needs both bank legs: metadata.from_element_id "
+        "and metadata.to_element_id (or resource_element_id) — link the chart "
+        "accounts for both bank accounts, then re-sync."
+      )
+    if to_element == from_element:
+      raise HandlerMetadataValidationError(
+        "An internal transfer's two legs resolve to the same chart account."
+      )
+    return [
+      JournalEntryLineItemInput(element_id=to_element, debit_amount=magnitude),
+      JournalEntryLineItemInput(element_id=from_element, credit_amount=magnitude),
+    ]
+
+  if not resource_element_id:
+    raise HandlerMetadataValidationError(
+      "This bank event has no chart account linked to its bank account "
+      "(resource_element_id); link the account and re-sync before posting."
+    )
+  contras = contra_allocations(metadata, amount=amount)
+  if contras is None:
+    return None
+  if any(a.element_id == resource_element_id for a in contras):
+    raise HandlerMetadataValidationError(
+      "A bank line cannot be classified to the bank account it moved through."
+    )
+
+  money_in = amount > 0
+  bank_line = JournalEntryLineItemInput(
+    element_id=resource_element_id,
+    debit_amount=magnitude if money_in else 0,
+    credit_amount=0 if money_in else magnitude,
+  )
+  contra_lines = [
+    JournalEntryLineItemInput(
+      element_id=allocation.element_id,
+      debit_amount=0 if money_in else allocation.amount,
+      credit_amount=allocation.amount if money_in else 0,
+    )
+    for allocation in contras
+  ]
+  return [bank_line, *contra_lines] if money_in else [*contra_lines, bank_line]
+
+
+def _journal_metadata(
+  *,
+  posting_date: date,
+  memo: str,
+  lines: list[JournalEntryLineItemInput],
+  connection_id: str | None,
+) -> JournalEntryRecordedMetadata:
+  return JournalEntryRecordedMetadata(
+    posting_date=posting_date,
+    memo=memo,
+    line_items=lines,
+    status="draft",
+    connection_id=connection_id,
+    # A bank line is evidence of the bank's own record; it is never
+    # published to a source system, whatever the connection's policy.
+    publish_to_source=False,
+  )
+
+
+def _memo(event: Event) -> str:
+  return (event.description or event.event_type or "Bank transaction")[:255]
+
+
+def _agent_type(session: Session, agent_id: str | None) -> str | None:
+  if agent_id is None:
+    return None
+  agent = session.get(Agent, agent_id)
+  return agent.agent_type if agent is not None else None
+
+
+def _apply_dsl_floor(session: Session, event: Event, created_by: str) -> HandlerResult:
+  """An unclassified bank event posts through a matching tenant rule, if any."""
+  try:
+    handler = resolve_handler(
+      session,
+      event_type=event.event_type,
+      event_category=event.event_category,
+      source=event.source,
+      agent_type=_agent_type(session, event.agent_id),
+      resource_type=event.resource_type,
+      metadata=dict(event.metadata_ or {}),
+    )
+  except HandlerNotFoundError:
+    raise BankEventNotClassifiedError(
+      f"Bank event {event.id} has no account chosen and no rule matches it. "
+      "Classify it first — set metadata.classified_element_id (or "
+      "accept_suggestion: true to take the suggestion) — then commit."
+    ) from None
+  except HandlerAmbiguousError as exc:
+    raise BankEventNotClassifiedError(
+      f"Bank event {event.id} matches more than one rule ({exc}); classify it "
+      "explicitly instead."
+    ) from exc
+  transactions = apply_handler(session, event, handler, created_by=created_by)
+  transaction_ids = [str(t.id) for t in transactions]
+  entry_ids = [
+    str(entry_id)
+    for (entry_id,) in session.execute(
+      select(Entry.id).where(Entry.transaction_id.in_(transaction_ids))
+    ).all()
+  ]
+  logger.info(
+    "bank event %s posted through rule '%s': %d transaction(s)",
+    event.id,
+    handler.name,
+    len(transaction_ids),
+  )
+  return HandlerResult(entry_ids=entry_ids, transaction_ids=transaction_ids)
+
+
+def dispatch(
+  session: Session,
+  event: Event,
+  metadata: BankFeedMetadata,
+  created_by: str,
+) -> HandlerResult:
+  """Write the classified bank line as a draft entry, or refuse."""
+  lines = plan_lines(
+    event_type=event.event_type,
+    resource_element_id=event.resource_element_id,
+    amount=event.amount,
+    metadata=metadata,
+  )
+  if lines is None:
+    return _apply_dsl_floor(session, event, created_by)
+
+  journal = _journal_metadata(
+    posting_date=posting_date_for_event(
+      effective_at=event.effective_at, occurred_at=event.occurred_at
+    ),
+    memo=_memo(event),
+    lines=lines,
+    connection_id=metadata.connection_id,
+  )
+  result = journal_dispatch(session, event, journal, created_by)
+  logger.info(
+    "bank event %s (%s) posted: %s by %s",
+    event.id,
+    event.event_type,
+    "split" if metadata.classified_allocations else "single account",
+    metadata.classified_by or "caller",
+  )
+  return result
+
+
+def dispatch_preview(
+  session: Session,
+  body: CreateEventBlockRequest,
+  metadata: BankFeedMetadata,
+) -> HandlerPreview:
+  """The entry the commit would write — the inbox's preview of an approve."""
+  try:
+    lines = plan_lines(
+      event_type=body.event_type,
+      resource_element_id=body.resource_element_id,
+      amount=body.amount,
+      metadata=metadata,
+    )
+  except HandlerMetadataValidationError as exc:
+    return HandlerPreview(would_succeed=False, validation_errors=[str(exc)])
+  if lines is None:
+    return HandlerPreview(
+      would_succeed=False,
+      validation_errors=[
+        "No account chosen: set classified_element_id, classified_allocations, "
+        "or accept_suggestion before committing."
+      ],
+      computed_values={"suggested_element_id": metadata.suggested_element_id},
+    )
+  journal = _journal_metadata(
+    posting_date=posting_date_for_event(
+      effective_at=body.effective_at, occurred_at=body.occurred_at
+    ),
+    memo=(body.description or body.event_type)[:255],
+    lines=lines,
+    connection_id=metadata.connection_id,
+  )
+  preview = journal_dispatch_preview(session, body, journal)
+  preview.computed_values = {
+    **(preview.computed_values or {}),
+    "direction": "in" if (body.amount or 0) > 0 else "out",
+    "contra_element_ids": [
+      line.element_id for line in lines if line.element_id != body.resource_element_id
+    ],
+  }
+  return preview
+
+
+def _handler(event_type: str, display_name: str) -> EventBlockPythonHandler:
+  return EventBlockPythonHandler(
+    event_type=event_type,
+    display_name=display_name,
+    metadata_schema=BankFeedMetadata,
+    # A draft that close posts; the same target the journal handler keeps.
+    target_status="classified",
+    dispatch=dispatch,
+    dispatch_preview=dispatch_preview,
+  )
+
+
+BANK_TRANSACTION_HANDLER = _handler(BANK_TRANSACTION, "Bank Transaction")
+BANK_FEE_HANDLER = _handler(BANK_FEE, "Bank Fee")
+EXTERNAL_TRANSFER_HANDLER = _handler(EXTERNAL_TRANSFER, "External Transfer")
+INTERNAL_TRANSFER_HANDLER = _handler(INTERNAL_TRANSFER, "Internal Transfer")
+
+BANK_FEED_HANDLERS: dict[str, EventBlockPythonHandler] = {
+  handler.event_type: handler
+  for handler in (
+    BANK_TRANSACTION_HANDLER,
+    BANK_FEE_HANDLER,
+    EXTERNAL_TRANSFER_HANDLER,
+    INTERNAL_TRANSFER_HANDLER,
+  )
+}
+
+
+def classification_summary(metadata: dict[str, Any]) -> str:
+  """One line for logs and the inbox: what the event is classified to."""
+  if metadata.get("classified_allocations"):
+    return f"split across {len(metadata['classified_allocations'])} accounts"
+  if metadata.get("classified_element_id"):
+    return f"account {metadata['classified_element_id']}"
+  if metadata.get("accept_suggestion") and metadata.get("suggested_element_id"):
+    return f"suggested account {metadata['suggested_element_id']}"
+  return "unclassified"

--- a/robosystems/operations/event_block/python_handlers/bank_feed.py
+++ b/robosystems/operations/event_block/python_handlers/bank_feed.py
@@ -215,10 +215,24 @@ def _journal_metadata(
     line_items=lines,
     status="draft",
     connection_id=connection_id,
-    # A bank line is evidence of the bank's own record; it is never
-    # published to a source system, whatever the connection's policy.
     publish_to_source=False,
   )
+
+
+def _pin_to_local_lane(event: Event) -> None:
+  """A bank line is evidence of the bank's own record; it is never published
+  to a source system, whatever the connection's policy.
+
+  Close decides the write-back lane from the *persisted* event's
+  ``metadata.publish_to_source`` (``qb_writeback.writeback_source_clause``),
+  not from anything a handler passes along, so the pin has to land on the
+  row. Today ``source='mercury'`` is outside the write-back sources anyway;
+  the explicit flag keeps that true if the source list ever widens.
+  """
+  metadata = dict(event.metadata_ or {})
+  if metadata.get("publish_to_source") is not False:
+    metadata["publish_to_source"] = False
+    event.metadata_ = metadata
 
 
 def _memo(event: Event) -> str:
@@ -286,8 +300,10 @@ def dispatch(
     metadata=metadata,
   )
   if lines is None:
+    _pin_to_local_lane(event)
     return _apply_dsl_floor(session, event, created_by)
 
+  _pin_to_local_lane(event)
   journal = _journal_metadata(
     posting_date=posting_date_for_event(
       effective_at=event.effective_at, occurred_at=event.occurred_at

--- a/robosystems/operations/event_block/python_handlers/registry.py
+++ b/robosystems/operations/event_block/python_handlers/registry.py
@@ -13,6 +13,7 @@ Adding a new handler:
 from __future__ import annotations
 
 from .asset_disposed import ASSET_DISPOSED_HANDLER
+from .bank_feed import BANK_FEED_HANDLERS
 from .bill_paid import BILL_PAID_HANDLER
 from .journal_entry_recorded import JOURNAL_ENTRY_RECORDED_HANDLER
 from .journal_entry_reversed import JOURNAL_ENTRY_REVERSED_HANDLER
@@ -49,6 +50,10 @@ EVENT_BLOCK_PYTHON_REGISTRY: dict[str, EventBlockPythonHandler] = {
   "credit_card_refund": JOURNAL_ENTRY_RECORDED_HANDLER,
   "deposit_received": JOURNAL_ENTRY_RECORDED_HANDLER,
   "inventory_adjusted": JOURNAL_ENTRY_RECORDED_HANDLER,
+  # Bank-feed events (Mercury): captured with a suggestion, posted only once
+  # classified — the handler builds the entry from the account choice and
+  # refuses an unclassified commit.
+  **BANK_FEED_HANDLERS,
 }
 
 

--- a/robosystems/routers/extensions/roboledger/operations.py
+++ b/robosystems/routers/extensions/roboledger/operations.py
@@ -1616,14 +1616,18 @@ update_event_block_op = _registrar.register(
     name="update-event-block",
     summary="Update Event Block",
     description=(
-      "Apply a status transition (captured → committed | voided) and/or "
-      "field corrections (description, effective_at, metadata_patch) to an "
-      "existing event block. Only supplied fields are updated. When the "
-      "transition is captured/classified → committed, the registered "
-      "Python handler fires against the captured metadata to produce the "
-      "GL rows; errors from the handler (validation, element resolution, "
-      "closed period, unbalanced lines) surface as 422 here so the inbox "
-      "UI can display the failure reason without retry."
+      "Apply a status transition (captured → classified | committed | voided) "
+      "and/or field corrections (description, effective_at, metadata_patch) "
+      "to an existing event block. Only supplied fields are updated. "
+      "captured → classified records an account choice without posting — "
+      "for a bank-feed line, patch metadata.classified_element_id (or "
+      "accept_suggestion: true) in the same call. When the transition is "
+      "captured/classified → committed, the registered Python handler fires "
+      "against the captured metadata to produce the GL rows; a bank-feed "
+      "line with no account chosen and no matching rule is refused. Errors "
+      "from the handler (validation, element resolution, closed period, "
+      "unbalanced lines) surface as 422 here so the inbox UI can display "
+      "the failure reason without retry."
     ),
     command=cmd_update_event_block,
     request_model=UpdateEventBlockRequest,

--- a/tests/middleware/mcp/tools/test_instructions.py
+++ b/tests/middleware/mcp/tools/test_instructions.py
@@ -141,3 +141,37 @@ class TestInvariant:
     assert "get-graph-sync-status" not in out
     # but the orient line still works off the remaining tools
     assert "get-fiscal-calendar" in out
+
+
+class TestInboxRouting:
+  _INBOX = _LEDGER | {
+    "list-event-blocks",
+    "update-event-block",
+    "preview-event-block",
+    "recall",
+    "remember",
+  }
+
+  def _build(self, tools):
+    return build_instructions(
+      graph_id="kg1", tool_names=tools, is_shared_repo=False, read_only=False
+    )
+
+  def test_bank_feed_loop_present_with_the_write_tools(self) -> None:
+    out = self._build(self._INBOX)
+    assert "INBOX / BANK FEED" in out
+    assert "transition_to='classified'" in out
+    assert "accept_suggestion: true" in out
+    assert "refused at commit" in out
+    assert "`recall` the counterparty" in out
+    assert "`preview-event-block`" in out
+
+  def test_bank_feed_loop_absent_without_update_tool(self) -> None:
+    out = self._build(_LEDGER | {"list-event-blocks"})
+    assert "INBOX / BANK FEED" not in out
+
+  def test_memory_and_preview_lines_track_their_tools(self) -> None:
+    out = self._build(_LEDGER | {"list-event-blocks", "update-event-block"})
+    assert "INBOX / BANK FEED" in out
+    assert "`recall`" not in out
+    assert "`preview-event-block`" not in out

--- a/tests/operations/event_block/python_handlers/test_bank_feed.py
+++ b/tests/operations/event_block/python_handlers/test_bank_feed.py
@@ -1,0 +1,385 @@
+"""Tests for the bank-feed handlers: the classify-then-commit half of a feed."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from robosystems.models.api.event_block import CreateEventBlockRequest
+from robosystems.operations.event_block.python_handlers.bank_feed import (
+  BANK_EVENT_TYPES,
+  BANK_FEED_HANDLERS,
+  BankEventNotClassifiedError,
+  BankFeedMetadata,
+  classification_summary,
+  contra_allocations,
+  dispatch,
+  dispatch_preview,
+  plan_lines,
+)
+from robosystems.operations.event_block.python_handlers.types import (
+  HandlerMetadataValidationError,
+)
+from robosystems.operations.event_block.registry import (
+  HandlerAmbiguousError,
+  HandlerNotFoundError,
+)
+
+MODULE = "robosystems.operations.event_block.python_handlers.bank_feed"
+
+
+def _event(
+  event_type: str = "bank_transaction",
+  amount: int = -4250,
+  resource_element_id: str | None = "elem_card",
+  metadata: dict | None = None,
+):
+  event = MagicMock()
+  event.id = "evt_bank"
+  event.event_type = event_type
+  event.event_category = "purchase"
+  event.source = "mercury"
+  event.resource_type = "money"
+  event.agent_id = "agt_staples"
+  event.amount = amount
+  event.resource_element_id = resource_element_id
+  event.description = "Staples (card)"
+  event.occurred_at = datetime(2026, 3, 14, 15, 4, 5, tzinfo=UTC)
+  event.effective_at = None
+  event.metadata_ = metadata or {}
+  return event
+
+
+def _lines_as_tuples(lines):
+  return [(li.element_id, li.debit_amount, li.credit_amount) for li in lines]
+
+
+@pytest.mark.unit
+class TestMetadata:
+  def test_open_schema_keeps_the_feed_keys(self):
+    meta = BankFeedMetadata.model_validate(
+      {"bank_description": "STAPLES", "suggested_element_id": "elem_office"}
+    )
+    assert meta.suggested_element_id == "elem_office"
+    assert meta.model_extra == {"bank_description": "STAPLES"}
+
+  def test_allocation_amount_must_be_positive(self):
+    with pytest.raises(ValidationError):
+      BankFeedMetadata.model_validate(
+        {"classified_allocations": [{"element_id": "e", "amount": 0}]}
+      )
+
+  def test_contra_allocations_precedence(self):
+    both = BankFeedMetadata(
+      classified_element_id="elem_single",
+      classified_allocations=[
+        {"element_id": "elem_a", "amount": 1000},
+        {"element_id": "elem_b", "amount": 3250},
+      ],
+    )
+    assert [a.element_id for a in contra_allocations(both, amount=-4250)] == [
+      "elem_a",
+      "elem_b",
+    ]
+    single = BankFeedMetadata(classified_element_id="elem_single")
+    assert [a.element_id for a in contra_allocations(single, amount=-4250)] == [
+      "elem_single"
+    ]
+    accepted = BankFeedMetadata(
+      accept_suggestion=True, suggested_element_id="elem_sugg"
+    )
+    assert [a.element_id for a in contra_allocations(accepted, amount=99)] == [
+      "elem_sugg"
+    ]
+    unaccepted = BankFeedMetadata(suggested_element_id="elem_sugg")
+    assert contra_allocations(unaccepted, amount=99) is None
+
+  def test_split_must_add_up(self):
+    meta = BankFeedMetadata(
+      classified_allocations=[{"element_id": "elem_a", "amount": 1000}]
+    )
+    with pytest.raises(HandlerMetadataValidationError, match="sum to 1000"):
+      contra_allocations(meta, amount=-4250)
+
+
+@pytest.mark.unit
+class TestPlanLines:
+  def test_money_out_debits_the_contra_and_credits_the_bank(self):
+    lines = plan_lines(
+      event_type="bank_transaction",
+      resource_element_id="elem_card",
+      amount=-4250,
+      metadata=BankFeedMetadata(classified_element_id="elem_office"),
+    )
+    assert _lines_as_tuples(lines) == [
+      ("elem_office", 4250, 0),
+      ("elem_card", 0, 4250),
+    ]
+
+  def test_money_in_debits_the_bank_and_credits_the_contra(self):
+    lines = plan_lines(
+      event_type="bank_transaction",
+      resource_element_id="elem_checking",
+      amount=9514,
+      metadata=BankFeedMetadata(
+        accept_suggestion=True, suggested_element_id="elem_revenue"
+      ),
+    )
+    assert _lines_as_tuples(lines) == [
+      ("elem_checking", 9514, 0),
+      ("elem_revenue", 0, 9514),
+    ]
+
+  def test_split_posts_one_line_per_allocation(self):
+    lines = plan_lines(
+      event_type="bank_transaction",
+      resource_element_id="elem_card",
+      amount=-4250,
+      metadata=BankFeedMetadata(
+        classified_allocations=[
+          {"element_id": "elem_office", "amount": 4000},
+          {"element_id": "elem_tax", "amount": 250},
+        ]
+      ),
+    )
+    assert _lines_as_tuples(lines) == [
+      ("elem_office", 4000, 0),
+      ("elem_tax", 250, 0),
+      ("elem_card", 0, 4250),
+    ]
+
+  def test_fee_and_external_transfer_share_the_shape(self):
+    for event_type in ("bank_fee", "external_transfer"):
+      lines = plan_lines(
+        event_type=event_type,
+        resource_element_id="elem_checking",
+        amount=-1500,
+        metadata=BankFeedMetadata(classified_element_id="elem_contra"),
+      )
+      assert _lines_as_tuples(lines) == [
+        ("elem_contra", 1500, 0),
+        ("elem_checking", 0, 1500),
+      ]
+
+  def test_internal_transfer_uses_both_bank_legs(self):
+    lines = plan_lines(
+      event_type="internal_transfer",
+      resource_element_id="elem_savings",
+      amount=50000,
+      metadata=BankFeedMetadata(
+        from_element_id="elem_checking", to_element_id="elem_savings"
+      ),
+    )
+    assert _lines_as_tuples(lines) == [
+      ("elem_savings", 50000, 0),
+      ("elem_checking", 0, 50000),
+    ]
+
+  def test_internal_transfer_missing_a_leg_is_refused(self):
+    with pytest.raises(HandlerMetadataValidationError, match="both bank legs"):
+      plan_lines(
+        event_type="internal_transfer",
+        resource_element_id="elem_savings",
+        amount=50000,
+        metadata=BankFeedMetadata(),
+      )
+
+  def test_unclassified_is_none_not_an_error(self):
+    assert (
+      plan_lines(
+        event_type="bank_transaction",
+        resource_element_id="elem_card",
+        amount=-100,
+        metadata=BankFeedMetadata(suggested_element_id="elem_sugg"),
+      )
+      is None
+    )
+
+  def test_no_bank_leg_is_refused(self):
+    with pytest.raises(HandlerMetadataValidationError, match="no chart account linked"):
+      plan_lines(
+        event_type="bank_transaction",
+        resource_element_id=None,
+        amount=-100,
+        metadata=BankFeedMetadata(classified_element_id="elem_x"),
+      )
+
+  def test_zero_amount_is_refused(self):
+    with pytest.raises(HandlerMetadataValidationError, match="non-zero"):
+      plan_lines(
+        event_type="bank_transaction",
+        resource_element_id="elem_card",
+        amount=0,
+        metadata=BankFeedMetadata(classified_element_id="elem_x"),
+      )
+
+  def test_classifying_to_the_bank_account_itself_is_refused(self):
+    with pytest.raises(HandlerMetadataValidationError, match="moved through"):
+      plan_lines(
+        event_type="bank_transaction",
+        resource_element_id="elem_card",
+        amount=-100,
+        metadata=BankFeedMetadata(classified_element_id="elem_card"),
+      )
+
+
+@pytest.mark.unit
+class TestDispatch:
+  def test_classified_event_posts_a_draft_in_the_local_lane(self):
+    event = _event(metadata={"connection_id": "conn_1"})
+    session = MagicMock()
+    metadata = BankFeedMetadata(
+      classified_element_id="elem_office",
+      connection_id="conn_1",
+      classified_by="claude",
+    )
+    with patch(f"{MODULE}.journal_dispatch") as journal:
+      journal.return_value = MagicMock(entry_ids=["je_1"], transaction_ids=["txn_1"])
+      result = dispatch(session, event, metadata, "usr_1")
+    journal.assert_called_once()
+    _session, _event_arg, journal_meta, created_by = journal.call_args.args
+    assert created_by == "usr_1"
+    assert journal_meta.status == "draft"
+    assert journal_meta.publish_to_source is False
+    assert journal_meta.connection_id == "conn_1"
+    assert journal_meta.memo == "Staples (card)"
+    assert journal_meta.posting_date.isoformat() == "2026-03-14"
+    assert _lines_as_tuples(journal_meta.line_items) == [
+      ("elem_office", 4250, 0),
+      ("elem_card", 0, 4250),
+    ]
+    assert result.entry_ids == ["je_1"]
+
+  def test_unclassified_event_with_no_rule_is_refused(self):
+    event = _event()
+    session = MagicMock()
+    with (
+      patch(
+        f"{MODULE}.resolve_handler",
+        side_effect=HandlerNotFoundError("bank_transaction", "purchase"),
+      ),
+      patch(f"{MODULE}.journal_dispatch") as journal,
+    ):
+      with pytest.raises(BankEventNotClassifiedError, match="Classify it first"):
+        dispatch(
+          session, event, BankFeedMetadata(suggested_element_id="elem_sugg"), "usr_1"
+        )
+    journal.assert_not_called()
+
+  def test_refusal_is_a_handler_validation_error_for_the_router(self):
+    assert issubclass(BankEventNotClassifiedError, HandlerMetadataValidationError)
+
+  def test_ambiguous_rules_are_refused_too(self):
+    event = _event()
+    rules = [MagicMock(name="a", priority=5), MagicMock(name="b", priority=5)]
+    ambiguous = HandlerAmbiguousError("bank_transaction", rules)
+    with patch(f"{MODULE}.resolve_handler", side_effect=ambiguous):
+      with pytest.raises(BankEventNotClassifiedError, match="more than one rule"):
+        dispatch(MagicMock(), event, BankFeedMetadata(), "usr_1")
+
+  def test_unclassified_event_posts_through_a_matching_rule(self):
+    event = _event()
+    session = MagicMock()
+    session.get.return_value = MagicMock(agent_type="vendor")
+    session.execute.return_value.all.return_value = [("je_rule",)]
+    rule = MagicMock(name="stripe-rule")
+    rule.name = "Stripe payouts"
+    txn = MagicMock()
+    txn.id = "txn_rule"
+    with (
+      patch(f"{MODULE}.resolve_handler", return_value=rule) as resolve,
+      patch(f"{MODULE}.apply_handler", return_value=[txn]) as apply,
+      patch(f"{MODULE}.journal_dispatch") as journal,
+    ):
+      result = dispatch(session, event, BankFeedMetadata(), "usr_1")
+    journal.assert_not_called()
+    resolve.assert_called_once()
+    assert resolve.call_args.kwargs["agent_type"] == "vendor"
+    assert resolve.call_args.kwargs["source"] == "mercury"
+    apply.assert_called_once_with(session, event, rule, created_by="usr_1")
+    assert result.transaction_ids == ["txn_rule"]
+    assert result.entry_ids == ["je_rule"]
+
+  def test_handlers_registered_for_every_bank_event_type(self):
+    from robosystems.operations.event_block.python_handlers.registry import (
+      get_python_handler,
+    )
+
+    for event_type in BANK_EVENT_TYPES:
+      handler = get_python_handler(event_type)
+      assert handler is BANK_FEED_HANDLERS[event_type]
+      assert handler.metadata_schema is BankFeedMetadata
+      assert handler.target_status == "classified"
+
+
+@pytest.mark.unit
+class TestPreview:
+  def _body(self, **overrides) -> CreateEventBlockRequest:
+    base = {
+      "event_type": "bank_transaction",
+      "event_category": "purchase",
+      "event_class": "economic",
+      "resource_type": "money",
+      "resource_element_id": "elem_card",
+      "occurred_at": datetime(2026, 3, 14, tzinfo=UTC),
+      "source": "mercury",
+      "external_id": "mercury_txn_1",
+      "amount": -4250,
+      "description": "Staples (card)",
+      "metadata": {"suggested_element_id": "elem_office"},
+    }
+    base.update(overrides)
+    return CreateEventBlockRequest.model_validate(base)
+
+  def test_unclassified_preview_names_the_missing_choice(self):
+    preview = dispatch_preview(
+      MagicMock(), self._body(), BankFeedMetadata(suggested_element_id="elem_office")
+    )
+    assert preview.would_succeed is False
+    assert "No account chosen" in preview.validation_errors[0]
+    assert preview.computed_values["suggested_element_id"] == "elem_office"
+
+  def test_classified_preview_delegates_and_annotates(self):
+    body = self._body()
+    with patch(f"{MODULE}.journal_dispatch_preview") as journal_preview:
+      journal_preview.return_value = MagicMock(
+        would_succeed=True, computed_values={"total_debit": 4250}
+      )
+      preview = dispatch_preview(
+        MagicMock(), body, BankFeedMetadata(classified_element_id="elem_office")
+      )
+    journal_meta = journal_preview.call_args.args[2]
+    assert _lines_as_tuples(journal_meta.line_items) == [
+      ("elem_office", 4250, 0),
+      ("elem_card", 0, 4250),
+    ]
+    assert preview.would_succeed is True
+    assert preview.computed_values["direction"] == "out"
+    assert preview.computed_values["contra_element_ids"] == ["elem_office"]
+    assert preview.computed_values["total_debit"] == 4250
+
+  def test_bad_split_preview_fails_without_raising(self):
+    preview = dispatch_preview(
+      MagicMock(),
+      self._body(),
+      BankFeedMetadata(classified_allocations=[{"element_id": "elem_a", "amount": 1}]),
+    )
+    assert preview.would_succeed is False
+    assert "sum to 1" in preview.validation_errors[0]
+
+
+@pytest.mark.unit
+def test_classification_summary():
+  assert classification_summary({}) == "unclassified"
+  assert classification_summary({"classified_element_id": "e1"}) == "account e1"
+  assert (
+    classification_summary({"accept_suggestion": True, "suggested_element_id": "e2"})
+    == "suggested account e2"
+  )
+  assert (
+    classification_summary({"classified_allocations": [{}, {}]})
+    == "split across 2 accounts"
+  )

--- a/tests/operations/event_block/python_handlers/test_bank_feed.py
+++ b/tests/operations/event_block/python_handlers/test_bank_feed.py
@@ -243,7 +243,9 @@ class TestDispatch:
     _session, _event_arg, journal_meta, created_by = journal.call_args.args
     assert created_by == "usr_1"
     assert journal_meta.status == "draft"
-    assert journal_meta.publish_to_source is False
+    # The pin close reads is the persisted event's own metadata.
+    assert event.metadata_["publish_to_source"] is False
+    assert event.metadata_["connection_id"] == "conn_1"
     assert journal_meta.connection_id == "conn_1"
     assert journal_meta.memo == "Staples (card)"
     assert journal_meta.posting_date.isoformat() == "2026-03-14"
@@ -302,6 +304,33 @@ class TestDispatch:
     apply.assert_called_once_with(session, event, rule, created_by="usr_1")
     assert result.transaction_ids == ["txn_rule"]
     assert result.entry_ids == ["je_rule"]
+
+  def test_rule_posted_line_is_pinned_to_the_local_lane_too(self):
+    event = _event(metadata={"connection_id": "conn_1"})
+    session = MagicMock()
+    session.get.return_value = None
+    session.execute.return_value.all.return_value = []
+    txn = MagicMock()
+    txn.id = "txn_rule"
+    with (
+      patch(f"{MODULE}.resolve_handler", return_value=MagicMock(name="rule")),
+      patch(f"{MODULE}.apply_handler", return_value=[txn]),
+    ):
+      dispatch(session, event, BankFeedMetadata(), "usr_1")
+    assert event.metadata_["publish_to_source"] is False
+
+  def test_pin_is_idempotent_on_the_metadata_dict(self):
+    from robosystems.operations.event_block.python_handlers.bank_feed import (
+      _pin_to_local_lane,
+    )
+
+    event = _event(metadata={"publish_to_source": False, "k": 1})
+    before = event.metadata_
+    _pin_to_local_lane(event)
+    assert event.metadata_ is before  # untouched when already pinned
+    event.metadata_ = {"k": 1}
+    _pin_to_local_lane(event)
+    assert event.metadata_ == {"k": 1, "publish_to_source": False}
 
   def test_handlers_registered_for_every_bank_event_type(self):
     from robosystems.operations.event_block.python_handlers.registry import (

--- a/tests/operations/event_block/python_handlers/test_registry.py
+++ b/tests/operations/event_block/python_handlers/test_registry.py
@@ -115,7 +115,8 @@ def test_registry_has_expected_handlers() -> None:
   QB JournalReport surfaces when Purchase / Deposit / Credit Card Credit /
   Inventory Adjustment rows flow through. All share the
   journal_entry_recorded handler — the on-approve GL shape is identical;
-  the distinct keys let the inbox filter by source class."""
+  the distinct keys let the inbox filter by source class. The four bank-feed
+  types have their own handler (bank_feed.py)."""
   assert set(EVENT_BLOCK_PYTHON_REGISTRY.keys()) == {
     "asset_disposed",
     "schedule_created",
@@ -133,4 +134,26 @@ def test_registry_has_expected_handlers() -> None:
     "credit_card_refund",
     "deposit_received",
     "inventory_adjusted",
+    # Bank-feed lines (Mercury): posted from their classification.
+    "bank_transaction",
+    "bank_fee",
+    "external_transfer",
+    "internal_transfer",
   }
+
+
+def test_bank_feed_event_types_use_the_bank_handlers() -> None:
+  """A bank-feed line posts from its classification, never from the journal
+  shape — and an unclassified one is refused rather than landing empty."""
+  from robosystems.operations.event_block.python_handlers.bank_feed import (
+    BANK_FEED_HANDLERS,
+  )
+
+  for event_type in (
+    "bank_transaction",
+    "bank_fee",
+    "external_transfer",
+    "internal_transfer",
+  ):
+    assert get_python_handler(event_type) is BANK_FEED_HANDLERS[event_type]
+    assert get_python_handler(event_type) is not JOURNAL_ENTRY_RECORDED_HANDLER

--- a/tests/operations/event_block/test_commands_update.py
+++ b/tests/operations/event_block/test_commands_update.py
@@ -740,3 +740,60 @@ class TestLockContention:
       update_event_block(
         session, body, created_by="usr_test", graph_id="kg00000000000000aa"
       )
+
+
+class TestClassifyTransition:
+  """`captured → classified` records an account choice without posting."""
+
+  @pytest.fixture(autouse=True)
+  def _no_locks_or_fences(self):
+    with (
+      patch("robosystems.operations.event_block.commands.bounded_lock_wait"),
+      patch("robosystems.operations.event_block.commands.assert_period_not_closed"),
+    ):
+      yield
+
+  def test_captured_to_classified_patches_metadata_and_fires_nothing(self) -> None:
+    event = _event("evt_bank", status="captured")
+    event.event_type = "bank_transaction"
+    event.metadata_ = {"suggested_element_id": "elem_sugg", "connection_id": "conn_1"}
+    session = _session_with_events(event)
+    body = UpdateEventBlockRequest(
+      event_id="evt_bank",
+      transition_to="classified",
+      metadata_patch={
+        "classified_element_id": "elem_office",
+        "classified_by": "claude",
+      },
+    )
+    with (
+      patch(
+        "robosystems.operations.event_block.commands.fire_handler_on_commit"
+      ) as fire,
+      patch("robosystems.operations.event_block.commands._validate_routed_connection"),
+    ):
+      envelope = update_event_block(session, body, "usr_1", graph_id="kg_test")
+    fire.assert_not_called()
+    assert event.status == "classified"
+    assert event.metadata_["classified_element_id"] == "elem_office"
+    assert event.metadata_["suggested_element_id"] == "elem_sugg"
+    assert envelope.status == "classified"
+
+  def test_classified_to_classified_is_not_a_transition(self) -> None:
+    """Re-classifying is a metadata patch with no transition, not a move."""
+    event = _event("evt_bank", status="classified")
+    session = _session_with_events(event)
+    body = UpdateEventBlockRequest(
+      event_id="evt_bank",
+      transition_to="classified",
+      metadata_patch={"classified_element_id": "elem_b"},
+    )
+    with pytest.raises(InvalidEventTransitionError):
+      update_event_block(session, body, "usr_1", graph_id="kg_test")
+
+  def test_committed_cannot_go_back_to_classified(self) -> None:
+    event = _event("evt_bank", status="committed")
+    session = _session_with_events(event)
+    body = UpdateEventBlockRequest(event_id="evt_bank", transition_to="classified")
+    with pytest.raises(InvalidEventTransitionError):
+      update_event_block(session, body, "usr_1", graph_id="kg_test")


### PR DESCRIPTION
## Summary

The second half of the Mercury bank feed (#1381): the loop that turns a captured bank line into a posted entry. The feed captures every posted transaction into the inbox with an account suggestion; until now nothing posted it, and approving one in the inbox moved it to `committed` with no GL rows, because no handler existed for the bank event types and the dispatch falls through silently. This PR makes classify-then-commit real, over MCP first (the spec's §6 doctrine) and for the inbox UI's approve button.

## Changes

- **Transitions** (`operations/event_block/commands.py`, `models/api/event_block.py`): `captured → classified` is open to callers. It records the account choice — `metadata.classified_element_id`, a `classified_allocations` split, or `accept_suggestion: true` — without posting; the later commit fires the handler. The request model's `transition_to` literal and the `update-event-block` operation description follow.
- **Bank-feed handlers** (`python_handlers/bank_feed.py`, registered for `bank_transaction`, `bank_fee`, `external_transfer`, `internal_transfer`): build the balanced entry from the classification (money in: DR bank / CR contra; money out: the reverse; a split posts one contra line per allocation and must add up; an internal transfer posts from its two bank legs) and delegate the GL write to `journal_entry_recorded` as a local-lane draft (`publish_to_source=False`, never written back anywhere) that close posts. The closed-period fence, balance check and the postability guard are the journal handler's. An unclassified commit falls back to the tenant's DSL rules — the deterministic floor for a counterparty that never varies — and is refused (422, `BankEventNotClassifiedError`) when none matches or several tie. `preview-event-block` shows the planned entry and names the missing choice.
- **MCP instructions** (`middleware/mcp/tools/instructions.py`): an INBOX / BANK FEED block, present only when the graph exposes the write tools: find the captured lines, recall the counterparty, classify, commit, remember the decision; the `recall`/`remember` and preview lines track their tools.
- Reviewers: `bank_feed.py::plan_lines` (the posting shape) and `_apply_dsl_floor` (what an unclassified commit does) carry the doctrine.

## Breaking Changes

None. Generated-tier addition: `classified` joins `UpdateEventBlockRequest.transition_to`. Both client SDKs regenerate once more on their open Mercury branches so 1.17.0 carries the provider and this together.

## Testing

- `just test-code` green (ruff, format, basedpyright, cf-lint).
- `just test`: see the follow-up comment once the full run finishes; the event-block, MCP-instructions, model and extension-router suites pass locally (1,313 tests).
- New: `tests/operations/event_block/python_handlers/test_bank_feed.py` (metadata precedence, every posting shape, the refusals, the DSL fallback, preview), transition tests in `test_commands_update.py`, registry and instruction tests.
- Not run: a live classify-and-commit against the Mercury sandbox on a local graph; owed with the whole-loop run recorded in the spec.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188CbjDiNBtxdEYjSJ5Y7mX
