### PR TITLE
fix(taxonomy): keep a mapped chart of accounts editable

### DIFF
--- a/robosystems/operations/taxonomy_block/update_validator.py
+++ b/robosystems/operations/taxonomy_block/update_validator.py
@@ -204,11 +204,27 @@ def validate_update_envelope(
     )
   virtual_structures.extend(payload.structures_to_add)
 
+  # Arcs that leave the taxonomy — a chart's mapping arcs into the rs-gaap
+  # library, or any block's arc to a concept it does not own — are created
+  # by the mapping commands, not by an envelope, and the create validator
+  # can only resolve a foreign endpoint through a *parent* taxonomy
+  # (``_load_library_qnames``). Projecting them for an unparented block
+  # would report every one as a phantom and refuse any update on a chart
+  # that has ever been mapped. They are left out of the projection; the
+  # mapping commands own their integrity.
+  current_element_ids = {str(e.id) for e in current_elements}
+  resolves_foreign = taxonomy.parent_taxonomy_id is not None
+
   virtual_associations: list[TaxonomyBlockAssociationRequest] = []
   for a in current_associations:
     if a.id in associations_to_remove_ids:
       continue
     if a.structure_id in structures_to_remove:
+      continue
+    if not resolves_foreign and (
+      str(a.from_element_id) not in current_element_ids
+      or str(a.to_element_id) not in current_element_ids
+    ):
       continue
     if (
       str(a.from_element_id) in missing_qname_element_ids

--- a/tests/operations/taxonomy_block/test_update_validator_coa_traits.py
+++ b/tests/operations/taxonomy_block/test_update_validator_coa_traits.py
@@ -138,3 +138,81 @@ class TestCoaUpdateProjectionTraits:
     flagged = [i for i in issues if i.code == "coa_missing_classification"]
     assert len(flagged) == 1
     assert flagged[0].context["element_qname"] == "rl:MysteryAccount"
+
+
+@pytest.fixture()
+def mapped_coa_taxonomy(ext_session, coa_taxonomy):
+  """The chart above, mapped into a library concept the way a template
+  initialization or the MappingOperator maps it: a ``coa_mapping`` structure
+  on the chart whose arc lands on an element of another taxonomy."""
+  from robosystems.models.extensions import Association, Structure
+
+  library = Taxonomy(name="rs-gaap v1", taxonomy_type="reporting_standard")
+  ext_session.add(library)
+  ext_session.flush()
+  concept = Element(
+    name="Rent Expense",
+    qname="rs-gaap:RentExpense",
+    balance_type="debit",
+    period_type="duration",
+    taxonomy_id=library.id,
+    source="rs-gaap",
+  )
+  ext_session.add(concept)
+  ext_session.flush()
+
+  mapping = Structure(
+    name="rs-gaap mapping", block_type="coa_mapping", taxonomy_id=coa_taxonomy.id
+  )
+  ext_session.add(mapping)
+  ext_session.flush()
+  rent = ext_session.query(Element).filter_by(qname="rl:RentExpense").one()
+  ext_session.add(
+    Association(
+      structure_id=mapping.id,
+      from_element_id=rent.id,
+      to_element_id=concept.id,
+      association_type="mapping",
+    )
+  )
+  ext_session.flush()
+  return coa_taxonomy
+
+
+class TestCoaUpdateProjectionMappingArcs:
+  """A mapped chart must stay editable.
+
+  The projection re-runs the create phases over the chart's existing
+  associations. A chart's mapping arcs land on library concepts the
+  envelope can never resolve (a chart has no parent taxonomy), so before
+  the fix every update on a template-initialized or auto-mapped chart
+  failed reference resolution with one ``phantom_to_ref`` per arc.
+  """
+
+  def test_add_account_on_a_mapped_chart_passes(self, ext_session, mapped_coa_taxonomy):
+    payload = UpdateTaxonomyBlockRequest(
+      taxonomy_id=str(mapped_coa_taxonomy.id),
+      elements_to_add=[
+        TaxonomyBlockElementRequest(
+          qname="rl:MercuryChecking",
+          name="Mercury Checking",
+          trait="asset",
+          balance_type="debit",
+          period_type="instant",
+          code="1010",
+        )
+      ],
+    )
+
+    issues = validate_update_envelope(ext_session, mapped_coa_taxonomy, payload)
+
+    phantom = [i for i in issues if i.code in ("phantom_to_ref", "phantom_from_ref")]
+    assert phantom == [], f"library-bound mapping arcs must not be projected: {phantom}"
+    assert issues == []
+
+  def test_rename_on_a_mapped_chart_passes(self, ext_session, mapped_coa_taxonomy):
+    payload = UpdateTaxonomyBlockRequest(
+      taxonomy_id=str(mapped_coa_taxonomy.id),
+      elements_to_update=[ElementUpdatePatch(qname="rl:Cash", name="Operating cash")],
+    )
+    assert validate_update_envelope(ext_session, mapped_coa_taxonomy, payload) == []


### PR DESCRIPTION
## Summary

Every `update-taxonomy-block` on a chart of accounts that had ever been mapped failed with one `phantom_to_ref` per mapping arc — a template-initialized chart from the first edit, a QuickBooks chart after the mapping operator ran. Found by the first local run of the Mercury feed, whose link-or-create step adds a chart account through the envelope and was refused by the template chart. Reproduced with a plain account add on the same chart; it is a Stage 0 defect that shipped in v1.11.19, not a Mercury one.

## Changes

- `operations/taxonomy_block/update_validator.py`: the projection of a block's existing associations into the virtual create request now leaves out arcs whose endpoint lies outside an **unparented** block. Those arcs (a chart's mapping arcs into the rs-gaap library) are created by the mapping commands, not by an envelope, and the create validator can only resolve a foreign endpoint through a parent taxonomy. Parented blocks (reporting extensions) keep projecting theirs, resolved through the parent as before.
- `tests/operations/taxonomy_block/test_update_validator_coa_traits.py`: a real-Postgres fixture with a chart mapped into a library concept; an account add and a rename both validate clean.

## Breaking Changes

None.

## Testing

- `just test-code` green; `tests/operations/taxonomy_block` 254 passed (real Postgres).
- On the local stack with the fix mounted: a plain `elements_to_update` on the template chart returned 200 where it had returned 422, and the Mercury link-or-create step then created 10 chart accounts through the envelope.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188CbjDiNBtxdEYjSJ5Y7mX
