### PR TITLE
fix(adapters): a placeholder posting date never opens the books at year 1

### DIFF
--- a/robosystems/adapters/mercury/pipeline/assets.py
+++ b/robosystems/adapters/mercury/pipeline/assets.py
@@ -327,12 +327,8 @@ def _bootstrap_fiscal_calendar_if_needed(
         context.log.info("Fiscal calendar already initialized; skipping bootstrap")
         return
       current = current_month_period()
-      first_period = (
-        earliest_occurred_at[:7]
-        if earliest_occurred_at and len(earliest_occurred_at) >= 7
-        else None
-      )
-      if first_period and first_period < current:
+      first_period = _first_period(earliest_occurred_at, current)
+      if first_period is not None:
         closed_through = previous_period(first_period)
       else:
         closed_through = previous_period(previous_period(current))
@@ -361,6 +357,23 @@ def _bootstrap_fiscal_calendar_if_needed(
     context.log.info("Fiscal calendar already initialized (race); skipping bootstrap")
   except Exception as exc:
     context.log.warning(f"Failed to bootstrap fiscal calendar (non-fatal): {exc}")
+
+
+# The earliest month the books can open at. A feed can carry a placeholder
+# date (the Mercury sandbox posts transactions dated year 1); a calendar
+# opened there would seed thousands of periods, or fail on year 0.
+EARLIEST_BOOKS_PERIOD = "1990-01"
+
+
+def _first_period(earliest_occurred_at: str | None, current: str) -> str | None:
+  """The first posted month, or ``None`` when it is missing, in the future,
+  or implausibly early."""
+  if not earliest_occurred_at or len(earliest_occurred_at) < 7:
+    return None
+  period = earliest_occurred_at[:7]
+  if not (EARLIEST_BOOKS_PERIOD <= period < current):
+    return None
+  return period
 
 
 def _mark_graph_stale(

--- a/robosystems/adapters/mercury/pipeline/load.py
+++ b/robosystems/adapters/mercury/pipeline/load.py
@@ -114,8 +114,16 @@ def load_feed(
   report.skipped = result.skipped
   report.classification = result.classification
   report.resolved = result.resolved
-  if result.events:
-    report.earliest_occurred_at = str(result.events[0]["occurred_at"])
+  # The earliest *plausible* posting: a feed can carry a placeholder date
+  # (the sandbox posts transactions dated year 1), and the calendar
+  # bootstrap must not open the books there.
+  sane = [
+    str(event["occurred_at"])
+    for event in result.events
+    if str(event["occurred_at"])[:4] >= "1990"
+  ]
+  if sane:
+    report.earliest_occurred_at = min(sane)
 
   existing = _existing_events(
     session, source, [str(event["external_id"]) for event in result.events]

--- a/robosystems/adapters/mercury/pipeline/transform.py
+++ b/robosystems/adapters/mercury/pipeline/transform.py
@@ -289,12 +289,25 @@ def transform(
   return result
 
 
+# Mercury's sandbox posts some transactions with a placeholder ``postedAt`` of
+# year 1. A date that early is not a posting date; ``createdAt`` stands in.
+_PLACEHOLDER_DATE_CEILING = "1990"
+
+
+def _posted_at(txn: dict[str, Any]) -> str | None:
+  posted = txn.get("postedAt")
+  if posted and str(posted)[:4] >= _PLACEHOLDER_DATE_CEILING:
+    return str(posted)
+  created = txn.get("createdAt")
+  return str(created) if created else None
+
+
 def _day(txn: dict[str, Any]) -> str:
-  return str(txn.get("postedAt") or txn.get("createdAt") or "")[:10]
+  return (_posted_at(txn) or "")[:10]
 
 
 def _when(txn: dict[str, Any]) -> str:
-  return str(txn.get("postedAt") or txn.get("createdAt"))
+  return str(_posted_at(txn))
 
 
 def _suggest(txn: dict[str, Any]) -> tuple[AccountHint | None, str]:

--- a/tests/adapters/mercury/test_assets.py
+++ b/tests/adapters/mercury/test_assets.py
@@ -11,6 +11,7 @@ from dagster import MaterializeResult, build_asset_context
 from robosystems.adapters.mercury.pipeline.assets import (
   MercurySyncConfig,
   _bootstrap_fiscal_calendar_if_needed,
+  _first_period,
   _since_date,
   default_backfill_start,
   get_dagster_components,
@@ -56,6 +57,23 @@ class TestSinceDate:
     assert _since_date(
       cfg, {"since_date": late_start}, datetime.now(UTC)
     ) == date.fromisoformat(late_start)
+
+
+@pytest.mark.unit
+class TestFirstPeriod:
+  def test_plausible_first_month_opens_the_books_there(self):
+    assert _first_period("2026-03-14T15:04:05Z", "2026-09") == "2026-03"
+
+  def test_placeholder_year_one_is_ignored(self):
+    assert _first_period("0001-01-01T00:00:00Z", "2026-09") is None
+
+  def test_future_or_current_month_is_ignored(self):
+    assert _first_period("2026-09-01T00:00:00Z", "2026-09") is None
+    assert _first_period("2027-01-01T00:00:00Z", "2026-09") is None
+
+  def test_missing_or_short_is_ignored(self):
+    assert _first_period(None, "2026-09") is None
+    assert _first_period("2026", "2026-09") is None
 
 
 @pytest.mark.unit

--- a/tests/adapters/mercury/test_load.py
+++ b/tests/adapters/mercury/test_load.py
@@ -99,6 +99,24 @@ class TestLoadFeed:
     assert session.nested == 9
     assert report.earliest_occurred_at == "2026-03-14T15:04:05Z"
 
+  def test_earliest_posting_ignores_placeholder_dates(self):
+    session = _Session()
+    raw = raw_pull()
+    raw["transactions"][0]["postedAt"] = "0001-01-01T00:00:00Z"
+    raw["transactions"][0]["createdAt"] = None
+    with patch(f"{MODULE}.create_event_block_in_session"):
+      report = load_feed(
+        session,
+        graph_id="kg_test",
+        connection_id="conn_1",
+        created_by="usr_1",
+        source="mercury",
+        raw=raw,
+        account_elements=ELEMENTS,
+        chart=ChartIndex(),
+      )
+    assert report.earliest_occurred_at == "2026-03-14T15:04:05Z"
+
   def test_agent_ids_flow_into_events(self):
     session = _Session(existing_agents=[("cp_stripe", "agt_existing")])
     report, create = _run(session)

--- a/tests/adapters/mercury/test_transform.py
+++ b/tests/adapters/mercury/test_transform.py
@@ -212,6 +212,19 @@ class TestTransform:
     assert result.resolved["resolved"] == 0
     assert result.resolved["hint_only"] >= 4
 
+  def test_placeholder_posted_at_falls_back_to_created_at(self):
+    raw = raw_pull()
+    raw["transactions"][0]["postedAt"] = "0001-01-01T00:00:00Z"
+    raw["transactions"][0]["createdAt"] = "2026-03-14T12:00:00Z"
+    result = transform(
+      raw, source="mercury", connection_id="conn_1", account_elements=ELEMENTS
+    )
+    event = next(
+      e for e in result.events if e["external_id"] == "mercury_txn_txn_office"
+    )
+    assert event["occurred_at"] == "2026-03-14T12:00:00Z"
+    assert event["metadata"]["posted_at"] == "0001-01-01T00:00:00Z"  # raw value kept
+
   def test_events_sorted_by_occurred_at(self):
     result, _ = _events()
     stamps = [e["occurred_at"] for e in result.events]


### PR DESCRIPTION
## Summary

Found by the first whole-loop run of the Mercury feed against the sandbox on a local graph. The sandbox posts a few transactions with a placeholder `postedAt` of `0001-01-01`; the feed captured them at that date and the fiscal-calendar bootstrap, which opens the books the month before the first posting, failed on year 0. A fresh company's first sync therefore left no calendar (non-fatal, logged), and the placeholder date sat on the captured lines.

## Changes

- `adapters/mercury/pipeline/transform.py`: a `postedAt` before 1990 is treated as absent and `createdAt` stands in for `occurred_at` (the raw value stays in `metadata.posted_at`).
- `adapters/mercury/pipeline/load.py`: the loader reports the earliest *plausible* posting to the asset.
- `adapters/mercury/pipeline/assets.py`: the bootstrap opens at the first posted month only when it is plausible and in the past; otherwise the month before last, as QuickBooks does.
- Tests for each guard.

## Breaking Changes

None.

## Testing

- `just test-code` green; `tests/adapters/mercury` 97 passed.
- Re-ran the sync on the local graph with the fix mounted: the calendar bootstrapped at the first real posting month (`closed_through` 2026-03, target 2026-04); the incremental window recognized all 137 lines and re-linked the 10 accounts by their stored link.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188CbjDiNBtxdEYjSJ5Y7mX
