### PR TITLE
fix(ledger): a classified bank line is one the commit can post

### DIFF
--- a/robosystems/middleware/mcp/tools/instructions.py
+++ b/robosystems/middleware/mcp/tools/instructions.py
@@ -133,8 +133,12 @@ def build_instructions(
         "- Classify one → `update-event-block(event_id, "
         "transition_to='classified', metadata_patch={classified_element_id, "
         "classified_by: 'claude', basis})`. A split: `classified_allocations: "
-        "[{element_id, amount}]` summing to the amount. To take the "
-        "suggestion as-is: `metadata_patch={accept_suggestion: true}`."
+        "[{element_id, amount}]` — positive cents summing to the line's "
+        "absolute amount. To take the suggestion as-is: "
+        "`metadata_patch={accept_suggestion: true}` (only when "
+        "`suggested_element_id` is set; a name-only suggestion needs a "
+        "choice). Classifying validates the choice — one that resolves no "
+        "account is refused there, with the reason."
       ),
       (
         "- Post it → `transition_to='committed'` (a person, or you when "
@@ -152,8 +156,9 @@ def build_instructions(
       )
     if has("preview-event-block"):
       inbox_lines.append(
-        "- Unsure what a commit would write? `preview-event-block` shows the "
-        "planned entry."
+        "- Unsure what a commit would write? `preview-event-block` with the "
+        "line's fields (from `get-event-block`) and your classification in "
+        "`metadata` shows the planned entry."
       )
     sections.append(_block(*inbox_lines))
 

--- a/robosystems/operations/event_block/commands.py
+++ b/robosystems/operations/event_block/commands.py
@@ -62,7 +62,10 @@ from .engine import (
   resolve_agent_type,
 )
 from .python_handlers import get_python_handler
-from .python_handlers.types import HandlerMetadataValidationError
+from .python_handlers.types import (
+  EventBlockPythonHandler,
+  HandlerMetadataValidationError,
+)
 from .registry import (
   HandlerAmbiguousError,
   HandlerNotFoundError,
@@ -589,6 +592,26 @@ def fire_handler_on_commit(
   python_handler.dispatch(session, event, typed_metadata, created_by)
 
 
+def _validate_classification(event: Event) -> None:
+  """Let the event's Python handler refuse a ``classified`` it could not post.
+
+  Runs after the metadata patch, so the handler sees the caller's choice.
+  Handlers without the hook (most) accept the transition as before.
+  """
+  python_handler = get_python_handler(event.event_type)
+  if python_handler is None or python_handler.validate_classification is None:
+    return
+  raw_metadata = dict(event.metadata_ or {})
+  try:
+    typed_metadata = python_handler.metadata_schema.model_validate(raw_metadata)
+  except ValidationError as e:
+    raise HandlerMetadataValidationError(
+      f"Event {event.id} (type={event.event_type}): metadata fails handler "
+      f"validation — cannot classify. {e}"
+    )
+  python_handler.validate_classification(event, typed_metadata)
+
+
 def update_event_block(
   session: Session,
   body: UpdateEventBlockRequest,
@@ -603,6 +626,8 @@ def update_event_block(
   against the captured metadata to produce the corresponding GL rows.
   Handler errors roll back the entire update, including the status
   change — a failed commit leaves the event in its pre-approval state.
+  ``captured → classified`` gives the same handler a veto: a choice it
+  could not post is refused here, with the reason, rather than at commit.
   """
   # Lock the row for the life of the transaction. The transition check below
   # is read-decide-write, and the decision is only sound if nothing else can
@@ -750,6 +775,9 @@ def update_event_block(
   if body.event_action is not None:
     event.event_action = body.event_action
 
+  if body.transition_to == "classified":
+    _validate_classification(event)
+
   if fire_handler:
     # Handler runs after metadata patches so it sees the final shape.
     # Errors propagate; the surrounding transaction rolls back.
@@ -762,8 +790,15 @@ def update_event_block(
   return envelope
 
 
-def _python_preview_to_response(preview) -> PreviewEventBlockResponse:
-  """Map a Python HandlerPreview to the public PreviewEventBlockResponse shape."""
+def _python_preview_to_response(
+  preview, handler: EventBlockPythonHandler
+) -> PreviewEventBlockResponse:
+  """Map a Python HandlerPreview to the public PreviewEventBlockResponse shape.
+
+  ``matched_handler`` is the DSL row shape and stays empty for a Python
+  handler; the handler's name rides in ``handler_metadata`` instead so a
+  reader can see that one matched.
+  """
 
   def _line_element_ref(li: dict) -> str:
     # The metadata schema requires exactly one of element_id or
@@ -802,7 +837,10 @@ def _python_preview_to_response(preview) -> PreviewEventBlockResponse:
     planned_transactions=planned,
     validation_errors=preview.validation_errors,
     would_succeed=preview.would_succeed,
-    handler_metadata=preview.computed_values,
+    handler_metadata={
+      "handler": handler.display_name,
+      **(preview.computed_values or {}),
+    },
   )
 
 
@@ -831,7 +869,7 @@ def preview_event_block(
         would_succeed=False,
       )
     preview = python_handler.dispatch_preview(session, body, typed_metadata)
-    return _python_preview_to_response(preview)
+    return _python_preview_to_response(preview, python_handler)
 
   # 2. DSL registry fallback
   errors: list[str] = []

--- a/robosystems/operations/event_block/python_handlers/bank_feed.py
+++ b/robosystems/operations/event_block/python_handlers/bank_feed.py
@@ -28,7 +28,10 @@ account takes no new lines) are the ledger's own.
 An unclassified event falls back to the tenant's DSL rules — the
 deterministic floor for a counterparty that never varies — and, when no
 rule matches, refuses to commit: a bank event must never land
-``committed`` with no rows behind it.
+``committed`` with no rows behind it. The same test runs when a caller
+marks a line ``classified``: a patch that resolves no account (a split
+that does not add up, ``accept_suggestion`` on a suggestion the chart
+never matched) is refused there, with the reason, not later at commit.
 """
 
 from __future__ import annotations
@@ -103,6 +106,7 @@ class BankFeedMetadata(BaseModel):
   classified_allocations: list[BankAllocation] | None = None
   accept_suggestion: bool = False
   suggested_element_id: str | None = None
+  suggested_account_name: str | None = None
   from_element_id: str | None = None
   to_element_id: str | None = None
   classified_by: str | None = None
@@ -133,6 +137,39 @@ def contra_allocations(
   if not element_id:
     return None
   return [BankAllocation(element_id=element_id, amount=magnitude)]
+
+
+def unclassified_reason(metadata: BankFeedMetadata) -> str:
+  """Why this line has no contra account yet, and what would give it one.
+
+  Names the case the caller is actually in: ``accept_suggestion`` on a
+  suggestion the chart never matched is the common one — the feed keeps
+  the suggested *name* on the line, and telling that caller to set
+  ``accept_suggestion`` again helps nobody.
+  """
+  suggested_name = metadata.suggested_account_name
+  if metadata.accept_suggestion and not metadata.suggested_element_id:
+    if suggested_name:
+      return (
+        f"accept_suggestion was set, but the suggestion '{suggested_name}' "
+        "matches no account on this chart. Choose one: set "
+        "classified_element_id or classified_allocations."
+      )
+    return (
+      "accept_suggestion was set, but this line carries no suggestion. "
+      "Set classified_element_id or classified_allocations."
+    )
+  if metadata.suggested_element_id:
+    take = (
+      f"accept_suggestion: true to take the suggestion '{suggested_name}'"
+      if suggested_name
+      else "accept_suggestion: true to take the suggestion"
+    )
+    return (
+      "No account chosen. Set classified_element_id or classified_allocations, "
+      f"or {take}."
+    )
+  return "No account chosen. Set classified_element_id or classified_allocations."
 
 
 def plan_lines(
@@ -239,8 +276,16 @@ def _memo(event: Event) -> str:
   return (event.description or event.event_type or "Bank transaction")[:255]
 
 
-def _apply_dsl_floor(session: Session, event: Event, created_by: str) -> HandlerResult:
+def _apply_dsl_floor(
+  session: Session,
+  event: Event,
+  created_by: str,
+  *,
+  metadata: BankFeedMetadata | None = None,
+) -> HandlerResult:
   """An unclassified bank event posts through a matching tenant rule, if any."""
+  if metadata is None:
+    metadata = BankFeedMetadata.model_validate(dict(event.metadata_ or {}))
   try:
     handler = resolve_handler(
       session,
@@ -253,9 +298,8 @@ def _apply_dsl_floor(session: Session, event: Event, created_by: str) -> Handler
     )
   except HandlerNotFoundError:
     raise BankEventNotClassifiedError(
-      f"Bank event {event.id} has no account chosen and no rule matches it. "
-      "Classify it first — set metadata.classified_element_id (or "
-      "accept_suggestion: true to take the suggestion) — then commit."
+      f"Bank event {event.id} is not classified and no rule matches it. "
+      f"{unclassified_reason(metadata)} Classify it first, then commit."
     ) from None
   except HandlerAmbiguousError as exc:
     raise BankEventNotClassifiedError(
@@ -294,7 +338,7 @@ def dispatch(
   )
   if lines is None:
     _pin_to_local_lane(event)
-    return _apply_dsl_floor(session, event, created_by)
+    return _apply_dsl_floor(session, event, created_by, metadata=metadata)
 
   _pin_to_local_lane(event)
   journal = _journal_metadata(
@@ -334,10 +378,7 @@ def dispatch_preview(
   if lines is None:
     return HandlerPreview(
       would_succeed=False,
-      validation_errors=[
-        "No account chosen: set classified_element_id, classified_allocations, "
-        "or accept_suggestion before committing."
-      ],
+      validation_errors=[unclassified_reason(metadata)],
       computed_values={"suggested_element_id": metadata.suggested_element_id},
     )
   journal = _journal_metadata(
@@ -359,6 +400,28 @@ def dispatch_preview(
   return preview
 
 
+def validate_classification(event: Event, metadata: BankFeedMetadata) -> None:
+  """Refuse ``captured → classified`` when the commit could not post it.
+
+  Runs the same plan the commit will run. A split that does not add up
+  or a missing bank leg raises as it would at commit; a line with no
+  resolvable contra account is refused with ``unclassified_reason``. An
+  internal transfer always plans (both legs are on the line), so it
+  passes as it is.
+  """
+  lines = plan_lines(
+    event_type=event.event_type,
+    resource_element_id=event.resource_element_id,
+    amount=event.amount,
+    metadata=metadata,
+  )
+  if lines is None:
+    raise BankEventNotClassifiedError(
+      f"Bank event {event.id} cannot be marked classified: "
+      f"{unclassified_reason(metadata)}"
+    )
+
+
 def _handler(event_type: str, display_name: str) -> EventBlockPythonHandler:
   return EventBlockPythonHandler(
     event_type=event_type,
@@ -368,6 +431,7 @@ def _handler(event_type: str, display_name: str) -> EventBlockPythonHandler:
     target_status="classified",
     dispatch=dispatch,
     dispatch_preview=dispatch_preview,
+    validate_classification=validate_classification,
   )
 
 

--- a/robosystems/operations/event_block/python_handlers/types.py
+++ b/robosystems/operations/event_block/python_handlers/types.py
@@ -43,6 +43,10 @@ class EventBlockPythonHandler:
      that produce further work)
   - `dispatch`: the real execution path — reads, computes, writes
   - `dispatch_preview`: the dry-run path — reads, computes, returns plan only
+  - `validate_classification` (optional): refuses a caller's
+    ``captured → classified`` transition when the metadata records no
+    choice the later commit could honour — so ``classified`` is never a
+    status the commit then contradicts (bank-feed lines)
   """
 
   event_type: str
@@ -53,6 +57,7 @@ class EventBlockPythonHandler:
   dispatch_preview: Callable[
     [Session, CreateEventBlockRequest, BaseModel], HandlerPreview
   ]
+  validate_classification: Callable[[Event, BaseModel], None] | None = None
 
 
 class HandlerMetadataValidationError(Exception):

--- a/tests/operations/event_block/python_handlers/test_bank_feed.py
+++ b/tests/operations/event_block/python_handlers/test_bank_feed.py
@@ -19,6 +19,8 @@ from robosystems.operations.event_block.python_handlers.bank_feed import (
   dispatch,
   dispatch_preview,
   plan_lines,
+  unclassified_reason,
+  validate_classification,
 )
 from robosystems.operations.event_block.python_handlers.types import (
   HandlerMetadataValidationError,
@@ -271,6 +273,23 @@ class TestDispatch:
         )
     journal.assert_not_called()
 
+  def test_accepting_a_name_only_suggestion_says_the_chart_has_no_match(self):
+    """The feed keeps the suggested *name* when the chart has no such
+    account; 'set accept_suggestion' is exactly what this caller did."""
+    event = _event()
+    metadata = BankFeedMetadata(
+      accept_suggestion=True, suggested_account_name="Office Supplies"
+    )
+    with patch(
+      f"{MODULE}.resolve_handler",
+      side_effect=HandlerNotFoundError("bank_transaction", "purchase"),
+    ):
+      with pytest.raises(BankEventNotClassifiedError) as exc:
+        dispatch(MagicMock(), event, metadata, "usr_1")
+    message = str(exc.value)
+    assert "'Office Supplies' matches no account on this chart" in message
+    assert "accept_suggestion: true to take" not in message
+
   def test_refusal_is_a_handler_validation_error_for_the_router(self):
     assert issubclass(BankEventNotClassifiedError, HandlerMetadataValidationError)
 
@@ -365,10 +384,15 @@ class TestPreview:
 
   def test_unclassified_preview_names_the_missing_choice(self):
     preview = dispatch_preview(
-      MagicMock(), self._body(), BankFeedMetadata(suggested_element_id="elem_office")
+      MagicMock(),
+      self._body(),
+      BankFeedMetadata(
+        suggested_element_id="elem_office", suggested_account_name="Office"
+      ),
     )
     assert preview.would_succeed is False
-    assert "No account chosen" in preview.validation_errors[0]
+    assert preview.validation_errors[0].startswith("No account chosen")
+    assert "take the suggestion 'Office'" in preview.validation_errors[0]
     assert preview.computed_values["suggested_element_id"] == "elem_office"
 
   def test_classified_preview_delegates_and_annotates(self):
@@ -412,3 +436,66 @@ def test_classification_summary():
     classification_summary({"classified_allocations": [{}, {}]})
     == "split across 2 accounts"
   )
+
+
+@pytest.mark.unit
+class TestUnclassifiedReason:
+  def test_accepted_but_unresolved_names_the_suggestion(self):
+    reason = unclassified_reason(
+      BankFeedMetadata(accept_suggestion=True, suggested_account_name="Office")
+    )
+    assert reason.startswith("accept_suggestion was set, but the suggestion 'Office'")
+    assert "matches no account on this chart" in reason
+
+  def test_accepted_with_no_suggestion_at_all(self):
+    reason = unclassified_reason(BankFeedMetadata(accept_suggestion=True))
+    assert "carries no suggestion" in reason
+
+  def test_resolved_suggestion_offers_the_one_click(self):
+    reason = unclassified_reason(
+      BankFeedMetadata(suggested_element_id="e1", suggested_account_name="Fees")
+    )
+    assert reason.startswith("No account chosen")
+    assert "accept_suggestion: true to take the suggestion 'Fees'" in reason
+
+  def test_nothing_suggested_asks_for_a_choice_only(self):
+    reason = unclassified_reason(BankFeedMetadata())
+    assert reason == (
+      "No account chosen. Set classified_element_id or classified_allocations."
+    )
+
+
+@pytest.mark.unit
+class TestValidateClassification:
+  """`captured → classified` runs the commit's plan and refuses what it
+  could not post — so `classified` never lies."""
+
+  def test_a_resolvable_choice_passes(self):
+    validate_classification(_event(), BankFeedMetadata(classified_element_id="e1"))
+
+  def test_accepting_a_name_only_suggestion_is_refused_with_the_reason(self):
+    with pytest.raises(BankEventNotClassifiedError) as exc:
+      validate_classification(
+        _event(),
+        BankFeedMetadata(accept_suggestion=True, suggested_account_name="Office"),
+      )
+    assert "cannot be marked classified" in str(exc.value)
+    assert "'Office' matches no account on this chart" in str(exc.value)
+
+  def test_a_split_that_does_not_add_up_is_refused(self):
+    with pytest.raises(HandlerMetadataValidationError, match="whole amount"):
+      validate_classification(
+        _event(amount=-4250),
+        BankFeedMetadata(
+          classified_allocations=[
+            {"element_id": "e1", "amount": 4000},
+            {"element_id": "e2", "amount": 100},
+          ]
+        ),
+      )
+
+  def test_an_internal_transfer_passes_as_it_is(self):
+    event = _event(event_type="internal_transfer", amount=50000)
+    validate_classification(
+      event, BankFeedMetadata(from_element_id="e_chk", to_element_id="e_sav")
+    )

--- a/tests/operations/event_block/test_commands_python_handler.py
+++ b/tests/operations/event_block/test_commands_python_handler.py
@@ -145,6 +145,7 @@ class TestPreviewEventBlockPythonHandlerPath:
     body = _make_body()
 
     python_handler = MagicMock()
+    python_handler.display_name = "Asset Disposed"
     python_handler.metadata_schema.model_validate.return_value = MagicMock()
     python_handler.dispatch_preview.return_value = HandlerPreview(
       would_succeed=True,
@@ -171,6 +172,10 @@ class TestPreviewEventBlockPythonHandlerPath:
 
     assert resp.would_succeed is True
     assert resp.handler_metadata["nbv_cents"] == 10000
+    # A Python handler is not an event_handlers row, so matched_handler stays
+    # empty; its name rides in handler_metadata so a reader sees the match.
+    assert resp.matched_handler is None
+    assert resp.handler_metadata["handler"] == "Asset Disposed"
     assert len(resp.planned_transactions) == 1
     assert resp.planned_transactions[0].debit_element_id == "elem_accum_dep"
     assert resp.planned_transactions[0].credit_element_id == "elem_asset"

--- a/tests/operations/event_block/test_commands_update.py
+++ b/tests/operations/event_block/test_commands_update.py
@@ -756,6 +756,8 @@ class TestClassifyTransition:
   def test_captured_to_classified_patches_metadata_and_fires_nothing(self) -> None:
     event = _event("evt_bank", status="captured")
     event.event_type = "bank_transaction"
+    event.amount = -4250
+    event.resource_element_id = "elem_card"
     event.metadata_ = {"suggested_element_id": "elem_sugg", "connection_id": "conn_1"}
     session = _session_with_events(event)
     body = UpdateEventBlockRequest(
@@ -777,6 +779,44 @@ class TestClassifyTransition:
     assert event.status == "classified"
     assert event.metadata_["classified_element_id"] == "elem_office"
     assert event.metadata_["suggested_element_id"] == "elem_sugg"
+    assert envelope.status == "classified"
+
+  def test_a_choice_the_handler_cannot_post_is_refused_with_its_reason(
+    self,
+  ) -> None:
+    """The bank handler's plan runs on classify: accept_suggestion on a
+    suggestion the chart never matched is refused here, not at commit."""
+    event = _event("evt_bank", status="captured")
+    event.event_type = "bank_transaction"
+    event.amount = -2900
+    event.resource_element_id = "elem_card"
+    event.metadata_ = {"suggested_account_name": "Office Supplies"}
+    session = _session_with_events(event)
+    body = UpdateEventBlockRequest(
+      event_id="evt_bank",
+      transition_to="classified",
+      metadata_patch={"accept_suggestion": True},
+    )
+    with patch(
+      "robosystems.operations.event_block.commands._validate_routed_connection"
+    ):
+      with pytest.raises(HandlerMetadataValidationError) as exc:
+        update_event_block(session, body, "usr_1", graph_id="kg_test")
+    assert "'Office Supplies' matches no account on this chart" in str(exc.value)
+    session.commit.assert_not_called()
+
+  def test_handlers_without_the_hook_accept_classified_as_before(self) -> None:
+    event = _event("evt_x", status="captured")
+    session = _session_with_events(event)
+    body = UpdateEventBlockRequest(event_id="evt_x", transition_to="classified")
+    handler = MagicMock()
+    handler.validate_classification = None
+    with patch(
+      "robosystems.operations.event_block.commands.get_python_handler",
+      return_value=handler,
+    ):
+      envelope = update_event_block(session, body, "usr_1", graph_id="kg_test")
+    handler.metadata_schema.model_validate.assert_not_called()
     assert envelope.status == "classified"
 
   def test_classified_to_classified_is_not_a_transition(self) -> None:


### PR DESCRIPTION
## Summary

Found in the second local end-to-end run of the Mercury bank feed, walking the inbox loop over MCP. A bank line could be marked `classified` with a choice the commit could not post (`accept_suggestion: true` on a suggestion the chart never matched), and the refusal that followed at commit told the caller to set `accept_suggestion` — the step they had just taken. The classify transition now runs the same plan the commit runs and refuses with the actual reason; the preview names its handler; the per-graph MCP instructions say what a split's amounts are and what `preview-event-block` needs.

## Changes

- `operations/event_block/python_handlers/types.py` — `EventBlockPythonHandler.validate_classification`, an optional hook a handler declares to veto `captured → classified` when the metadata records no choice it could post. Handlers without it (all but the bank feed) behave as before.
- `operations/event_block/python_handlers/bank_feed.py` — `unclassified_reason` names the case the caller is in (accepted but unresolved suggestion / suggestion available / nothing suggested) and is used by the commit-time refusal and the preview; `validate_classification` runs `plan_lines` on classify; `BankFeedMetadata` gains `suggested_account_name` so the refusal can name the suggestion.
- `operations/event_block/commands.py` — `update_event_block` calls the hook after the metadata patch on a `classified` transition (refusals surface as 422 like a commit's); `_python_preview_to_response` puts the handler's display name in `handler_metadata.handler`, since `matched_handler` is the DSL row shape and stays empty for a Python handler.
- `middleware/mcp/tools/instructions.py` — the INBOX / BANK FEED block: split amounts are positive cents summing to the line's absolute amount; `accept_suggestion` applies only when `suggested_element_id` is set; classifying validates; `preview-event-block` takes the line's fields plus the classification.
- Tests: the new reason branches, the classify hook (resolvable choice passes, name-only suggestion refused with the reason, a split that does not add up, an internal transfer as-is), the command wiring (refusal with reason, handlers without the hook untouched), the preview's handler name.

## Breaking Changes

None. No API shape changes — `handler_metadata` gains a key, and a `classified` transition that used to succeed silently on an unpostable choice now returns the same 422 the commit would have. Generated SDK tier unaffected.

## Testing

- `uv run pytest` on the five touched test files: 145 passed.
- `ruff check` + `ruff format` clean; `basedpyright` on the three changed modules: 0 errors.
- Verified live on the local stack against the Mercury sandbox graph over MCP: classify with `accept_suggestion` on a name-only suggestion → refused naming 'Office Supplies' as unmatched; commit of an unclassified line → refused with the choice to make; preview → `handler_metadata.handler = "Bank Transaction"`.
- Full `just test-all` not run this session.

## Certification

- [x] I have the right to submit this work under the Apache 2.0 license, and do so. Where any part of it is owned by my employer, I have their permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmuU6KfAcqtfL8pfhRJWW7
